### PR TITLE
Update `cuda::ptx` to CTK 13

### DIFF
--- a/docs/libcudacxx/ptx/instructions/generated/clusterlaunchcontrol.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/clusterlaunchcontrol.rst
@@ -15,7 +15,7 @@ clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.m
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 [addr], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 [addr], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    template <typename = void>
    __device__ static inline void clusterlaunchcontrol_try_cancel_multicast(
      void* addr,

--- a/docs/libcudacxx/ptx/instructions/generated/cp_async_bulk_multicast.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/cp_async_bulk_multicast.rst
@@ -5,7 +5,7 @@ cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::clu
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.dst.src.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [srcMem], size, [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+   // cp.async.bulk.dst.src.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [srcMem], size, [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    template <typename = void>

--- a/docs/libcudacxx/ptx/instructions/generated/cp_async_bulk_tensor.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/cp_async_bulk_tensor.rst
@@ -37,7 +37,7 @@ cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -55,7 +55,7 @@ cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -120,7 +120,7 @@ cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -138,7 +138,7 @@ cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -203,7 +203,7 @@ cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -221,7 +221,7 @@ cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -286,7 +286,7 @@ cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -304,7 +304,7 @@ cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -369,7 +369,7 @@ cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -387,7 +387,7 @@ cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }

--- a/docs/libcudacxx/ptx/instructions/generated/cp_async_bulk_tensor_gather_scatter.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/cp_async_bulk_tensor_gather_scatter.rst
@@ -21,7 +21,7 @@ cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -39,7 +39,7 @@ cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cta }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -57,7 +57,7 @@ cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    template <typename = void>
@@ -74,7 +74,7 @@ cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -93,7 +93,7 @@ cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -112,7 +112,7 @@ cp.async.bulk.tensor.2d.global.shared::cta.tile::scatter4.bulk_group
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile::scatter4.bulk_group [tensorMap, tensorCoords], [srcMem]; // PTX ISA 86, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile::scatter4.bulk_group [tensorMap, tensorCoords], [srcMem]; // PTX ISA 86, SM_100a, SM_110a
    // .dst       = { .global }
    // .src       = { .shared::cta }
    template <typename = void>

--- a/docs/libcudacxx/ptx/instructions/generated/cp_async_bulk_tensor_multicast.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/cp_async_bulk_tensor_multicast.rst
@@ -5,7 +5,7 @@ cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+   // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    template <typename = void>
@@ -22,7 +22,7 @@ cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+   // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -41,7 +41,7 @@ cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+   // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -60,7 +60,7 @@ cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    template <typename = void>
@@ -77,7 +77,7 @@ cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -96,7 +96,7 @@ cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+   // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -115,7 +115,7 @@ cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+   // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    template <typename = void>
@@ -132,7 +132,7 @@ cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+   // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -151,7 +151,7 @@ cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+   // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -170,7 +170,7 @@ cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+   // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    template <typename = void>
@@ -187,7 +187,7 @@ cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+   // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -206,7 +206,7 @@ cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+   // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -225,7 +225,7 @@ cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+   // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    template <typename = void>
@@ -242,7 +242,7 @@ cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+   // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -261,7 +261,7 @@ cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+   // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
    // .dst       = { .shared::cluster }
    // .src       = { .global }
    // .cta_group = { .cta_group::1, .cta_group::2 }

--- a/docs/libcudacxx/ptx/instructions/generated/ld.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/ld.rst
@@ -12,6 +12,17 @@ ld.global.b8
      cuda::ptx::space_global_t,
      const B8* addr);
 
+ld.global.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_L2_256B(
+     cuda::ptx::space_global_t,
+     const B8* addr);
+
 ld.global.b16
 ^^^^^^^^^^^^^
 .. code:: cuda
@@ -20,6 +31,17 @@ ld.global.b16
    // .space     = { .global }
    template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
    __device__ static inline B16 ld(
+     cuda::ptx::space_global_t,
+     const B16* addr);
+
+ld.global.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_L2_256B(
      cuda::ptx::space_global_t,
      const B16* addr);
 
@@ -34,6 +56,17 @@ ld.global.b32
      cuda::ptx::space_global_t,
      const B32* addr);
 
+ld.global.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_L2_256B(
+     cuda::ptx::space_global_t,
+     const B32* addr);
+
 ld.global.b64
 ^^^^^^^^^^^^^
 .. code:: cuda
@@ -42,6 +75,17 @@ ld.global.b64
    // .space     = { .global }
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline B64 ld(
+     cuda::ptx::space_global_t,
+     const B64* addr);
+
+ld.global.L2::256B.b64
+^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+   __device__ static inline B64 ld_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr);
 
@@ -56,160 +100,6 @@ ld.global.b128
      cuda::ptx::space_global_t,
      const B128* addr);
 
-ld.global.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L2::256B.b64
-^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L2_256B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
 ld.global.L2::256B.b128
 ^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -221,6 +111,17 @@ ld.global.L2::256B.b128
      cuda::ptx::space_global_t,
      const B128* addr);
 
+ld.global.v4.b64
+^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld(
+     cuda::ptx::space_global_t,
+     const B256* addr);
+
 ld.global.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -229,6 +130,18 @@ ld.global.L2::cache_hint.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B8* addr,
+     uint64_t cache_policy);
+
+ld.global.L2::cache_hint.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr,
      uint64_t cache_policy);
@@ -245,6 +158,18 @@ ld.global.L2::cache_hint.b16
      const B16* addr,
      uint64_t cache_policy);
 
+ld.global.L2::cache_hint.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_L2_cache_hint_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr,
+     uint64_t cache_policy);
+
 ld.global.L2::cache_hint.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -253,6 +178,18 @@ ld.global.L2::cache_hint.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B32* addr,
+     uint64_t cache_policy);
+
+ld.global.L2::cache_hint.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr,
      uint64_t cache_policy);
@@ -269,174 +206,6 @@ ld.global.L2::cache_hint.b64
      const B64* addr,
      uint64_t cache_policy);
 
-ld.global.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
 ld.global.L2::cache_hint.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -447,6 +216,18 @@ ld.global.L2::cache_hint.L2::256B.b64
    __device__ static inline B64 ld_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr,
+     uint64_t cache_policy);
+
+ld.global.L2::cache_hint.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B128* addr,
      uint64_t cache_policy);
 
 ld.global.L2::cache_hint.L2::256B.b128
@@ -461,924 +242,16 @@ ld.global.L2::cache_hint.L2::256B.b128
      const B128* addr,
      uint64_t cache_policy);
 
-ld.global.L1::evict_normal.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_normal.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_normal.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_normal.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_normal.b128
+ld.global.L2::cache_hint.v4.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.space.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_70
+   // ld.space.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
    // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_normal(
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_L2_cache_hint(
      cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_normal.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_normal_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_normal.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_normal_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_normal.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_normal_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_normal.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_normal_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_normal.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_normal_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_normal.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_normal_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_normal.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_normal_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_normal.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_normal_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_normal.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_normal_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_normal.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_normal_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_normal.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_normal_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_normal.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_normal_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_normal.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_normal_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_normal.L2::256B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_normal_L2_256B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_normal.L2::256B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_normal_L2_256B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_normal.L2::cache_hint.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_normal_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_normal_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_normal_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_normal_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_normal_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_normal_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_normal_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_normal_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_normal_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_normal_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_normal_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_normal_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_normal_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_normal_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_normal.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_normal_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_unchanged.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_unchanged.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_unchanged.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_unchanged.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_70
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_unchanged.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_unchanged_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_unchanged.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_unchanged_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_unchanged.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_unchanged_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_unchanged.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_unchanged_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_unchanged.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_unchanged_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_unchanged.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_unchanged_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_unchanged.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_unchanged_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_unchanged.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_unchanged_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_unchanged.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_unchanged_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_unchanged.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_unchanged_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_unchanged.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_unchanged_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_unchanged.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_unchanged_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_unchanged.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_unchanged_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_unchanged.L2::256B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_unchanged_L2_256B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_unchanged.L2::256B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_unchanged_L2_256B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_unchanged_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_unchanged_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_unchanged_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_unchanged_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_unchanged_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_unchanged_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_unchanged_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_unchanged_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_unchanged_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_unchanged_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_unchanged_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_unchanged_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_unchanged_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_unchanged_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_unchanged.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_unchanged_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
+     const B256* addr,
      uint64_t cache_policy);
 
 ld.global.L1::evict_first.b8
@@ -1389,6 +262,17 @@ ld.global.L1::evict_first.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_L1_evict_first(
+     cuda::ptx::space_global_t,
+     const B8* addr);
+
+ld.global.L1::evict_first.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_L1_evict_first_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr);
 
@@ -1403,6 +287,17 @@ ld.global.L1::evict_first.b16
      cuda::ptx::space_global_t,
      const B16* addr);
 
+ld.global.L1::evict_first.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_L1_evict_first_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr);
+
 ld.global.L1::evict_first.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -1411,6 +306,17 @@ ld.global.L1::evict_first.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_L1_evict_first(
+     cuda::ptx::space_global_t,
+     const B32* addr);
+
+ld.global.L1::evict_first.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_L1_evict_first_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr);
 
@@ -1425,160 +331,6 @@ ld.global.L1::evict_first.b64
      cuda::ptx::space_global_t,
      const B64* addr);
 
-ld.global.L1::evict_first.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_70
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_first(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_first.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_first_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_first.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_first_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_first.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_first_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_first.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_first_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_first.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_first_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_first.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_first_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_first.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_first_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_first.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_first_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_first.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_first_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_first.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_first_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_first.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_first_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_first.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_first_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_first.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_first_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
 ld.global.L1::evict_first.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -1589,6 +341,17 @@ ld.global.L1::evict_first.L2::256B.b64
    __device__ static inline B64 ld_L1_evict_first_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr);
+
+ld.global.L1::evict_first.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_70
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_L1_evict_first(
+     cuda::ptx::space_global_t,
+     const B128* addr);
 
 ld.global.L1::evict_first.L2::256B.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -1601,6 +364,17 @@ ld.global.L1::evict_first.L2::256B.b128
      cuda::ptx::space_global_t,
      const B128* addr);
 
+ld.global.L1::evict_first.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_first.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_L1_evict_first(
+     cuda::ptx::space_global_t,
+     const B256* addr);
+
 ld.global.L1::evict_first.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -1609,6 +383,18 @@ ld.global.L1::evict_first.L2::cache_hint.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_L1_evict_first_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B8* addr,
+     uint64_t cache_policy);
+
+ld.global.L1::evict_first.L2::cache_hint.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_L1_evict_first_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr,
      uint64_t cache_policy);
@@ -1625,6 +411,18 @@ ld.global.L1::evict_first.L2::cache_hint.b16
      const B16* addr,
      uint64_t cache_policy);
 
+ld.global.L1::evict_first.L2::cache_hint.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_first.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_L1_evict_first_L2_cache_hint_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr,
+     uint64_t cache_policy);
+
 ld.global.L1::evict_first.L2::cache_hint.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -1633,6 +431,18 @@ ld.global.L1::evict_first.L2::cache_hint.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_L1_evict_first_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B32* addr,
+     uint64_t cache_policy);
+
+ld.global.L1::evict_first.L2::cache_hint.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_first.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_L1_evict_first_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr,
      uint64_t cache_policy);
@@ -1649,174 +459,6 @@ ld.global.L1::evict_first.L2::cache_hint.b64
      const B64* addr,
      uint64_t cache_policy);
 
-ld.global.L1::evict_first.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_first_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_first_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_first_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_first_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_first_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_first_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_first_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_first_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_first_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_first_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_first_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_first_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_first_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_first.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_first.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_first_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
 ld.global.L1::evict_first.L2::cache_hint.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -1827,6 +469,18 @@ ld.global.L1::evict_first.L2::cache_hint.L2::256B.b64
    __device__ static inline B64 ld_L1_evict_first_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr,
+     uint64_t cache_policy);
+
+ld.global.L1::evict_first.L2::cache_hint.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_first.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_L1_evict_first_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B128* addr,
      uint64_t cache_policy);
 
 ld.global.L1::evict_first.L2::cache_hint.L2::256B.b128
@@ -1841,6 +495,18 @@ ld.global.L1::evict_first.L2::cache_hint.L2::256B.b128
      const B128* addr,
      uint64_t cache_policy);
 
+ld.global.L1::evict_first.L2::cache_hint.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_first.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_L1_evict_first_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B256* addr,
+     uint64_t cache_policy);
+
 ld.global.L1::evict_last.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -1849,6 +515,17 @@ ld.global.L1::evict_last.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_L1_evict_last(
+     cuda::ptx::space_global_t,
+     const B8* addr);
+
+ld.global.L1::evict_last.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_L1_evict_last_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr);
 
@@ -1863,6 +540,17 @@ ld.global.L1::evict_last.b16
      cuda::ptx::space_global_t,
      const B16* addr);
 
+ld.global.L1::evict_last.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_L1_evict_last_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr);
+
 ld.global.L1::evict_last.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -1871,6 +559,17 @@ ld.global.L1::evict_last.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_L1_evict_last(
+     cuda::ptx::space_global_t,
+     const B32* addr);
+
+ld.global.L1::evict_last.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_L1_evict_last_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr);
 
@@ -1885,160 +584,6 @@ ld.global.L1::evict_last.b64
      cuda::ptx::space_global_t,
      const B64* addr);
 
-ld.global.L1::evict_last.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_70
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_last(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_last.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_last_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_last.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_last_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_last.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_last_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_last.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_last_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_last.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_last_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_last.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_last_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_last.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_last_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_last.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_last_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::evict_last.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_last_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::evict_last.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_last_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::evict_last.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_last_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::evict_last.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_last_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::evict_last.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_last_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
 ld.global.L1::evict_last.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2049,6 +594,17 @@ ld.global.L1::evict_last.L2::256B.b64
    __device__ static inline B64 ld_L1_evict_last_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr);
+
+ld.global.L1::evict_last.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_70
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_L1_evict_last(
+     cuda::ptx::space_global_t,
+     const B128* addr);
 
 ld.global.L1::evict_last.L2::256B.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2061,6 +617,17 @@ ld.global.L1::evict_last.L2::256B.b128
      cuda::ptx::space_global_t,
      const B128* addr);
 
+ld.global.L1::evict_last.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_last.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_L1_evict_last(
+     cuda::ptx::space_global_t,
+     const B256* addr);
+
 ld.global.L1::evict_last.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2069,6 +636,18 @@ ld.global.L1::evict_last.L2::cache_hint.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_L1_evict_last_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B8* addr,
+     uint64_t cache_policy);
+
+ld.global.L1::evict_last.L2::cache_hint.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_L1_evict_last_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr,
      uint64_t cache_policy);
@@ -2085,6 +664,18 @@ ld.global.L1::evict_last.L2::cache_hint.b16
      const B16* addr,
      uint64_t cache_policy);
 
+ld.global.L1::evict_last.L2::cache_hint.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_last.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_L1_evict_last_L2_cache_hint_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr,
+     uint64_t cache_policy);
+
 ld.global.L1::evict_last.L2::cache_hint.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2093,6 +684,18 @@ ld.global.L1::evict_last.L2::cache_hint.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_L1_evict_last_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B32* addr,
+     uint64_t cache_policy);
+
+ld.global.L1::evict_last.L2::cache_hint.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_last.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_L1_evict_last_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr,
      uint64_t cache_policy);
@@ -2109,174 +712,6 @@ ld.global.L1::evict_last.L2::cache_hint.b64
      const B64* addr,
      uint64_t cache_policy);
 
-ld.global.L1::evict_last.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_last_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_last_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_last_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_last_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_last_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_last_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_last_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_last_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_last_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_evict_last_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_evict_last_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_evict_last_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_evict_last_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::evict_last.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::evict_last.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_evict_last_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
 ld.global.L1::evict_last.L2::cache_hint.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2287,6 +722,18 @@ ld.global.L1::evict_last.L2::cache_hint.L2::256B.b64
    __device__ static inline B64 ld_L1_evict_last_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr,
+     uint64_t cache_policy);
+
+ld.global.L1::evict_last.L2::cache_hint.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_last.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_L1_evict_last_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B128* addr,
      uint64_t cache_policy);
 
 ld.global.L1::evict_last.L2::cache_hint.L2::256B.b128
@@ -2301,6 +748,18 @@ ld.global.L1::evict_last.L2::cache_hint.L2::256B.b128
      const B128* addr,
      uint64_t cache_policy);
 
+ld.global.L1::evict_last.L2::cache_hint.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::evict_last.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_L1_evict_last_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B256* addr,
+     uint64_t cache_policy);
+
 ld.global.L1::no_allocate.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2309,6 +768,17 @@ ld.global.L1::no_allocate.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_L1_no_allocate(
+     cuda::ptx::space_global_t,
+     const B8* addr);
+
+ld.global.L1::no_allocate.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_L1_no_allocate_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr);
 
@@ -2323,6 +793,17 @@ ld.global.L1::no_allocate.b16
      cuda::ptx::space_global_t,
      const B16* addr);
 
+ld.global.L1::no_allocate.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_L1_no_allocate_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr);
+
 ld.global.L1::no_allocate.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2331,6 +812,17 @@ ld.global.L1::no_allocate.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_L1_no_allocate(
+     cuda::ptx::space_global_t,
+     const B32* addr);
+
+ld.global.L1::no_allocate.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_L1_no_allocate_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr);
 
@@ -2345,160 +837,6 @@ ld.global.L1::no_allocate.b64
      cuda::ptx::space_global_t,
      const B64* addr);
 
-ld.global.L1::no_allocate.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_70
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_no_allocate(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::no_allocate.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_no_allocate_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::no_allocate.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_no_allocate_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::no_allocate.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_no_allocate_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::no_allocate.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_no_allocate_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::no_allocate.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_no_allocate_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::no_allocate.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_no_allocate_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::no_allocate.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_no_allocate_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::no_allocate.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_no_allocate_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.L1::no_allocate.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_no_allocate_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.L1::no_allocate.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_no_allocate_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.L1::no_allocate.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_no_allocate_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.L1::no_allocate.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_no_allocate_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.L1::no_allocate.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_no_allocate_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
 ld.global.L1::no_allocate.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2509,6 +847,17 @@ ld.global.L1::no_allocate.L2::256B.b64
    __device__ static inline B64 ld_L1_no_allocate_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr);
+
+ld.global.L1::no_allocate.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_70
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_L1_no_allocate(
+     cuda::ptx::space_global_t,
+     const B128* addr);
 
 ld.global.L1::no_allocate.L2::256B.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2521,6 +870,17 @@ ld.global.L1::no_allocate.L2::256B.b128
      cuda::ptx::space_global_t,
      const B128* addr);
 
+ld.global.L1::no_allocate.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::no_allocate.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_L1_no_allocate(
+     cuda::ptx::space_global_t,
+     const B256* addr);
+
 ld.global.L1::no_allocate.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2529,6 +889,18 @@ ld.global.L1::no_allocate.L2::cache_hint.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_L1_no_allocate_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B8* addr,
+     uint64_t cache_policy);
+
+ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_L1_no_allocate_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr,
      uint64_t cache_policy);
@@ -2545,6 +917,18 @@ ld.global.L1::no_allocate.L2::cache_hint.b16
      const B16* addr,
      uint64_t cache_policy);
 
+ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_L1_no_allocate_L2_cache_hint_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr,
+     uint64_t cache_policy);
+
 ld.global.L1::no_allocate.L2::cache_hint.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2553,6 +937,18 @@ ld.global.L1::no_allocate.L2::cache_hint.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_L1_no_allocate_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B32* addr,
+     uint64_t cache_policy);
+
+ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_L1_no_allocate_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr,
      uint64_t cache_policy);
@@ -2569,174 +965,6 @@ ld.global.L1::no_allocate.L2::cache_hint.b64
      const B64* addr,
      uint64_t cache_policy);
 
-ld.global.L1::no_allocate.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_no_allocate_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_no_allocate_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_no_allocate_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_no_allocate_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_no_allocate_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_no_allocate_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_no_allocate_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_no_allocate_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_no_allocate_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_L1_no_allocate_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_L1_no_allocate_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_L1_no_allocate_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_L1_no_allocate_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_L1_no_allocate_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
 ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2747,6 +975,18 @@ ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b64
    __device__ static inline B64 ld_L1_no_allocate_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr,
+     uint64_t cache_policy);
+
+ld.global.L1::no_allocate.L2::cache_hint.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::no_allocate.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_L1_no_allocate_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B128* addr,
      uint64_t cache_policy);
 
 ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b128
@@ -2761,6 +1001,18 @@ ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b128
      const B128* addr,
      uint64_t cache_policy);
 
+ld.global.L1::no_allocate.L2::cache_hint.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.L1::no_allocate.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_L1_no_allocate_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B256* addr,
+     uint64_t cache_policy);
+
 ld.global.nc.b8
 ^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2769,6 +1021,17 @@ ld.global.nc.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_nc(
+     cuda::ptx::space_global_t,
+     const B8* addr);
+
+ld.global.nc.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_nc_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr);
 
@@ -2783,6 +1046,17 @@ ld.global.nc.b16
      cuda::ptx::space_global_t,
      const B16* addr);
 
+ld.global.nc.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_nc_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr);
+
 ld.global.nc.b32
 ^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2791,6 +1065,17 @@ ld.global.nc.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_nc(
+     cuda::ptx::space_global_t,
+     const B32* addr);
+
+ld.global.nc.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_nc_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr);
 
@@ -2805,160 +1090,6 @@ ld.global.nc.b64
      cuda::ptx::space_global_t,
      const B64* addr);
 
-ld.global.nc.b128
-^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.b128 dest, [addr]; // PTX ISA 83, SM_70
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
 ld.global.nc.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2969,6 +1100,17 @@ ld.global.nc.L2::256B.b64
    __device__ static inline B64 ld_nc_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr);
+
+ld.global.nc.b128
+^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.b128 dest, [addr]; // PTX ISA 83, SM_70
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_nc(
+     cuda::ptx::space_global_t,
+     const B128* addr);
 
 ld.global.nc.L2::256B.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -2981,6 +1123,17 @@ ld.global.nc.L2::256B.b128
      cuda::ptx::space_global_t,
      const B128* addr);
 
+ld.global.nc.v4.b64
+^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_nc(
+     cuda::ptx::space_global_t,
+     const B256* addr);
+
 ld.global.nc.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -2989,6 +1142,18 @@ ld.global.nc.L2::cache_hint.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_nc_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B8* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L2::cache_hint.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_nc_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr,
      uint64_t cache_policy);
@@ -3005,6 +1170,18 @@ ld.global.nc.L2::cache_hint.b16
      const B16* addr,
      uint64_t cache_policy);
 
+ld.global.nc.L2::cache_hint.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_nc_L2_cache_hint_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr,
+     uint64_t cache_policy);
+
 ld.global.nc.L2::cache_hint.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -3013,6 +1190,18 @@ ld.global.nc.L2::cache_hint.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_nc_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B32* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L2::cache_hint.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_nc_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr,
      uint64_t cache_policy);
@@ -3029,174 +1218,6 @@ ld.global.nc.L2::cache_hint.b64
      const B64* addr,
      uint64_t cache_policy);
 
-ld.global.nc.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
 ld.global.nc.L2::cache_hint.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -3207,6 +1228,18 @@ ld.global.nc.L2::cache_hint.L2::256B.b64
    __device__ static inline B64 ld_nc_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L2::cache_hint.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_nc_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B128* addr,
      uint64_t cache_policy);
 
 ld.global.nc.L2::cache_hint.L2::256B.b128
@@ -3221,924 +1254,16 @@ ld.global.nc.L2::cache_hint.L2::256B.b128
      const B128* addr,
      uint64_t cache_policy);
 
-ld.global.nc.L1::evict_normal.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_normal.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_normal.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_normal.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_normal.b128
+ld.global.nc.L2::cache_hint.v4.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // ld.space.nc.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_70
+   // ld.space.nc.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
    // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_normal(
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_nc_L2_cache_hint(
      cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_normal.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_normal_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_normal.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_normal_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_normal.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_normal_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_normal.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_normal_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_normal.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_normal_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_normal.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_normal_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_normal.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_normal_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_normal.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_normal_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_normal.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_normal_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_normal.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_normal_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_normal.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_normal_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_normal.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_normal_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_normal.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_normal_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_normal.L2::256B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_normal_L2_256B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_normal.L2::256B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_normal_L2_256B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_normal.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_unchanged.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_unchanged.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_unchanged.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_unchanged.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_70
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_unchanged_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_unchanged_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_unchanged_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_unchanged_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_unchanged_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_unchanged_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_unchanged_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_unchanged_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_unchanged_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_unchanged_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_unchanged_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_unchanged_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_unchanged_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::256B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_unchanged_L2_256B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::256B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_unchanged_L2_256B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
+     const B256* addr,
      uint64_t cache_policy);
 
 ld.global.nc.L1::evict_first.b8
@@ -4149,6 +1274,17 @@ ld.global.nc.L1::evict_first.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_nc_L1_evict_first(
+     cuda::ptx::space_global_t,
+     const B8* addr);
+
+ld.global.nc.L1::evict_first.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_nc_L1_evict_first_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr);
 
@@ -4163,6 +1299,17 @@ ld.global.nc.L1::evict_first.b16
      cuda::ptx::space_global_t,
      const B16* addr);
 
+ld.global.nc.L1::evict_first.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_nc_L1_evict_first_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr);
+
 ld.global.nc.L1::evict_first.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -4171,6 +1318,17 @@ ld.global.nc.L1::evict_first.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_nc_L1_evict_first(
+     cuda::ptx::space_global_t,
+     const B32* addr);
+
+ld.global.nc.L1::evict_first.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_nc_L1_evict_first_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr);
 
@@ -4185,160 +1343,6 @@ ld.global.nc.L1::evict_first.b64
      cuda::ptx::space_global_t,
      const B64* addr);
 
-ld.global.nc.L1::evict_first.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_70
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_first(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_first.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_first_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_first.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_first_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_first.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_first_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_first.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_first_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_first.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_first_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_first.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_first_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_first.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_first_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_first.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_first_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_first.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_first_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_first.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_first_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_first.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_first_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_first.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_first_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_first.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_first_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
 ld.global.nc.L1::evict_first.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -4349,6 +1353,17 @@ ld.global.nc.L1::evict_first.L2::256B.b64
    __device__ static inline B64 ld_nc_L1_evict_first_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr);
+
+ld.global.nc.L1::evict_first.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_first.b128 dest, [addr]; // PTX ISA 83, SM_70
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_nc_L1_evict_first(
+     cuda::ptx::space_global_t,
+     const B128* addr);
 
 ld.global.nc.L1::evict_first.L2::256B.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -4361,6 +1376,17 @@ ld.global.nc.L1::evict_first.L2::256B.b128
      cuda::ptx::space_global_t,
      const B128* addr);
 
+ld.global.nc.L1::evict_first.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_first.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_nc_L1_evict_first(
+     cuda::ptx::space_global_t,
+     const B256* addr);
+
 ld.global.nc.L1::evict_first.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -4369,6 +1395,18 @@ ld.global.nc.L1::evict_first.L2::cache_hint.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B8* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr,
      uint64_t cache_policy);
@@ -4385,6 +1423,18 @@ ld.global.nc.L1::evict_first.L2::cache_hint.b16
      const B16* addr,
      uint64_t cache_policy);
 
+ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr,
+     uint64_t cache_policy);
+
 ld.global.nc.L1::evict_first.L2::cache_hint.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -4393,6 +1443,18 @@ ld.global.nc.L1::evict_first.L2::cache_hint.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B32* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr,
      uint64_t cache_policy);
@@ -4409,174 +1471,6 @@ ld.global.nc.L1::evict_first.L2::cache_hint.b64
      const B64* addr,
      uint64_t cache_policy);
 
-ld.global.nc.L1::evict_first.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_first_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_first_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_first_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_first_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_first_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_first_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_first_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
 ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -4587,6 +1481,18 @@ ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b64
    __device__ static inline B64 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L1::evict_first.L2::cache_hint.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_first.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_nc_L1_evict_first_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B128* addr,
      uint64_t cache_policy);
 
 ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b128
@@ -4601,6 +1507,18 @@ ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b128
      const B128* addr,
      uint64_t cache_policy);
 
+ld.global.nc.L1::evict_first.L2::cache_hint.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_first.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_nc_L1_evict_first_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B256* addr,
+     uint64_t cache_policy);
+
 ld.global.nc.L1::evict_last.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -4609,6 +1527,17 @@ ld.global.nc.L1::evict_last.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_nc_L1_evict_last(
+     cuda::ptx::space_global_t,
+     const B8* addr);
+
+ld.global.nc.L1::evict_last.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_nc_L1_evict_last_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr);
 
@@ -4623,6 +1552,17 @@ ld.global.nc.L1::evict_last.b16
      cuda::ptx::space_global_t,
      const B16* addr);
 
+ld.global.nc.L1::evict_last.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_nc_L1_evict_last_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr);
+
 ld.global.nc.L1::evict_last.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -4631,6 +1571,17 @@ ld.global.nc.L1::evict_last.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_nc_L1_evict_last(
+     cuda::ptx::space_global_t,
+     const B32* addr);
+
+ld.global.nc.L1::evict_last.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_nc_L1_evict_last_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr);
 
@@ -4645,160 +1596,6 @@ ld.global.nc.L1::evict_last.b64
      cuda::ptx::space_global_t,
      const B64* addr);
 
-ld.global.nc.L1::evict_last.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_70
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_last(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_last.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_last_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_last.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_last_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_last.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_last_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_last.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_last_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_last.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_last_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_last.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_last_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_last.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_last_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_last.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_last_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::evict_last.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_last_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::evict_last.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_last_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::evict_last.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_last_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::evict_last.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_last_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::evict_last.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_last_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
 ld.global.nc.L1::evict_last.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -4809,6 +1606,17 @@ ld.global.nc.L1::evict_last.L2::256B.b64
    __device__ static inline B64 ld_nc_L1_evict_last_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr);
+
+ld.global.nc.L1::evict_last.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_last.b128 dest, [addr]; // PTX ISA 83, SM_70
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_nc_L1_evict_last(
+     cuda::ptx::space_global_t,
+     const B128* addr);
 
 ld.global.nc.L1::evict_last.L2::256B.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -4821,6 +1629,17 @@ ld.global.nc.L1::evict_last.L2::256B.b128
      cuda::ptx::space_global_t,
      const B128* addr);
 
+ld.global.nc.L1::evict_last.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_last.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_nc_L1_evict_last(
+     cuda::ptx::space_global_t,
+     const B256* addr);
+
 ld.global.nc.L1::evict_last.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -4829,6 +1648,18 @@ ld.global.nc.L1::evict_last.L2::cache_hint.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B8* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr,
      uint64_t cache_policy);
@@ -4845,6 +1676,18 @@ ld.global.nc.L1::evict_last.L2::cache_hint.b16
      const B16* addr,
      uint64_t cache_policy);
 
+ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr,
+     uint64_t cache_policy);
+
 ld.global.nc.L1::evict_last.L2::cache_hint.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -4853,6 +1696,18 @@ ld.global.nc.L1::evict_last.L2::cache_hint.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B32* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr,
      uint64_t cache_policy);
@@ -4869,174 +1724,6 @@ ld.global.nc.L1::evict_last.L2::cache_hint.b64
      const B64* addr,
      uint64_t cache_policy);
 
-ld.global.nc.L1::evict_last.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_last_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_last_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_last_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_last_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_last_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_evict_last_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_evict_last_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
 ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -5047,6 +1734,18 @@ ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b64
    __device__ static inline B64 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L1::evict_last.L2::cache_hint.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_last.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_nc_L1_evict_last_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B128* addr,
      uint64_t cache_policy);
 
 ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b128
@@ -5061,6 +1760,18 @@ ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b128
      const B128* addr,
      uint64_t cache_policy);
 
+ld.global.nc.L1::evict_last.L2::cache_hint.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::evict_last.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_nc_L1_evict_last_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B256* addr,
+     uint64_t cache_policy);
+
 ld.global.nc.L1::no_allocate.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -5069,6 +1780,17 @@ ld.global.nc.L1::no_allocate.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_nc_L1_no_allocate(
+     cuda::ptx::space_global_t,
+     const B8* addr);
+
+ld.global.nc.L1::no_allocate.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_nc_L1_no_allocate_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr);
 
@@ -5083,6 +1805,17 @@ ld.global.nc.L1::no_allocate.b16
      cuda::ptx::space_global_t,
      const B16* addr);
 
+ld.global.nc.L1::no_allocate.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_nc_L1_no_allocate_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr);
+
 ld.global.nc.L1::no_allocate.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -5091,6 +1824,17 @@ ld.global.nc.L1::no_allocate.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_nc_L1_no_allocate(
+     cuda::ptx::space_global_t,
+     const B32* addr);
+
+ld.global.nc.L1::no_allocate.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_nc_L1_no_allocate_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr);
 
@@ -5105,160 +1849,6 @@ ld.global.nc.L1::no_allocate.b64
      cuda::ptx::space_global_t,
      const B64* addr);
 
-ld.global.nc.L1::no_allocate.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_70
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_no_allocate(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::no_allocate.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_no_allocate_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::no_allocate.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_no_allocate_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::no_allocate.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_no_allocate_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::no_allocate.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_no_allocate_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::no_allocate.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_no_allocate_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::no_allocate.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_no_allocate_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::no_allocate.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_no_allocate_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::no_allocate.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_no_allocate_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
-ld.global.nc.L1::no_allocate.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_no_allocate_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr);
-
-ld.global.nc.L1::no_allocate.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_no_allocate_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr);
-
-ld.global.nc.L1::no_allocate.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_no_allocate_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr);
-
-ld.global.nc.L1::no_allocate.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_no_allocate_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr);
-
-ld.global.nc.L1::no_allocate.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_no_allocate_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr);
-
 ld.global.nc.L1::no_allocate.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -5269,6 +1859,17 @@ ld.global.nc.L1::no_allocate.L2::256B.b64
    __device__ static inline B64 ld_nc_L1_no_allocate_L2_256B(
      cuda::ptx::space_global_t,
      const B64* addr);
+
+ld.global.nc.L1::no_allocate.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::no_allocate.b128 dest, [addr]; // PTX ISA 83, SM_70
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_nc_L1_no_allocate(
+     cuda::ptx::space_global_t,
+     const B128* addr);
 
 ld.global.nc.L1::no_allocate.L2::256B.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -5281,6 +1882,17 @@ ld.global.nc.L1::no_allocate.L2::256B.b128
      cuda::ptx::space_global_t,
      const B128* addr);
 
+ld.global.nc.L1::no_allocate.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::no_allocate.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_nc_L1_no_allocate(
+     cuda::ptx::space_global_t,
+     const B256* addr);
+
 ld.global.nc.L1::no_allocate.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -5289,6 +1901,18 @@ ld.global.nc.L1::no_allocate.L2::cache_hint.b8
    // .space     = { .global }
    template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
    __device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B8* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b8
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+   __device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B8* addr,
      uint64_t cache_policy);
@@ -5305,6 +1929,18 @@ ld.global.nc.L1::no_allocate.L2::cache_hint.b16
      const B16* addr,
      uint64_t cache_policy);
 
+ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b16
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+   __device__ static inline B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
+     cuda::ptx::space_global_t,
+     const B16* addr,
+     uint64_t cache_policy);
+
 ld.global.nc.L1::no_allocate.L2::cache_hint.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -5313,6 +1949,18 @@ ld.global.nc.L1::no_allocate.L2::cache_hint.b32
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B32* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b32
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+   // .space     = { .global }
+   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+   __device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B32* addr,
      uint64_t cache_policy);
@@ -5329,174 +1977,6 @@ ld.global.nc.L1::no_allocate.L2::cache_hint.b64
      const B64* addr,
      uint64_t cache_policy);
 
-ld.global.nc.L1::no_allocate.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_no_allocate_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline B64 ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B64* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline B128 ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(
-     cuda::ptx::space_global_t,
-     const B128* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B8* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B16* addr,
-     uint64_t cache_policy);
-
-ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
-     cuda::ptx::space_global_t,
-     const B32* addr,
-     uint64_t cache_policy);
-
 ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -5509,6 +1989,18 @@ ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b64
      const B64* addr,
      uint64_t cache_policy);
 
+ld.global.nc.L1::no_allocate.L2::cache_hint.b128
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::no_allocate.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
+   // .space     = { .global }
+   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
+   __device__ static inline B128 ld_nc_L1_no_allocate_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B128* addr,
+     uint64_t cache_policy);
+
 ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b128
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -5519,4 +2011,16 @@ ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b128
    __device__ static inline B128 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
      cuda::ptx::space_global_t,
      const B128* addr,
+     uint64_t cache_policy);
+
+ld.global.nc.L1::no_allocate.L2::cache_hint.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // ld.space.nc.L1::no_allocate.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline B256 ld_nc_L1_no_allocate_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     const B256* addr,
      uint64_t cache_policy);

--- a/docs/libcudacxx/ptx/instructions/generated/st.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/st.rst
@@ -61,6 +61,18 @@ st.global.b128
      B128* addr,
      B128 src);
 
+st.global.v4.b64
+^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // st.space.v4.b64 [addr], src; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline void st(
+     cuda::ptx::space_global_t,
+     B256* addr,
+     B256 src);
+
 st.global.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -126,254 +138,17 @@ st.global.L2::cache_hint.b128
      B128 src,
      uint64_t cache_policy);
 
-st.global.L1::evict_normal.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_normal.b8 [addr], src; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline void st_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     B8* addr,
-     B8 src);
-
-st.global.L1::evict_normal.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_normal.b16 [addr], src; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline void st_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     B16* addr,
-     B16 src);
-
-st.global.L1::evict_normal.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_normal.b32 [addr], src; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline void st_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     B32* addr,
-     B32 src);
-
-st.global.L1::evict_normal.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_normal.b64 [addr], src; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline void st_L1_evict_normal(
-     cuda::ptx::space_global_t,
-     B64* addr,
-     B64 src);
-
-st.global.L1::evict_normal.b128
+st.global.L2::cache_hint.v4.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // st.space.L1::evict_normal.b128 [addr], src; // PTX ISA 83, SM_70
+   // st.space.L2::cache_hint.v4.b64 [addr], src, cache_policy; // PTX ISA 88, SM_100
    // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline void st_L1_evict_normal(
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline void st_L2_cache_hint(
      cuda::ptx::space_global_t,
-     B128* addr,
-     B128 src);
-
-st.global.L1::evict_normal.L2::cache_hint.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_normal.L2::cache_hint.b8 [addr], src, cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline void st_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     B8* addr,
-     B8 src,
-     uint64_t cache_policy);
-
-st.global.L1::evict_normal.L2::cache_hint.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_normal.L2::cache_hint.b16 [addr], src, cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline void st_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     B16* addr,
-     B16 src,
-     uint64_t cache_policy);
-
-st.global.L1::evict_normal.L2::cache_hint.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_normal.L2::cache_hint.b32 [addr], src, cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline void st_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     B32* addr,
-     B32 src,
-     uint64_t cache_policy);
-
-st.global.L1::evict_normal.L2::cache_hint.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_normal.L2::cache_hint.b64 [addr], src, cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline void st_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     B64* addr,
-     B64 src,
-     uint64_t cache_policy);
-
-st.global.L1::evict_normal.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_normal.L2::cache_hint.b128 [addr], src, cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline void st_L1_evict_normal_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     B128* addr,
-     B128 src,
-     uint64_t cache_policy);
-
-st.global.L1::evict_unchanged.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_unchanged.b8 [addr], src; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline void st_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     B8* addr,
-     B8 src);
-
-st.global.L1::evict_unchanged.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_unchanged.b16 [addr], src; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline void st_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     B16* addr,
-     B16 src);
-
-st.global.L1::evict_unchanged.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_unchanged.b32 [addr], src; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline void st_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     B32* addr,
-     B32 src);
-
-st.global.L1::evict_unchanged.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_unchanged.b64 [addr], src; // PTX ISA 74, SM_70
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline void st_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     B64* addr,
-     B64 src);
-
-st.global.L1::evict_unchanged.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_unchanged.b128 [addr], src; // PTX ISA 83, SM_70
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline void st_L1_evict_unchanged(
-     cuda::ptx::space_global_t,
-     B128* addr,
-     B128 src);
-
-st.global.L1::evict_unchanged.L2::cache_hint.b8
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_unchanged.L2::cache_hint.b8 [addr], src, cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-   __device__ static inline void st_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     B8* addr,
-     B8 src,
-     uint64_t cache_policy);
-
-st.global.L1::evict_unchanged.L2::cache_hint.b16
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_unchanged.L2::cache_hint.b16 [addr], src, cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-   __device__ static inline void st_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     B16* addr,
-     B16 src,
-     uint64_t cache_policy);
-
-st.global.L1::evict_unchanged.L2::cache_hint.b32
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_unchanged.L2::cache_hint.b32 [addr], src, cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-   __device__ static inline void st_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     B32* addr,
-     B32 src,
-     uint64_t cache_policy);
-
-st.global.L1::evict_unchanged.L2::cache_hint.b64
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_unchanged.L2::cache_hint.b64 [addr], src, cache_policy; // PTX ISA 74, SM_80
-   // .space     = { .global }
-   template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-   __device__ static inline void st_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     B64* addr,
-     B64 src,
-     uint64_t cache_policy);
-
-st.global.L1::evict_unchanged.L2::cache_hint.b128
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. code:: cuda
-
-   // st.space.L1::evict_unchanged.L2::cache_hint.b128 [addr], src, cache_policy; // PTX ISA 83, SM_80
-   // .space     = { .global }
-   template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-   __device__ static inline void st_L1_evict_unchanged_L2_cache_hint(
-     cuda::ptx::space_global_t,
-     B128* addr,
-     B128 src,
+     B256* addr,
+     B256 src,
      uint64_t cache_policy);
 
 st.global.L1::evict_first.b8
@@ -435,6 +210,18 @@ st.global.L1::evict_first.b128
      cuda::ptx::space_global_t,
      B128* addr,
      B128 src);
+
+st.global.L1::evict_first.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // st.space.L1::evict_first.v4.b64 [addr], src; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline void st_L1_evict_first(
+     cuda::ptx::space_global_t,
+     B256* addr,
+     B256 src);
 
 st.global.L1::evict_first.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -501,6 +288,19 @@ st.global.L1::evict_first.L2::cache_hint.b128
      B128 src,
      uint64_t cache_policy);
 
+st.global.L1::evict_first.L2::cache_hint.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // st.space.L1::evict_first.L2::cache_hint.v4.b64 [addr], src, cache_policy; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline void st_L1_evict_first_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     B256* addr,
+     B256 src,
+     uint64_t cache_policy);
+
 st.global.L1::evict_last.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -560,6 +360,18 @@ st.global.L1::evict_last.b128
      cuda::ptx::space_global_t,
      B128* addr,
      B128 src);
+
+st.global.L1::evict_last.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // st.space.L1::evict_last.v4.b64 [addr], src; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline void st_L1_evict_last(
+     cuda::ptx::space_global_t,
+     B256* addr,
+     B256 src);
 
 st.global.L1::evict_last.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -626,6 +438,19 @@ st.global.L1::evict_last.L2::cache_hint.b128
      B128 src,
      uint64_t cache_policy);
 
+st.global.L1::evict_last.L2::cache_hint.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // st.space.L1::evict_last.L2::cache_hint.v4.b64 [addr], src, cache_policy; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline void st_L1_evict_last_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     B256* addr,
+     B256 src,
+     uint64_t cache_policy);
+
 st.global.L1::no_allocate.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
@@ -685,6 +510,18 @@ st.global.L1::no_allocate.b128
      cuda::ptx::space_global_t,
      B128* addr,
      B128 src);
+
+st.global.L1::no_allocate.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // st.space.L1::no_allocate.v4.b64 [addr], src; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline void st_L1_no_allocate(
+     cuda::ptx::space_global_t,
+     B256* addr,
+     B256 src);
 
 st.global.L1::no_allocate.L2::cache_hint.b8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -749,4 +586,17 @@ st.global.L1::no_allocate.L2::cache_hint.b128
      cuda::ptx::space_global_t,
      B128* addr,
      B128 src,
+     uint64_t cache_policy);
+
+st.global.L1::no_allocate.L2::cache_hint.v4.b64
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. code:: cuda
+
+   // st.space.L1::no_allocate.L2::cache_hint.v4.b64 [addr], src, cache_policy; // PTX ISA 88, SM_100
+   // .space     = { .global }
+   template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+   __device__ static inline void st_L1_no_allocate_L2_cache_hint(
+     cuda::ptx::space_global_t,
+     B256* addr,
+     B256 src,
      uint64_t cache_policy);

--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_alloc.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_alloc.rst
@@ -5,7 +5,7 @@ tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.alloc.cta_group.sync.aligned.shared::cta.b32 [dst], nCols; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.alloc.cta_group.sync.aligned.shared::cta.b32 [dst], nCols; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_alloc(
@@ -17,7 +17,7 @@ tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.alloc.cta_group.sync.aligned.shared::cta.b32 [dst], nCols; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.alloc.cta_group.sync.aligned.shared::cta.b32 [dst], nCols; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_alloc(
@@ -29,7 +29,7 @@ tcgen05.dealloc.cta_group::1.sync.aligned.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.dealloc.cta_group.sync.aligned.b32 taddr, nCols; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.dealloc.cta_group.sync.aligned.b32 taddr, nCols; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_dealloc(
@@ -41,7 +41,7 @@ tcgen05.dealloc.cta_group::2.sync.aligned.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.dealloc.cta_group.sync.aligned.b32 taddr, nCols; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.dealloc.cta_group.sync.aligned.b32 taddr, nCols; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_dealloc(
@@ -53,7 +53,7 @@ tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.relinquish_alloc_permit.cta_group.sync.aligned; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.relinquish_alloc_permit.cta_group.sync.aligned; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_relinquish_alloc_permit(
@@ -63,7 +63,7 @@ tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.relinquish_alloc_permit.cta_group.sync.aligned; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.relinquish_alloc_permit.cta_group.sync.aligned; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_relinquish_alloc_permit(

--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_commit.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_commit.rst
@@ -5,7 +5,7 @@ tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.b64 [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.b64 [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_commit(
@@ -16,7 +16,7 @@ tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.b64 [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.b64 [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_commit(
@@ -27,7 +27,7 @@ tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.multicast::clu
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64 [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64 [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_commit_multicast(
@@ -39,7 +39,7 @@ tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.multicast::clu
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64 [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64 [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_commit_multicast(

--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_cp.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_cp.rst
@@ -5,7 +5,7 @@ tcgen05.cp.cta_group::1.128x256b
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x256b(
@@ -17,7 +17,7 @@ tcgen05.cp.cta_group::2.128x256b
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x256b(
@@ -29,7 +29,7 @@ tcgen05.cp.cta_group::1.4x256b
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.4x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.4x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_4x256b(
@@ -41,7 +41,7 @@ tcgen05.cp.cta_group::2.4x256b
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.4x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.4x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_4x256b(
@@ -53,7 +53,7 @@ tcgen05.cp.cta_group::1.128x128b
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x128b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x128b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x128b(
@@ -65,7 +65,7 @@ tcgen05.cp.cta_group::2.128x128b
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x128b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x128b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x128b(
@@ -77,7 +77,7 @@ tcgen05.cp.cta_group::1.64x128b.warpx2::02_13
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::02_13 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::02_13 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13(
@@ -89,7 +89,7 @@ tcgen05.cp.cta_group::2.64x128b.warpx2::02_13
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::02_13 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::02_13 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13(
@@ -101,7 +101,7 @@ tcgen05.cp.cta_group::1.64x128b.warpx2::01_23
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::01_23 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::01_23 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23(
@@ -113,7 +113,7 @@ tcgen05.cp.cta_group::2.64x128b.warpx2::01_23
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::01_23 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::01_23 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23(
@@ -125,7 +125,7 @@ tcgen05.cp.cta_group::1.32x128b.warpx4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.32x128b.warpx4 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.32x128b.warpx4 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_32x128b_warpx4(
@@ -137,7 +137,7 @@ tcgen05.cp.cta_group::2.32x128b.warpx4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.32x128b.warpx4 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.32x128b.warpx4 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_32x128b_warpx4(
@@ -149,7 +149,7 @@ tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x256b_b8x16_b6x16_p32(
@@ -161,7 +161,7 @@ tcgen05.cp.cta_group::2.128x256b.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x256b_b8x16_b6x16_p32(
@@ -173,7 +173,7 @@ tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.4x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.4x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_4x256b_b8x16_b6x16_p32(
@@ -185,7 +185,7 @@ tcgen05.cp.cta_group::2.4x256b.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.4x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.4x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_4x256b_b8x16_b6x16_p32(
@@ -197,7 +197,7 @@ tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x128b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x128b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x128b_b8x16_b6x16_p32(
@@ -209,7 +209,7 @@ tcgen05.cp.cta_group::2.128x128b.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x128b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x128b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x128b_b8x16_b6x16_p32(
@@ -221,7 +221,7 @@ tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32(
@@ -233,7 +233,7 @@ tcgen05.cp.cta_group::2.64x128b.warpx2::02_13.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32(
@@ -245,7 +245,7 @@ tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32(
@@ -257,7 +257,7 @@ tcgen05.cp.cta_group::2.64x128b.warpx2::01_23.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32(
@@ -269,7 +269,7 @@ tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32(
@@ -281,7 +281,7 @@ tcgen05.cp.cta_group::2.32x128b.warpx4.b8x16.b6x16_p32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32(
@@ -293,7 +293,7 @@ tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x256b_b8x16_b4x16_p64(
@@ -305,7 +305,7 @@ tcgen05.cp.cta_group::2.128x256b.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x256b_b8x16_b4x16_p64(
@@ -317,7 +317,7 @@ tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.4x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.4x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_4x256b_b8x16_b4x16_p64(
@@ -329,7 +329,7 @@ tcgen05.cp.cta_group::2.4x256b.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.4x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.4x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_4x256b_b8x16_b4x16_p64(
@@ -341,7 +341,7 @@ tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x128b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x128b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x128b_b8x16_b4x16_p64(
@@ -353,7 +353,7 @@ tcgen05.cp.cta_group::2.128x128b.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.128x128b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.128x128b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_128x128b_b8x16_b4x16_p64(
@@ -365,7 +365,7 @@ tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64(
@@ -377,7 +377,7 @@ tcgen05.cp.cta_group::2.64x128b.warpx2::02_13.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64(
@@ -389,7 +389,7 @@ tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64(
@@ -401,7 +401,7 @@ tcgen05.cp.cta_group::2.64x128b.warpx2::01_23.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64(
@@ -413,7 +413,7 @@ tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64(
@@ -425,7 +425,7 @@ tcgen05.cp.cta_group::2.32x128b.warpx4.b8x16.b4x16_p64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64(

--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_fence.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_fence.rst
@@ -5,7 +5,7 @@ tcgen05.fence::before_thread_sync
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.fence::before_thread_sync; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.fence::before_thread_sync; // PTX ISA 86, SM_100a, SM_110a
    template <typename = void>
    __device__ static inline void tcgen05_fence_before_thread_sync();
 
@@ -13,6 +13,6 @@ tcgen05.fence::after_thread_sync
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.fence::after_thread_sync; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.fence::after_thread_sync; // PTX ISA 86, SM_100a, SM_110a
    template <typename = void>
    __device__ static inline void tcgen05_fence_after_thread_sync();

--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_ld.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_ld.rst
@@ -5,7 +5,7 @@ tcgen05.ld.sync.aligned.16x64b.x1.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b(
      B32 (&out)[1],
@@ -15,7 +15,7 @@ tcgen05.ld.sync.aligned.16x64b.x1.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b_pack_16b(
      B32 (&out)[1],
@@ -25,7 +25,7 @@ tcgen05.ld.sync.aligned.16x64b.x2.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b(
      B32 (&out)[2],
@@ -35,7 +35,7 @@ tcgen05.ld.sync.aligned.16x64b.x2.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b_pack_16b(
      B32 (&out)[2],
@@ -45,7 +45,7 @@ tcgen05.ld.sync.aligned.16x64b.x4.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b(
      B32 (&out)[4],
@@ -55,7 +55,7 @@ tcgen05.ld.sync.aligned.16x64b.x4.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b_pack_16b(
      B32 (&out)[4],
@@ -65,7 +65,7 @@ tcgen05.ld.sync.aligned.16x64b.x8.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b(
      B32 (&out)[8],
@@ -75,7 +75,7 @@ tcgen05.ld.sync.aligned.16x64b.x8.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b_pack_16b(
      B32 (&out)[8],
@@ -85,7 +85,7 @@ tcgen05.ld.sync.aligned.16x64b.x16.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b(
      B32 (&out)[16],
@@ -95,7 +95,7 @@ tcgen05.ld.sync.aligned.16x64b.x16.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b_pack_16b(
      B32 (&out)[16],
@@ -105,7 +105,7 @@ tcgen05.ld.sync.aligned.16x64b.x32.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b(
      B32 (&out)[32],
@@ -115,7 +115,7 @@ tcgen05.ld.sync.aligned.16x64b.x32.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b_pack_16b(
      B32 (&out)[32],
@@ -125,7 +125,7 @@ tcgen05.ld.sync.aligned.16x64b.x64.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b(
      B32 (&out)[64],
@@ -135,7 +135,7 @@ tcgen05.ld.sync.aligned.16x64b.x64.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b_pack_16b(
      B32 (&out)[64],
@@ -145,7 +145,7 @@ tcgen05.ld.sync.aligned.16x64b.x128.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x128.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x128.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b(
      B32 (&out)[128],
@@ -155,7 +155,7 @@ tcgen05.ld.sync.aligned.16x64b.x128.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x64b.x128.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x64b.x128.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x64b_pack_16b(
      B32 (&out)[128],
@@ -165,7 +165,7 @@ tcgen05.ld.sync.aligned.16x128b.x1.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b(
      B32 (&out)[2],
@@ -175,7 +175,7 @@ tcgen05.ld.sync.aligned.16x128b.x1.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b_pack_16b(
      B32 (&out)[2],
@@ -185,7 +185,7 @@ tcgen05.ld.sync.aligned.16x128b.x2.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b(
      B32 (&out)[4],
@@ -195,7 +195,7 @@ tcgen05.ld.sync.aligned.16x128b.x2.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b_pack_16b(
      B32 (&out)[4],
@@ -205,7 +205,7 @@ tcgen05.ld.sync.aligned.16x128b.x4.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b(
      B32 (&out)[8],
@@ -215,7 +215,7 @@ tcgen05.ld.sync.aligned.16x128b.x4.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b_pack_16b(
      B32 (&out)[8],
@@ -225,7 +225,7 @@ tcgen05.ld.sync.aligned.16x128b.x8.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b(
      B32 (&out)[16],
@@ -235,7 +235,7 @@ tcgen05.ld.sync.aligned.16x128b.x8.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b_pack_16b(
      B32 (&out)[16],
@@ -245,7 +245,7 @@ tcgen05.ld.sync.aligned.16x128b.x16.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b(
      B32 (&out)[32],
@@ -255,7 +255,7 @@ tcgen05.ld.sync.aligned.16x128b.x16.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b_pack_16b(
      B32 (&out)[32],
@@ -265,7 +265,7 @@ tcgen05.ld.sync.aligned.16x128b.x32.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b(
      B32 (&out)[64],
@@ -275,7 +275,7 @@ tcgen05.ld.sync.aligned.16x128b.x32.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b_pack_16b(
      B32 (&out)[64],
@@ -285,7 +285,7 @@ tcgen05.ld.sync.aligned.16x128b.x64.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b(
      B32 (&out)[128],
@@ -295,7 +295,7 @@ tcgen05.ld.sync.aligned.16x128b.x64.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x128b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x128b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x128b_pack_16b(
      B32 (&out)[128],
@@ -305,7 +305,7 @@ tcgen05.ld.sync.aligned.16x256b.x1.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b(
      B32 (&out)[4],
@@ -315,7 +315,7 @@ tcgen05.ld.sync.aligned.16x256b.x1.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b_pack_16b(
      B32 (&out)[4],
@@ -325,7 +325,7 @@ tcgen05.ld.sync.aligned.16x256b.x2.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b(
      B32 (&out)[8],
@@ -335,7 +335,7 @@ tcgen05.ld.sync.aligned.16x256b.x2.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b_pack_16b(
      B32 (&out)[8],
@@ -345,7 +345,7 @@ tcgen05.ld.sync.aligned.16x256b.x4.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b(
      B32 (&out)[16],
@@ -355,7 +355,7 @@ tcgen05.ld.sync.aligned.16x256b.x4.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b_pack_16b(
      B32 (&out)[16],
@@ -365,7 +365,7 @@ tcgen05.ld.sync.aligned.16x256b.x8.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b(
      B32 (&out)[32],
@@ -375,7 +375,7 @@ tcgen05.ld.sync.aligned.16x256b.x8.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b_pack_16b(
      B32 (&out)[32],
@@ -385,7 +385,7 @@ tcgen05.ld.sync.aligned.16x256b.x16.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b(
      B32 (&out)[64],
@@ -395,7 +395,7 @@ tcgen05.ld.sync.aligned.16x256b.x16.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b_pack_16b(
      B32 (&out)[64],
@@ -405,7 +405,7 @@ tcgen05.ld.sync.aligned.16x256b.x32.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b(
      B32 (&out)[128],
@@ -415,7 +415,7 @@ tcgen05.ld.sync.aligned.16x256b.x32.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x256b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x256b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_16x256b_pack_16b(
      B32 (&out)[128],
@@ -425,7 +425,7 @@ tcgen05.ld.sync.aligned.32x32b.x1.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b(
      B32 (&out)[1],
@@ -435,7 +435,7 @@ tcgen05.ld.sync.aligned.32x32b.x1.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b_pack_16b(
      B32 (&out)[1],
@@ -445,7 +445,7 @@ tcgen05.ld.sync.aligned.32x32b.x2.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b(
      B32 (&out)[2],
@@ -455,7 +455,7 @@ tcgen05.ld.sync.aligned.32x32b.x2.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b_pack_16b(
      B32 (&out)[2],
@@ -465,7 +465,7 @@ tcgen05.ld.sync.aligned.32x32b.x4.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b(
      B32 (&out)[4],
@@ -475,7 +475,7 @@ tcgen05.ld.sync.aligned.32x32b.x4.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b_pack_16b(
      B32 (&out)[4],
@@ -485,7 +485,7 @@ tcgen05.ld.sync.aligned.32x32b.x8.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b(
      B32 (&out)[8],
@@ -495,7 +495,7 @@ tcgen05.ld.sync.aligned.32x32b.x8.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b_pack_16b(
      B32 (&out)[8],
@@ -505,7 +505,7 @@ tcgen05.ld.sync.aligned.32x32b.x16.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b(
      B32 (&out)[16],
@@ -515,7 +515,7 @@ tcgen05.ld.sync.aligned.32x32b.x16.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b_pack_16b(
      B32 (&out)[16],
@@ -525,7 +525,7 @@ tcgen05.ld.sync.aligned.32x32b.x32.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b(
      B32 (&out)[32],
@@ -535,7 +535,7 @@ tcgen05.ld.sync.aligned.32x32b.x32.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b_pack_16b(
      B32 (&out)[32],
@@ -545,7 +545,7 @@ tcgen05.ld.sync.aligned.32x32b.x64.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b(
      B32 (&out)[64],
@@ -555,7 +555,7 @@ tcgen05.ld.sync.aligned.32x32b.x64.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b_pack_16b(
      B32 (&out)[64],
@@ -565,7 +565,7 @@ tcgen05.ld.sync.aligned.32x32b.x128.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x128.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x128.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b(
      B32 (&out)[128],
@@ -575,7 +575,7 @@ tcgen05.ld.sync.aligned.32x32b.x128.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.32x32b.x128.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.32x32b.x128.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_ld_32x32b_pack_16b(
      B32 (&out)[128],
@@ -585,7 +585,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x1.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x1.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x1.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2(
      B32 (&out)[1],
@@ -596,7 +596,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x1.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x1.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x1.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
      B32 (&out)[1],
@@ -607,7 +607,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x2.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x2.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x2.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2(
      B32 (&out)[2],
@@ -618,7 +618,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x2.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x2.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x2.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
      B32 (&out)[2],
@@ -629,7 +629,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x4.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x4.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x4.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2(
      B32 (&out)[4],
@@ -640,7 +640,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x4.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x4.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x4.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
      B32 (&out)[4],
@@ -651,7 +651,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x8.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x8.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x8.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2(
      B32 (&out)[8],
@@ -662,7 +662,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x8.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x8.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x8.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
      B32 (&out)[8],
@@ -673,7 +673,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x16.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x16.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x16.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2(
      B32 (&out)[16],
@@ -684,7 +684,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x16.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x16.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x16.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
      B32 (&out)[16],
@@ -695,7 +695,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x32.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x32.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x32.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2(
      B32 (&out)[32],
@@ -706,7 +706,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x32.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x32.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x32.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
      B32 (&out)[32],
@@ -717,7 +717,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x64.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x64.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x64.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2(
      B32 (&out)[64],
@@ -728,7 +728,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x64.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x64.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x64.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
      B32 (&out)[64],
@@ -739,7 +739,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x128.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x128.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x128.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2(
      B32 (&out)[128],
@@ -750,7 +750,7 @@ tcgen05.ld.sync.aligned.16x32bx2.x128.pack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.ld.sync.aligned.16x32bx2.x128.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.ld.sync.aligned.16x32bx2.x128.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
    __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
      B32 (&out)[128],

--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_mma.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_mma.rst
@@ -81,7 +81,7 @@ tcgen05.mma.cta_group::1.kind::f16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1 }
    template <cuda::ptx::dot_kind Kind>
@@ -99,7 +99,7 @@ tcgen05.mma.cta_group::1.kind::tf32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1 }
    template <cuda::ptx::dot_kind Kind>
@@ -117,7 +117,7 @@ tcgen05.mma.cta_group::1.kind::f8f6f4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1 }
    template <cuda::ptx::dot_kind Kind>
@@ -135,7 +135,7 @@ tcgen05.mma.cta_group::1.kind::i8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1 }
    template <cuda::ptx::dot_kind Kind>
@@ -153,7 +153,7 @@ tcgen05.mma.cta_group::2.kind::f16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::2 }
    template <cuda::ptx::dot_kind Kind>
@@ -171,7 +171,7 @@ tcgen05.mma.cta_group::2.kind::tf32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::2 }
    template <cuda::ptx::dot_kind Kind>
@@ -189,7 +189,7 @@ tcgen05.mma.cta_group::2.kind::f8f6f4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::2 }
    template <cuda::ptx::dot_kind Kind>
@@ -207,7 +207,7 @@ tcgen05.mma.cta_group::2.kind::i8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::2 }
    template <cuda::ptx::dot_kind Kind>
@@ -297,7 +297,7 @@ tcgen05.mma.cta_group::1.kind::f16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -314,7 +314,7 @@ tcgen05.mma.cta_group::2.kind::f16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -331,7 +331,7 @@ tcgen05.mma.cta_group::1.kind::tf32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -348,7 +348,7 @@ tcgen05.mma.cta_group::2.kind::tf32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -365,7 +365,7 @@ tcgen05.mma.cta_group::1.kind::f8f6f4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -382,7 +382,7 @@ tcgen05.mma.cta_group::2.kind::f8f6f4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -399,7 +399,7 @@ tcgen05.mma.cta_group::1.kind::i8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -416,7 +416,7 @@ tcgen05.mma.cta_group::2.kind::i8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -509,7 +509,7 @@ tcgen05.mma.cta_group::1.kind::f16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1 }
    template <cuda::ptx::dot_kind Kind>
@@ -527,7 +527,7 @@ tcgen05.mma.cta_group::1.kind::tf32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1 }
    template <cuda::ptx::dot_kind Kind>
@@ -545,7 +545,7 @@ tcgen05.mma.cta_group::1.kind::f8f6f4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1 }
    template <cuda::ptx::dot_kind Kind>
@@ -563,7 +563,7 @@ tcgen05.mma.cta_group::1.kind::i8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1 }
    template <cuda::ptx::dot_kind Kind>
@@ -581,7 +581,7 @@ tcgen05.mma.cta_group::2.kind::f16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::2 }
    template <cuda::ptx::dot_kind Kind>
@@ -599,7 +599,7 @@ tcgen05.mma.cta_group::2.kind::tf32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::2 }
    template <cuda::ptx::dot_kind Kind>
@@ -617,7 +617,7 @@ tcgen05.mma.cta_group::2.kind::f8f6f4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::2 }
    template <cuda::ptx::dot_kind Kind>
@@ -635,7 +635,7 @@ tcgen05.mma.cta_group::2.kind::i8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::2 }
    template <cuda::ptx::dot_kind Kind>
@@ -725,7 +725,7 @@ tcgen05.mma.cta_group::1.kind::f16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -742,7 +742,7 @@ tcgen05.mma.cta_group::2.kind::f16
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -759,7 +759,7 @@ tcgen05.mma.cta_group::1.kind::tf32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -776,7 +776,7 @@ tcgen05.mma.cta_group::2.kind::tf32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -793,7 +793,7 @@ tcgen05.mma.cta_group::1.kind::f8f6f4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -810,7 +810,7 @@ tcgen05.mma.cta_group::2.kind::f8f6f4
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -827,7 +827,7 @@ tcgen05.mma.cta_group::1.kind::i8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -844,7 +844,7 @@ tcgen05.mma.cta_group::2.kind::i8
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -861,7 +861,7 @@ tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -880,7 +880,7 @@ tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -899,7 +899,7 @@ tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -918,7 +918,7 @@ tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -937,7 +937,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -956,7 +956,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -975,7 +975,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -994,7 +994,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1013,7 +1013,7 @@ tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1032,7 +1032,7 @@ tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1051,7 +1051,7 @@ tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1070,7 +1070,7 @@ tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1089,7 +1089,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1108,7 +1108,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1127,7 +1127,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1146,7 +1146,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1165,7 +1165,7 @@ tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1184,7 +1184,7 @@ tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1203,7 +1203,7 @@ tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1222,7 +1222,7 @@ tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1241,7 +1241,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1260,7 +1260,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1279,7 +1279,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1298,7 +1298,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1317,7 +1317,7 @@ tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1336,7 +1336,7 @@ tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1355,7 +1355,7 @@ tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1374,7 +1374,7 @@ tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1393,7 +1393,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1412,7 +1412,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1431,7 +1431,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1450,7 +1450,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1469,7 +1469,7 @@ tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1488,7 +1488,7 @@ tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1507,7 +1507,7 @@ tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1526,7 +1526,7 @@ tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1545,7 +1545,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1564,7 +1564,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1583,7 +1583,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1602,7 +1602,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1621,7 +1621,7 @@ tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1640,7 +1640,7 @@ tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1659,7 +1659,7 @@ tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1678,7 +1678,7 @@ tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1697,7 +1697,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1716,7 +1716,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1735,7 +1735,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1754,7 +1754,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1773,7 +1773,7 @@ tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1792,7 +1792,7 @@ tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1811,7 +1811,7 @@ tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::last
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1830,7 +1830,7 @@ tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::last
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1849,7 +1849,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1868,7 +1868,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1887,7 +1887,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1906,7 +1906,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1925,7 +1925,7 @@ tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1944,7 +1944,7 @@ tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1963,7 +1963,7 @@ tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::last
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1982,7 +1982,7 @@ tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::last
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2001,7 +2001,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2020,7 +2020,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2039,7 +2039,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2058,7 +2058,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2077,7 +2077,7 @@ tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2096,7 +2096,7 @@ tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2115,7 +2115,7 @@ tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::disc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2134,7 +2134,7 @@ tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::disc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2153,7 +2153,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2172,7 +2172,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2191,7 +2191,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2210,7 +2210,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2229,7 +2229,7 @@ tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2248,7 +2248,7 @@ tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf8f6f4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2267,7 +2267,7 @@ tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::disc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2286,7 +2286,7 @@ tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::disc
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2305,7 +2305,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2324,7 +2324,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2343,7 +2343,7 @@ tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2362,7 +2362,7 @@ tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .kind      = { .kind::mxf4nvf4 }
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>

--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_mma_ws.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_mma_ws.rst
@@ -5,7 +5,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -23,7 +23,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -41,7 +41,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -59,7 +59,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -77,7 +77,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -94,7 +94,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -111,7 +111,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -128,7 +128,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -145,7 +145,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -163,7 +163,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -181,7 +181,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -199,7 +199,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -217,7 +217,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -234,7 +234,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -251,7 +251,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -268,7 +268,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -285,7 +285,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -303,7 +303,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -321,7 +321,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -339,7 +339,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -357,7 +357,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -374,7 +374,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -391,7 +391,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -408,7 +408,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -425,7 +425,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -443,7 +443,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -461,7 +461,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -479,7 +479,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -497,7 +497,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -514,7 +514,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -531,7 +531,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -548,7 +548,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -565,7 +565,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -583,7 +583,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -601,7 +601,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -619,7 +619,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -637,7 +637,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -654,7 +654,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -671,7 +671,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -688,7 +688,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -705,7 +705,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -723,7 +723,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -741,7 +741,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -759,7 +759,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -777,7 +777,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -794,7 +794,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -811,7 +811,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -828,7 +828,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -845,7 +845,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -863,7 +863,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -881,7 +881,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -899,7 +899,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -917,7 +917,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -934,7 +934,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -951,7 +951,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -968,7 +968,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -985,7 +985,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1003,7 +1003,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1021,7 +1021,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1039,7 +1039,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1057,7 +1057,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1074,7 +1074,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1091,7 +1091,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1108,7 +1108,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b0::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1125,7 +1125,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1143,7 +1143,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1161,7 +1161,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1179,7 +1179,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1197,7 +1197,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1214,7 +1214,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1231,7 +1231,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1248,7 +1248,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1265,7 +1265,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1283,7 +1283,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1301,7 +1301,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1319,7 +1319,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1337,7 +1337,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1354,7 +1354,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1371,7 +1371,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1388,7 +1388,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1405,7 +1405,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1423,7 +1423,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1441,7 +1441,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1459,7 +1459,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1477,7 +1477,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1494,7 +1494,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1511,7 +1511,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1528,7 +1528,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1545,7 +1545,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1563,7 +1563,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1581,7 +1581,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1599,7 +1599,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1617,7 +1617,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1634,7 +1634,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1651,7 +1651,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1668,7 +1668,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1685,7 +1685,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1703,7 +1703,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1721,7 +1721,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1739,7 +1739,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1757,7 +1757,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1774,7 +1774,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1791,7 +1791,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1808,7 +1808,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1825,7 +1825,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1843,7 +1843,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1861,7 +1861,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1879,7 +1879,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1897,7 +1897,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1914,7 +1914,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1931,7 +1931,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1948,7 +1948,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1965,7 +1965,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -1983,7 +1983,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2001,7 +2001,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2019,7 +2019,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2037,7 +2037,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2054,7 +2054,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2071,7 +2071,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2088,7 +2088,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2105,7 +2105,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2123,7 +2123,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2141,7 +2141,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2159,7 +2159,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2177,7 +2177,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2194,7 +2194,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2211,7 +2211,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2228,7 +2228,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b1::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2245,7 +2245,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2263,7 +2263,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2281,7 +2281,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2299,7 +2299,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2317,7 +2317,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2334,7 +2334,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2351,7 +2351,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2368,7 +2368,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2385,7 +2385,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2403,7 +2403,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2421,7 +2421,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2439,7 +2439,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2457,7 +2457,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2474,7 +2474,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2491,7 +2491,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2508,7 +2508,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2525,7 +2525,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2543,7 +2543,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2561,7 +2561,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2579,7 +2579,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2597,7 +2597,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2614,7 +2614,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2631,7 +2631,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2648,7 +2648,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2665,7 +2665,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2683,7 +2683,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2701,7 +2701,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2719,7 +2719,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2737,7 +2737,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2754,7 +2754,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2771,7 +2771,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2788,7 +2788,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2805,7 +2805,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2823,7 +2823,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2841,7 +2841,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2859,7 +2859,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2877,7 +2877,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2894,7 +2894,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2911,7 +2911,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2928,7 +2928,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2945,7 +2945,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2963,7 +2963,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2981,7 +2981,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -2999,7 +2999,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3017,7 +3017,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3034,7 +3034,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3051,7 +3051,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3068,7 +3068,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3085,7 +3085,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3103,7 +3103,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3121,7 +3121,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3139,7 +3139,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3157,7 +3157,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3174,7 +3174,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3191,7 +3191,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3208,7 +3208,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3225,7 +3225,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3243,7 +3243,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3261,7 +3261,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3279,7 +3279,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3297,7 +3297,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3314,7 +3314,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3331,7 +3331,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3348,7 +3348,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b2::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3365,7 +3365,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3383,7 +3383,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3401,7 +3401,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3419,7 +3419,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3437,7 +3437,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3454,7 +3454,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3471,7 +3471,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3488,7 +3488,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3505,7 +3505,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3523,7 +3523,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3541,7 +3541,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3559,7 +3559,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3577,7 +3577,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3594,7 +3594,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3611,7 +3611,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3628,7 +3628,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::fill
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3645,7 +3645,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3663,7 +3663,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3681,7 +3681,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3699,7 +3699,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3717,7 +3717,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3734,7 +3734,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3751,7 +3751,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3768,7 +3768,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3785,7 +3785,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3803,7 +3803,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3821,7 +3821,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3839,7 +3839,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3857,7 +3857,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3874,7 +3874,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3891,7 +3891,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3908,7 +3908,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::use
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3925,7 +3925,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3943,7 +3943,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3961,7 +3961,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3979,7 +3979,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -3997,7 +3997,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4014,7 +4014,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4031,7 +4031,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4048,7 +4048,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4065,7 +4065,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4083,7 +4083,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4101,7 +4101,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4119,7 +4119,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4137,7 +4137,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4154,7 +4154,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4171,7 +4171,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4188,7 +4188,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::lastuse
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4205,7 +4205,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4223,7 +4223,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4241,7 +4241,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4259,7 +4259,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4277,7 +4277,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4294,7 +4294,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4311,7 +4311,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4328,7 +4328,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4345,7 +4345,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4363,7 +4363,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4381,7 +4381,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4399,7 +4399,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4417,7 +4417,7 @@ tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4434,7 +4434,7 @@ tcgen05.mma.ws.cta_group::1.kind::tf32.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4451,7 +4451,7 @@ tcgen05.mma.ws.cta_group::1.kind::f8f6f4.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>
@@ -4468,7 +4468,7 @@ tcgen05.mma.ws.cta_group::1.kind::i8.collector::b3::discard
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1 }
    // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
    template <cuda::ptx::dot_kind Kind>

--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_shift.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_shift.rst
@@ -5,7 +5,7 @@ tcgen05.shift.cta_group::1.down
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.shift.cta_group.down [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.shift.cta_group.down [taddr]; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_shift_down(
@@ -16,7 +16,7 @@ tcgen05.shift.cta_group::2.down
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.shift.cta_group.down [taddr]; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.shift.cta_group.down [taddr]; // PTX ISA 86, SM_100a, SM_110a
    // .cta_group = { .cta_group::1, .cta_group::2 }
    template <cuda::ptx::dot_cta_group Cta_Group>
    __device__ static inline void tcgen05_shift_down(

--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_st.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_st.rst
@@ -5,7 +5,7 @@ tcgen05.st.sync.aligned.16x64b.x1.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b(
      uint32_t taddr,
@@ -15,7 +15,7 @@ tcgen05.st.sync.aligned.16x64b.x1.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b_unpack_16b(
      uint32_t taddr,
@@ -25,7 +25,7 @@ tcgen05.st.sync.aligned.16x64b.x2.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b(
      uint32_t taddr,
@@ -35,7 +35,7 @@ tcgen05.st.sync.aligned.16x64b.x2.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b_unpack_16b(
      uint32_t taddr,
@@ -45,7 +45,7 @@ tcgen05.st.sync.aligned.16x64b.x4.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b(
      uint32_t taddr,
@@ -55,7 +55,7 @@ tcgen05.st.sync.aligned.16x64b.x4.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b_unpack_16b(
      uint32_t taddr,
@@ -65,7 +65,7 @@ tcgen05.st.sync.aligned.16x64b.x8.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b(
      uint32_t taddr,
@@ -75,7 +75,7 @@ tcgen05.st.sync.aligned.16x64b.x8.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b_unpack_16b(
      uint32_t taddr,
@@ -85,7 +85,7 @@ tcgen05.st.sync.aligned.16x64b.x16.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b(
      uint32_t taddr,
@@ -95,7 +95,7 @@ tcgen05.st.sync.aligned.16x64b.x16.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b_unpack_16b(
      uint32_t taddr,
@@ -105,7 +105,7 @@ tcgen05.st.sync.aligned.16x64b.x32.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b(
      uint32_t taddr,
@@ -115,7 +115,7 @@ tcgen05.st.sync.aligned.16x64b.x32.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b_unpack_16b(
      uint32_t taddr,
@@ -125,7 +125,7 @@ tcgen05.st.sync.aligned.16x64b.x64.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b(
      uint32_t taddr,
@@ -135,7 +135,7 @@ tcgen05.st.sync.aligned.16x64b.x64.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b_unpack_16b(
      uint32_t taddr,
@@ -145,7 +145,7 @@ tcgen05.st.sync.aligned.16x64b.x128.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x128.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x128.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b(
      uint32_t taddr,
@@ -155,7 +155,7 @@ tcgen05.st.sync.aligned.16x64b.x128.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x64b.x128.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x64b.x128.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x64b_unpack_16b(
      uint32_t taddr,
@@ -165,7 +165,7 @@ tcgen05.st.sync.aligned.16x128b.x1.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b(
      uint32_t taddr,
@@ -175,7 +175,7 @@ tcgen05.st.sync.aligned.16x128b.x1.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b_unpack_16b(
      uint32_t taddr,
@@ -185,7 +185,7 @@ tcgen05.st.sync.aligned.16x128b.x2.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b(
      uint32_t taddr,
@@ -195,7 +195,7 @@ tcgen05.st.sync.aligned.16x128b.x2.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b_unpack_16b(
      uint32_t taddr,
@@ -205,7 +205,7 @@ tcgen05.st.sync.aligned.16x128b.x4.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b(
      uint32_t taddr,
@@ -215,7 +215,7 @@ tcgen05.st.sync.aligned.16x128b.x4.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b_unpack_16b(
      uint32_t taddr,
@@ -225,7 +225,7 @@ tcgen05.st.sync.aligned.16x128b.x8.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b(
      uint32_t taddr,
@@ -235,7 +235,7 @@ tcgen05.st.sync.aligned.16x128b.x8.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b_unpack_16b(
      uint32_t taddr,
@@ -245,7 +245,7 @@ tcgen05.st.sync.aligned.16x128b.x16.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b(
      uint32_t taddr,
@@ -255,7 +255,7 @@ tcgen05.st.sync.aligned.16x128b.x16.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b_unpack_16b(
      uint32_t taddr,
@@ -265,7 +265,7 @@ tcgen05.st.sync.aligned.16x128b.x32.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b(
      uint32_t taddr,
@@ -275,7 +275,7 @@ tcgen05.st.sync.aligned.16x128b.x32.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b_unpack_16b(
      uint32_t taddr,
@@ -285,7 +285,7 @@ tcgen05.st.sync.aligned.16x128b.x64.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b(
      uint32_t taddr,
@@ -295,7 +295,7 @@ tcgen05.st.sync.aligned.16x128b.x64.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x128b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x128b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x128b_unpack_16b(
      uint32_t taddr,
@@ -305,7 +305,7 @@ tcgen05.st.sync.aligned.16x256b.x1.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b(
      uint32_t taddr,
@@ -315,7 +315,7 @@ tcgen05.st.sync.aligned.16x256b.x1.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b_unpack_16b(
      uint32_t taddr,
@@ -325,7 +325,7 @@ tcgen05.st.sync.aligned.16x256b.x2.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b(
      uint32_t taddr,
@@ -335,7 +335,7 @@ tcgen05.st.sync.aligned.16x256b.x2.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b_unpack_16b(
      uint32_t taddr,
@@ -345,7 +345,7 @@ tcgen05.st.sync.aligned.16x256b.x4.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b(
      uint32_t taddr,
@@ -355,7 +355,7 @@ tcgen05.st.sync.aligned.16x256b.x4.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b_unpack_16b(
      uint32_t taddr,
@@ -365,7 +365,7 @@ tcgen05.st.sync.aligned.16x256b.x8.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b(
      uint32_t taddr,
@@ -375,7 +375,7 @@ tcgen05.st.sync.aligned.16x256b.x8.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b_unpack_16b(
      uint32_t taddr,
@@ -385,7 +385,7 @@ tcgen05.st.sync.aligned.16x256b.x16.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b(
      uint32_t taddr,
@@ -395,7 +395,7 @@ tcgen05.st.sync.aligned.16x256b.x16.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b_unpack_16b(
      uint32_t taddr,
@@ -405,7 +405,7 @@ tcgen05.st.sync.aligned.16x256b.x32.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b(
      uint32_t taddr,
@@ -415,7 +415,7 @@ tcgen05.st.sync.aligned.16x256b.x32.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x256b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x256b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x256b_unpack_16b(
      uint32_t taddr,
@@ -425,7 +425,7 @@ tcgen05.st.sync.aligned.32x32b.x1.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b(
      uint32_t taddr,
@@ -435,7 +435,7 @@ tcgen05.st.sync.aligned.32x32b.x1.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b_unpack_16b(
      uint32_t taddr,
@@ -445,7 +445,7 @@ tcgen05.st.sync.aligned.32x32b.x2.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b(
      uint32_t taddr,
@@ -455,7 +455,7 @@ tcgen05.st.sync.aligned.32x32b.x2.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b_unpack_16b(
      uint32_t taddr,
@@ -465,7 +465,7 @@ tcgen05.st.sync.aligned.32x32b.x4.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b(
      uint32_t taddr,
@@ -475,7 +475,7 @@ tcgen05.st.sync.aligned.32x32b.x4.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b_unpack_16b(
      uint32_t taddr,
@@ -485,7 +485,7 @@ tcgen05.st.sync.aligned.32x32b.x8.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b(
      uint32_t taddr,
@@ -495,7 +495,7 @@ tcgen05.st.sync.aligned.32x32b.x8.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b_unpack_16b(
      uint32_t taddr,
@@ -505,7 +505,7 @@ tcgen05.st.sync.aligned.32x32b.x16.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b(
      uint32_t taddr,
@@ -515,7 +515,7 @@ tcgen05.st.sync.aligned.32x32b.x16.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b_unpack_16b(
      uint32_t taddr,
@@ -525,7 +525,7 @@ tcgen05.st.sync.aligned.32x32b.x32.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b(
      uint32_t taddr,
@@ -535,7 +535,7 @@ tcgen05.st.sync.aligned.32x32b.x32.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b_unpack_16b(
      uint32_t taddr,
@@ -545,7 +545,7 @@ tcgen05.st.sync.aligned.32x32b.x64.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b(
      uint32_t taddr,
@@ -555,7 +555,7 @@ tcgen05.st.sync.aligned.32x32b.x64.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b_unpack_16b(
      uint32_t taddr,
@@ -565,7 +565,7 @@ tcgen05.st.sync.aligned.32x32b.x128.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x128.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x128.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b(
      uint32_t taddr,
@@ -575,7 +575,7 @@ tcgen05.st.sync.aligned.32x32b.x128.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.32x32b.x128.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.32x32b.x128.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_32x32b_unpack_16b(
      uint32_t taddr,
@@ -585,7 +585,7 @@ tcgen05.st.sync.aligned.16x32bx2.x1.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x1.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x1.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2(
      uint32_t taddr,
@@ -596,7 +596,7 @@ tcgen05.st.sync.aligned.16x32bx2.x1.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x1.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x1.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
      uint32_t taddr,
@@ -607,7 +607,7 @@ tcgen05.st.sync.aligned.16x32bx2.x2.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x2.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x2.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2(
      uint32_t taddr,
@@ -618,7 +618,7 @@ tcgen05.st.sync.aligned.16x32bx2.x2.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x2.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x2.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
      uint32_t taddr,
@@ -629,7 +629,7 @@ tcgen05.st.sync.aligned.16x32bx2.x4.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x4.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x4.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2(
      uint32_t taddr,
@@ -640,7 +640,7 @@ tcgen05.st.sync.aligned.16x32bx2.x4.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x4.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x4.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
      uint32_t taddr,
@@ -651,7 +651,7 @@ tcgen05.st.sync.aligned.16x32bx2.x8.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x8.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x8.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2(
      uint32_t taddr,
@@ -662,7 +662,7 @@ tcgen05.st.sync.aligned.16x32bx2.x8.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x8.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x8.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
      uint32_t taddr,
@@ -673,7 +673,7 @@ tcgen05.st.sync.aligned.16x32bx2.x16.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x16.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x16.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2(
      uint32_t taddr,
@@ -684,7 +684,7 @@ tcgen05.st.sync.aligned.16x32bx2.x16.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x16.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x16.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
      uint32_t taddr,
@@ -695,7 +695,7 @@ tcgen05.st.sync.aligned.16x32bx2.x32.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x32.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x32.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2(
      uint32_t taddr,
@@ -706,7 +706,7 @@ tcgen05.st.sync.aligned.16x32bx2.x32.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x32.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x32.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
      uint32_t taddr,
@@ -717,7 +717,7 @@ tcgen05.st.sync.aligned.16x32bx2.x64.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x64.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x64.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2(
      uint32_t taddr,
@@ -728,7 +728,7 @@ tcgen05.st.sync.aligned.16x32bx2.x64.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x64.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x64.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
      uint32_t taddr,
@@ -739,7 +739,7 @@ tcgen05.st.sync.aligned.16x32bx2.x128.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x128.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x128.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2(
      uint32_t taddr,
@@ -750,7 +750,7 @@ tcgen05.st.sync.aligned.16x32bx2.x128.unpack::16b.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.st.sync.aligned.16x32bx2.x128.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.st.sync.aligned.16x32bx2.x128.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
      uint32_t taddr,

--- a/docs/libcudacxx/ptx/instructions/generated/tcgen05_wait.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tcgen05_wait.rst
@@ -5,7 +5,7 @@ tcgen05.wait::ld.sync.aligned
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.wait::ld.sync.aligned; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.wait::ld.sync.aligned; // PTX ISA 86, SM_100a, SM_110a
    template <typename = void>
    __device__ static inline void tcgen05_wait_ld();
 
@@ -13,6 +13,6 @@ tcgen05.wait::st.sync.aligned
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tcgen05.wait::st.sync.aligned; // PTX ISA 86, SM_100a, SM_101a
+   // tcgen05.wait::st.sync.aligned; // PTX ISA 86, SM_100a, SM_110a
    template <typename = void>
    __device__ static inline void tcgen05_wait_st();

--- a/docs/libcudacxx/ptx/instructions/generated/tensormap_replace.rst
+++ b/docs/libcudacxx/ptx/instructions/generated/tensormap_replace.rst
@@ -5,7 +5,7 @@ tensormap.replace.tile.global_address.global.b1024.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.global_address.space.b1024.b64 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.global_address.space.b1024.b64 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline void tensormap_replace_global_address(
@@ -17,7 +17,7 @@ tensormap.replace.tile.global_address.shared::cta.b1024.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.global_address.space.b1024.b64 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.global_address.space.b1024.b64 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline void tensormap_replace_global_address(
@@ -29,7 +29,7 @@ tensormap.replace.tile.rank.global.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.rank.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.rank.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tensormap_replace_rank(
@@ -41,7 +41,7 @@ tensormap.replace.tile.rank.shared::cta.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.rank.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.rank.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tensormap_replace_rank(
@@ -53,7 +53,7 @@ tensormap.replace.tile.box_dim.global.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.box_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.box_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tensormap_replace_box_dim(
@@ -66,7 +66,7 @@ tensormap.replace.tile.box_dim.shared::cta.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.box_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.box_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tensormap_replace_box_dim(
@@ -79,7 +79,7 @@ tensormap.replace.tile.global_dim.global.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.global_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.global_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tensormap_replace_global_dim(
@@ -92,7 +92,7 @@ tensormap.replace.tile.global_dim.shared::cta.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.global_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.global_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tensormap_replace_global_dim(
@@ -105,7 +105,7 @@ tensormap.replace.tile.global_stride.global.b1024.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.global_stride.space.b1024.b64 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.global_stride.space.b1024.b64 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <int N32, typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline void tensormap_replace_global_stride(
@@ -118,7 +118,7 @@ tensormap.replace.tile.global_stride.shared::cta.b1024.b64
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.global_stride.space.b1024.b64 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.global_stride.space.b1024.b64 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <int N32, typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
    __device__ static inline void tensormap_replace_global_stride(
@@ -131,7 +131,7 @@ tensormap.replace.tile.element_stride.global.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tensormap_replace_element_stride(
@@ -144,7 +144,7 @@ tensormap.replace.tile.element_stride.shared::cta.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tensormap_replace_element_stride(
@@ -157,7 +157,7 @@ tensormap.replace.tile.element_stride.global.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tensormap_replace_element_size(
@@ -170,7 +170,7 @@ tensormap.replace.tile.element_stride.shared::cta.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
    __device__ static inline void tensormap_replace_element_size(
@@ -183,7 +183,7 @@ tensormap.replace.tile.elemtype.global.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.elemtype.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.elemtype.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <int N32>
    __device__ static inline void tensormap_replace_elemtype(
@@ -195,7 +195,7 @@ tensormap.replace.tile.elemtype.shared::cta.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.elemtype.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.elemtype.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <int N32>
    __device__ static inline void tensormap_replace_elemtype(
@@ -207,7 +207,7 @@ tensormap.replace.tile.interleave_layout.global.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.interleave_layout.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.interleave_layout.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <int N32>
    __device__ static inline void tensormap_replace_interleave_layout(
@@ -219,7 +219,7 @@ tensormap.replace.tile.interleave_layout.shared::cta.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.interleave_layout.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.interleave_layout.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <int N32>
    __device__ static inline void tensormap_replace_interleave_layout(
@@ -231,7 +231,7 @@ tensormap.replace.tile.swizzle_mode.global.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.swizzle_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.swizzle_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <int N32>
    __device__ static inline void tensormap_replace_swizzle_mode(
@@ -243,7 +243,7 @@ tensormap.replace.tile.swizzle_mode.shared::cta.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.swizzle_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.swizzle_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <int N32>
    __device__ static inline void tensormap_replace_swizzle_mode(
@@ -255,7 +255,7 @@ tensormap.replace.tile.fill_mode.global.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.fill_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.fill_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .global }
    template <int N32>
    __device__ static inline void tensormap_replace_fill_mode(
@@ -267,7 +267,7 @@ tensormap.replace.tile.fill_mode.shared::cta.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.fill_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+   // tensormap.replace.tile.fill_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <int N32>
    __device__ static inline void tensormap_replace_fill_mode(
@@ -279,7 +279,7 @@ tensormap.replace.tile.swizzle_atomicity.global.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.swizzle_atomicity.space.b1024.b32 [tm_addr], new_val; // PTX ISA 86, SM_100a, SM_101a
+   // tensormap.replace.tile.swizzle_atomicity.space.b1024.b32 [tm_addr], new_val; // PTX ISA 86, SM_100a, SM_110a
    // .space     = { .global }
    template <int N32>
    __device__ static inline void tensormap_replace_swizzle_atomicity(
@@ -291,7 +291,7 @@ tensormap.replace.tile.swizzle_atomicity.shared::cta.b1024.b32
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. code:: cuda
 
-   // tensormap.replace.tile.swizzle_atomicity.space.b1024.b32 [tm_addr], new_val; // PTX ISA 86, SM_100a, SM_101a
+   // tensormap.replace.tile.swizzle_atomicity.space.b1024.b32 [tm_addr], new_val; // PTX ISA 86, SM_100a, SM_110a
    // .space     = { .shared::cta }
    template <int N32>
    __device__ static inline void tensormap_replace_swizzle_atomicity(

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/clusterlaunchcontrol.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/clusterlaunchcontrol.h
@@ -29,18 +29,18 @@ _CCCL_DEVICE static inline void clusterlaunchcontrol_try_cancel(void* __addr, _C
 
 /*
 // clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 [addr],
-[smem_bar]; // PTX ISA 86, SM_100a, SM_101a template <typename = void>
+[smem_bar]; // PTX ISA 86, SM_100a, SM_110a template <typename = void>
 __device__ static inline void clusterlaunchcontrol_try_cancel_multicast(
   void* addr,
   uint64_t* smem_bar);
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_clusterlaunchcontrol_try_cancel_multicast_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_clusterlaunchcontrol_try_cancel_multicast_is_not_supported_before_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void clusterlaunchcontrol_try_cancel_multicast(void* __addr, _CUDA_VSTD::uint64_t* __smem_bar)
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128 "
       "[%0], [%1];"
       :
@@ -48,7 +48,7 @@ _CCCL_DEVICE static inline void clusterlaunchcontrol_try_cancel_multicast(void* 
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_clusterlaunchcontrol_try_cancel_multicast_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_clusterlaunchcontrol_try_cancel_multicast_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_multicast.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_multicast.h
@@ -5,7 +5,7 @@
 
 /*
 // cp.async.bulk.dst.src.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [srcMem], size, [smem_bar], ctaMask;
-// PTX ISA 80, SM_90a, SM_100a, SM_101a
+// PTX ISA 80, SM_90a, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 template <typename = void>
@@ -19,7 +19,7 @@ __device__ static inline void cp_async_bulk(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void cp_async_bulk(
   space_cluster_t,
@@ -33,7 +33,7 @@ _CCCL_DEVICE static inline void cp_async_bulk(
 // __space == space_cluster (due to parameter type constraint)
 // __space == space_global (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster [%0], [%1], %2, [%3], %4;"
       :
       : "r"(__as_ptr_smem(__dstMem)),
@@ -44,7 +44,7 @@ _CCCL_DEVICE static inline void cp_async_bulk(
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor.h
@@ -83,7 +83,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
 
 /*
 // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords],
-[smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+[smem_bar]; // PTX ISA 86, SM_100a, SM_110a
 // .dst       = { .shared::cta }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -98,7 +98,7 @@ __device__ static inline void cp_async_bulk_tensor(
   uint64_t* smem_bar);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_shared_t,
@@ -112,7 +112,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   // __space == space_shared (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::1 [%0], [%1, {%2}], "
@@ -131,7 +131,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
@@ -260,7 +260,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
 
 /*
 // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords],
-[smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+[smem_bar]; // PTX ISA 86, SM_100a, SM_110a
 // .dst       = { .shared::cta }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -275,7 +275,7 @@ __device__ static inline void cp_async_bulk_tensor(
   uint64_t* smem_bar);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_shared_t,
@@ -289,7 +289,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   // __space == space_shared (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::1 [%0], [%1, {%2, "
@@ -316,7 +316,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
@@ -447,7 +447,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
 
 /*
 // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords],
-[smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+[smem_bar]; // PTX ISA 86, SM_100a, SM_110a
 // .dst       = { .shared::cta }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -462,7 +462,7 @@ __device__ static inline void cp_async_bulk_tensor(
   uint64_t* smem_bar);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_shared_t,
@@ -476,7 +476,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   // __space == space_shared (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::1 [%0], [%1, {%2, %3, "
@@ -505,7 +505,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
@@ -643,7 +643,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
 
 /*
 // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords],
-[smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+[smem_bar]; // PTX ISA 86, SM_100a, SM_110a
 // .dst       = { .shared::cta }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -658,7 +658,7 @@ __device__ static inline void cp_async_bulk_tensor(
   uint64_t* smem_bar);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_shared_t,
@@ -672,7 +672,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   // __space == space_shared (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::1 [%0], [%1, {%2, %3, "
@@ -703,7 +703,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
@@ -845,7 +845,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
 
 /*
 // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap, tensorCoords],
-[smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+[smem_bar]; // PTX ISA 86, SM_100a, SM_110a
 // .dst       = { .shared::cta }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -860,7 +860,7 @@ __device__ static inline void cp_async_bulk_tensor(
   uint64_t* smem_bar);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_shared_t,
@@ -874,7 +874,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   // __space == space_shared (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::1 [%0], [%1, {%2, %3, "
@@ -907,7 +907,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor_gather_scatter.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor_gather_scatter.h
@@ -52,7 +52,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
 
 /*
 // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.cta_group [dstMem], [tensorMap,
-tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+tensorCoords], [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
 // .dst       = { .shared::cta }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -67,7 +67,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4(
   uint64_t* smem_bar);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
   space_shared_t,
@@ -81,7 +81,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
   // __space == space_shared (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::1 [%0], [%1, "
@@ -114,14 +114,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 template <typename = void>
@@ -135,7 +135,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
   space_cluster_t,
@@ -148,7 +148,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
 {
 // __space == space_cluster (due to parameter type constraint)
 // __space == space_global (due to parameter type constraint)
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster "
       "[%0], [%1, {%2, %3, %4, %5, %6}], [%7], %8;"
       :
@@ -164,14 +164,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // cp.async.bulk.tensor.2d.dst.src.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem],
-[tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_101a
+[tensorMap, tensorCoords], [smem_bar], ctaMask; // PTX ISA 86, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -187,7 +187,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_gather4(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
   space_cluster_t,
@@ -202,7 +202,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
   // __space == space_cluster (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster."
@@ -237,14 +237,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_gather4(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_tile_gather4_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // cp.async.bulk.tensor.2d.dst.src.tile::scatter4.bulk_group [tensorMap, tensorCoords], [srcMem]; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .dst       = { .global }
 // .src       = { .shared::cta }
 template <typename = void>
@@ -256,7 +256,7 @@ __device__ static inline void cp_async_bulk_tensor_tile_scatter4(
   const void* srcMem);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_tile_scatter4_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_tile_scatter4_is_not_supported_before_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_scatter4(
   space_global_t,
@@ -267,7 +267,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_scatter4(
 {
 // __space == space_global (due to parameter type constraint)
 // __space == space_shared (due to parameter type constraint)
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("cp.async.bulk.tensor.2d.global.shared::cta.tile::scatter4.bulk_group [%0, {%1, %2, %3, %4, %5}], [%6];"
       :
       : "l"(__tensorMap),
@@ -280,7 +280,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor_tile_scatter4(
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_tile_scatter4_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_tile_scatter4_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor_multicast.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/cp_async_bulk_tensor_multicast.h
@@ -5,7 +5,7 @@
 
 /*
 // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 template <typename = void>
@@ -19,7 +19,7 @@ __device__ static inline void cp_async_bulk_tensor(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_cluster_t,
@@ -33,7 +33,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
 // __space == space_cluster (due to parameter type constraint)
 // __space == space_global (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [%0], [%1, "
       "{%2}], [%3], %4;"
       :
@@ -45,14 +45,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800
 
 /*
 // cp.async.bulk.tensor.1d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -68,7 +68,7 @@ __device__ static inline void cp_async_bulk_tensor(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_cluster_t,
@@ -83,7 +83,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   // __space == space_cluster (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group:"
@@ -110,14 +110,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800
 
 /*
 // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 template <typename = void>
@@ -131,7 +131,7 @@ __device__ static inline void cp_async_bulk_tensor(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_cluster_t,
@@ -145,7 +145,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
 // __space == space_cluster (due to parameter type constraint)
 // __space == space_global (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [%0], [%1, "
       "{%2, %3}], [%4], %5;"
       :
@@ -158,14 +158,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800
 
 /*
 // cp.async.bulk.tensor.2d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -181,7 +181,7 @@ __device__ static inline void cp_async_bulk_tensor(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_cluster_t,
@@ -196,7 +196,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   // __space == space_cluster (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group:"
@@ -225,14 +225,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800
 
 /*
 // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 template <typename = void>
@@ -246,7 +246,7 @@ __device__ static inline void cp_async_bulk_tensor(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_cluster_t,
@@ -260,7 +260,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
 // __space == space_cluster (due to parameter type constraint)
 // __space == space_global (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [%0], [%1, "
       "{%2, %3, %4}], [%5], %6;"
       :
@@ -274,14 +274,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800
 
 /*
 // cp.async.bulk.tensor.3d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -297,7 +297,7 @@ __device__ static inline void cp_async_bulk_tensor(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_cluster_t,
@@ -312,7 +312,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   // __space == space_cluster (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group:"
@@ -343,14 +343,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800
 
 /*
 // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 template <typename = void>
@@ -364,7 +364,7 @@ __device__ static inline void cp_async_bulk_tensor(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_cluster_t,
@@ -378,7 +378,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
 // __space == space_cluster (due to parameter type constraint)
 // __space == space_global (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [%0], [%1, "
       "{%2, %3, %4, %5}], [%6], %7;"
       :
@@ -393,14 +393,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800
 
 /*
 // cp.async.bulk.tensor.4d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -416,7 +416,7 @@ __device__ static inline void cp_async_bulk_tensor(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_cluster_t,
@@ -431,7 +431,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   // __space == space_cluster (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group:"
@@ -464,14 +464,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800
 
 /*
 // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_90a, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 template <typename = void>
@@ -485,7 +485,7 @@ __device__ static inline void cp_async_bulk_tensor(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_cluster_t,
@@ -499,7 +499,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
 // __space == space_cluster (due to parameter type constraint)
 // __space == space_global (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [%0], [%1, "
       "{%2, %3, %4, %5, %6}], [%7], %8;"
       :
@@ -515,14 +515,14 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800
 
 /*
 // cp.async.bulk.tensor.5d.dst.src.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group [dstMem], [tensorMap,
-tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_101a
+tensorCoords], [smem_bar], ctaMask; // PTX ISA 80, SM_100a, SM_110a
 // .dst       = { .shared::cluster }
 // .src       = { .global }
 // .cta_group = { .cta_group::1, .cta_group::2 }
@@ -538,7 +538,7 @@ __device__ static inline void cp_async_bulk_tensor(
   const uint16_t& ctaMask);
 */
 #if __cccl_ptx_isa >= 800
-extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   space_cluster_t,
@@ -553,7 +553,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   // __space == space_cluster (due to parameter type constraint)
   // __space == space_global (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group:"
@@ -588,7 +588,7 @@ _CCCL_DEVICE static inline void cp_async_bulk_tensor(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_cp_async_bulk_tensor_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 800

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/ld.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/ld.h
@@ -32,6 +32,34 @@ _CCCL_DEVICE static inline _B8 ld(space_global_t, const _B8* __addr)
 #endif // __cccl_ptx_isa >= 100
 
 /*
+// ld.space.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_L2_256B(space_global_t, const _B8* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.b16 dest, [addr]; // PTX ISA 10, SM_50
 // .space     = { .global }
 template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
@@ -58,6 +86,34 @@ _CCCL_DEVICE static inline _B16 ld(space_global_t, const _B16* __addr)
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
+
+/*
+// ld.space.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_L2_256B(space_global_t, const _B16* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.space.b32 dest, [addr]; // PTX ISA 10, SM_50
@@ -88,6 +144,34 @@ _CCCL_DEVICE static inline _B32 ld(space_global_t, const _B32* __addr)
 #endif // __cccl_ptx_isa >= 100
 
 /*
+// ld.space.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_L2_256B(space_global_t, const _B32* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.b64 dest, [addr]; // PTX ISA 10, SM_50
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -114,6 +198,34 @@ _CCCL_DEVICE static inline _B64 ld(space_global_t, const _B64* __addr)
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
+
+/*
+// ld.space.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_L2_256B(space_global_t, const _B64* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.space.b128 dest, [addr]; // PTX ISA 83, SM_70
@@ -150,410 +262,6 @@ _CCCL_DEVICE static inline _B128 ld(space_global_t, const _B128* __addr)
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -588,6 +296,37 @@ _CCCL_DEVICE static inline _B128 ld_L2_256B(space_global_t, const _B128* __addr)
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld(
+  cuda::ptx::space_global_t,
+  const B256* addr);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256 ld(space_global_t, const _B256* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.v4.b64 {%0, %1, %2, %3}, [%4];"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr))
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -613,6 +352,39 @@ _CCCL_DEVICE static inline _B8 ld_L2_cache_hint(space_global_t, const _B8* __add
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8
+ld_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -652,6 +424,39 @@ _CCCL_DEVICE static inline _B16 ld_L2_cache_hint(space_global_t, const _B16* __a
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16
+ld_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
+      : "=h"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -684,6 +489,39 @@ _CCCL_DEVICE static inline _B32 ld_L2_cache_hint(space_global_t, const _B32* __a
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32
+ld_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -709,6 +547,39 @@ _CCCL_DEVICE static inline _B64 ld_L2_cache_hint(space_global_t, const _B64* __a
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64
+ld_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
+      : "=l"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -752,474 +623,6 @@ ld_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cac
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -1256,2516 +659,37 @@ ld_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
+// ld.space.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
 // .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_normal(
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_L2_cache_hint(
   cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_normal(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_normal(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_normal.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_normal(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_normal(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_normal.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_70
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_normal(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_normal.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_is_not_supported_before_SM_70__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_normal.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_normal_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_normal_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_normal_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_normal_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_normal.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_normal_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_normal_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_normal_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_normal_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_normal.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_normal_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_normal_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_normal.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_normal.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_normal_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_normal_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_normal_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_normal_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_normal.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_normal_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_normal_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_normal_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_normal_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_normal.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_normal_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_normal_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_normal.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_normal.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_normal_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_normal_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_normal_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_normal_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_normal.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_normal_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_normal_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_normal_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_normal_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_normal.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_normal_L2_256B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_normal_L2_256B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_normal.L2::256B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B8* addr,
+  const B256* addr,
   uint64_t cache_policy);
 */
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_normal_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256
+ld_L2_cache_hint(space_global_t, const _B256* __addr, _CUDA_VSTD::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.b8 %0, [%1], %2;"
-      : "=r"(__dest)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.L2::cache_hint.v4.b64 {%0, %1, %2, %3}, [%4], %5;"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
       : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
       : "memory");
-  return __u32_as_b8<_B8>(__dest);
+  return *reinterpret_cast<_B256*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
+  __cuda_ptx_ld_L2_cache_hint_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
 #  endif
 }
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_normal_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_normal_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_normal_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_normal_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_normal.L2::cache_hint.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_normal_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_normal_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_normal_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_normal_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_normal_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_normal_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_normal_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_normal_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_normal_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_normal_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_normal_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_normal_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_normal_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_normal_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_normal_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_normal_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_normal_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_normal_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_normal_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_normal_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_normal_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_normal_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_normal_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_normal_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_normal_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_normal_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_normal_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_normal_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_normal.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_normal_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_normal_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_unchanged(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_unchanged(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_unchanged.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_unchanged(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_unchanged(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_unchanged.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_70
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_unchanged(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_unchanged.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_unchanged.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_unchanged_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_unchanged_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_unchanged_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_unchanged_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_unchanged_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_unchanged_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_unchanged_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_unchanged_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_unchanged_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_unchanged_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_unchanged.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_unchanged.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_unchanged_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_unchanged_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_unchanged_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_unchanged_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_unchanged_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_unchanged_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_unchanged_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_unchanged_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_unchanged_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_unchanged_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_unchanged.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_unchanged.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_unchanged_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_unchanged_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_unchanged_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_unchanged_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_unchanged_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_unchanged_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_unchanged_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_unchanged_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_unchanged_L2_256B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_unchanged_L2_256B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_unchanged.L2::256B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_unchanged_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_unchanged_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_unchanged_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_unchanged_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_unchanged_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_unchanged.L2::cache_hint.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_unchanged_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_unchanged_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_unchanged_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_unchanged_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_unchanged_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_unchanged_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_unchanged_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_unchanged_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_unchanged_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_unchanged_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_unchanged_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_unchanged_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_unchanged_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_unchanged_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_unchanged_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_unchanged_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_unchanged_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_unchanged_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_unchanged_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_unchanged_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_unchanged_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_unchanged_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_unchanged_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_unchanged_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_unchanged_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_unchanged_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_unchanged_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_unchanged_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_unchanged.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_unchanged_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_unchanged_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 880
 
 /*
 // ld.space.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_70
@@ -3789,6 +713,34 @@ _CCCL_DEVICE static inline _B8 ld_L1_evict_first(space_global_t, const _B8* __ad
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_evict_first_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_L1_evict_first_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_L1_evict_first_L2_256B(space_global_t, const _B8* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::evict_first.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -3824,6 +776,34 @@ _CCCL_DEVICE static inline _B16 ld_L1_evict_first(space_global_t, const _B16* __
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_L1_evict_first_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_L1_evict_first_L2_256B(space_global_t, const _B16* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.L1::evict_first.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -3852,6 +832,34 @@ _CCCL_DEVICE static inline _B32 ld_L1_evict_first(space_global_t, const _B32* __
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_L1_evict_first_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_L1_evict_first_L2_256B(space_global_t, const _B32* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::evict_first.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -3873,6 +881,34 @@ _CCCL_DEVICE static inline _B64 ld_L1_evict_first(space_global_t, const _B64* __
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_evict_first_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::evict_first.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_L1_evict_first_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_L1_evict_first_L2_256B(space_global_t, const _B64* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.L1::evict_first.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -3914,410 +950,6 @@ _CCCL_DEVICE static inline _B128 ld_L1_evict_first(space_global_t, const _B128* 
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.L1::evict_first.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_first_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_first_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_first_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_first_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_first.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_first_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_first_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_first_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_first_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_first.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_first_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_first_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_first.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_first.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_first_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_first_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_first_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_first_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_first.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_first_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_first_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_first_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_first_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_first.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_first_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_first_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_first.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_first_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_first_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_first_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_first_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_first.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_first_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_first_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_first_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_first_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_first.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.L1::evict_first.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -4352,6 +984,37 @@ _CCCL_DEVICE static inline _B128 ld_L1_evict_first_L2_256B(space_global_t, const
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.L1::evict_first.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_L1_evict_first(
+  cuda::ptx::space_global_t,
+  const B256* addr);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256 ld_L1_evict_first(space_global_t, const _B256* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.L1::evict_first.v4.b64 {%0, %1, %2, %3}, [%4];"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr))
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_first_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.L1::evict_first.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -4378,6 +1041,39 @@ ld_L1_evict_first_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD::u
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_evict_first_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_L1_evict_first_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8
+ld_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::evict_first.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -4418,6 +1114,39 @@ ld_L1_evict_first_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VSTD::
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::evict_first.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_L1_evict_first_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16
+ld_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.L1::evict_first.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
+      : "=h"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::evict_first.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -4451,6 +1180,39 @@ ld_L1_evict_first_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VSTD::
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::evict_first.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_L1_evict_first_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32
+ld_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::evict_first.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::evict_first.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -4477,6 +1239,39 @@ ld_L1_evict_first_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VSTD::
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_evict_first_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::evict_first.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_L1_evict_first_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64
+ld_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.L1::evict_first.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
+      : "=l"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -4520,474 +1315,6 @@ ld_L1_evict_first_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VSTD:
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.L1::evict_first.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_first_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_first_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_first_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_first_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_first_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_first_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_first_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_first_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_first_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_first_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_first.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_first_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_first_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_first_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_first_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_first_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_first_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_first_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_first_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_first_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_first_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_first.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_first_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_first_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_first_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_first.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_first_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_first.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.L1::evict_first.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -5024,6 +1351,39 @@ ld_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, _CU
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.L1::evict_first.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_L1_evict_first_L2_cache_hint(
+  cuda::ptx::space_global_t,
+  const B256* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_first_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256
+ld_L1_evict_first_L2_cache_hint(space_global_t, const _B256* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.L1::evict_first.L2::cache_hint.v4.b64 {%0, %1, %2, %3}, [%4], %5;"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_first_L2_cache_hint_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -5045,6 +1405,34 @@ _CCCL_DEVICE static inline _B8 ld_L1_evict_last(space_global_t, const _B8* __add
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_evict_last_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_L1_evict_last_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_L1_evict_last_L2_256B(space_global_t, const _B8* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::evict_last.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -5080,6 +1468,34 @@ _CCCL_DEVICE static inline _B16 ld_L1_evict_last(space_global_t, const _B16* __a
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_L1_evict_last_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_L1_evict_last_L2_256B(space_global_t, const _B16* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.L1::evict_last.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -5108,6 +1524,34 @@ _CCCL_DEVICE static inline _B32 ld_L1_evict_last(space_global_t, const _B32* __a
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_L1_evict_last_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_L1_evict_last_L2_256B(space_global_t, const _B32* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::evict_last.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -5129,6 +1573,34 @@ _CCCL_DEVICE static inline _B64 ld_L1_evict_last(space_global_t, const _B64* __a
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_evict_last_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::evict_last.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_L1_evict_last_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_L1_evict_last_L2_256B(space_global_t, const _B64* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.L1::evict_last.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -5170,410 +1642,6 @@ _CCCL_DEVICE static inline _B128 ld_L1_evict_last(space_global_t, const _B128* _
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.L1::evict_last.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_last_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_last_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_last_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_last_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_last.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_last_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_last_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_last_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_last_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_last.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_last_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_last_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_last.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_last.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_last_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_last_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_last_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_last_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_last.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_last_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_last_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_last_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_last_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_last.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_last_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_evict_last_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_last.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_last_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_evict_last_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_last_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_evict_last_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_last.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_last_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_evict_last_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_last_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_evict_last_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_last.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.L1::evict_last.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -5608,6 +1676,37 @@ _CCCL_DEVICE static inline _B128 ld_L1_evict_last_L2_256B(space_global_t, const 
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.L1::evict_last.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_L1_evict_last(
+  cuda::ptx::space_global_t,
+  const B256* addr);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256 ld_L1_evict_last(space_global_t, const _B256* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.L1::evict_last.v4.b64 {%0, %1, %2, %3}, [%4];"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr))
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_last_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.L1::evict_last.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -5634,6 +1733,39 @@ ld_L1_evict_last_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD::ui
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_evict_last_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_L1_evict_last_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8
+ld_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::evict_last.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -5674,6 +1806,39 @@ ld_L1_evict_last_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VSTD::u
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::evict_last.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_L1_evict_last_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16
+ld_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.L1::evict_last.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
+      : "=h"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::evict_last.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -5707,6 +1872,39 @@ ld_L1_evict_last_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VSTD::u
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::evict_last.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_L1_evict_last_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32
+ld_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::evict_last.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::evict_last.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -5733,6 +1931,39 @@ ld_L1_evict_last_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VSTD::u
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_evict_last_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::evict_last.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_L1_evict_last_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64
+ld_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.L1::evict_last.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
+      : "=l"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -5776,474 +2007,6 @@ ld_L1_evict_last_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VSTD::
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.L1::evict_last.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_last_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_last_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_last_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_last_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_last_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_last_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_last_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_last_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_last_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_last_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_last.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_last_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_last_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_last_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_last_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_last_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_last_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_last_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_last_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_evict_last_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_evict_last_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::evict_last.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_evict_last_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_evict_last_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_evict_last_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::evict_last.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_evict_last_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::evict_last.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.L1::evict_last.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -6280,6 +2043,39 @@ ld_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, _CUD
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.L1::evict_last.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_L1_evict_last_L2_cache_hint(
+  cuda::ptx::space_global_t,
+  const B256* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_evict_last_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256
+ld_L1_evict_last_L2_cache_hint(space_global_t, const _B256* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.L1::evict_last.L2::cache_hint.v4.b64 {%0, %1, %2, %3}, [%4], %5;"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_evict_last_L2_cache_hint_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -6301,6 +2097,34 @@ _CCCL_DEVICE static inline _B8 ld_L1_no_allocate(space_global_t, const _B8* __ad
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_no_allocate_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_L1_no_allocate_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_L1_no_allocate_L2_256B(space_global_t, const _B8* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::no_allocate.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -6336,6 +2160,34 @@ _CCCL_DEVICE static inline _B16 ld_L1_no_allocate(space_global_t, const _B16* __
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_L1_no_allocate_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_L1_no_allocate_L2_256B(space_global_t, const _B16* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.L1::no_allocate.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -6364,6 +2216,34 @@ _CCCL_DEVICE static inline _B32 ld_L1_no_allocate(space_global_t, const _B32* __
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_L1_no_allocate_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_L1_no_allocate_L2_256B(space_global_t, const _B32* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::no_allocate.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -6385,6 +2265,34 @@ _CCCL_DEVICE static inline _B64 ld_L1_no_allocate(space_global_t, const _B64* __
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_no_allocate_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::no_allocate.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_L1_no_allocate_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_L1_no_allocate_L2_256B(space_global_t, const _B64* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.L1::no_allocate.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -6426,410 +2334,6 @@ _CCCL_DEVICE static inline _B128 ld_L1_no_allocate(space_global_t, const _B128* 
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.L1::no_allocate.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_no_allocate_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_no_allocate_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_no_allocate_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_no_allocate_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::no_allocate.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_no_allocate_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_no_allocate_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_no_allocate_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_no_allocate_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::no_allocate.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_no_allocate_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_no_allocate_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::no_allocate.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::no_allocate.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_no_allocate_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_no_allocate_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_no_allocate_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_no_allocate_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::no_allocate.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_no_allocate_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_no_allocate_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_no_allocate_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_no_allocate_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::no_allocate.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_no_allocate_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_L1_no_allocate_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::no_allocate.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_no_allocate_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_L1_no_allocate_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_no_allocate_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_L1_no_allocate_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::no_allocate.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_no_allocate_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_L1_no_allocate_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_no_allocate_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_L1_no_allocate_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::no_allocate.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.L1::no_allocate.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -6864,6 +2368,37 @@ _CCCL_DEVICE static inline _B128 ld_L1_no_allocate_L2_256B(space_global_t, const
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.L1::no_allocate.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_L1_no_allocate(
+  cuda::ptx::space_global_t,
+  const B256* addr);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256 ld_L1_no_allocate(space_global_t, const _B256* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.L1::no_allocate.v4.b64 {%0, %1, %2, %3}, [%4];"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr))
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_no_allocate_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.L1::no_allocate.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -6890,6 +2425,39 @@ ld_L1_no_allocate_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD::u
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_L1_no_allocate_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8
+ld_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -6930,6 +2498,39 @@ ld_L1_no_allocate_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VSTD::
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_L1_no_allocate_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16
+ld_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
+      : "=h"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::no_allocate.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -6963,6 +2564,39 @@ ld_L1_no_allocate_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VSTD::
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_L1_no_allocate_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32
+ld_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.L1::no_allocate.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -6989,6 +2623,39 @@ ld_L1_no_allocate_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VSTD::
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_L1_no_allocate_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64
+ld_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
+      : "=l"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -7032,474 +2699,6 @@ ld_L1_no_allocate_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VSTD:
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_no_allocate_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_no_allocate_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_no_allocate_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_no_allocate_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_no_allocate_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_no_allocate_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_no_allocate_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_no_allocate_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_no_allocate_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_no_allocate_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_no_allocate_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_no_allocate_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_no_allocate_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_no_allocate_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_no_allocate_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_no_allocate_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_no_allocate_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_no_allocate_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_L1_no_allocate_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_L1_no_allocate_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_L1_no_allocate_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_L1_no_allocate_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_L1_no_allocate_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_L1_no_allocate_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.L1::no_allocate.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -7536,6 +2735,39 @@ ld_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, _CU
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.L1::no_allocate.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_L1_no_allocate_L2_cache_hint(
+  cuda::ptx::space_global_t,
+  const B256* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256
+ld_L1_no_allocate_L2_cache_hint(space_global_t, const _B256* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.L1::no_allocate.L2::cache_hint.v4.b64 {%0, %1, %2, %3}, [%4], %5;"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_L1_no_allocate_L2_cache_hint_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.nc.b8 dest, [addr]; // PTX ISA 10, SM_50
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -7562,6 +2794,34 @@ _CCCL_DEVICE static inline _B8 ld_nc(space_global_t, const _B8* __addr)
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
+
+/*
+// ld.space.nc.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_nc_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_nc_L2_256B(space_global_t, const _B8* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.space.nc.b16 dest, [addr]; // PTX ISA 10, SM_50
@@ -7592,6 +2852,34 @@ _CCCL_DEVICE static inline _B16 ld_nc(space_global_t, const _B16* __addr)
 #endif // __cccl_ptx_isa >= 100
 
 /*
+// ld.space.nc.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_nc_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_nc_L2_256B(space_global_t, const _B16* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.nc.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.b32 dest, [addr]; // PTX ISA 10, SM_50
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -7620,6 +2908,34 @@ _CCCL_DEVICE static inline _B32 ld_nc(space_global_t, const _B32* __addr)
 #endif // __cccl_ptx_isa >= 100
 
 /*
+// ld.space.nc.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_nc_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_nc_L2_256B(space_global_t, const _B32* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.b64 dest, [addr]; // PTX ISA 10, SM_50
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -7646,6 +2962,34 @@ _CCCL_DEVICE static inline _B64 ld_nc(space_global_t, const _B64* __addr)
 #  endif
 }
 #endif // __cccl_ptx_isa >= 100
+
+/*
+// ld.space.nc.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_nc_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_nc_L2_256B(space_global_t, const _B64* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.nc.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
 
 /*
 // ld.space.nc.b128 dest, [addr]; // PTX ISA 83, SM_70
@@ -7682,410 +3026,6 @@ _CCCL_DEVICE static inline _B128 ld_nc(space_global_t, const _B128* __addr)
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.nc.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.nc.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -8120,6 +3060,37 @@ _CCCL_DEVICE static inline _B128 ld_nc_L2_256B(space_global_t, const _B128* __ad
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.nc.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_nc(
+  cuda::ptx::space_global_t,
+  const B256* addr);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256 ld_nc(space_global_t, const _B256* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.nc.v4.b64 {%0, %1, %2, %3}, [%4];"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr))
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.nc.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -8146,6 +3117,39 @@ ld_nc_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __ca
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_nc_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8
+ld_nc_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -8186,6 +3190,39 @@ ld_nc_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __c
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_nc_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16
+ld_nc_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.nc.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
+      : "=h"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -8219,6 +3256,39 @@ ld_nc_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __c
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_nc_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32
+ld_nc_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -8245,6 +3315,39 @@ ld_nc_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __c
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_nc_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64
+ld_nc_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.nc.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
+      : "=l"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -8288,474 +3391,6 @@ ld_nc_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.nc.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.nc.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -8792,2516 +3427,37 @@ ld_nc_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, _CUDA_VSTD::uin
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.nc.L1::evict_normal.b8 dest, [addr]; // PTX ISA 74, SM_70
+// ld.space.nc.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
 // .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_normal(
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_nc_L2_cache_hint(
   cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_normal(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.b16 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_normal(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_normal.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.b32 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_normal(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.b64 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_normal(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_normal.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.b128 dest, [addr]; // PTX ISA 83, SM_70
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_normal(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_normal.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_is_not_supported_before_SM_70__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_normal.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_normal_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_normal_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_normal_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_normal_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_normal_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_normal_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_normal_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_normal_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_normal_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_normal_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_normal.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_normal.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_normal_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_normal_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_normal_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_normal_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_normal_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_normal_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_normal_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_normal_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_normal_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_normal_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_normal.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_normal.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_normal_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_normal_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_normal_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_normal_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_normal_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_normal_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_normal_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_normal_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_normal_L2_256B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_normal_L2_256B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_normal.L2::256B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B8* addr,
+  const B256* addr,
   uint64_t cache_policy);
 */
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_normal_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256
+ld_nc_L2_cache_hint(space_global_t, const _B256* __addr, _CUDA_VSTD::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.b8 %0, [%1], %2;"
-      : "=r"(__dest)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.nc.L2::cache_hint.v4.b64 {%0, %1, %2, %3}, [%4], %5;"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
       : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
       : "memory");
-  return __u32_as_b8<_B8>(__dest);
+  return *reinterpret_cast<_B256*>(&__dest);
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
+  __cuda_ptx_ld_nc_L2_cache_hint_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
 #  endif
 }
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_normal_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_normal_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_normal_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_normal_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_normal.L2::cache_hint.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_normal_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_normal_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_normal.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_normal_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_normal_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_unchanged.b8 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_unchanged(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.b16 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_unchanged(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.b32 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_unchanged(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.b64 dest, [addr]; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_unchanged(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.b128 dest, [addr]; // PTX ISA 83, SM_70
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_unchanged(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_unchanged.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_is_not_supported_before_SM_70__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_unchanged_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_unchanged_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_unchanged_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_unchanged_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_unchanged_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_unchanged_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_unchanged_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_unchanged_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_unchanged_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_unchanged_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_unchanged.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_unchanged_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_unchanged_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_unchanged_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_unchanged_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_unchanged_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_unchanged_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_unchanged_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_unchanged_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_unchanged_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_unchanged_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_unchanged.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_unchanged_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_unchanged_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_unchanged_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_unchanged_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_unchanged_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_unchanged_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_unchanged_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_unchanged_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_unchanged_L2_256B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_unchanged_L2_256B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_unchanged.L2::256B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_unchanged_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_unchanged_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_unchanged_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_unchanged_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_unchanged_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_unchanged.L2::cache_hint.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 880
 
 /*
 // ld.space.nc.L1::evict_first.b8 dest, [addr]; // PTX ISA 74, SM_70
@@ -11325,6 +3481,34 @@ _CCCL_DEVICE static inline _B8 ld_nc_L1_evict_first(space_global_t, const _B8* _
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_evict_first_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_nc_L1_evict_first_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_first_L2_256B(space_global_t, const _B8* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::evict_first.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -11360,6 +3544,34 @@ _CCCL_DEVICE static inline _B16 ld_nc_L1_evict_first(space_global_t, const _B16*
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_nc_L1_evict_first_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_first_L2_256B(space_global_t, const _B16* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.nc.L1::evict_first.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::evict_first.b32 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -11388,6 +3600,34 @@ _CCCL_DEVICE static inline _B32 ld_nc_L1_evict_first(space_global_t, const _B32*
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_nc_L1_evict_first_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_first_L2_256B(space_global_t, const _B32* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::evict_first.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::evict_first.b64 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -11409,6 +3649,34 @@ _CCCL_DEVICE static inline _B64 ld_nc_L1_evict_first(space_global_t, const _B64*
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_evict_first_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::evict_first.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_nc_L1_evict_first_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_first_L2_256B(space_global_t, const _B64* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.nc.L1::evict_first.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -11450,410 +3718,6 @@ _CCCL_DEVICE static inline _B128 ld_nc_L1_evict_first(space_global_t, const _B12
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.nc.L1::evict_first.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_first_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_first_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_first_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_first_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_first_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_first_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_first_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_first_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_first_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_first_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_first.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_first.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_first_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_first_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_first_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_first_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_first_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_first_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_first_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_first_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_first_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_first_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_first.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_first.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_first_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_first_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_first_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_first_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_first_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_first_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_first_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_first_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.nc.L1::evict_first.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -11888,6 +3752,37 @@ _CCCL_DEVICE static inline _B128 ld_nc_L1_evict_first_L2_256B(space_global_t, co
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.nc.L1::evict_first.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_nc_L1_evict_first(
+  cuda::ptx::space_global_t,
+  const B256* addr);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256 ld_nc_L1_evict_first(space_global_t, const _B256* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.nc.L1::evict_first.v4.b64 {%0, %1, %2, %3}, [%4];"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr))
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_first_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.nc.L1::evict_first.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -11914,6 +3809,39 @@ ld_nc_L1_evict_first_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8
+ld_nc_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -11954,6 +3882,39 @@ ld_nc_L1_evict_first_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VST
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16
+ld_nc_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
+      : "=h"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::evict_first.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -11987,6 +3948,39 @@ ld_nc_L1_evict_first_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VST
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32
+ld_nc_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::evict_first.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -12013,6 +4007,39 @@ ld_nc_L1_evict_first_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VST
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64
+ld_nc_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
+      : "=l"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -12056,474 +4083,6 @@ ld_nc_L1_evict_first_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VS
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_first_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_first_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_first_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_first_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_first_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_first_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_first_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_first_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_first_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_first_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_first_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_first_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_first_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_first_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_first_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_first_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_first_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.nc.L1::evict_first.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -12560,6 +4119,39 @@ ld_nc_L1_evict_first_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, 
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.nc.L1::evict_first.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_nc_L1_evict_first_L2_cache_hint(
+  cuda::ptx::space_global_t,
+  const B256* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256
+ld_nc_L1_evict_first_L2_cache_hint(space_global_t, const _B256* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.nc.L1::evict_first.L2::cache_hint.v4.b64 {%0, %1, %2, %3}, [%4], %5;"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_first_L2_cache_hint_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.nc.L1::evict_last.b8 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -12581,6 +4173,34 @@ _CCCL_DEVICE static inline _B8 ld_nc_L1_evict_last(space_global_t, const _B8* __
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_evict_last_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_nc_L1_evict_last_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_last_L2_256B(space_global_t, const _B8* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::evict_last.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -12616,6 +4236,34 @@ _CCCL_DEVICE static inline _B16 ld_nc_L1_evict_last(space_global_t, const _B16* 
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_nc_L1_evict_last_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_last_L2_256B(space_global_t, const _B16* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.nc.L1::evict_last.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::evict_last.b32 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -12644,6 +4292,34 @@ _CCCL_DEVICE static inline _B32 ld_nc_L1_evict_last(space_global_t, const _B32* 
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_nc_L1_evict_last_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_last_L2_256B(space_global_t, const _B32* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::evict_last.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::evict_last.b64 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -12665,6 +4341,34 @@ _CCCL_DEVICE static inline _B64 ld_nc_L1_evict_last(space_global_t, const _B64* 
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_evict_last_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::evict_last.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_nc_L1_evict_last_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_last_L2_256B(space_global_t, const _B64* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.nc.L1::evict_last.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -12706,410 +4410,6 @@ _CCCL_DEVICE static inline _B128 ld_nc_L1_evict_last(space_global_t, const _B128
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.nc.L1::evict_last.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_last_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_last_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_last_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_last_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_last_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_last_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_last_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_last_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_last_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_last_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_last.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_last.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_last_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_last_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_last_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_last_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_last_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_last_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_last_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_last_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_last_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_evict_last_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_last.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_last.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_last_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_evict_last_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_last_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_evict_last_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_last_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_evict_last_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_last_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_evict_last_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.nc.L1::evict_last.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -13144,6 +4444,37 @@ _CCCL_DEVICE static inline _B128 ld_nc_L1_evict_last_L2_256B(space_global_t, con
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.nc.L1::evict_last.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_nc_L1_evict_last(
+  cuda::ptx::space_global_t,
+  const B256* addr);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256 ld_nc_L1_evict_last(space_global_t, const _B256* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.nc.L1::evict_last.v4.b64 {%0, %1, %2, %3}, [%4];"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr))
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_last_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.nc.L1::evict_last.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -13170,6 +4501,39 @@ ld_nc_L1_evict_last_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD:
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8
+ld_nc_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -13210,6 +4574,39 @@ ld_nc_L1_evict_last_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VSTD
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16
+ld_nc_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
+      : "=h"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::evict_last.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -13243,6 +4640,39 @@ ld_nc_L1_evict_last_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VSTD
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32
+ld_nc_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::evict_last.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -13269,6 +4699,39 @@ ld_nc_L1_evict_last_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VSTD
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64
+ld_nc_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
+      : "=l"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -13312,474 +4775,6 @@ ld_nc_L1_evict_last_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VST
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_last_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_last_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_last_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_last_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_last_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_last_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_last_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_last_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_last_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_last_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_last_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_last_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_last_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_last_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_evict_last_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_evict_last_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_evict_last_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.nc.L1::evict_last.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -13816,6 +4811,39 @@ ld_nc_L1_evict_last_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, _
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.nc.L1::evict_last.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_nc_L1_evict_last_L2_cache_hint(
+  cuda::ptx::space_global_t,
+  const B256* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256
+ld_nc_L1_evict_last_L2_cache_hint(space_global_t, const _B256* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.nc.L1::evict_last.L2::cache_hint.v4.b64 {%0, %1, %2, %3}, [%4], %5;"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_evict_last_L2_cache_hint_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.nc.L1::no_allocate.b8 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -13837,6 +4865,34 @@ _CCCL_DEVICE static inline _B8 ld_nc_L1_no_allocate(space_global_t, const _B8* _
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_no_allocate_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_nc_L1_no_allocate_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8 ld_nc_L1_no_allocate_L2_256B(space_global_t, const _B8* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::no_allocate.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -13872,6 +4928,34 @@ _CCCL_DEVICE static inline _B16 ld_nc_L1_no_allocate(space_global_t, const _B16*
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_nc_L1_no_allocate_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16 ld_nc_L1_no_allocate_L2_256B(space_global_t, const _B16* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.nc.L1::no_allocate.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::no_allocate.b32 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -13900,6 +4984,34 @@ _CCCL_DEVICE static inline _B32 ld_nc_L1_no_allocate(space_global_t, const _B32*
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_nc_L1_no_allocate_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32 ld_nc_L1_no_allocate_L2_256B(space_global_t, const _B32* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::no_allocate.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::no_allocate.b64 dest, [addr]; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -13921,6 +5033,34 @@ _CCCL_DEVICE static inline _B64 ld_nc_L1_no_allocate(space_global_t, const _B64*
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_no_allocate_is_not_supported_before_SM_70__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::no_allocate.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_nc_L1_no_allocate_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64 ld_nc_L1_no_allocate_L2_256B(space_global_t, const _B64* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.nc.L1::no_allocate.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -13962,410 +5102,6 @@ _CCCL_DEVICE static inline _B128 ld_nc_L1_no_allocate(space_global_t, const _B12
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.nc.L1::no_allocate.L2::64B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_no_allocate_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_no_allocate_L2_64B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::64B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::64B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_no_allocate_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_no_allocate_L2_64B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::64B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::64B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_no_allocate_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_no_allocate_L2_64B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::64B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::64B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_no_allocate_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_no_allocate_L2_64B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::64B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::64B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_no_allocate_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_no_allocate_L2_64B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::no_allocate.L2::64B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_64B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::no_allocate.L2::128B.b8 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_no_allocate_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_no_allocate_L2_128B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::128B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::128B.b16 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_no_allocate_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_no_allocate_L2_128B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::128B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::128B.b32 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_no_allocate_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_no_allocate_L2_128B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::128B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::128B.b64 dest, [addr]; // PTX ISA 74, SM_75
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_no_allocate_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_no_allocate_L2_128B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::128B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::128B.b128 dest, [addr]; // PTX ISA 83, SM_75
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_no_allocate_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128 ld_nc_L1_no_allocate_L2_128B(space_global_t, const _B128* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 750
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::no_allocate.L2::128B.b128 B128_dest, [%2];\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr))
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_128B_is_not_supported_before_SM_75__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::no_allocate.L2::256B.b8 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_no_allocate_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8 ld_nc_L1_no_allocate_L2_256B(space_global_t, const _B8* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::256B.b8 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::256B.b16 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_no_allocate_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16 ld_nc_L1_no_allocate_L2_256B(space_global_t, const _B16* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::256B.b16 %0, [%1];" : "=h"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::256B.b32 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_no_allocate_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32 ld_nc_L1_no_allocate_L2_256B(space_global_t, const _B32* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::256B.b32 %0, [%1];" : "=r"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::256B.b64 dest, [addr]; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_no_allocate_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64 ld_nc_L1_no_allocate_L2_256B(space_global_t, const _B64* __addr)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::256B.b64 %0, [%1];" : "=l"(__dest) : "l"(__as_ptr_gmem(__addr)) : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.nc.L1::no_allocate.L2::256B.b128 dest, [addr]; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -14400,6 +5136,37 @@ _CCCL_DEVICE static inline _B128 ld_nc_L1_no_allocate_L2_256B(space_global_t, co
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// ld.space.nc.L1::no_allocate.v4.b64 dest, [addr]; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_nc_L1_no_allocate(
+  cuda::ptx::space_global_t,
+  const B256* addr);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256 ld_nc_L1_no_allocate(space_global_t, const _B256* __addr)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.nc.L1::no_allocate.v4.b64 {%0, %1, %2, %3}, [%4];"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr))
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_no_allocate_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // ld.space.nc.L1::no_allocate.L2::cache_hint.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -14426,6 +5193,39 @@ ld_nc_L1_no_allocate_L2_cache_hint(space_global_t, const _B8* __addr, _CUDA_VSTD
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B8*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
+__device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B8* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+_CCCL_DEVICE static inline _B8
+ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B8) == 1, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return __u32_as_b8<_B8>(__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint32_t __err_out_var = 0;
   return *reinterpret_cast<_B8*>(&__err_out_var);
 #  endif
@@ -14466,6 +5266,39 @@ ld_nc_L1_no_allocate_L2_cache_hint(space_global_t, const _B16* __addr, _CUDA_VST
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
+__device__ static inline B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B16* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
+_CCCL_DEVICE static inline _B16
+ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B16) == 2, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint16_t __dest;
+  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
+      : "=h"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B16*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint16_t __err_out_var = 0;
+  return *reinterpret_cast<_B16*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::no_allocate.L2::cache_hint.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
@@ -14499,6 +5332,39 @@ ld_nc_L1_no_allocate_L2_cache_hint(space_global_t, const _B32* __addr, _CUDA_VST
 #endif // __cccl_ptx_isa >= 740
 
 /*
+// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+__device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B32* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
+_CCCL_DEVICE static inline _B32
+ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B32) == 4, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint32_t __dest;
+  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
+      : "=r"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B32*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint32_t __err_out_var = 0;
+  return *reinterpret_cast<_B32*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
 // ld.space.nc.L1::no_allocate.L2::cache_hint.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
@@ -14525,6 +5391,39 @@ ld_nc_L1_no_allocate_L2_cache_hint(space_global_t, const _B64* __addr, _CUDA_VST
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
   __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_is_not_supported_before_SM_80__();
+  _CUDA_VSTD::uint64_t __err_out_var = 0;
+  return *reinterpret_cast<_B64*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 740
+
+/*
+// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
+// .space     = { .global }
+template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
+__device__ static inline B64 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
+  cuda::ptx::space_global_t,
+  const B64* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 740
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
+template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
+_CCCL_DEVICE static inline _B64
+ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B64) == 8, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
+  _CUDA_VSTD::uint64_t __dest;
+  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
+      : "=l"(__dest)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B64*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
   _CUDA_VSTD::uint64_t __err_out_var = 0;
   return *reinterpret_cast<_B64*>(&__err_out_var);
 #  endif
@@ -14568,474 +5467,6 @@ ld_nc_L1_no_allocate_L2_cache_hint(space_global_t, const _B128* __addr, _CUDA_VS
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_no_allocate_L2_cache_hint_L2_64B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_64B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline B128 ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(
-  cuda::ptx::space_global_t,
-  const B128* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline _B128
-ld_nc_L1_no_allocate_L2_cache_hint_L2_128B(space_global_t, const _B128* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  longlong2 __dest;
-  asm("{\n\t .reg .b128 B128_dest; \n\t"
-      "ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b128 B128_dest, [%2], %3;\n\t"
-      "mov.b128 {%0, %1}, B128_dest; \n"
-      "}"
-      : "=l"(__dest.x), "=l"(__dest.y)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B128*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_128B_is_not_supported_before_SM_80__();
-  longlong2 __err_out_var{0, 0};
-  return *reinterpret_cast<_B128*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline B8 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B8* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline _B8
-ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B8* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b8 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return __u32_as_b8<_B8>(__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B8*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline B16 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B16* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline _B16
-ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B16* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint16_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b16 %0, [%1], %2;"
-      : "=h"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B16*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint16_t __err_out_var = 0;
-  return *reinterpret_cast<_B16*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline B32 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B32* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline _B32
-ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B32* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint32_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b32 %0, [%1], %2;"
-      : "=r"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B32*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint32_t __err_out_var = 0;
-  return *reinterpret_cast<_B32*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline B64 ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(
-  cuda::ptx::space_global_t,
-  const B64* addr,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline _B64
-ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B64* __addr, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  _CUDA_VSTD::uint64_t __dest;
-  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b64 %0, [%1], %2;"
-      : "=l"(__dest)
-      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
-      : "memory");
-  return *reinterpret_cast<_B64*>(&__dest);
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_L2_256B_is_not_supported_before_SM_80__();
-  _CUDA_VSTD::uint64_t __err_out_var = 0;
-  return *reinterpret_cast<_B64*>(&__err_out_var);
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
 // ld.space.nc.L1::no_allocate.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy; // PTX ISA 83, SM_80
 // .space     = { .global }
 template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
@@ -15070,5 +5501,38 @@ ld_nc_L1_no_allocate_L2_cache_hint_L2_256B(space_global_t, const _B128* __addr, 
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
+
+/*
+// ld.space.nc.L1::no_allocate.L2::cache_hint.v4.b64 dest, [addr], cache_policy; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline B256 ld_nc_L1_no_allocate_L2_cache_hint(
+  cuda::ptx::space_global_t,
+  const B256* addr,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline _B256
+ld_nc_L1_no_allocate_L2_cache_hint(space_global_t, const _B256* __addr, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  longlong4 __dest;
+  asm("ld.global.nc.L1::no_allocate.L2::cache_hint.v4.b64 {%0, %1, %2, %3}, [%4], %5;"
+      : "=l"(__dest.x), "=l"(__dest.y), "=l"(__dest.z), "=l"(__dest.w)
+      : "l"(__as_ptr_gmem(__addr)), "l"(__cache_policy)
+      : "memory");
+  return *reinterpret_cast<_B256*>(&__dest);
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_ld_nc_L1_no_allocate_L2_cache_hint_is_not_supported_before_SM_100__();
+  longlong4 __err_out_var{0, 0, 0, 0};
+  return *reinterpret_cast<_B256*>(&__err_out_var);
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
 
 #endif // _CUDA_PTX_GENERATED_LD_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/st.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/st.h
@@ -146,6 +146,38 @@ _CCCL_DEVICE static inline void st(space_global_t, _B128* __addr, _B128 __src)
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// st.space.v4.b64 [addr], src; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline void st(
+  cuda::ptx::space_global_t,
+  B256* addr,
+  B256 src);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline void st(space_global_t, _B256* __addr, _B256 __src)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  asm("st.global.v4.b64 [%0], {%1, %2, %3, %4};"
+      :
+      : "l"(__as_ptr_gmem(__addr)),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).x),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).y),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).z),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).w)
+      : "memory");
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_st_is_not_supported_before_SM_100__();
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // st.space.L2::cache_hint.b8 [addr], src, cache_policy; // PTX ISA 74, SM_80
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -308,612 +340,39 @@ st_L2_cache_hint(space_global_t, _B128* __addr, _B128 __src, _CUDA_VSTD::uint64_
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// st.space.L1::evict_normal.b8 [addr], src; // PTX ISA 74, SM_70
+// st.space.L2::cache_hint.v4.b64 [addr], src, cache_policy; // PTX ISA 88, SM_100
 // .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline void st_L1_evict_normal(
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline void st_L2_cache_hint(
   cuda::ptx::space_global_t,
-  B8* addr,
-  B8 src);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_normal(space_global_t, _B8* __addr, _B8 __src)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  asm("st.global.L1::evict_normal.b8 [%0], %1;" : : "l"(__as_ptr_gmem(__addr)), "r"(__b8_as_u32(__src)) : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_normal_is_not_supported_before_SM_70__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_normal.b16 [addr], src; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline void st_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  B16* addr,
-  B16 src);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_normal(space_global_t, _B16* __addr, _B16 __src)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  asm("st.global.L1::evict_normal.b16 [%0], %1;"
-      :
-      : "l"(__as_ptr_gmem(__addr)), "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__src))
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_normal_is_not_supported_before_SM_70__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_normal.b32 [addr], src; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline void st_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  B32* addr,
-  B32 src);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_normal(space_global_t, _B32* __addr, _B32 __src)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  asm("st.global.L1::evict_normal.b32 [%0], %1;"
-      :
-      : "l"(__as_ptr_gmem(__addr)), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__src))
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_normal_is_not_supported_before_SM_70__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_normal.b64 [addr], src; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline void st_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  B64* addr,
-  B64 src);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_normal(space_global_t, _B64* __addr, _B64 __src)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  asm("st.global.L1::evict_normal.b64 [%0], %1;"
-      :
-      : "l"(__as_ptr_gmem(__addr)), "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__src))
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_normal_is_not_supported_before_SM_70__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_normal.b128 [addr], src; // PTX ISA 83, SM_70
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline void st_L1_evict_normal(
-  cuda::ptx::space_global_t,
-  B128* addr,
-  B128 src);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_normal_is_not_supported_before_SM_70__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_normal(space_global_t, _B128* __addr, _B128 __src)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  asm("{\n\t .reg .b128 B128_src; \n\t"
-      "mov.b128 B128_src, {%1, %2}; \n"
-      "st.global.L1::evict_normal.b128 [%0], B128_src;\n\t"
-      "}"
-      :
-      : "l"(__as_ptr_gmem(__addr)),
-        "l"((*reinterpret_cast<longlong2*>(&__src)).x),
-        "l"((*reinterpret_cast<longlong2*>(&__src)).y)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_normal_is_not_supported_before_SM_70__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// st.space.L1::evict_normal.L2::cache_hint.b8 [addr], src, cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline void st_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  B8* addr,
-  B8 src,
+  B256* addr,
+  B256 src,
   uint64_t cache_policy);
 */
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
 _CCCL_DEVICE static inline void
-st_L1_evict_normal_L2_cache_hint(space_global_t, _B8* __addr, _B8 __src, _CUDA_VSTD::uint64_t __cache_policy)
+st_L2_cache_hint(space_global_t, _B256* __addr, _B256 __src, _CUDA_VSTD::uint64_t __cache_policy)
 {
   // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  asm("st.global.L1::evict_normal.L2::cache_hint.b8 [%0], %1, %2;"
-      :
-      : "l"(__as_ptr_gmem(__addr)), "r"(__b8_as_u32(__src)), "l"(__cache_policy)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_normal.L2::cache_hint.b16 [addr], src, cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline void st_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  B16* addr,
-  B16 src,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void
-st_L1_evict_normal_L2_cache_hint(space_global_t, _B16* __addr, _B16 __src, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  asm("st.global.L1::evict_normal.L2::cache_hint.b16 [%0], %1, %2;"
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  asm("st.global.L2::cache_hint.v4.b64 [%0], {%1, %2, %3, %4}, %5;"
       :
       : "l"(__as_ptr_gmem(__addr)),
-        "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__src)),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).x),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).y),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).z),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).w),
         "l"(__cache_policy)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
+  __cuda_ptx_st_L2_cache_hint_is_not_supported_before_SM_100__();
 #  endif
 }
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_normal.L2::cache_hint.b32 [addr], src, cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline void st_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  B32* addr,
-  B32 src,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void
-st_L1_evict_normal_L2_cache_hint(space_global_t, _B32* __addr, _B32 __src, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  asm("st.global.L1::evict_normal.L2::cache_hint.b32 [%0], %1, %2;"
-      :
-      : "l"(__as_ptr_gmem(__addr)),
-        "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__src)),
-        "l"(__cache_policy)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_normal.L2::cache_hint.b64 [addr], src, cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline void st_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  B64* addr,
-  B64 src,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void
-st_L1_evict_normal_L2_cache_hint(space_global_t, _B64* __addr, _B64 __src, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  asm("st.global.L1::evict_normal.L2::cache_hint.b64 [%0], %1, %2;"
-      :
-      : "l"(__as_ptr_gmem(__addr)),
-        "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__src)),
-        "l"(__cache_policy)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_normal.L2::cache_hint.b128 [addr], src, cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline void st_L1_evict_normal_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  B128* addr,
-  B128 src,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void
-st_L1_evict_normal_L2_cache_hint(space_global_t, _B128* __addr, _B128 __src, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  asm("{\n\t .reg .b128 B128_src; \n\t"
-      "mov.b128 B128_src, {%1, %2}; \n"
-      "st.global.L1::evict_normal.L2::cache_hint.b128 [%0], B128_src, %3;\n\t"
-      "}"
-      :
-      : "l"(__as_ptr_gmem(__addr)),
-        "l"((*reinterpret_cast<longlong2*>(&__src)).x),
-        "l"((*reinterpret_cast<longlong2*>(&__src)).y),
-        "l"(__cache_policy)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_normal_L2_cache_hint_is_not_supported_before_SM_80__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// st.space.L1::evict_unchanged.b8 [addr], src; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline void st_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  B8* addr,
-  B8 src);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_unchanged(space_global_t, _B8* __addr, _B8 __src)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  asm("st.global.L1::evict_unchanged.b8 [%0], %1;" : : "l"(__as_ptr_gmem(__addr)), "r"(__b8_as_u32(__src)) : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_unchanged_is_not_supported_before_SM_70__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_unchanged.b16 [addr], src; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline void st_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  B16* addr,
-  B16 src);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_unchanged(space_global_t, _B16* __addr, _B16 __src)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  asm("st.global.L1::evict_unchanged.b16 [%0], %1;"
-      :
-      : "l"(__as_ptr_gmem(__addr)), "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__src))
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_unchanged_is_not_supported_before_SM_70__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_unchanged.b32 [addr], src; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline void st_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  B32* addr,
-  B32 src);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_unchanged(space_global_t, _B32* __addr, _B32 __src)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  asm("st.global.L1::evict_unchanged.b32 [%0], %1;"
-      :
-      : "l"(__as_ptr_gmem(__addr)), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__src))
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_unchanged_is_not_supported_before_SM_70__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_unchanged.b64 [addr], src; // PTX ISA 74, SM_70
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline void st_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  B64* addr,
-  B64 src);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_unchanged(space_global_t, _B64* __addr, _B64 __src)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  asm("st.global.L1::evict_unchanged.b64 [%0], %1;"
-      :
-      : "l"(__as_ptr_gmem(__addr)), "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__src))
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_unchanged_is_not_supported_before_SM_70__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_unchanged.b128 [addr], src; // PTX ISA 83, SM_70
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline void st_L1_evict_unchanged(
-  cuda::ptx::space_global_t,
-  B128* addr,
-  B128 src);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_unchanged_is_not_supported_before_SM_70__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void st_L1_evict_unchanged(space_global_t, _B128* __addr, _B128 __src)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 700
-  asm("{\n\t .reg .b128 B128_src; \n\t"
-      "mov.b128 B128_src, {%1, %2}; \n"
-      "st.global.L1::evict_unchanged.b128 [%0], B128_src;\n\t"
-      "}"
-      :
-      : "l"(__as_ptr_gmem(__addr)),
-        "l"((*reinterpret_cast<longlong2*>(&__src)).x),
-        "l"((*reinterpret_cast<longlong2*>(&__src)).y)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_unchanged_is_not_supported_before_SM_70__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
-
-/*
-// st.space.L1::evict_unchanged.L2::cache_hint.b8 [addr], src, cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
-__device__ static inline void st_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  B8* addr,
-  B8 src,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B8, _CUDA_VSTD::enable_if_t<sizeof(_B8) == 1, bool> = true>
-_CCCL_DEVICE static inline void
-st_L1_evict_unchanged_L2_cache_hint(space_global_t, _B8* __addr, _B8 __src, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B8) == 1, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  asm("st.global.L1::evict_unchanged.L2::cache_hint.b8 [%0], %1, %2;"
-      :
-      : "l"(__as_ptr_gmem(__addr)), "r"(__b8_as_u32(__src)), "l"(__cache_policy)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_unchanged.L2::cache_hint.b16 [addr], src, cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B16, enable_if_t<sizeof(B16) == 2, bool> = true>
-__device__ static inline void st_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  B16* addr,
-  B16 src,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B16, _CUDA_VSTD::enable_if_t<sizeof(_B16) == 2, bool> = true>
-_CCCL_DEVICE static inline void
-st_L1_evict_unchanged_L2_cache_hint(space_global_t, _B16* __addr, _B16 __src, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B16) == 2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  asm("st.global.L1::evict_unchanged.L2::cache_hint.b16 [%0], %1, %2;"
-      :
-      : "l"(__as_ptr_gmem(__addr)),
-        "h"(/*as_b16*/ *reinterpret_cast<const _CUDA_VSTD::int16_t*>(&__src)),
-        "l"(__cache_policy)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_unchanged.L2::cache_hint.b32 [addr], src, cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
-__device__ static inline void st_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  B32* addr,
-  B32 src,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
-_CCCL_DEVICE static inline void
-st_L1_evict_unchanged_L2_cache_hint(space_global_t, _B32* __addr, _B32 __src, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  asm("st.global.L1::evict_unchanged.L2::cache_hint.b32 [%0], %1, %2;"
-      :
-      : "l"(__as_ptr_gmem(__addr)),
-        "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__src)),
-        "l"(__cache_policy)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_unchanged.L2::cache_hint.b64 [addr], src, cache_policy; // PTX ISA 74, SM_80
-// .space     = { .global }
-template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
-__device__ static inline void st_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  B64* addr,
-  B64 src,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 740
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
-_CCCL_DEVICE static inline void
-st_L1_evict_unchanged_L2_cache_hint(space_global_t, _B64* __addr, _B64 __src, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B64) == 8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  asm("st.global.L1::evict_unchanged.L2::cache_hint.b64 [%0], %1, %2;"
-      :
-      : "l"(__as_ptr_gmem(__addr)),
-        "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__src)),
-        "l"(__cache_policy)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 740
-
-/*
-// st.space.L1::evict_unchanged.L2::cache_hint.b128 [addr], src, cache_policy; // PTX ISA 83, SM_80
-// .space     = { .global }
-template <typename B128, enable_if_t<sizeof(B128) == 16, bool> = true>
-__device__ static inline void st_L1_evict_unchanged_L2_cache_hint(
-  cuda::ptx::space_global_t,
-  B128* addr,
-  B128 src,
-  uint64_t cache_policy);
-*/
-#if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-template <typename _B128, _CUDA_VSTD::enable_if_t<sizeof(_B128) == 16, bool> = true>
-_CCCL_DEVICE static inline void
-st_L1_evict_unchanged_L2_cache_hint(space_global_t, _B128* __addr, _B128 __src, _CUDA_VSTD::uint64_t __cache_policy)
-{
-  // __space == space_global (due to parameter type constraint)
-  static_assert(sizeof(_B128) == 16, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 800
-  asm("{\n\t .reg .b128 B128_src; \n\t"
-      "mov.b128 B128_src, {%1, %2}; \n"
-      "st.global.L1::evict_unchanged.L2::cache_hint.b128 [%0], B128_src, %3;\n\t"
-      "}"
-      :
-      : "l"(__as_ptr_gmem(__addr)),
-        "l"((*reinterpret_cast<longlong2*>(&__src)).x),
-        "l"((*reinterpret_cast<longlong2*>(&__src)).y),
-        "l"(__cache_policy)
-      : "memory");
-#  else
-  // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_st_L1_evict_unchanged_L2_cache_hint_is_not_supported_before_SM_80__();
-#  endif
-}
-#endif // __cccl_ptx_isa >= 830
+#endif // __cccl_ptx_isa >= 880
 
 /*
 // st.space.L1::evict_first.b8 [addr], src; // PTX ISA 74, SM_70
@@ -1056,6 +515,38 @@ _CCCL_DEVICE static inline void st_L1_evict_first(space_global_t, _B128* __addr,
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
+
+/*
+// st.space.L1::evict_first.v4.b64 [addr], src; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline void st_L1_evict_first(
+  cuda::ptx::space_global_t,
+  B256* addr,
+  B256 src);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_first_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline void st_L1_evict_first(space_global_t, _B256* __addr, _B256 __src)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  asm("st.global.L1::evict_first.v4.b64 [%0], {%1, %2, %3, %4};"
+      :
+      : "l"(__as_ptr_gmem(__addr)),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).x),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).y),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).z),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).w)
+      : "memory");
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_st_L1_evict_first_is_not_supported_before_SM_100__();
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
 
 /*
 // st.space.L1::evict_first.L2::cache_hint.b8 [addr], src, cache_policy; // PTX ISA 74, SM_80
@@ -1220,6 +711,41 @@ st_L1_evict_first_L2_cache_hint(space_global_t, _B128* __addr, _B128 __src, _CUD
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// st.space.L1::evict_first.L2::cache_hint.v4.b64 [addr], src, cache_policy; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline void st_L1_evict_first_L2_cache_hint(
+  cuda::ptx::space_global_t,
+  B256* addr,
+  B256 src,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_first_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline void
+st_L1_evict_first_L2_cache_hint(space_global_t, _B256* __addr, _B256 __src, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  asm("st.global.L1::evict_first.L2::cache_hint.v4.b64 [%0], {%1, %2, %3, %4}, %5;"
+      :
+      : "l"(__as_ptr_gmem(__addr)),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).x),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).y),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).z),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).w),
+        "l"(__cache_policy)
+      : "memory");
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_st_L1_evict_first_L2_cache_hint_is_not_supported_before_SM_100__();
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // st.space.L1::evict_last.b8 [addr], src; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -1360,6 +886,38 @@ _CCCL_DEVICE static inline void st_L1_evict_last(space_global_t, _B128* __addr, 
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
+
+/*
+// st.space.L1::evict_last.v4.b64 [addr], src; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline void st_L1_evict_last(
+  cuda::ptx::space_global_t,
+  B256* addr,
+  B256 src);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_last_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline void st_L1_evict_last(space_global_t, _B256* __addr, _B256 __src)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  asm("st.global.L1::evict_last.v4.b64 [%0], {%1, %2, %3, %4};"
+      :
+      : "l"(__as_ptr_gmem(__addr)),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).x),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).y),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).z),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).w)
+      : "memory");
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_st_L1_evict_last_is_not_supported_before_SM_100__();
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
 
 /*
 // st.space.L1::evict_last.L2::cache_hint.b8 [addr], src, cache_policy; // PTX ISA 74, SM_80
@@ -1524,6 +1082,41 @@ st_L1_evict_last_L2_cache_hint(space_global_t, _B128* __addr, _B128 __src, _CUDA
 #endif // __cccl_ptx_isa >= 830
 
 /*
+// st.space.L1::evict_last.L2::cache_hint.v4.b64 [addr], src, cache_policy; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline void st_L1_evict_last_L2_cache_hint(
+  cuda::ptx::space_global_t,
+  B256* addr,
+  B256 src,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_evict_last_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline void
+st_L1_evict_last_L2_cache_hint(space_global_t, _B256* __addr, _B256 __src, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  asm("st.global.L1::evict_last.L2::cache_hint.v4.b64 [%0], {%1, %2, %3, %4}, %5;"
+      :
+      : "l"(__as_ptr_gmem(__addr)),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).x),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).y),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).z),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).w),
+        "l"(__cache_policy)
+      : "memory");
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_st_L1_evict_last_L2_cache_hint_is_not_supported_before_SM_100__();
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
+
+/*
 // st.space.L1::no_allocate.b8 [addr], src; // PTX ISA 74, SM_70
 // .space     = { .global }
 template <typename B8, enable_if_t<sizeof(B8) == 1, bool> = true>
@@ -1664,6 +1257,38 @@ _CCCL_DEVICE static inline void st_L1_no_allocate(space_global_t, _B128* __addr,
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
+
+/*
+// st.space.L1::no_allocate.v4.b64 [addr], src; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline void st_L1_no_allocate(
+  cuda::ptx::space_global_t,
+  B256* addr,
+  B256 src);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_no_allocate_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline void st_L1_no_allocate(space_global_t, _B256* __addr, _B256 __src)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  asm("st.global.L1::no_allocate.v4.b64 [%0], {%1, %2, %3, %4};"
+      :
+      : "l"(__as_ptr_gmem(__addr)),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).x),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).y),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).z),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).w)
+      : "memory");
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_st_L1_no_allocate_is_not_supported_before_SM_100__();
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
 
 /*
 // st.space.L1::no_allocate.L2::cache_hint.b8 [addr], src, cache_policy; // PTX ISA 74, SM_80
@@ -1826,5 +1451,40 @@ st_L1_no_allocate_L2_cache_hint(space_global_t, _B128* __addr, _B128 __src, _CUD
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
+
+/*
+// st.space.L1::no_allocate.L2::cache_hint.v4.b64 [addr], src, cache_policy; // PTX ISA 88, SM_100
+// .space     = { .global }
+template <typename B256, enable_if_t<sizeof(B256) == 32, bool> = true>
+__device__ static inline void st_L1_no_allocate_L2_cache_hint(
+  cuda::ptx::space_global_t,
+  B256* addr,
+  B256 src,
+  uint64_t cache_policy);
+*/
+#if __cccl_ptx_isa >= 880
+extern "C" _CCCL_DEVICE void __cuda_ptx_st_L1_no_allocate_L2_cache_hint_is_not_supported_before_SM_100__();
+template <typename _B256, _CUDA_VSTD::enable_if_t<sizeof(_B256) == 32, bool> = true>
+_CCCL_DEVICE static inline void
+st_L1_no_allocate_L2_cache_hint(space_global_t, _B256* __addr, _B256 __src, _CUDA_VSTD::uint64_t __cache_policy)
+{
+  // __space == space_global (due to parameter type constraint)
+  static_assert(sizeof(_B256) == 32, "");
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH__ >= 1000
+  asm("st.global.L1::no_allocate.L2::cache_hint.v4.b64 [%0], {%1, %2, %3, %4}, %5;"
+      :
+      : "l"(__as_ptr_gmem(__addr)),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).x),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).y),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).z),
+        "l"((*reinterpret_cast<longlong4*>(&__src)).w),
+        "l"(__cache_policy)
+      : "memory");
+#  else
+  // Unsupported architectures will have a linker error with a semi-decent error message
+  __cuda_ptx_st_L1_no_allocate_L2_cache_hint_is_not_supported_before_SM_100__();
+#  endif
+}
+#endif // __cccl_ptx_isa >= 880
 
 #endif // _CUDA_PTX_GENERATED_ST_H_

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_alloc.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_alloc.h
@@ -4,7 +4,7 @@
 #define _CUDA_PTX_GENERATED_TCGEN05_ALLOC_H_
 
 /*
-// tcgen05.alloc.cta_group.sync.aligned.shared::cta.b32 [dst], nCols; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.alloc.cta_group.sync.aligned.shared::cta.b32 [dst], nCols; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_alloc(
@@ -13,13 +13,13 @@ __device__ static inline void tcgen05_alloc(
   const uint32_t& nCols);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_alloc_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_alloc_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void
 tcgen05_alloc(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t* __dst, const _CUDA_VSTD::uint32_t& __nCols)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile("tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [%0], %1;"
@@ -36,13 +36,13 @@ tcgen05_alloc(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t* __dst, 
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_alloc_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_alloc_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.dealloc.cta_group.sync.aligned.b32 taddr, nCols; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.dealloc.cta_group.sync.aligned.b32 taddr, nCols; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_dealloc(
@@ -51,13 +51,13 @@ __device__ static inline void tcgen05_dealloc(
   const uint32_t& nCols);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_dealloc_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_dealloc_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void
 tcgen05_dealloc(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, const _CUDA_VSTD::uint32_t& __nCols)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile("tcgen05.dealloc.cta_group::1.sync.aligned.b32 %0, %1;" : : "r"(__taddr), "r"(__nCols) : "memory");
@@ -68,25 +68,25 @@ tcgen05_dealloc(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __tadd
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_dealloc_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_dealloc_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.relinquish_alloc_permit.cta_group.sync.aligned; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.relinquish_alloc_permit.cta_group.sync.aligned; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_relinquish_alloc_permit(
   cuda::ptx::cta_group_t<Cta_Group> cta_group);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_relinquish_alloc_permit_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_relinquish_alloc_permit_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_relinquish_alloc_permit(cta_group_t<_Cta_Group> __cta_group)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile("tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;" : : : "memory");
@@ -97,7 +97,7 @@ _CCCL_DEVICE static inline void tcgen05_relinquish_alloc_permit(cta_group_t<_Cta
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_relinquish_alloc_permit_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_relinquish_alloc_permit_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_commit.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_commit.h
@@ -4,7 +4,7 @@
 #define _CUDA_PTX_GENERATED_TCGEN05_COMMIT_H_
 
 /*
-// tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.b64 [smem_bar]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.b64 [smem_bar]; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_commit(
@@ -12,12 +12,12 @@ __device__ static inline void tcgen05_commit(
   uint64_t* smem_bar);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_commit_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_commit_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_commit(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint64_t* __smem_bar)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile("tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [%0];"
@@ -34,14 +34,14 @@ _CCCL_DEVICE static inline void tcgen05_commit(cta_group_t<_Cta_Group> __cta_gro
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_commit_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_commit_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.commit.cta_group.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64 [smem_bar], ctaMask; // PTX ISA
-86, SM_100a, SM_101a
+86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_commit_multicast(
@@ -50,13 +50,13 @@ __device__ static inline void tcgen05_commit_multicast(
   uint16_t ctaMask);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_commit_multicast_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_commit_multicast_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_commit_multicast(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint64_t* __smem_bar, _CUDA_VSTD::uint16_t __ctaMask)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile("tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64 [%0], %1;"
@@ -73,7 +73,7 @@ _CCCL_DEVICE static inline void tcgen05_commit_multicast(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_commit_multicast_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_commit_multicast_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_cp.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_cp.h
@@ -4,7 +4,7 @@
 #define _CUDA_PTX_GENERATED_TCGEN05_CP_H_
 
 /*
-// tcgen05.cp.cta_group.128x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.128x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_128x256b(
@@ -13,13 +13,13 @@ __device__ static inline void tcgen05_cp_128x256b(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void
 tcgen05_cp_128x256b(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.128x256b [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -30,13 +30,13 @@ tcgen05_cp_128x256b(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_128x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_128x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.4x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.4x256b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_4x256b(
@@ -45,13 +45,13 @@ __device__ static inline void tcgen05_cp_4x256b(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_4x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_4x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void
 tcgen05_cp_4x256b(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.4x256b [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -62,13 +62,13 @@ tcgen05_cp_4x256b(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __ta
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_4x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_4x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.128x128b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.128x128b [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_128x128b(
@@ -77,13 +77,13 @@ __device__ static inline void tcgen05_cp_128x128b(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void
 tcgen05_cp_128x128b(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.128x128b [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -94,13 +94,13 @@ tcgen05_cp_128x128b(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_128x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_128x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.64x128b.warpx2::02_13 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.64x128b.warpx2::02_13 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13(
@@ -109,13 +109,13 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_02_13(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -126,13 +126,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_02_13(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.64x128b.warpx2::01_23 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.64x128b.warpx2::01_23 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23(
@@ -141,13 +141,13 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_01_23(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -158,13 +158,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_01_23(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.32x128b.warpx4 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.32x128b.warpx4 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_32x128b_warpx4(
@@ -173,13 +173,13 @@ __device__ static inline void tcgen05_cp_32x128b_warpx4(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_32x128b_warpx4_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_32x128b_warpx4_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_32x128b_warpx4(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.32x128b.warpx4 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -190,13 +190,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_32x128b_warpx4(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_32x128b_warpx4_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_32x128b_warpx4_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.128x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.128x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_128x256b_b8x16_b6x16_p32(
@@ -205,13 +205,13 @@ __device__ static inline void tcgen05_cp_128x256b_b8x16_b6x16_p32(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x256b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x256b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_128x256b_b8x16_b6x16_p32(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -222,13 +222,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_128x256b_b8x16_b6x16_p32(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_128x256b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_128x256b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.4x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.4x256b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_4x256b_b8x16_b6x16_p32(
@@ -237,13 +237,13 @@ __device__ static inline void tcgen05_cp_4x256b_b8x16_b6x16_p32(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_4x256b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_4x256b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_4x256b_b8x16_b6x16_p32(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -254,13 +254,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_4x256b_b8x16_b6x16_p32(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_4x256b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_4x256b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.128x128b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.128x128b.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_128x128b_b8x16_b6x16_p32(
@@ -269,13 +269,13 @@ __device__ static inline void tcgen05_cp_128x128b_b8x16_b6x16_p32(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x128b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x128b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_128x128b_b8x16_b6x16_p32(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -286,13 +286,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_128x128b_b8x16_b6x16_p32(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_128x128b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_128x128b_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32(
@@ -302,13 +302,13 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [%0], %1;"
@@ -325,13 +325,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32(
@@ -341,13 +341,13 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [%0], %1;"
@@ -364,13 +364,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32(
@@ -380,13 +380,13 @@ __device__ static inline void tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -397,13 +397,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.128x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.128x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_128x256b_b8x16_b4x16_p64(
@@ -412,13 +412,13 @@ __device__ static inline void tcgen05_cp_128x256b_b8x16_b4x16_p64(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x256b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x256b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_128x256b_b8x16_b4x16_p64(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -429,13 +429,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_128x256b_b8x16_b4x16_p64(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_128x256b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_128x256b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.4x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.4x256b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_4x256b_b8x16_b4x16_p64(
@@ -444,13 +444,13 @@ __device__ static inline void tcgen05_cp_4x256b_b8x16_b4x16_p64(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_4x256b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_4x256b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_4x256b_b8x16_b4x16_p64(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -461,13 +461,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_4x256b_b8x16_b4x16_p64(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_4x256b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_4x256b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.128x128b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.128x128b.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_128x128b_b8x16_b4x16_p64(
@@ -476,13 +476,13 @@ __device__ static inline void tcgen05_cp_128x128b_b8x16_b4x16_p64(
   uint64_t s_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x128b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_cp_128x128b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_128x128b_b8x16_b4x16_p64(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -493,13 +493,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_128x128b_b8x16_b4x16_p64(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_128x128b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_128x128b_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64(
@@ -509,13 +509,13 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [%0], %1;"
@@ -532,13 +532,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64(
@@ -548,13 +548,13 @@ __device__ static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [%0], %1;"
@@ -571,13 +571,13 @@ _CCCL_DEVICE static inline void tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.cp.cta_group.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64(
@@ -587,13 +587,13 @@ __device__ static inline void tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64(
   cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr, _CUDA_VSTD::uint64_t __s_desc)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm("tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [%0], %1;" : : "r"(__taddr), "l"(__s_desc) : "memory");
@@ -604,7 +604,7 @@ _CCCL_DEVICE static inline void tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_fence.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_fence.h
@@ -4,39 +4,39 @@
 #define _CUDA_PTX_GENERATED_TCGEN05_FENCE_H_
 
 /*
-// tcgen05.fence::before_thread_sync; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.fence::before_thread_sync; // PTX ISA 86, SM_100a, SM_110a
 template <typename = void>
 __device__ static inline void tcgen05_fence_before_thread_sync();
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_fence_before_thread_sync_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_fence_before_thread_sync_is_not_supported_before_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void tcgen05_fence_before_thread_sync()
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm volatile("tcgen05.fence::before_thread_sync;" : : : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_fence_before_thread_sync_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_fence_before_thread_sync_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.fence::after_thread_sync; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.fence::after_thread_sync; // PTX ISA 86, SM_100a, SM_110a
 template <typename = void>
 __device__ static inline void tcgen05_fence_after_thread_sync();
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_fence_after_thread_sync_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_fence_after_thread_sync_is_not_supported_before_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void tcgen05_fence_after_thread_sync()
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm volatile("tcgen05.fence::after_thread_sync;" : : : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_fence_after_thread_sync_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_fence_after_thread_sync_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_ld.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_ld.h
@@ -4,163 +4,163 @@
 #define _CUDA_PTX_GENERATED_TCGEN05_LD_H_
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b(
   B32 (&out)[1],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[1], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x64b.x1.b32 {%0}, [%1];" : "=r"(__out[0]) : "r"(__taddr) : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b_pack_16b(
   B32 (&out)[1],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[1], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x64b.x1.pack::16b.b32 {%0}, [%1];" : "=r"(__out[0]) : "r"(__taddr) : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b(
   B32 (&out)[2],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[2], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x64b.x2.b32 {%0, %1}, [%2];"
       : "=r"(__out[0]), "=r"(__out[1])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b_pack_16b(
   B32 (&out)[2],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[2], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x64b.x2.pack::16b.b32 {%0, %1}, [%2];"
       : "=r"(__out[0]), "=r"(__out[1])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b(
   B32 (&out)[4],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[4], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x64b.x4.b32 {%0, %1, %2, %3}, [%4];"
       : "=r"(__out[0]), "=r"(__out[1]), "=r"(__out[2]), "=r"(__out[3])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b_pack_16b(
   B32 (&out)[4],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[4], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x64b.x4.pack::16b.b32 {%0, %1, %2, %3}, [%4];"
       : "=r"(__out[0]), "=r"(__out[1]), "=r"(__out[2]), "=r"(__out[3])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b(
   B32 (&out)[8],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x64b.x8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
       : "=r"(__out[0]),
         "=r"(__out[1]),
@@ -174,25 +174,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[8], _CUDA_VSTD::
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b_pack_16b(
   B32 (&out)[8],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x64b.x8.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
       : "=r"(__out[0]),
         "=r"(__out[1]),
@@ -206,25 +206,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[8], _CU
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b(
   B32 (&out)[16],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x64b.x16.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, "
       "[%16];"
       : "=r"(__out[0]),
@@ -247,25 +247,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[16], _CUDA_VSTD:
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b_pack_16b(
   B32 (&out)[16],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x64b.x16.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
       "%14, %15}, [%16];"
       : "=r"(__out[0]),
@@ -288,25 +288,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[16], _C
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b(
   B32 (&out)[32],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x64b.x32.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
@@ -346,25 +346,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[32], _CUDA_VSTD:
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b_pack_16b(
   B32 (&out)[32],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x64b.x32.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
@@ -404,25 +404,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[32], _C
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b(
   B32 (&out)[64],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x64b.x64.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -496,25 +496,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[64], _CUDA_VSTD:
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b_pack_16b(
   B32 (&out)[64],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x64b.x64.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -588,25 +588,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[64], _C
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x128.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x128.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b(
   B32 (&out)[128],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x64b.x128.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -747,25 +747,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x64b(_B32 (&__out)[128], _CUDA_VSTD
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x64b.x128.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x64b.x128.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x64b_pack_16b(
   B32 (&out)[128],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x64b.x128.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -906,125 +906,125 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x64b_pack_16b(_B32 (&__out)[128], _
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x64b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b(
   B32 (&out)[2],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[2], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x128b.x1.b32 {%0, %1}, [%2];"
       : "=r"(__out[0]), "=r"(__out[1])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b_pack_16b(
   B32 (&out)[2],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[2], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x128b.x1.pack::16b.b32 {%0, %1}, [%2];"
       : "=r"(__out[0]), "=r"(__out[1])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b(
   B32 (&out)[4],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[4], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x128b.x2.b32 {%0, %1, %2, %3}, [%4];"
       : "=r"(__out[0]), "=r"(__out[1]), "=r"(__out[2]), "=r"(__out[3])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b_pack_16b(
   B32 (&out)[4],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[4], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x128b.x2.pack::16b.b32 {%0, %1, %2, %3}, [%4];"
       : "=r"(__out[0]), "=r"(__out[1]), "=r"(__out[2]), "=r"(__out[3])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b(
   B32 (&out)[8],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x128b.x4.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
       : "=r"(__out[0]),
         "=r"(__out[1]),
@@ -1038,25 +1038,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[8], _CUDA_VSTD:
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b_pack_16b(
   B32 (&out)[8],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x128b.x4.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
       : "=r"(__out[0]),
         "=r"(__out[1]),
@@ -1070,25 +1070,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[8], _C
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b(
   B32 (&out)[16],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x128b.x8.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, "
       "[%16];"
       : "=r"(__out[0]),
@@ -1111,25 +1111,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[16], _CUDA_VSTD
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b_pack_16b(
   B32 (&out)[16],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x128b.x8.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
       "%14, %15}, [%16];"
       : "=r"(__out[0]),
@@ -1152,25 +1152,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[16], _
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b(
   B32 (&out)[32],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x128b.x16.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
@@ -1210,25 +1210,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[32], _CUDA_VSTD
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b_pack_16b(
   B32 (&out)[32],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x128b.x16.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
@@ -1268,25 +1268,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[32], _
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b(
   B32 (&out)[64],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x128b.x32.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -1360,25 +1360,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[64], _CUDA_VSTD
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b_pack_16b(
   B32 (&out)[64],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x128b.x32.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -1452,25 +1452,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[64], _
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b(
   B32 (&out)[128],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x128b.x64.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -1611,25 +1611,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x128b(_B32 (&__out)[128], _CUDA_VST
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x128b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x128b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x128b_pack_16b(
   B32 (&out)[128],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x128b.x64.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -1770,75 +1770,75 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x128b_pack_16b(_B32 (&__out)[128], 
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x128b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b(
   B32 (&out)[4],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[4], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x256b.x1.b32 {%0, %1, %2, %3}, [%4];"
       : "=r"(__out[0]), "=r"(__out[1]), "=r"(__out[2]), "=r"(__out[3])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b_pack_16b(
   B32 (&out)[4],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[4], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x256b.x1.pack::16b.b32 {%0, %1, %2, %3}, [%4];"
       : "=r"(__out[0]), "=r"(__out[1]), "=r"(__out[2]), "=r"(__out[3])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b(
   B32 (&out)[8],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x256b.x2.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
       : "=r"(__out[0]),
         "=r"(__out[1]),
@@ -1852,25 +1852,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[8], _CUDA_VSTD:
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b_pack_16b(
   B32 (&out)[8],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x256b.x2.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
       : "=r"(__out[0]),
         "=r"(__out[1]),
@@ -1884,25 +1884,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[8], _C
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b(
   B32 (&out)[16],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x256b.x4.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, "
       "[%16];"
       : "=r"(__out[0]),
@@ -1925,25 +1925,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[16], _CUDA_VSTD
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b_pack_16b(
   B32 (&out)[16],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x256b.x4.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
       "%14, %15}, [%16];"
       : "=r"(__out[0]),
@@ -1966,25 +1966,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[16], _
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b(
   B32 (&out)[32],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x256b.x8.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
@@ -2024,25 +2024,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[32], _CUDA_VSTD
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b_pack_16b(
   B32 (&out)[32],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x256b.x8.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
@@ -2082,25 +2082,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[32], _
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b(
   B32 (&out)[64],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x256b.x16.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -2174,25 +2174,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[64], _CUDA_VSTD
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b_pack_16b(
   B32 (&out)[64],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x256b.x16.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -2266,25 +2266,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[64], _
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b(
   B32 (&out)[128],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x256b.x32.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -2425,25 +2425,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x256b(_B32 (&__out)[128], _CUDA_VST
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x256b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x256b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_16x256b_pack_16b(
   B32 (&out)[128],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x256b.x32.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -2584,169 +2584,169 @@ _CCCL_DEVICE static inline void tcgen05_ld_16x256b_pack_16b(_B32 (&__out)[128], 
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x256b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x1.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b(
   B32 (&out)[1],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[1], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.32x32b.x1.b32 {%0}, [%1];" : "=r"(__out[0]) : "r"(__taddr) : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x1.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b_pack_16b(
   B32 (&out)[1],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[1], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.32x32b.x1.pack::16b.b32 {%0}, [%1];" : "=r"(__out[0]) : "r"(__taddr) : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x2.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b(
   B32 (&out)[2],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[2], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.32x32b.x2.b32 {%0, %1}, [%2];"
       : "=r"(__out[0]), "=r"(__out[1])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x2.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b_pack_16b(
   B32 (&out)[2],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[2], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.32x32b.x2.pack::16b.b32 {%0, %1}, [%2];"
       : "=r"(__out[0]), "=r"(__out[1])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x4.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b(
   B32 (&out)[4],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[4], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.32x32b.x4.b32 {%0, %1, %2, %3}, [%4];"
       : "=r"(__out[0]), "=r"(__out[1]), "=r"(__out[2]), "=r"(__out[3])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x4.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b_pack_16b(
   B32 (&out)[4],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[4], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.32x32b.x4.pack::16b.b32 {%0, %1, %2, %3}, [%4];"
       : "=r"(__out[0]), "=r"(__out[1]), "=r"(__out[2]), "=r"(__out[3])
       : "r"(__taddr)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x8.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b(
   B32 (&out)[8],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.32x32b.x8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
       : "=r"(__out[0]),
         "=r"(__out[1]),
@@ -2760,25 +2760,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[8], _CUDA_VSTD::
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x8.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b_pack_16b(
   B32 (&out)[8],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.32x32b.x8.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
       : "=r"(__out[0]),
         "=r"(__out[1]),
@@ -2792,25 +2792,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[8], _CU
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x16.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b(
   B32 (&out)[16],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.32x32b.x16.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15}, "
       "[%16];"
       : "=r"(__out[0]),
@@ -2833,25 +2833,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[16], _CUDA_VSTD:
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x16.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b_pack_16b(
   B32 (&out)[16],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.32x32b.x16.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
       "%14, %15}, [%16];"
       : "=r"(__out[0]),
@@ -2874,25 +2874,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[16], _C
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x32.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b(
   B32 (&out)[32],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.32x32b.x32.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
@@ -2932,25 +2932,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[32], _CUDA_VSTD:
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x32.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b_pack_16b(
   B32 (&out)[32],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.32x32b.x32.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32];"
@@ -2990,25 +2990,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[32], _C
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x64.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b(
   B32 (&out)[64],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.32x32b.x64.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -3082,25 +3082,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[64], _CUDA_VSTD:
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x64.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b_pack_16b(
   B32 (&out)[64],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.32x32b.x64.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -3174,25 +3174,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[64], _C
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x128.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x128.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b(
   B32 (&out)[128],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.32x32b.x128.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -3333,25 +3333,25 @@ _CCCL_DEVICE static inline void tcgen05_ld_32x32b(_B32 (&__out)[128], _CUDA_VSTD
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.32x32b.x128.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.32x32b.x128.pack::16b.b32 out, [taddr]; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_ld_32x32b_pack_16b(
   B32 (&out)[128],
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.32x32b.x128.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -3492,13 +3492,13 @@ _CCCL_DEVICE static inline void tcgen05_ld_32x32b_pack_16b(_B32 (&__out)[128], _
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_32x32b_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x1.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x1.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2(
   B32 (&out)[1],
@@ -3506,26 +3506,26 @@ __device__ static inline void tcgen05_ld_16x32bx2(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2(_B32 (&__out)[1], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x32bx2.x1.b32 {%0}, [%1], %2;"
       : "=r"(__out[0])
       : "r"(__taddr), "n"(__immHalfSplitoff.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x1.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x1.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   B32 (&out)[1],
@@ -3533,26 +3533,26 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[1], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x32bx2.x1.pack::16b.b32 {%0}, [%1], %2;"
       : "=r"(__out[0])
       : "r"(__taddr), "n"(__immHalfSplitoff.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x2.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x2.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2(
   B32 (&out)[2],
@@ -3560,26 +3560,26 @@ __device__ static inline void tcgen05_ld_16x32bx2(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2(_B32 (&__out)[2], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x32bx2.x2.b32 {%0, %1}, [%2], %3;"
       : "=r"(__out[0]), "=r"(__out[1])
       : "r"(__taddr), "n"(__immHalfSplitoff.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x2.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x2.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   B32 (&out)[2],
@@ -3587,26 +3587,26 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[2], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x32bx2.x2.pack::16b.b32 {%0, %1}, [%2], %3;"
       : "=r"(__out[0]), "=r"(__out[1])
       : "r"(__taddr), "n"(__immHalfSplitoff.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x4.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x4.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2(
   B32 (&out)[4],
@@ -3614,26 +3614,26 @@ __device__ static inline void tcgen05_ld_16x32bx2(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2(_B32 (&__out)[4], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x32bx2.x4.b32 {%0, %1, %2, %3}, [%4], %5;"
       : "=r"(__out[0]), "=r"(__out[1]), "=r"(__out[2]), "=r"(__out[3])
       : "r"(__taddr), "n"(__immHalfSplitoff.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x4.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x4.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   B32 (&out)[4],
@@ -3641,26 +3641,26 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[4], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x32bx2.x4.pack::16b.b32 {%0, %1, %2, %3}, [%4], %5;"
       : "=r"(__out[0]), "=r"(__out[1]), "=r"(__out[2]), "=r"(__out[3])
       : "r"(__taddr), "n"(__immHalfSplitoff.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x8.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x8.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2(
   B32 (&out)[8],
@@ -3668,13 +3668,13 @@ __device__ static inline void tcgen05_ld_16x32bx2(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x32bx2.x8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8], %9;"
       : "=r"(__out[0]),
         "=r"(__out[1]),
@@ -3688,13 +3688,13 @@ tcgen05_ld_16x32bx2(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> 
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x8.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x8.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   B32 (&out)[8],
@@ -3702,13 +3702,13 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x32bx2.x8.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8], %9;"
       : "=r"(__out[0]),
         "=r"(__out[1]),
@@ -3722,13 +3722,13 @@ tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[8], _CUDA_VSTD::uint32_t __taddr, n32
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x16.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x16.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2(
   B32 (&out)[16],
@@ -3736,13 +3736,13 @@ __device__ static inline void tcgen05_ld_16x32bx2(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x32bx2.x16.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, "
       "%15}, [%16], %17;"
       : "=r"(__out[0]),
@@ -3765,13 +3765,13 @@ tcgen05_ld_16x32bx2(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32>
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x16.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x16.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   B32 (&out)[16],
@@ -3779,13 +3779,13 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.ld.sync.aligned.16x32bx2.x16.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
       "%14, %15}, [%16], %17;"
       : "=r"(__out[0]),
@@ -3808,13 +3808,13 @@ tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[16], _CUDA_VSTD::uint32_t __taddr, n3
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x32.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x32.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2(
   B32 (&out)[32],
@@ -3822,13 +3822,13 @@ __device__ static inline void tcgen05_ld_16x32bx2(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x32bx2.x32.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32], %33;"
@@ -3868,13 +3868,13 @@ tcgen05_ld_16x32bx2(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32>
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x32.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x32.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   B32 (&out)[32],
@@ -3882,13 +3882,13 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x32bx2.x32.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31}, [%32], %33;"
@@ -3928,13 +3928,13 @@ tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[32], _CUDA_VSTD::uint32_t __taddr, n3
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x64.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x64.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2(
   B32 (&out)[64],
@@ -3942,13 +3942,13 @@ __device__ static inline void tcgen05_ld_16x32bx2(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x32bx2.x64.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -4022,13 +4022,13 @@ tcgen05_ld_16x32bx2(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32>
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x64.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x64.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   B32 (&out)[64],
@@ -4036,13 +4036,13 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x32bx2.x64.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -4116,13 +4116,13 @@ tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[64], _CUDA_VSTD::uint32_t __taddr, n3
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x128.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x128.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2(
   B32 (&out)[128],
@@ -4130,13 +4130,13 @@ __device__ static inline void tcgen05_ld_16x32bx2(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x32bx2.x128.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -4277,13 +4277,13 @@ tcgen05_ld_16x32bx2(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.ld.sync.aligned.16x32bx2.x128.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.ld.sync.aligned.16x32bx2.x128.pack::16b.b32 out, [taddr], immHalfSplitoff; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true, int N32>
 __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   B32 (&out)[128],
@@ -4291,13 +4291,13 @@ __device__ static inline void tcgen05_ld_16x32bx2_pack_16b(
   cuda::ptx::n32_t<N32> immHalfSplitoff);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true, int _N32>
 _CCCL_DEVICE static inline void
 tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff)
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.ld.sync.aligned.16x32bx2.x128.pack::16b.b32 {%0, %1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -4438,7 +4438,7 @@ tcgen05_ld_16x32bx2_pack_16b(_B32 (&__out)[128], _CUDA_VSTD::uint32_t __taddr, n
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_ld_16x32bx2_pack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma.h
@@ -177,7 +177,7 @@ _CCCL_DEVICE static inline void tcgen05_mma(
 
 /*
 // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 // .cta_group = { .cta_group::1 }
 template <cuda::ptx::dot_kind Kind>
@@ -192,7 +192,7 @@ __device__ static inline void tcgen05_mma(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma(
   kind_t<_Kind> __kind,
@@ -206,7 +206,7 @@ _CCCL_DEVICE static inline void tcgen05_mma(
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
 // __cta_group == cta_group_1 (due to parameter type constraint)
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -285,14 +285,14 @@ _CCCL_DEVICE static inline void tcgen05_mma(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 // .cta_group = { .cta_group::2 }
 template <cuda::ptx::dot_kind Kind>
@@ -307,7 +307,7 @@ __device__ static inline void tcgen05_mma(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma(
   kind_t<_Kind> __kind,
@@ -321,7 +321,7 @@ _CCCL_DEVICE static inline void tcgen05_mma(
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
 // __cta_group == cta_group_2 (due to parameter type constraint)
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -419,7 +419,7 @@ _CCCL_DEVICE static inline void tcgen05_mma(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
@@ -527,7 +527,7 @@ _CCCL_DEVICE static inline void tcgen05_mma(
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -541,7 +541,7 @@ __device__ static inline void tcgen05_mma(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma(
   kind_t<_Kind> __kind,
@@ -554,7 +554,7 @@ _CCCL_DEVICE static inline void tcgen05_mma(
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -677,7 +677,7 @@ _CCCL_DEVICE static inline void tcgen05_mma(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
@@ -856,7 +856,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
 
 /*
 // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 // .cta_group = { .cta_group::1 }
 template <cuda::ptx::dot_kind Kind>
@@ -871,7 +871,7 @@ __device__ static inline void tcgen05_mma_tmem_a(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
   kind_t<_Kind> __kind,
@@ -885,7 +885,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
 // __cta_group == cta_group_1 (due to parameter type constraint)
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -964,14 +964,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 // .cta_group = { .cta_group::2 }
 template <cuda::ptx::dot_kind Kind>
@@ -986,7 +986,7 @@ __device__ static inline void tcgen05_mma_tmem_a(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
   kind_t<_Kind> __kind,
@@ -1000,7 +1000,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
 // __cta_group == cta_group_2 (due to parameter type constraint)
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1099,7 +1099,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
@@ -1207,7 +1207,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.mma.cta_group.kind [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1221,7 +1221,7 @@ __device__ static inline void tcgen05_mma_tmem_a(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
   kind_t<_Kind> __kind,
@@ -1234,7 +1234,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
 {
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -1357,14 +1357,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_tmem_a(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1380,7 +1380,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_1x_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x(
   kind_mxf8f6f4_t,
@@ -1395,7 +1395,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x(
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -1434,14 +1434,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1457,7 +1457,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2x_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2x_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x(
   kind_t<_Kind> __kind,
@@ -1472,7 +1472,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x(
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -1547,14 +1547,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1570,7 +1570,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_4x_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x(
   kind_mxf4nvf4_t,
@@ -1585,7 +1585,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x(
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -1624,14 +1624,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1648,7 +1648,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a(
   kind_mxf8f6f4_t,
@@ -1663,7 +1663,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a(
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -1702,14 +1702,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1725,7 +1725,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a(
   kind_t<_Kind> __kind,
@@ -1740,7 +1740,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a(
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -1815,14 +1815,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem], [scale_B_tmem],
-enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1839,7 +1839,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a(
   kind_mxf4nvf4_t,
@@ -1854,7 +1854,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a(
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -1893,14 +1893,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -1917,7 +1917,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_fill(
   kind_mxf8f6f4_t,
@@ -1932,7 +1932,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_fill(
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -1971,14 +1971,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -1995,7 +1995,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_fill(
   kind_t<_Kind> __kind,
@@ -2010,7 +2010,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_fill(
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -2085,14 +2085,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2109,7 +2109,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_fill(
   kind_mxf4nvf4_t,
@@ -2124,7 +2124,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_fill(
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -2163,14 +2163,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2187,7 +2187,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill(
   kind_mxf8f6f4_t,
@@ -2202,7 +2202,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -2241,14 +2241,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2265,7 +2265,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_f
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill(
   kind_t<_Kind> __kind,
@@ -2280,7 +2280,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -2355,14 +2355,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2379,7 +2379,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill(
   kind_mxf4nvf4_t,
@@ -2394,7 +2394,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -2433,14 +2433,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2457,7 +2457,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_use(
   kind_mxf8f6f4_t,
@@ -2472,7 +2472,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_use(
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -2511,14 +2511,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2535,7 +2535,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_use(
   kind_t<_Kind> __kind,
@@ -2550,7 +2550,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_use(
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -2625,14 +2625,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2649,7 +2649,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_use(
   kind_mxf4nvf4_t,
@@ -2664,7 +2664,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_use(
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -2703,14 +2703,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2727,7 +2727,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use(
   kind_mxf8f6f4_t,
@@ -2742,7 +2742,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -2781,14 +2781,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -2805,7 +2805,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_u
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use(
   kind_t<_Kind> __kind,
@@ -2820,7 +2820,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -2895,14 +2895,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2919,7 +2919,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use(
   kind_mxf4nvf4_t,
@@ -2934,7 +2934,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -2973,14 +2973,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -2997,7 +2997,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_lastuse
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_lastuse(
   kind_mxf8f6f4_t,
@@ -3012,7 +3012,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_lastu
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -3051,14 +3051,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_lastu
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -3075,7 +3075,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_lastuse
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_lastuse(
   kind_t<_Kind> __kind,
@@ -3090,7 +3090,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_lastu
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -3165,14 +3165,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_lastu
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3189,7 +3189,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_lastuse
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_lastuse(
   kind_mxf4nvf4_t,
@@ -3204,7 +3204,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_lastu
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -3243,14 +3243,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_lastu
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3267,7 +3267,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse(
   kind_mxf8f6f4_t,
@@ -3282,7 +3282,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -3321,14 +3321,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -3345,7 +3345,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_l
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse(
   kind_t<_Kind> __kind,
@@ -3360,7 +3360,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -3435,14 +3435,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3459,7 +3459,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse(
   kind_mxf4nvf4_t,
@@ -3474,7 +3474,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -3513,14 +3513,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3537,7 +3537,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_collector_a_discard
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_discard(
   kind_mxf8f6f4_t,
@@ -3552,7 +3552,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_disca
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -3591,14 +3591,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_collector_a_disca
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -3615,7 +3615,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2x_collector_a_discard
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_discard(
   kind_t<_Kind> __kind,
@@ -3630,7 +3630,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_disca
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -3705,14 +3705,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2x_collector_a_disca
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_2x_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3729,7 +3729,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_collector_a_discard
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_discard(
   kind_mxf4nvf4_t,
@@ -3744,7 +3744,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_disca
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -3783,14 +3783,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_collector_a_disca
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf8f6f4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3807,7 +3807,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard(
   kind_mxf8f6f4_t,
@@ -3822,7 +3822,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
 {
   // __kind == kind_mxf8f6f4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -3861,14 +3861,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_1x_tmem_a_collector_
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4, .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_kind Kind, cuda::ptx::dot_cta_group Cta_Group>
@@ -3885,7 +3885,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_d
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind, dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard(
   kind_t<_Kind> __kind,
@@ -3900,7 +3900,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
 {
   static_assert(__kind == kind_mxf4 || __kind == kind_mxf4nvf4, "");
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_mxf4 && __cta_group == cta_group_1)
   {
     asm volatile(
@@ -3975,14 +3975,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_2_tmem_a_collector_a
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.cta_group.kind.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc, b_desc, idesc,
-[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_101a
+[scale_A_tmem], [scale_B_tmem], enable_input_d; // PTX ISA 86, SM_100a, SM_110a
 // .kind      = { .kind::mxf4nvf4 }
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
@@ -3999,7 +3999,7 @@ __device__ static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard(
   kind_mxf4nvf4_t,
@@ -4014,7 +4014,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
 {
   // __kind == kind_mxf4nvf4 (due to parameter type constraint)
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile(
@@ -4053,7 +4053,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_block_scale_vec_4x_tmem_a_collector_
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma_ws.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_mma_ws.h
@@ -5,7 +5,7 @@
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -20,7 +20,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_fill(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_fill(
   cta_group_1_t,
@@ -34,7 +34,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -101,14 +101,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b0_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b0_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -122,7 +122,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_fill(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_fill(
   cta_group_1_t,
@@ -135,7 +135,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -198,14 +198,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b0_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b0_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -221,7 +221,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
   cta_group_1_t,
@@ -235,7 +235,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -302,14 +302,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -324,7 +324,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
   cta_group_1_t,
@@ -337,7 +337,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -400,14 +400,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -422,7 +422,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_use(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_use(
   cta_group_1_t,
@@ -436,7 +436,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -503,14 +503,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b0_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b0_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -524,7 +524,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_use(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_use(
   cta_group_1_t,
@@ -537,7 +537,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -600,14 +600,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b0_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b0_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -623,7 +623,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
   cta_group_1_t,
@@ -637,7 +637,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -704,14 +704,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -726,7 +726,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
   cta_group_1_t,
@@ -739,7 +739,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -802,14 +802,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -824,7 +824,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_lastuse(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_lastuse(
   cta_group_1_t,
@@ -838,7 +838,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -905,14 +905,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -926,7 +926,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_lastuse(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_lastuse(
   cta_group_1_t,
@@ -939,7 +939,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1002,14 +1002,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -1025,7 +1025,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
   cta_group_1_t,
@@ -1039,7 +1039,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1106,14 +1106,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA
-86, SM_100a, SM_101a
+86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -1128,7 +1128,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
   cta_group_1_t,
@@ -1141,7 +1141,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1204,14 +1204,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -1226,7 +1226,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_discard(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_discard(
   cta_group_1_t,
@@ -1240,7 +1240,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1307,14 +1307,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b0_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b0_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -1328,7 +1328,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b0_discard(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b0_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_discard(
   cta_group_1_t,
@@ -1341,7 +1341,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1404,14 +1404,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b0_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b0_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b0_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -1427,7 +1427,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
   cta_group_1_t,
@@ -1441,7 +1441,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1508,14 +1508,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA
-86, SM_100a, SM_101a
+86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -1530,7 +1530,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
   cta_group_1_t,
@@ -1543,7 +1543,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1606,14 +1606,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b0_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b0_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -1628,7 +1628,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_fill(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_fill(
   cta_group_1_t,
@@ -1642,7 +1642,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1709,14 +1709,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b1_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b1_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -1730,7 +1730,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_fill(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_fill(
   cta_group_1_t,
@@ -1743,7 +1743,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1806,14 +1806,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b1_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b1_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -1829,7 +1829,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
   cta_group_1_t,
@@ -1843,7 +1843,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -1910,14 +1910,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -1932,7 +1932,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
   cta_group_1_t,
@@ -1945,7 +1945,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -2008,14 +2008,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -2030,7 +2030,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_use(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_use(
   cta_group_1_t,
@@ -2044,7 +2044,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -2111,14 +2111,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b1_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b1_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -2132,7 +2132,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_use(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_use(
   cta_group_1_t,
@@ -2145,7 +2145,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -2208,14 +2208,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b1_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b1_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -2231,7 +2231,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
   cta_group_1_t,
@@ -2245,7 +2245,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -2312,14 +2312,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -2334,7 +2334,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
   cta_group_1_t,
@@ -2347,7 +2347,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -2410,14 +2410,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -2432,7 +2432,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_lastuse(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_lastuse(
   cta_group_1_t,
@@ -2446,7 +2446,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -2513,14 +2513,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -2534,7 +2534,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_lastuse(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_lastuse(
   cta_group_1_t,
@@ -2547,7 +2547,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -2610,14 +2610,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -2633,7 +2633,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
   cta_group_1_t,
@@ -2647,7 +2647,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -2714,14 +2714,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA
-86, SM_100a, SM_101a
+86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -2736,7 +2736,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
   cta_group_1_t,
@@ -2749,7 +2749,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -2812,14 +2812,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -2834,7 +2834,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_discard(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_discard(
   cta_group_1_t,
@@ -2848,7 +2848,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -2915,14 +2915,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b1_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b1_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -2936,7 +2936,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b1_discard(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b1_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_discard(
   cta_group_1_t,
@@ -2949,7 +2949,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -3012,14 +3012,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b1_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b1_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b1_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -3035,7 +3035,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
   cta_group_1_t,
@@ -3049,7 +3049,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -3116,14 +3116,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA
-86, SM_100a, SM_101a
+86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -3138,7 +3138,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
   cta_group_1_t,
@@ -3151,7 +3151,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -3214,14 +3214,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b1_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b1_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -3236,7 +3236,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_fill(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_fill(
   cta_group_1_t,
@@ -3250,7 +3250,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -3317,14 +3317,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b2_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b2_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -3338,7 +3338,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_fill(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_fill(
   cta_group_1_t,
@@ -3351,7 +3351,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -3414,14 +3414,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b2_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b2_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -3437,7 +3437,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
   cta_group_1_t,
@@ -3451,7 +3451,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -3518,14 +3518,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -3540,7 +3540,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
   cta_group_1_t,
@@ -3553,7 +3553,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -3616,14 +3616,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -3638,7 +3638,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_use(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_use(
   cta_group_1_t,
@@ -3652,7 +3652,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -3719,14 +3719,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b2_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b2_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -3740,7 +3740,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_use(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_use(
   cta_group_1_t,
@@ -3753,7 +3753,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -3816,14 +3816,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b2_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b2_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -3839,7 +3839,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
   cta_group_1_t,
@@ -3853,7 +3853,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -3920,14 +3920,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -3942,7 +3942,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
   cta_group_1_t,
@@ -3955,7 +3955,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -4018,14 +4018,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -4040,7 +4040,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_lastuse(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_lastuse(
   cta_group_1_t,
@@ -4054,7 +4054,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -4121,14 +4121,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -4142,7 +4142,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_lastuse(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_lastuse(
   cta_group_1_t,
@@ -4155,7 +4155,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -4218,14 +4218,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -4241,7 +4241,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
   cta_group_1_t,
@@ -4255,7 +4255,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -4322,14 +4322,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA
-86, SM_100a, SM_101a
+86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -4344,7 +4344,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
   cta_group_1_t,
@@ -4357,7 +4357,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -4420,14 +4420,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -4442,7 +4442,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_discard(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_discard(
   cta_group_1_t,
@@ -4456,7 +4456,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -4523,14 +4523,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b2_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b2_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -4544,7 +4544,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b2_discard(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b2_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_discard(
   cta_group_1_t,
@@ -4557,7 +4557,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -4620,14 +4620,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b2_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b2_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b2_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -4643,7 +4643,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
   cta_group_1_t,
@@ -4657,7 +4657,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -4724,14 +4724,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA
-86, SM_100a, SM_101a
+86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -4746,7 +4746,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
   cta_group_1_t,
@@ -4759,7 +4759,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -4822,14 +4822,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b2_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b2_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -4844,7 +4844,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_fill(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_fill(
   cta_group_1_t,
@@ -4858,7 +4858,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -4925,14 +4925,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b3_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b3_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -4946,7 +4946,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_fill(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_fill_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_fill(
   cta_group_1_t,
@@ -4959,7 +4959,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -5022,14 +5022,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b3_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b3_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -5045,7 +5045,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
   cta_group_1_t,
@@ -5059,7 +5059,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -5126,14 +5126,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -5148,7 +5148,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_fill_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_fill_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
   cta_group_1_t,
@@ -5161,7 +5161,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -5224,14 +5224,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_fill(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_fill_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_fill_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -5246,7 +5246,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_use(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_use(
   cta_group_1_t,
@@ -5260,7 +5260,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -5327,14 +5327,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b3_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b3_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -5348,7 +5348,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_use(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_use_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_use(
   cta_group_1_t,
@@ -5361,7 +5361,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -5424,14 +5424,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b3_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b3_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -5447,7 +5447,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
   cta_group_1_t,
@@ -5461,7 +5461,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -5528,14 +5528,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -5550,7 +5550,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_use_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_use_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
   cta_group_1_t,
@@ -5563,7 +5563,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -5626,14 +5626,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_use(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_use_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_use_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -5648,7 +5648,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_lastuse(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_lastuse(
   cta_group_1_t,
@@ -5662,7 +5662,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -5729,14 +5729,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -5750,7 +5750,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_lastuse(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_lastuse(
   cta_group_1_t,
@@ -5763,7 +5763,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -5826,14 +5826,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -5849,7 +5849,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
   cta_group_1_t,
@@ -5863,7 +5863,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -5930,14 +5930,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA
-86, SM_100a, SM_101a
+86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -5952,7 +5952,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
   cta_group_1_t,
@@ -5965,7 +5965,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -6028,14 +6028,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_lastuse(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_lastuse_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -6050,7 +6050,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_discard(
   uint64_t zero_column_mask_desc);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_discard(
   cta_group_1_t,
@@ -6064,7 +6064,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -6131,14 +6131,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b3_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b3_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d; // PTX ISA 86,
-SM_100a, SM_101a
+SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -6152,7 +6152,7 @@ __device__ static inline void tcgen05_mma_ws_collector_b3_discard(
   bool enable_input_d);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_discard_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_mma_ws_collector_b3_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_discard(
   cta_group_1_t,
@@ -6165,7 +6165,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -6228,14 +6228,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_collector_b3_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_collector_b3_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_collector_b3_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
-zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_101a
+zero_column_mask_desc; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -6251,7 +6251,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
   cta_group_1_t,
@@ -6265,7 +6265,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -6332,14 +6332,14 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.mma.ws.cta_group.kind.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc, enable_input_d; // PTX ISA
-86, SM_100a, SM_101a
+86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1 }
 // .kind      = { .kind::f16, .kind::tf32, .kind::f8f6f4, .kind::i8 }
 template <cuda::ptx::dot_kind Kind>
@@ -6354,7 +6354,7 @@ __device__ static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
 */
 #if __cccl_ptx_isa >= 860
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_discard_is_not_supported_before_SM_100a_SM_101a__();
+__cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_discard_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_kind _Kind>
 _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
   cta_group_1_t,
@@ -6367,7 +6367,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
 {
   // __cta_group == cta_group_1 (due to parameter type constraint)
   static_assert(__kind == kind_f16 || __kind == kind_tf32 || __kind == kind_f8f6f4 || __kind == kind_i8, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__kind == kind_f16)
   {
     asm volatile(
@@ -6430,7 +6430,7 @@ _CCCL_DEVICE static inline void tcgen05_mma_ws_tmem_a_collector_b3_discard(
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_discard_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_mma_ws_tmem_a_collector_b3_discard_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_shift.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_shift.h
@@ -4,7 +4,7 @@
 #define _CUDA_PTX_GENERATED_TCGEN05_SHIFT_H_
 
 /*
-// tcgen05.shift.cta_group.down [taddr]; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.shift.cta_group.down [taddr]; // PTX ISA 86, SM_100a, SM_110a
 // .cta_group = { .cta_group::1, .cta_group::2 }
 template <cuda::ptx::dot_cta_group Cta_Group>
 __device__ static inline void tcgen05_shift_down(
@@ -12,12 +12,12 @@ __device__ static inline void tcgen05_shift_down(
   uint32_t taddr);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_shift_down_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_shift_down_is_not_supported_before_SM_100a_SM_110a__();
 template <dot_cta_group _Cta_Group>
 _CCCL_DEVICE static inline void tcgen05_shift_down(cta_group_t<_Cta_Group> __cta_group, _CUDA_VSTD::uint32_t __taddr)
 {
   static_assert(__cta_group == cta_group_1 || __cta_group == cta_group_2, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   if constexpr (__cta_group == cta_group_1)
   {
     asm volatile("tcgen05.shift.cta_group::1.down [%0];" : : "r"(__taddr) : "memory");
@@ -28,7 +28,7 @@ _CCCL_DEVICE static inline void tcgen05_shift_down(cta_group_t<_Cta_Group> __cta
   }
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_shift_down_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_shift_down_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_st.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_st.h
@@ -4,69 +4,69 @@
 #define _CUDA_PTX_GENERATED_TCGEN05_ST_H_
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b(
   uint32_t taddr,
   const B32 (&values)[1]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x64b.x1.b32 [%0], {%1};"
       :
       : "r"(__taddr), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__values[0]))
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[1]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x64b.x1.unpack::16b.b32 [%0], {%1};"
       :
       : "r"(__taddr), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__values[0]))
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b(
   uint32_t taddr,
   const B32 (&values)[2]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x64b.x2.b32 [%0], {%1, %2};"
       :
       : "r"(__taddr),
@@ -75,25 +75,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, 
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[2]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x64b.x2.unpack::16b.b32 [%0], {%1, %2};"
       :
       : "r"(__taddr),
@@ -102,25 +102,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b(
   uint32_t taddr,
   const B32 (&values)[4]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x64b.x4.b32 [%0], {%1, %2, %3, %4};"
       :
       : "r"(__taddr),
@@ -131,25 +131,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, 
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[4]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x64b.x4.unpack::16b.b32 [%0], {%1, %2, %3, %4};"
       :
       : "r"(__taddr),
@@ -160,25 +160,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b(
   uint32_t taddr,
   const B32 (&values)[8]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x64b.x8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
       :
       : "r"(__taddr),
@@ -193,25 +193,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, 
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[8]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x64b.x8.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
       :
       : "r"(__taddr),
@@ -226,25 +226,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b(
   uint32_t taddr,
   const B32 (&values)[16]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x64b.x16.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
       "%16};"
       :
@@ -268,25 +268,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, 
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[16]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x64b.x16.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
       "%13, %14, %15, %16};"
       :
@@ -310,25 +310,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b(
   uint32_t taddr,
   const B32 (&values)[32]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x64b.x32.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
@@ -369,25 +369,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, 
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[32]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x64b.x32.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
@@ -428,25 +428,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b(
   uint32_t taddr,
   const B32 (&values)[64]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x64b.x64.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -521,25 +521,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, 
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[64]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x64b.x64.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -614,25 +614,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x128.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x128.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b(
   uint32_t taddr,
   const B32 (&values)[128]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x64b.x128.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -774,25 +774,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b(_CUDA_VSTD::uint32_t __taddr, 
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x64b.x128.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x64b.x128.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x64b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[128]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x64b.x128.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
     "%13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, "
@@ -934,25 +934,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x64b_unpack_16b(_CUDA_VSTD::uint32_
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x64b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b(
   uint32_t taddr,
   const B32 (&values)[2]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x128b.x1.b32 [%0], {%1, %2};"
       :
       : "r"(__taddr),
@@ -961,25 +961,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[2]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x128b.x1.unpack::16b.b32 [%0], {%1, %2};"
       :
       : "r"(__taddr),
@@ -988,25 +988,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b(
   uint32_t taddr,
   const B32 (&values)[4]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x128b.x2.b32 [%0], {%1, %2, %3, %4};"
       :
       : "r"(__taddr),
@@ -1017,25 +1017,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[4]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x128b.x2.unpack::16b.b32 [%0], {%1, %2, %3, %4};"
       :
       : "r"(__taddr),
@@ -1046,25 +1046,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b(
   uint32_t taddr,
   const B32 (&values)[8]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x128b.x4.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
       :
       : "r"(__taddr),
@@ -1079,25 +1079,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[8]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x128b.x4.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
       :
       : "r"(__taddr),
@@ -1112,25 +1112,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b(
   uint32_t taddr,
   const B32 (&values)[16]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x128b.x8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
       "%16};"
       :
@@ -1154,25 +1154,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[16]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x128b.x8.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
       "%13, %14, %15, %16};"
       :
@@ -1196,25 +1196,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b(
   uint32_t taddr,
   const B32 (&values)[32]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x128b.x16.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
@@ -1255,25 +1255,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr,
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[32]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x128b.x16.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
     "%13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
@@ -1314,25 +1314,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b(
   uint32_t taddr,
   const B32 (&values)[64]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x128b.x32.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -1407,25 +1407,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr,
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[64]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x128b.x32.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
     "%13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, "
@@ -1500,25 +1500,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b(
   uint32_t taddr,
   const B32 (&values)[128]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x128b.x64.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -1660,25 +1660,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b(_CUDA_VSTD::uint32_t __taddr,
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x128b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x128b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x128b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[128]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x128b.x64.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
     "%13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, "
@@ -1820,25 +1820,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x128b_unpack_16b(_CUDA_VSTD::uint32
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x128b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b(
   uint32_t taddr,
   const B32 (&values)[4]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x256b.x1.b32 [%0], {%1, %2, %3, %4};"
       :
       : "r"(__taddr),
@@ -1849,25 +1849,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[4]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x256b.x1.unpack::16b.b32 [%0], {%1, %2, %3, %4};"
       :
       : "r"(__taddr),
@@ -1878,25 +1878,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b(
   uint32_t taddr,
   const B32 (&values)[8]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x256b.x2.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
       :
       : "r"(__taddr),
@@ -1911,25 +1911,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[8]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x256b.x2.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
       :
       : "r"(__taddr),
@@ -1944,25 +1944,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b(
   uint32_t taddr,
   const B32 (&values)[16]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x256b.x4.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
       "%16};"
       :
@@ -1986,25 +1986,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[16]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x256b.x4.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
       "%13, %14, %15, %16};"
       :
@@ -2028,25 +2028,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b(
   uint32_t taddr,
   const B32 (&values)[32]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x256b.x8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
@@ -2087,25 +2087,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr,
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[32]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x256b.x8.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
@@ -2146,25 +2146,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b(
   uint32_t taddr,
   const B32 (&values)[64]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x256b.x16.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -2239,25 +2239,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr,
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[64]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x256b.x16.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
     "%13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, "
@@ -2332,25 +2332,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b(
   uint32_t taddr,
   const B32 (&values)[128]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x256b.x32.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -2492,25 +2492,25 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b(_CUDA_VSTD::uint32_t __taddr,
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x256b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x256b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x256b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[128]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x256b.x32.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
     "%13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, "
@@ -2652,75 +2652,75 @@ _CCCL_DEVICE static inline void tcgen05_st_16x256b_unpack_16b(_CUDA_VSTD::uint32
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x256b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x1.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b(
   uint32_t taddr,
   const B32 (&values)[1]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.32x32b.x1.b32 [%0], {%1};"
       :
       : "r"(__taddr), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__values[0]))
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x1.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[1]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.32x32b.x1.unpack::16b.b32 [%0], {%1};"
       :
       : "r"(__taddr), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__values[0]))
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x2.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b(
   uint32_t taddr,
   const B32 (&values)[2]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.32x32b.x2.b32 [%0], {%1, %2};"
       :
       : "r"(__taddr),
@@ -2729,25 +2729,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, 
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x2.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[2]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.32x32b.x2.unpack::16b.b32 [%0], {%1, %2};"
       :
       : "r"(__taddr),
@@ -2756,25 +2756,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x4.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b(
   uint32_t taddr,
   const B32 (&values)[4]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.32x32b.x4.b32 [%0], {%1, %2, %3, %4};"
       :
       : "r"(__taddr),
@@ -2785,25 +2785,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, 
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x4.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[4]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.32x32b.x4.unpack::16b.b32 [%0], {%1, %2, %3, %4};"
       :
       : "r"(__taddr),
@@ -2814,25 +2814,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x8.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b(
   uint32_t taddr,
   const B32 (&values)[8]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.32x32b.x8.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
       :
       : "r"(__taddr),
@@ -2847,25 +2847,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, 
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x8.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[8]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.32x32b.x8.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8};"
       :
       : "r"(__taddr),
@@ -2880,25 +2880,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x16.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b(
   uint32_t taddr,
   const B32 (&values)[16]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.32x32b.x16.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
       "%16};"
       :
@@ -2922,25 +2922,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, 
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x16.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[16]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.32x32b.x16.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
       "%13, %14, %15, %16};"
       :
@@ -2964,25 +2964,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x32.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b(
   uint32_t taddr,
   const B32 (&values)[32]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.32x32b.x32.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
@@ -3023,25 +3023,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, 
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x32.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[32]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.32x32b.x32.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32};"
@@ -3082,25 +3082,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x64.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b(
   uint32_t taddr,
   const B32 (&values)[64]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.32x32b.x64.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -3175,25 +3175,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, 
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x64.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[64]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.32x32b.x64.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, "
     "%14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, "
@@ -3268,25 +3268,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x128.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x128.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b(
   uint32_t taddr,
   const B32 (&values)[128]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.32x32b.x128.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -3428,25 +3428,25 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b(_CUDA_VSTD::uint32_t __taddr, 
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.32x32b.x128.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.32x32b.x128.unpack::16b.b32 [taddr], values; // PTX ISA 86, SM_100a, SM_110a
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_32x32b_unpack_16b(
   uint32_t taddr,
   const B32 (&values)[128]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_t __taddr, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.32x32b.x128.unpack::16b.b32 [%0], {%1, %2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
     "%13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, "
@@ -3588,13 +3588,13 @@ _CCCL_DEVICE static inline void tcgen05_st_32x32b_unpack_16b(_CUDA_VSTD::uint32_
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_32x32b_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x1.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x1.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2(
   uint32_t taddr,
@@ -3602,13 +3602,13 @@ __device__ static inline void tcgen05_st_16x32bx2(
   const B32 (&values)[1]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x32bx2.x1.b32 [%0], %1, {%2};"
       :
       : "r"(__taddr),
@@ -3617,13 +3617,13 @@ tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x1.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x1.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   uint32_t taddr,
@@ -3631,13 +3631,13 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   const B32 (&values)[1]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[1])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x32bx2.x1.unpack::16b.b32 [%0], %1, {%2};"
       :
       : "r"(__taddr),
@@ -3646,13 +3646,13 @@ tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHa
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x2.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x2.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2(
   uint32_t taddr,
@@ -3660,13 +3660,13 @@ __device__ static inline void tcgen05_st_16x32bx2(
   const B32 (&values)[2]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x32bx2.x2.b32 [%0], %1, {%2, %3};"
       :
       : "r"(__taddr),
@@ -3676,13 +3676,13 @@ tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x2.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x2.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   uint32_t taddr,
@@ -3690,13 +3690,13 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   const B32 (&values)[2]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[2])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x32bx2.x2.unpack::16b.b32 [%0], %1, {%2, %3};"
       :
       : "r"(__taddr),
@@ -3706,13 +3706,13 @@ tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHa
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x4.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x4.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2(
   uint32_t taddr,
@@ -3720,13 +3720,13 @@ __device__ static inline void tcgen05_st_16x32bx2(
   const B32 (&values)[4]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x32bx2.x4.b32 [%0], %1, {%2, %3, %4, %5};"
       :
       : "r"(__taddr),
@@ -3738,13 +3738,13 @@ tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x4.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x4.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   uint32_t taddr,
@@ -3752,13 +3752,13 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   const B32 (&values)[4]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[4])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x32bx2.x4.unpack::16b.b32 [%0], %1, {%2, %3, %4, %5};"
       :
       : "r"(__taddr),
@@ -3770,13 +3770,13 @@ tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHa
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x8.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x8.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2(
   uint32_t taddr,
@@ -3784,13 +3784,13 @@ __device__ static inline void tcgen05_st_16x32bx2(
   const B32 (&values)[8]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x32bx2.x8.b32 [%0], %1, {%2, %3, %4, %5, %6, %7, %8, %9};"
       :
       : "r"(__taddr),
@@ -3806,13 +3806,13 @@ tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x8.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x8.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   uint32_t taddr,
@@ -3820,13 +3820,13 @@ __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   const B32 (&values)[8]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[8])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x32bx2.x8.unpack::16b.b32 [%0], %1, {%2, %3, %4, %5, %6, %7, %8, %9};"
       :
       : "r"(__taddr),
@@ -3842,13 +3842,13 @@ tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHa
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x16.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x16.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2(
   uint32_t taddr,
@@ -3856,13 +3856,13 @@ __device__ static inline void tcgen05_st_16x32bx2(
   const B32 (&values)[16]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x32bx2.x16.b32 [%0], %1, {%2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, "
       "%15, %16, %17};"
       :
@@ -3887,27 +3887,27 @@ tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.st.sync.aligned.16x32bx2.x16.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a,
-SM_101a template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+SM_110a template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   uint32_t taddr,
   cuda::ptx::n32_t<N32> immHalfSplitoff,
   const B32 (&values)[16]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[16])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tcgen05.st.sync.aligned.16x32bx2.x16.unpack::16b.b32 [%0], %1, {%2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
       "%13, %14, %15, %16, %17};"
       :
@@ -3932,13 +3932,13 @@ tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHa
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x32.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x32.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2(
   uint32_t taddr,
@@ -3946,13 +3946,13 @@ __device__ static inline void tcgen05_st_16x32bx2(
   const B32 (&values)[32]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x32bx2.x32.b32 [%0], %1, {%2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33};"
@@ -3994,27 +3994,27 @@ tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff,
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.st.sync.aligned.16x32bx2.x32.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a,
-SM_101a template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+SM_110a template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   uint32_t taddr,
   cuda::ptx::n32_t<N32> immHalfSplitoff,
   const B32 (&values)[32]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[32])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x32bx2.x32.unpack::16b.b32 [%0], %1, {%2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
     "%13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33};"
@@ -4056,13 +4056,13 @@ tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHa
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x64.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x64.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2(
   uint32_t taddr,
@@ -4070,13 +4070,13 @@ __device__ static inline void tcgen05_st_16x32bx2(
   const B32 (&values)[64]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x32bx2.x64.b32 [%0], %1, {%2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, %15, "
     "%16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, %37, "
@@ -4152,27 +4152,27 @@ tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff,
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.st.sync.aligned.16x32bx2.x64.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a,
-SM_101a template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+SM_110a template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   uint32_t taddr,
   cuda::ptx::n32_t<N32> immHalfSplitoff,
   const B32 (&values)[64]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[64])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x32bx2.x64.unpack::16b.b32 [%0], %1, {%2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
     "%13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, "
@@ -4248,13 +4248,13 @@ tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHa
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.st.sync.aligned.16x32bx2.x128.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.st.sync.aligned.16x32bx2.x128.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a, SM_110a
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2(
   uint32_t taddr,
@@ -4262,13 +4262,13 @@ __device__ static inline void tcgen05_st_16x32bx2(
   const B32 (&values)[128]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x32bx2.x128.b32 [%0], %1, {%2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, %13, %14, "
     "%15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, %35, %36, "
@@ -4411,27 +4411,27 @@ tcgen05_st_16x32bx2(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff,
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
 // tcgen05.st.sync.aligned.16x32bx2.x128.unpack::16b.b32 [taddr], immHalfSplitoff, values; // PTX ISA 86, SM_100a,
-SM_101a template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
+SM_110a template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tcgen05_st_16x32bx2_unpack_16b(
   uint32_t taddr,
   cuda::ptx::n32_t<N32> immHalfSplitoff,
   const B32 (&values)[128]);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHalfSplitoff, const _B32 (&__values)[128])
 {
   static_assert(sizeof(_B32) == 4, "");
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm(
     "tcgen05.st.sync.aligned.16x32bx2.x128.unpack::16b.b32 [%0], %1, {%2, %3, %4, %5, %6, %7, %8, %9, %10, %11, %12, "
     "%13, %14, %15, %16, %17, %18, %19, %20, %21, %22, %23, %24, %25, %26, %27, %28, %29, %30, %31, %32, %33, %34, "
@@ -4574,7 +4574,7 @@ tcgen05_st_16x32bx2_unpack_16b(_CUDA_VSTD::uint32_t __taddr, n32_t<_N32> __immHa
     : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_st_16x32bx2_unpack_16b_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_wait.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tcgen05_wait.h
@@ -4,39 +4,39 @@
 #define _CUDA_PTX_GENERATED_TCGEN05_WAIT_H_
 
 /*
-// tcgen05.wait::ld.sync.aligned; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.wait::ld.sync.aligned; // PTX ISA 86, SM_100a, SM_110a
 template <typename = void>
 __device__ static inline void tcgen05_wait_ld();
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_wait_ld_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_wait_ld_is_not_supported_before_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void tcgen05_wait_ld()
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm volatile("tcgen05.wait::ld.sync.aligned;" : : : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_wait_ld_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_wait_ld_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tcgen05.wait::st.sync.aligned; // PTX ISA 86, SM_100a, SM_101a
+// tcgen05.wait::st.sync.aligned; // PTX ISA 86, SM_100a, SM_110a
 template <typename = void>
 __device__ static inline void tcgen05_wait_st();
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_wait_st_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tcgen05_wait_st_is_not_supported_before_SM_100a_SM_110a__();
 template <typename = void>
 _CCCL_DEVICE static inline void tcgen05_wait_st()
 {
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm volatile("tcgen05.wait::st.sync.aligned;" : : : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tcgen05_wait_st_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tcgen05_wait_st_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/include/cuda/__ptx/instructions/generated/tensormap_replace.h
+++ b/libcudacxx/include/cuda/__ptx/instructions/generated/tensormap_replace.h
@@ -4,7 +4,7 @@
 #define _CUDA_PTX_GENERATED_TENSORMAP_REPLACE_H_
 
 /*
-// tensormap.replace.tile.global_address.space.b1024.b64 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.global_address.space.b1024.b64 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .global }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void tensormap_replace_global_address(
@@ -14,27 +14,27 @@ __device__ static inline void tensormap_replace_global_address(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_global_address_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_global_address_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
 _CCCL_DEVICE static inline void tensormap_replace_global_address(space_global_t, void* __tm_addr, _B64 __new_val)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.global_address.global.b1024.b64 [%0], %1;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)), "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__new_val))
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_global_address_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_global_address_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.global_address.space.b1024.b64 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.global_address.space.b1024.b64 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .shared::cta }
 template <typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void tensormap_replace_global_address(
@@ -44,27 +44,27 @@ __device__ static inline void tensormap_replace_global_address(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_global_address_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_global_address_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
 _CCCL_DEVICE static inline void tensormap_replace_global_address(space_shared_t, void* __tm_addr, _B64 __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.global_address.shared::cta.b1024.b64 [%0], %1;"
       :
       : "r"(__as_ptr_smem(__tm_addr)), "l"(/*as_b64*/ *reinterpret_cast<const _CUDA_VSTD::int64_t*>(&__new_val))
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_global_address_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_global_address_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.rank.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.rank.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .global }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tensormap_replace_rank(
@@ -73,27 +73,27 @@ __device__ static inline void tensormap_replace_rank(
   B32 new_val);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_rank_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_rank_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tensormap_replace_rank(space_global_t, void* __tm_addr, _B32 __new_val)
 {
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.rank.global.b1024.b32 [%0], %1;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__new_val))
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_rank_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_rank_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.rank.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.rank.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .shared::cta }
 template <typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tensormap_replace_rank(
@@ -102,27 +102,27 @@ __device__ static inline void tensormap_replace_rank(
   B32 new_val);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_rank_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_rank_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void tensormap_replace_rank(space_shared_t, void* __tm_addr, _B32 __new_val)
 {
   // __space == space_shared (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.rank.shared::cta.b1024.b32 [%0], %1;"
       :
       : "r"(__as_ptr_smem(__tm_addr)), "r"(/*as_b32*/ *reinterpret_cast<const _CUDA_VSTD::int32_t*>(&__new_val))
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_rank_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_rank_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.box_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.box_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .global }
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tensormap_replace_box_dim(
@@ -132,7 +132,7 @@ __device__ static inline void tensormap_replace_box_dim(
   B32 new_val);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_box_dim_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_box_dim_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tensormap_replace_box_dim(space_global_t, void* __tm_addr, n32_t<_N32> __ord, _B32 __new_val)
@@ -140,7 +140,7 @@ tensormap_replace_box_dim(space_global_t, void* __tm_addr, n32_t<_N32> __ord, _B
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.box_dim.global.b1024.b32 [%0], %1, %2;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)),
@@ -149,13 +149,13 @@ tensormap_replace_box_dim(space_global_t, void* __tm_addr, n32_t<_N32> __ord, _B
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_box_dim_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_box_dim_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.box_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.box_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .shared::cta }
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tensormap_replace_box_dim(
@@ -165,7 +165,7 @@ __device__ static inline void tensormap_replace_box_dim(
   B32 new_val);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_box_dim_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_box_dim_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tensormap_replace_box_dim(space_shared_t, void* __tm_addr, n32_t<_N32> __ord, _B32 __new_val)
@@ -173,7 +173,7 @@ tensormap_replace_box_dim(space_shared_t, void* __tm_addr, n32_t<_N32> __ord, _B
   // __space == space_shared (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.box_dim.shared::cta.b1024.b32 [%0], %1, %2;"
       :
       : "r"(__as_ptr_smem(__tm_addr)),
@@ -182,13 +182,13 @@ tensormap_replace_box_dim(space_shared_t, void* __tm_addr, n32_t<_N32> __ord, _B
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_box_dim_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_box_dim_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.global_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.global_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .global }
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tensormap_replace_global_dim(
@@ -198,7 +198,7 @@ __device__ static inline void tensormap_replace_global_dim(
   B32 new_val);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_global_dim_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_global_dim_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tensormap_replace_global_dim(space_global_t, void* __tm_addr, n32_t<_N32> __ord, _B32 __new_val)
@@ -206,7 +206,7 @@ tensormap_replace_global_dim(space_global_t, void* __tm_addr, n32_t<_N32> __ord,
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.global_dim.global.b1024.b32 [%0], %1, %2;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)),
@@ -215,13 +215,13 @@ tensormap_replace_global_dim(space_global_t, void* __tm_addr, n32_t<_N32> __ord,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_global_dim_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_global_dim_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.global_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.global_dim.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .shared::cta }
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tensormap_replace_global_dim(
@@ -231,7 +231,7 @@ __device__ static inline void tensormap_replace_global_dim(
   B32 new_val);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_global_dim_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_global_dim_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tensormap_replace_global_dim(space_shared_t, void* __tm_addr, n32_t<_N32> __ord, _B32 __new_val)
@@ -239,7 +239,7 @@ tensormap_replace_global_dim(space_shared_t, void* __tm_addr, n32_t<_N32> __ord,
   // __space == space_shared (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.global_dim.shared::cta.b1024.b32 [%0], %1, %2;"
       :
       : "r"(__as_ptr_smem(__tm_addr)),
@@ -248,13 +248,13 @@ tensormap_replace_global_dim(space_shared_t, void* __tm_addr, n32_t<_N32> __ord,
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_global_dim_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_global_dim_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.global_stride.space.b1024.b64 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.global_stride.space.b1024.b64 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .global }
 template <int N32, typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void tensormap_replace_global_stride(
@@ -265,7 +265,7 @@ __device__ static inline void tensormap_replace_global_stride(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_global_stride_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_global_stride_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32, typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
 _CCCL_DEVICE static inline void
 tensormap_replace_global_stride(space_global_t, void* __tm_addr, n32_t<_N32> __ord, _B64 __new_val)
@@ -273,7 +273,7 @@ tensormap_replace_global_stride(space_global_t, void* __tm_addr, n32_t<_N32> __o
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.global_stride.global.b1024.b64 [%0], %1, %2;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)),
@@ -282,13 +282,13 @@ tensormap_replace_global_stride(space_global_t, void* __tm_addr, n32_t<_N32> __o
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_global_stride_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_global_stride_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.global_stride.space.b1024.b64 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.global_stride.space.b1024.b64 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .shared::cta }
 template <int N32, typename B64, enable_if_t<sizeof(B64) == 8, bool> = true>
 __device__ static inline void tensormap_replace_global_stride(
@@ -299,7 +299,7 @@ __device__ static inline void tensormap_replace_global_stride(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_global_stride_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_global_stride_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32, typename _B64, _CUDA_VSTD::enable_if_t<sizeof(_B64) == 8, bool> = true>
 _CCCL_DEVICE static inline void
 tensormap_replace_global_stride(space_shared_t, void* __tm_addr, n32_t<_N32> __ord, _B64 __new_val)
@@ -307,7 +307,7 @@ tensormap_replace_global_stride(space_shared_t, void* __tm_addr, n32_t<_N32> __o
   // __space == space_shared (due to parameter type constraint)
   static_assert(sizeof(_B64) == 8, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.global_stride.shared::cta.b1024.b64 [%0], %1, %2;"
       :
       : "r"(__as_ptr_smem(__tm_addr)),
@@ -316,14 +316,14 @@ tensormap_replace_global_stride(space_shared_t, void* __tm_addr, n32_t<_N32> __o
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_global_stride_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_global_stride_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a,
-SM_101a
+SM_110a
 // .space     = { .global }
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tensormap_replace_element_stride(
@@ -334,7 +334,7 @@ __device__ static inline void tensormap_replace_element_stride(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_element_stride_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_element_stride_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tensormap_replace_element_stride(space_global_t, void* __tm_addr, n32_t<_N32> __ord, _B32 __new_val)
@@ -342,7 +342,7 @@ tensormap_replace_element_stride(space_global_t, void* __tm_addr, n32_t<_N32> __
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.element_stride.global.b1024.b32 [%0], %1, %2;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)),
@@ -351,14 +351,14 @@ tensormap_replace_element_stride(space_global_t, void* __tm_addr, n32_t<_N32> __
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_element_stride_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_element_stride_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a,
-SM_101a
+SM_110a
 // .space     = { .shared::cta }
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tensormap_replace_element_stride(
@@ -369,7 +369,7 @@ __device__ static inline void tensormap_replace_element_stride(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_element_stride_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_element_stride_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tensormap_replace_element_stride(space_shared_t, void* __tm_addr, n32_t<_N32> __ord, _B32 __new_val)
@@ -377,7 +377,7 @@ tensormap_replace_element_stride(space_shared_t, void* __tm_addr, n32_t<_N32> __
   // __space == space_shared (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.element_stride.shared::cta.b1024.b32 [%0], %1, %2;"
       :
       : "r"(__as_ptr_smem(__tm_addr)),
@@ -386,14 +386,14 @@ tensormap_replace_element_stride(space_shared_t, void* __tm_addr, n32_t<_N32> __
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_element_stride_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_element_stride_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a,
-SM_101a
+SM_110a
 // .space     = { .global }
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tensormap_replace_element_size(
@@ -404,7 +404,7 @@ __device__ static inline void tensormap_replace_element_size(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_element_size_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_element_size_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tensormap_replace_element_size(space_global_t, void* __tm_addr, n32_t<_N32> __ord, _B32 __new_val)
@@ -412,7 +412,7 @@ tensormap_replace_element_size(space_global_t, void* __tm_addr, n32_t<_N32> __or
   // __space == space_global (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.element_stride.global.b1024.b32 [%0], %1, %2;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)),
@@ -421,14 +421,14 @@ tensormap_replace_element_size(space_global_t, void* __tm_addr, n32_t<_N32> __or
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_element_size_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_element_size_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
 // tensormap.replace.tile.element_stride.space.b1024.b32 [tm_addr], ord, new_val; // PTX ISA 83, SM_90a, SM_100a,
-SM_101a
+SM_110a
 // .space     = { .shared::cta }
 template <int N32, typename B32, enable_if_t<sizeof(B32) == 4, bool> = true>
 __device__ static inline void tensormap_replace_element_size(
@@ -439,7 +439,7 @@ __device__ static inline void tensormap_replace_element_size(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_element_size_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_element_size_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32, typename _B32, _CUDA_VSTD::enable_if_t<sizeof(_B32) == 4, bool> = true>
 _CCCL_DEVICE static inline void
 tensormap_replace_element_size(space_shared_t, void* __tm_addr, n32_t<_N32> __ord, _B32 __new_val)
@@ -447,7 +447,7 @@ tensormap_replace_element_size(space_shared_t, void* __tm_addr, n32_t<_N32> __or
   // __space == space_shared (due to parameter type constraint)
   static_assert(sizeof(_B32) == 4, "");
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.element_stride.shared::cta.b1024.b32 [%0], %1, %2;"
       :
       : "r"(__as_ptr_smem(__tm_addr)),
@@ -456,13 +456,13 @@ tensormap_replace_element_size(space_shared_t, void* __tm_addr, n32_t<_N32> __or
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_element_size_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_element_size_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.elemtype.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.elemtype.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .global }
 template <int N32>
 __device__ static inline void tensormap_replace_elemtype(
@@ -471,26 +471,26 @@ __device__ static inline void tensormap_replace_elemtype(
   cuda::ptx::n32_t<N32> new_val);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_elemtype_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_elemtype_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32>
 _CCCL_DEVICE static inline void tensormap_replace_elemtype(space_global_t, void* __tm_addr, n32_t<_N32> __new_val)
 {
 // __space == space_global (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.elemtype.global.b1024.b32 [%0], %1;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)), "n"(__new_val.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_elemtype_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_elemtype_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.elemtype.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.elemtype.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .shared::cta }
 template <int N32>
 __device__ static inline void tensormap_replace_elemtype(
@@ -499,26 +499,26 @@ __device__ static inline void tensormap_replace_elemtype(
   cuda::ptx::n32_t<N32> new_val);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_elemtype_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_elemtype_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32>
 _CCCL_DEVICE static inline void tensormap_replace_elemtype(space_shared_t, void* __tm_addr, n32_t<_N32> __new_val)
 {
 // __space == space_shared (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.elemtype.shared::cta.b1024.b32 [%0], %1;"
       :
       : "r"(__as_ptr_smem(__tm_addr)), "n"(__new_val.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_elemtype_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_elemtype_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.interleave_layout.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.interleave_layout.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .global }
 template <int N32>
 __device__ static inline void tensormap_replace_interleave_layout(
@@ -528,27 +528,27 @@ __device__ static inline void tensormap_replace_interleave_layout(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_interleave_layout_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_interleave_layout_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32>
 _CCCL_DEVICE static inline void
 tensormap_replace_interleave_layout(space_global_t, void* __tm_addr, n32_t<_N32> __new_val)
 {
 // __space == space_global (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.interleave_layout.global.b1024.b32 [%0], %1;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)), "n"(__new_val.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_interleave_layout_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_interleave_layout_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.interleave_layout.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.interleave_layout.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .shared::cta }
 template <int N32>
 __device__ static inline void tensormap_replace_interleave_layout(
@@ -558,27 +558,27 @@ __device__ static inline void tensormap_replace_interleave_layout(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_interleave_layout_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_interleave_layout_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32>
 _CCCL_DEVICE static inline void
 tensormap_replace_interleave_layout(space_shared_t, void* __tm_addr, n32_t<_N32> __new_val)
 {
 // __space == space_shared (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.interleave_layout.shared::cta.b1024.b32 [%0], %1;"
       :
       : "r"(__as_ptr_smem(__tm_addr)), "n"(__new_val.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_interleave_layout_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_interleave_layout_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.swizzle_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.swizzle_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .global }
 template <int N32>
 __device__ static inline void tensormap_replace_swizzle_mode(
@@ -588,26 +588,26 @@ __device__ static inline void tensormap_replace_swizzle_mode(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_swizzle_mode_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_swizzle_mode_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32>
 _CCCL_DEVICE static inline void tensormap_replace_swizzle_mode(space_global_t, void* __tm_addr, n32_t<_N32> __new_val)
 {
 // __space == space_global (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.swizzle_mode.global.b1024.b32 [%0], %1;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)), "n"(__new_val.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_swizzle_mode_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_swizzle_mode_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.swizzle_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.swizzle_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .shared::cta }
 template <int N32>
 __device__ static inline void tensormap_replace_swizzle_mode(
@@ -617,26 +617,26 @@ __device__ static inline void tensormap_replace_swizzle_mode(
 */
 #if __cccl_ptx_isa >= 830
 extern "C" _CCCL_DEVICE void
-__cuda_ptx_tensormap_replace_swizzle_mode_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+__cuda_ptx_tensormap_replace_swizzle_mode_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32>
 _CCCL_DEVICE static inline void tensormap_replace_swizzle_mode(space_shared_t, void* __tm_addr, n32_t<_N32> __new_val)
 {
 // __space == space_shared (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.swizzle_mode.shared::cta.b1024.b32 [%0], %1;"
       :
       : "r"(__as_ptr_smem(__tm_addr)), "n"(__new_val.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_swizzle_mode_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_swizzle_mode_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.fill_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.fill_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .global }
 template <int N32>
 __device__ static inline void tensormap_replace_fill_mode(
@@ -645,26 +645,26 @@ __device__ static inline void tensormap_replace_fill_mode(
   cuda::ptx::n32_t<N32> new_val);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_fill_mode_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_fill_mode_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32>
 _CCCL_DEVICE static inline void tensormap_replace_fill_mode(space_global_t, void* __tm_addr, n32_t<_N32> __new_val)
 {
 // __space == space_global (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.fill_mode.global.b1024.b32 [%0], %1;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)), "n"(__new_val.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_fill_mode_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_fill_mode_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.fill_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_101a
+// tensormap.replace.tile.fill_mode.space.b1024.b32 [tm_addr], new_val; // PTX ISA 83, SM_90a, SM_100a, SM_110a
 // .space     = { .shared::cta }
 template <int N32>
 __device__ static inline void tensormap_replace_fill_mode(
@@ -673,26 +673,26 @@ __device__ static inline void tensormap_replace_fill_mode(
   cuda::ptx::n32_t<N32> new_val);
 */
 #if __cccl_ptx_isa >= 830
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_fill_mode_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_fill_mode_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 template <int _N32>
 _CCCL_DEVICE static inline void tensormap_replace_fill_mode(space_shared_t, void* __tm_addr, n32_t<_N32> __new_val)
 {
 // __space == space_shared (due to parameter type constraint)
 #  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM90_ALL || __CUDA_ARCH_FEAT_SM100_ALL \
-    || __CUDA_ARCH_FEAT_SM101_ALL
+    || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.fill_mode.shared::cta.b1024.b32 [%0], %1;"
       :
       : "r"(__as_ptr_smem(__tm_addr)), "n"(__new_val.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_fill_mode_is_not_supported_before_SM_90a_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_fill_mode_is_not_supported_before_SM_90a_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 830
 
 /*
-// tensormap.replace.tile.swizzle_atomicity.space.b1024.b32 [tm_addr], new_val; // PTX ISA 86, SM_100a, SM_101a
+// tensormap.replace.tile.swizzle_atomicity.space.b1024.b32 [tm_addr], new_val; // PTX ISA 86, SM_100a, SM_110a
 // .space     = { .global }
 template <int N32>
 __device__ static inline void tensormap_replace_swizzle_atomicity(
@@ -701,26 +701,26 @@ __device__ static inline void tensormap_replace_swizzle_atomicity(
   cuda::ptx::n32_t<N32> new_val);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_swizzle_atomicity_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_swizzle_atomicity_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32>
 _CCCL_DEVICE static inline void
 tensormap_replace_swizzle_atomicity(space_global_t, void* __tm_addr, n32_t<_N32> __new_val)
 {
 // __space == space_global (due to parameter type constraint)
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.swizzle_atomicity.global.b1024.b32 [%0], %1;"
       :
       : "l"(__as_ptr_gmem(__tm_addr)), "n"(__new_val.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_swizzle_atomicity_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_swizzle_atomicity_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860
 
 /*
-// tensormap.replace.tile.swizzle_atomicity.space.b1024.b32 [tm_addr], new_val; // PTX ISA 86, SM_100a, SM_101a
+// tensormap.replace.tile.swizzle_atomicity.space.b1024.b32 [tm_addr], new_val; // PTX ISA 86, SM_100a, SM_110a
 // .space     = { .shared::cta }
 template <int N32>
 __device__ static inline void tensormap_replace_swizzle_atomicity(
@@ -729,20 +729,20 @@ __device__ static inline void tensormap_replace_swizzle_atomicity(
   cuda::ptx::n32_t<N32> new_val);
 */
 #if __cccl_ptx_isa >= 860
-extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_swizzle_atomicity_is_not_supported_before_SM_100a_SM_101a__();
+extern "C" _CCCL_DEVICE void __cuda_ptx_tensormap_replace_swizzle_atomicity_is_not_supported_before_SM_100a_SM_110a__();
 template <int _N32>
 _CCCL_DEVICE static inline void
 tensormap_replace_swizzle_atomicity(space_shared_t, void* __tm_addr, n32_t<_N32> __new_val)
 {
 // __space == space_shared (due to parameter type constraint)
-#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM101_ALL
+#  if _CCCL_CUDA_COMPILER(NVHPC) || __CUDA_ARCH_FEAT_SM100_ALL || __CUDA_ARCH_FEAT_SM110_ALL
   asm("tensormap.replace.tile.swizzle_atomicity.shared::cta.b1024.b32 [%0], %1;"
       :
       : "r"(__as_ptr_smem(__tm_addr)), "n"(__new_val.value)
       : "memory");
 #  else
   // Unsupported architectures will have a linker error with a semi-decent error message
-  __cuda_ptx_tensormap_replace_swizzle_atomicity_is_not_supported_before_SM_100a_SM_101a__();
+  __cuda_ptx_tensormap_replace_swizzle_atomicity_is_not_supported_before_SM_100a_SM_110a__();
 #  endif
 }
 #endif // __cccl_ptx_isa >= 860

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/clusterlaunchcontrol.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/clusterlaunchcontrol.h
@@ -34,7 +34,7 @@ __global__ void test_clusterlaunchcontrol(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(void*, uint64_t*)>(cuda::ptx::clusterlaunchcontrol_try_cancel_multicast));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // clusterlaunchcontrol.try_cancel.async.shared::cta.mbarrier::complete_tx::bytes.multicast::cluster::all.b128
         // [addr], [smem_bar];
@@ -42,45 +42,43 @@ __global__ void test_clusterlaunchcontrol(void** fn_ptr)
           static_cast<void (*)(void*, uint64_t*)>(cuda::ptx::clusterlaunchcontrol_try_cancel_multicast));));
 #endif // __cccl_ptx_isa >= 860
 
-#if _CCCL_HAS_INT128()
-#  if __cccl_ptx_isa >= 860
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(NV_PROVIDES_SM_100,
                (
                    // clusterlaunchcontrol.query_cancel.is_canceled.pred.b128 pred_is_canceled, try_cancel_response;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<bool (*)(longlong2)>(cuda::ptx::clusterlaunchcontrol_query_cancel_is_canceled));));
-#  endif // __cccl_ptx_isa >= 860
+#endif // __cccl_ptx_isa >= 860
 
-#  if __cccl_ptx_isa >= 860
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(NV_PROVIDES_SM_100,
                (
                    // clusterlaunchcontrol.query_cancel.get_first_ctaid::x.b32.b128 ret_dim, try_cancel_response;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(longlong2)>(
                      cuda::ptx::clusterlaunchcontrol_query_cancel_get_first_ctaid_x));));
-#  endif // __cccl_ptx_isa >= 860
+#endif // __cccl_ptx_isa >= 860
 
-#  if __cccl_ptx_isa >= 860
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(NV_PROVIDES_SM_100,
                (
                    // clusterlaunchcontrol.query_cancel.get_first_ctaid::y.b32.b128 ret_dim, try_cancel_response;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(longlong2)>(
                      cuda::ptx::clusterlaunchcontrol_query_cancel_get_first_ctaid_y));));
-#  endif // __cccl_ptx_isa >= 860
+#endif // __cccl_ptx_isa >= 860
 
-#  if __cccl_ptx_isa >= 860
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(NV_PROVIDES_SM_100,
                (
                    // clusterlaunchcontrol.query_cancel.get_first_ctaid::z.b32.b128 ret_dim, try_cancel_response;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(longlong2)>(
                      cuda::ptx::clusterlaunchcontrol_query_cancel_get_first_ctaid_z));));
-#  endif // __cccl_ptx_isa >= 860
+#endif // __cccl_ptx_isa >= 860
 
-#  if __cccl_ptx_isa >= 860
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(NV_PROVIDES_SM_100,
                (
                    // clusterlaunchcontrol.query_cancel.get_first_ctaid.v4.b32.b128 block_dim, try_cancel_response;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&block_dim)[4], longlong2)>(
                      cuda::ptx::clusterlaunchcontrol_query_cancel_get_first_ctaid));));
-#  endif // __cccl_ptx_isa >= 860
-#endif // _CCCL_HAS_INT128()
+#endif // __cccl_ptx_isa >= 860
 }

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_multicast.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_multicast.h
@@ -44,7 +44,7 @@ __global__ void test_cp_async_bulk_multicast(void** fn_ptr)
                                uint64_t*,
                                const uint16_t&)>(cuda::ptx::cp_async_bulk));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.shared::cluster.global.mbarrier::complete_tx::bytes.multicast::cluster [dstMem], [srcMem],
         // size, [smem_bar], ctaMask;

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor.h
@@ -65,7 +65,7 @@ __global__ void test_cp_async_bulk_tensor(void** fn_ptr)
                                    const int32_t (&)[1],
                                    uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::1 [dstMem],
         // [tensorMap, tensorCoords], [smem_bar];
@@ -149,7 +149,7 @@ __global__ void test_cp_async_bulk_tensor(void** fn_ptr)
                                    const int32_t (&)[2],
                                    uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::1 [dstMem],
         // [tensorMap, tensorCoords], [smem_bar];
@@ -233,7 +233,7 @@ __global__ void test_cp_async_bulk_tensor(void** fn_ptr)
                                    const int32_t (&)[3],
                                    uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::1 [dstMem],
         // [tensorMap, tensorCoords], [smem_bar];
@@ -317,7 +317,7 @@ __global__ void test_cp_async_bulk_tensor(void** fn_ptr)
                                    const int32_t (&)[4],
                                    uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::1 [dstMem],
         // [tensorMap, tensorCoords], [smem_bar];
@@ -401,7 +401,7 @@ __global__ void test_cp_async_bulk_tensor(void** fn_ptr)
                                    const int32_t (&)[5],
                                    uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::1 [dstMem],
         // [tensorMap, tensorCoords], [smem_bar];

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor_gather_scatter.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor_gather_scatter.h
@@ -53,7 +53,7 @@ __global__ void test_cp_async_bulk_tensor_gather_scatter(void** fn_ptr)
                                    const int32_t (&)[5],
                                    uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::1 [dstMem],
         // [tensorMap, tensorCoords], [smem_bar];
@@ -92,7 +92,7 @@ __global__ void test_cp_async_bulk_tensor_gather_scatter(void** fn_ptr)
                                uint64_t*,
                                const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster
         // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -133,7 +133,7 @@ __global__ void test_cp_async_bulk_tensor_gather_scatter(void** fn_ptr)
                                    uint64_t*,
                                    const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::1
         // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -169,7 +169,7 @@ __global__ void test_cp_async_bulk_tensor_gather_scatter(void** fn_ptr)
             cuda::ptx::space_global_t, cuda::ptx::space_shared_t, const void*, const int32_t (&)[5], const void*)>(
             cuda::ptx::cp_async_bulk_tensor_tile_scatter4));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.2d.global.shared::cta.tile::scatter4.bulk_group [tensorMap, tensorCoords], [srcMem];
         * fn_ptr++ = reinterpret_cast<void*>(

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor_multicast.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor_multicast.h
@@ -44,7 +44,7 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                uint64_t*,
                                const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
         // [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -85,7 +85,7 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                    uint64_t*,
                                    const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::1
         // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -139,7 +139,7 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                uint64_t*,
                                const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
         // [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -180,7 +180,7 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                    uint64_t*,
                                    const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::1
         // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -234,7 +234,7 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                uint64_t*,
                                const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
         // [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -275,7 +275,7 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                    uint64_t*,
                                    const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::1
         // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -329,7 +329,7 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                uint64_t*,
                                const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
         // [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -370,7 +370,7 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                    uint64_t*,
                                    const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::1
         // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -424,7 +424,7 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                uint64_t*,
                                const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
         // [tensorMap, tensorCoords], [smem_bar], ctaMask;
@@ -465,7 +465,7 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                    uint64_t*,
                                    const uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::1
         // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/ld.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/ld.h
@@ -24,118 +24,6 @@ __global__ void test_ld(void** fn_ptr)
                      static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld));));
 #endif // __cccl_ptx_isa >= 100
 
-#if __cccl_ptx_isa >= 100
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // ld.global.b16 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld));));
-#endif // __cccl_ptx_isa >= 100
-
-#if __cccl_ptx_isa >= 100
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // ld.global.b32 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld));));
-#endif // __cccl_ptx_isa >= 100
-
-#if __cccl_ptx_isa >= 100
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // ld.global.b64 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld));));
-#endif // __cccl_ptx_isa >= 100
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_70,
-               (
-                   // ld.global.b128 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.L2::64B.b8 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.L2::64B.b16 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.L2::64B.b32 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.L2::64B.b64 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.L2::64B.b128 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.L2::128B.b8 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.L2::128B.b16 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.L2::128B.b32 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.L2::128B.b64 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.L2::128B.b128 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
@@ -143,6 +31,14 @@ __global__ void test_ld(void** fn_ptr)
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // ld.global.b16 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld));));
+#endif // __cccl_ptx_isa >= 100
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
@@ -152,6 +48,14 @@ __global__ void test_ld(void** fn_ptr)
                      static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // ld.global.b32 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld));));
+#endif // __cccl_ptx_isa >= 100
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
@@ -159,6 +63,14 @@ __global__ void test_ld(void** fn_ptr)
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // ld.global.b64 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld));));
+#endif // __cccl_ptx_isa >= 100
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
@@ -169,12 +81,28 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
+               (
+                   // ld.global.b128 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld));));
+#endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
                    // ld.global.L2::256B.b128 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(NV_PROVIDES_SM_100,
+               (
+                   // ld.global.v4.b64 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*)>(cuda::ptx::ld));));
+#endif // __cccl_ptx_isa >= 880
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
@@ -189,144 +117,18 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
-        // ld.global.L2::cache_hint.b16 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(cuda::ptx::ld_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(cuda::ptx::ld_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(cuda::ptx::ld_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
         // ld.global.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
           cuda::ptx::ld_L2_cache_hint_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L2::cache_hint.b16 dest, [addr], cache_policy;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(cuda::ptx::ld_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -343,10 +145,28 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
+        // ld.global.L2::cache_hint.b32 dest, [addr], cache_policy;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(cuda::ptx::ld_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
         // ld.global.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
             cuda::ptx::ld_L2_cache_hint_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L2::cache_hint.b64 dest, [addr], cache_policy;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(cuda::ptx::ld_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -363,763 +183,31 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
+        // ld.global.L2::cache_hint.b128 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
+            cuda::ptx::ld_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
         // ld.global.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
             cuda::ptx::ld_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
-#if __cccl_ptx_isa >= 740
+#if __cccl_ptx_isa >= 880
   NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
+    NV_PROVIDES_SM_100,
     (
-        // ld.global.L1::evict_normal.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_normal.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_normal.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_normal.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_normal.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_normal.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_normal_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_normal.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_evict_normal_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_normal.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_normal_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_normal.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_normal_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_normal.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_evict_normal_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_normal.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_normal_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_normal.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_L1_evict_normal_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_normal.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_L1_evict_normal_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_normal.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_L1_evict_normal_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_normal.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_evict_normal_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_normal_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::256B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_L1_evict_normal_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::256B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_L1_evict_normal_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::256B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_L1_evict_normal_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::256B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_evict_normal_L2_256B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.b16 dest, [addr], cache_policy;
+        // ld.global.L2::cache_hint.v4.b64 dest, [addr], cache_policy;
         * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_normal.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_normal_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_unchanged.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_unchanged.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_unchanged.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_unchanged.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_unchanged.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_unchanged.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_unchanged.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_unchanged.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_unchanged.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_unchanged.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_unchanged.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_unchanged.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_unchanged.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_unchanged.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_unchanged.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::256B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::256B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::256B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::256B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_256B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_unchanged.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_unchanged_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 830
+          reinterpret_cast<void*>(static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*, uint64_t)>(
+            cuda::ptx::ld_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
@@ -1128,6 +216,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.L1::evict_first.b8 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::evict_first.L2::256B.b8 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_first_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -1141,137 +238,20 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_first.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_first));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_first.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_first));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_first.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L1_evict_first));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_first.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_first_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_first.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_evict_first_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_first.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_first_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_first.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_first_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_first.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_evict_first_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_first.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_first_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_first.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_evict_first_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_first.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_first_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_first.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_first_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_first.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_evict_first_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_first_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.L1::evict_first.L2::256B.b16 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.L1::evict_first.b32 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_first));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -1285,12 +265,30 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.L1::evict_first.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.L1::evict_first.L2::256B.b64 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_first_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.L1::evict_first.b128 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -1301,6 +299,15 @@ __global__ void test_ld(void** fn_ptr)
           cuda::ptx::ld_L1_evict_first_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.L1::evict_first.v4.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*)>(cuda::ptx::ld_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
@@ -1308,6 +315,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.L1::evict_first.L2::cache_hint.b8 dest, [addr], cache_policy;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
           cuda::ptx::ld_L1_evict_first_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
+          cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -1324,147 +340,20 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
-        // ld.global.L1::evict_first.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
         // ld.global.L1::evict_first.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
             cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::evict_first.L2::cache_hint.b32 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
+            cuda::ptx::ld_L1_evict_first_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -1481,11 +370,31 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
+        // ld.global.L1::evict_first.L2::cache_hint.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
+            cuda::ptx::ld_L1_evict_first_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
         // ld.global.L1::evict_first.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
             cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::evict_first.L2::cache_hint.b128 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
+            cuda::ptx::ld_L1_evict_first_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -1497,12 +406,31 @@ __global__ void test_ld(void** fn_ptr)
             cuda::ptx::ld_L1_evict_first_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.L1::evict_first.L2::cache_hint.v4.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*, uint64_t)>(
+            cuda::ptx::ld_L1_evict_first_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
                    // ld.global.L1::evict_last.b8 dest, [addr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::evict_last.L2::256B.b8 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_last_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -1516,137 +444,20 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_last.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_last));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_last.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_last));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::evict_last.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L1_evict_last));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_last.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_last_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_last.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_evict_last_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_last.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_last_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_last.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_last_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_last.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_evict_last_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_last.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_last_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_last.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_evict_last_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_last.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_last_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_last.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_last_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::evict_last.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_evict_last_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_evict_last_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.L1::evict_last.L2::256B.b16 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.L1::evict_last.b32 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_evict_last));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -1660,12 +471,30 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.L1::evict_last.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.L1::evict_last.L2::256B.b64 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_evict_last_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.L1::evict_last.b128 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -1676,6 +505,15 @@ __global__ void test_ld(void** fn_ptr)
           cuda::ptx::ld_L1_evict_last_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.L1::evict_last.v4.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*)>(cuda::ptx::ld_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
@@ -1683,6 +521,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.L1::evict_last.L2::cache_hint.b8 dest, [addr], cache_policy;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
           cuda::ptx::ld_L1_evict_last_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
+          cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -1699,147 +546,20 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
-        // ld.global.L1::evict_last.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
         // ld.global.L1::evict_last.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
             cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::evict_last.L2::cache_hint.b32 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
+            cuda::ptx::ld_L1_evict_last_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -1856,11 +576,31 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
+        // ld.global.L1::evict_last.L2::cache_hint.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
+            cuda::ptx::ld_L1_evict_last_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
         // ld.global.L1::evict_last.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
             cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::evict_last.L2::cache_hint.b128 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
+            cuda::ptx::ld_L1_evict_last_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -1872,6 +612,16 @@ __global__ void test_ld(void** fn_ptr)
             cuda::ptx::ld_L1_evict_last_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.L1::evict_last.L2::cache_hint.v4.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*, uint64_t)>(
+            cuda::ptx::ld_L1_evict_last_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_70,
@@ -1879,6 +629,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.L1::no_allocate.b8 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::no_allocate.L2::256B.b8 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_no_allocate_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -1892,137 +651,20 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::no_allocate.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_no_allocate));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::no_allocate.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_no_allocate));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.L1::no_allocate.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L1_no_allocate));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::no_allocate.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_no_allocate_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::no_allocate.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_no_allocate_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::no_allocate.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_no_allocate_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::no_allocate.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_no_allocate_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::no_allocate.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_no_allocate_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::no_allocate.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_no_allocate_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::no_allocate.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_no_allocate_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::no_allocate.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_no_allocate_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::no_allocate.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_no_allocate_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.L1::no_allocate.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_L1_no_allocate_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_L1_no_allocate_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.L1::no_allocate.L2::256B.b16 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.L1::no_allocate.b32 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_L1_no_allocate));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -2036,12 +678,30 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.L1::no_allocate.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.L1::no_allocate.L2::256B.b64 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_L1_no_allocate_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.L1::no_allocate.b128 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -2052,6 +712,15 @@ __global__ void test_ld(void** fn_ptr)
           cuda::ptx::ld_L1_no_allocate_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.L1::no_allocate.v4.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*)>(cuda::ptx::ld_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
@@ -2059,6 +728,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.L1::no_allocate.L2::cache_hint.b8 dest, [addr], cache_policy;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
           cuda::ptx::ld_L1_no_allocate_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
+          cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -2075,147 +753,20 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
-        // ld.global.L1::no_allocate.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
         // ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
             cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::no_allocate.L2::cache_hint.b32 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
+            cuda::ptx::ld_L1_no_allocate_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -2232,11 +783,31 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
+        // ld.global.L1::no_allocate.L2::cache_hint.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
+            cuda::ptx::ld_L1_no_allocate_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
         // ld.global.L1::no_allocate.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
             cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.L1::no_allocate.L2::cache_hint.b128 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
+            cuda::ptx::ld_L1_no_allocate_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -2248,6 +819,16 @@ __global__ void test_ld(void** fn_ptr)
             cuda::ptx::ld_L1_no_allocate_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.L1::no_allocate.L2::cache_hint.v4.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*, uint64_t)>(
+            cuda::ptx::ld_L1_no_allocate_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 100
   NV_IF_TARGET(NV_PROVIDES_SM_50,
                (
@@ -2255,120 +836,6 @@ __global__ void test_ld(void** fn_ptr)
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc));));
 #endif // __cccl_ptx_isa >= 100
-
-#if __cccl_ptx_isa >= 100
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // ld.global.nc.b16 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_nc));));
-#endif // __cccl_ptx_isa >= 100
-
-#if __cccl_ptx_isa >= 100
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // ld.global.nc.b32 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc));));
-#endif // __cccl_ptx_isa >= 100
-
-#if __cccl_ptx_isa >= 100
-  NV_IF_TARGET(NV_PROVIDES_SM_50,
-               (
-                   // ld.global.nc.b64 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc));));
-#endif // __cccl_ptx_isa >= 100
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(NV_PROVIDES_SM_70,
-               (
-                   // ld.global.nc.b128 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.nc.L2::64B.b8 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.nc.L2::64B.b16 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_nc_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.nc.L2::64B.b32 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.nc.L2::64B.b64 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.nc.L2::128B.b8 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.nc.L2::128B.b16 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_nc_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.nc.L2::128B.b32 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(NV_PROVIDES_SM_75,
-               (
-                   // ld.global.nc.L2::128B.b64 dest, [addr];
-                   * fn_ptr++ = reinterpret_cast<void*>(
-                     static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
@@ -2378,6 +845,14 @@ __global__ void test_ld(void** fn_ptr)
                      static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // ld.global.nc.b16 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_nc));));
+#endif // __cccl_ptx_isa >= 100
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
@@ -2386,6 +861,14 @@ __global__ void test_ld(void** fn_ptr)
                      static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_nc_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // ld.global.nc.b32 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc));));
+#endif // __cccl_ptx_isa >= 100
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                (
@@ -2393,6 +876,14 @@ __global__ void test_ld(void** fn_ptr)
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 100
+  NV_IF_TARGET(NV_PROVIDES_SM_50,
+               (
+                   // ld.global.nc.b64 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc));));
+#endif // __cccl_ptx_isa >= 100
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_80,
@@ -2403,6 +894,14 @@ __global__ void test_ld(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(NV_PROVIDES_SM_70,
+               (
+                   // ld.global.nc.b128 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc));));
+#endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
@@ -2411,6 +910,14 @@ __global__ void test_ld(void** fn_ptr)
           static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(NV_PROVIDES_SM_100,
+               (
+                   // ld.global.nc.v4.b64 dest, [addr];
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*)>(cuda::ptx::ld_nc));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
@@ -2418,6 +925,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.nc.L2::cache_hint.b8 dest, [addr], cache_policy;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
           cuda::ptx::ld_nc_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
+          cuda::ptx::ld_nc_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -2434,147 +950,20 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
-        // ld.global.nc.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
         // ld.global.nc.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
             cuda::ptx::ld_nc_L2_cache_hint_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L2::cache_hint.b32 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
+            cuda::ptx::ld_nc_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -2591,11 +980,31 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
+        // ld.global.nc.L2::cache_hint.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
+            cuda::ptx::ld_nc_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
         // ld.global.nc.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
             cuda::ptx::ld_nc_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L2::cache_hint.b128 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
+            cuda::ptx::ld_nc_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -2607,757 +1016,15 @@ __global__ void test_ld(void** fn_ptr)
             cuda::ptx::ld_nc_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
-#if __cccl_ptx_isa >= 740
+#if __cccl_ptx_isa >= 880
   NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
+    NV_PROVIDES_SM_100,
     (
-        // ld.global.nc.L1::evict_normal.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_normal.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_nc_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_normal.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_normal.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_normal.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_normal.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_normal.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_normal.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_normal.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_normal.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_normal.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_normal.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_normal.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_normal.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_normal.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::256B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::256B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::256B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::256B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_256B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.b16 dest, [addr], cache_policy;
+        // ld.global.nc.L2::cache_hint.v4.b64 dest, [addr], cache_policy;
         * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_normal.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_normal_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_unchanged.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_unchanged.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(cuda::ptx::ld_nc_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_unchanged.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_unchanged.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_unchanged.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::256B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::256B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::256B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::256B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_256B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_unchanged.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_unchanged_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 830
+          reinterpret_cast<void*>(static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*, uint64_t)>(
+            cuda::ptx::ld_nc_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
@@ -3366,6 +1033,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.nc.L1::evict_first.b8 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::evict_first.L2::256B.b8 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
+          cuda::ptx::ld_nc_L1_evict_first_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -3379,137 +1055,20 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_first.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L1_evict_first));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_first.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc_L1_evict_first));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_first.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc_L1_evict_first));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_first.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_evict_first_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_first.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_first.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_first.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_first.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_first.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_first.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_first.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_first.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_first.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.nc.L1::evict_first.L2::256B.b16 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
           cuda::ptx::ld_nc_L1_evict_first_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.nc.L1::evict_first.b32 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L1_evict_first));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -3523,12 +1082,30 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.nc.L1::evict_first.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.nc.L1::evict_first.L2::256B.b64 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
           cuda::ptx::ld_nc_L1_evict_first_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.nc.L1::evict_first.b128 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -3539,6 +1116,15 @@ __global__ void test_ld(void** fn_ptr)
           cuda::ptx::ld_nc_L1_evict_first_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.nc.L1::evict_first.v4.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*)>(cuda::ptx::ld_nc_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
@@ -3546,6 +1132,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.nc.L1::evict_first.L2::cache_hint.b8 dest, [addr], cache_policy;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
           cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
+          cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -3562,147 +1157,20 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
         // ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
             cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::evict_first.L2::cache_hint.b32 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -3719,11 +1187,31 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
+        // ld.global.nc.L1::evict_first.L2::cache_hint.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
         // ld.global.nc.L1::evict_first.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
             cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::evict_first.L2::cache_hint.b128 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -3735,6 +1223,16 @@ __global__ void test_ld(void** fn_ptr)
             cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.nc.L1::evict_first.L2::cache_hint.v4.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_evict_first_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_70,
@@ -3742,6 +1240,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.nc.L1::evict_last.b8 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::evict_last.L2::256B.b8 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_evict_last_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -3755,137 +1262,20 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_last.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L1_evict_last));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_last.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc_L1_evict_last));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::evict_last.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc_L1_evict_last));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_last.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_evict_last_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_last.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_last.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_last.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_last.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_last.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_evict_last_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_last.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_last.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_last.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::evict_last.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_evict_last_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.nc.L1::evict_last.L2::256B.b16 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
           cuda::ptx::ld_nc_L1_evict_last_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.nc.L1::evict_last.b32 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L1_evict_last));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -3899,12 +1289,30 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.nc.L1::evict_last.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.nc.L1::evict_last.L2::256B.b64 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
           cuda::ptx::ld_nc_L1_evict_last_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.nc.L1::evict_last.b128 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -3915,6 +1323,15 @@ __global__ void test_ld(void** fn_ptr)
           cuda::ptx::ld_nc_L1_evict_last_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.nc.L1::evict_last.v4.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*)>(cuda::ptx::ld_nc_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
@@ -3922,6 +1339,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.nc.L1::evict_last.L2::cache_hint.b8 dest, [addr], cache_policy;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
           cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
+          cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -3938,147 +1364,20 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
         // ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
             cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::evict_last.L2::cache_hint.b32 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -4095,11 +1394,31 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
+        // ld.global.nc.L1::evict_last.L2::cache_hint.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
         // ld.global.nc.L1::evict_last.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
             cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::evict_last.L2::cache_hint.b128 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -4111,6 +1430,16 @@ __global__ void test_ld(void** fn_ptr)
             cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.nc.L1::evict_last.L2::cache_hint.v4.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_evict_last_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_70,
@@ -4118,6 +1447,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.nc.L1::no_allocate.b8 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::no_allocate.L2::256B.b8 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
+          cuda::ptx::ld_nc_L1_no_allocate_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -4131,137 +1469,20 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::no_allocate.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L1_no_allocate));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::no_allocate.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc_L1_no_allocate));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // ld.global.nc.L1::no_allocate.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc_L1_no_allocate));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::no_allocate.L2::64B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(cuda::ptx::ld_nc_L1_no_allocate_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::no_allocate.L2::64B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::no_allocate.L2::64B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::no_allocate.L2::64B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::no_allocate.L2::64B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::no_allocate.L2::128B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::no_allocate.L2::128B.b16 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::no_allocate.L2::128B.b32 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::no_allocate.L2::128B.b64 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_75,
-    (
-        // ld.global.nc.L1::no_allocate.L2::128B.b128 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::256B.b8 dest, [addr];
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.nc.L1::no_allocate.L2::256B.b16 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*)>(
           cuda::ptx::ld_nc_L1_no_allocate_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.nc.L1::no_allocate.b32 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*)>(cuda::ptx::ld_nc_L1_no_allocate));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -4275,12 +1496,30 @@ __global__ void test_ld(void** fn_ptr)
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.nc.L1::no_allocate.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(cuda::ptx::ld_nc_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
         // ld.global.nc.L1::no_allocate.L2::256B.b64 dest, [addr];
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*)>(
           cuda::ptx::ld_nc_L1_no_allocate_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_70,
+    (
+        // ld.global.nc.L1::no_allocate.b128 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*)>(cuda::ptx::ld_nc_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 830
 
 #if __cccl_ptx_isa >= 830
   NV_IF_TARGET(
@@ -4291,6 +1530,15 @@ __global__ void test_ld(void** fn_ptr)
           cuda::ptx::ld_nc_L1_no_allocate_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.nc.L1::no_allocate.v4.b64 dest, [addr];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*)>(cuda::ptx::ld_nc_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
@@ -4298,6 +1546,15 @@ __global__ void test_ld(void** fn_ptr)
         // ld.global.nc.L1::no_allocate.L2::cache_hint.b8 dest, [addr], cache_policy;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
           cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
+        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
+          cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -4314,147 +1571,20 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::64B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_64B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b16 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b32 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b64 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::128B.b128 dest, [addr], cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
-            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_128B));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b8 dest, [addr], cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<int8_t (*)(cuda::ptx::space_global_t, const int8_t*, uint64_t)>(
-          cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_256B));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
         // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b16 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int16_t (*)(cuda::ptx::space_global_t, const int16_t*, uint64_t)>(
             cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_256B));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
+        // ld.global.nc.L1::no_allocate.L2::cache_hint.b32 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int32_t (*)(cuda::ptx::space_global_t, const int32_t*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 740
 
 #if __cccl_ptx_isa >= 740
@@ -4471,6 +1601,16 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
+        // ld.global.nc.L1::no_allocate.L2::cache_hint.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 740
+
+#if __cccl_ptx_isa >= 740
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
         // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b64 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<int64_t (*)(cuda::ptx::space_global_t, const int64_t*, uint64_t)>(
@@ -4481,9 +1621,29 @@ __global__ void test_ld(void** fn_ptr)
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
     (
+        // ld.global.nc.L1::no_allocate.L2::cache_hint.b128 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 830
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_80,
+    (
         // ld.global.nc.L1::no_allocate.L2::cache_hint.L2::256B.b128 dest, [addr], cache_policy;
         * fn_ptr++ =
           reinterpret_cast<void*>(static_cast<longlong2 (*)(cuda::ptx::space_global_t, const longlong2*, uint64_t)>(
             cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint_L2_256B));));
 #endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // ld.global.nc.L1::no_allocate.L2::cache_hint.v4.b64 dest, [addr], cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<longlong4 (*)(cuda::ptx::space_global_t, const longlong4*, uint64_t)>(
+            cuda::ptx::ld_nc_L1_no_allocate_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
 }

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/st.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/st.h
@@ -56,6 +56,14 @@ __global__ void test_st(void** fn_ptr)
                      static_cast<void (*)(cuda::ptx::space_global_t, longlong2*, longlong2)>(cuda::ptx::st));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(NV_PROVIDES_SM_100,
+               (
+                   // st.global.v4.b64 [addr], src;
+                   * fn_ptr++ = reinterpret_cast<void*>(
+                     static_cast<void (*)(cuda::ptx::space_global_t, longlong4*, longlong4)>(cuda::ptx::st));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_80,
@@ -102,193 +110,15 @@ __global__ void test_st(void** fn_ptr)
             cuda::ptx::st_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 830
 
-#if __cccl_ptx_isa >= 740
+#if __cccl_ptx_isa >= 880
   NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
+    NV_PROVIDES_SM_100,
     (
-        // st.global.L1::evict_normal.b8 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_global_t, int8_t*, int8_t)>(cuda::ptx::st_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // st.global.L1::evict_normal.b16 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_global_t, int16_t*, int16_t)>(cuda::ptx::st_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // st.global.L1::evict_normal.b32 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_global_t, int32_t*, int32_t)>(cuda::ptx::st_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // st.global.L1::evict_normal.b64 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_global_t, int64_t*, int64_t)>(cuda::ptx::st_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // st.global.L1::evict_normal.b128 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_global_t, longlong2*, longlong2)>(cuda::ptx::st_L1_evict_normal));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // st.global.L1::evict_normal.L2::cache_hint.b8 [addr], src, cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, int8_t*, int8_t, uint64_t)>(
-          cuda::ptx::st_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // st.global.L1::evict_normal.L2::cache_hint.b16 [addr], src, cache_policy;
+        // st.global.L2::cache_hint.v4.b64 [addr], src, cache_policy;
         * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, int16_t*, int16_t, uint64_t)>(
-            cuda::ptx::st_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // st.global.L1::evict_normal.L2::cache_hint.b32 [addr], src, cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, int32_t*, int32_t, uint64_t)>(
-            cuda::ptx::st_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // st.global.L1::evict_normal.L2::cache_hint.b64 [addr], src, cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, int64_t*, int64_t, uint64_t)>(
-            cuda::ptx::st_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // st.global.L1::evict_normal.L2::cache_hint.b128 [addr], src, cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, longlong2*, longlong2, uint64_t)>(
-            cuda::ptx::st_L1_evict_normal_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // st.global.L1::evict_unchanged.b8 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_global_t, int8_t*, int8_t)>(cuda::ptx::st_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // st.global.L1::evict_unchanged.b16 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_global_t, int16_t*, int16_t)>(cuda::ptx::st_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // st.global.L1::evict_unchanged.b32 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_global_t, int32_t*, int32_t)>(cuda::ptx::st_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // st.global.L1::evict_unchanged.b64 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_global_t, int64_t*, int64_t)>(cuda::ptx::st_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_70,
-    (
-        // st.global.L1::evict_unchanged.b128 [addr], src;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_global_t, longlong2*, longlong2)>(cuda::ptx::st_L1_evict_unchanged));));
-#endif // __cccl_ptx_isa >= 830
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // st.global.L1::evict_unchanged.L2::cache_hint.b8 [addr], src, cache_policy;
-        * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, int8_t*, int8_t, uint64_t)>(
-          cuda::ptx::st_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // st.global.L1::evict_unchanged.L2::cache_hint.b16 [addr], src, cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, int16_t*, int16_t, uint64_t)>(
-            cuda::ptx::st_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // st.global.L1::evict_unchanged.L2::cache_hint.b32 [addr], src, cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, int32_t*, int32_t, uint64_t)>(
-            cuda::ptx::st_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 740
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // st.global.L1::evict_unchanged.L2::cache_hint.b64 [addr], src, cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, int64_t*, int64_t, uint64_t)>(
-            cuda::ptx::st_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 740
-
-#if __cccl_ptx_isa >= 830
-  NV_IF_TARGET(
-    NV_PROVIDES_SM_80,
-    (
-        // st.global.L1::evict_unchanged.L2::cache_hint.b128 [addr], src, cache_policy;
-        * fn_ptr++ =
-          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, longlong2*, longlong2, uint64_t)>(
-            cuda::ptx::st_L1_evict_unchanged_L2_cache_hint));));
-#endif // __cccl_ptx_isa >= 830
+          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, longlong4*, longlong4, uint64_t)>(
+            cuda::ptx::st_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
@@ -334,6 +164,15 @@ __global__ void test_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::space_global_t, longlong2*, longlong2)>(cuda::ptx::st_L1_evict_first));));
 #endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // st.global.L1::evict_first.v4.b64 [addr], src;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t, longlong4*, longlong4)>(cuda::ptx::st_L1_evict_first));));
+#endif // __cccl_ptx_isa >= 880
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
@@ -384,6 +223,16 @@ __global__ void test_st(void** fn_ptr)
             cuda::ptx::st_L1_evict_first_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // st.global.L1::evict_first.L2::cache_hint.v4.b64 [addr], src, cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, longlong4*, longlong4, uint64_t)>(
+            cuda::ptx::st_L1_evict_first_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                (
@@ -427,6 +276,15 @@ __global__ void test_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::space_global_t, longlong2*, longlong2)>(cuda::ptx::st_L1_evict_last));));
 #endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // st.global.L1::evict_last.v4.b64 [addr], src;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t, longlong4*, longlong4)>(cuda::ptx::st_L1_evict_last));));
+#endif // __cccl_ptx_isa >= 880
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
@@ -477,6 +335,16 @@ __global__ void test_st(void** fn_ptr)
             cuda::ptx::st_L1_evict_last_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 830
 
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // st.global.L1::evict_last.L2::cache_hint.v4.b64 [addr], src, cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, longlong4*, longlong4, uint64_t)>(
+            cuda::ptx::st_L1_evict_last_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
+
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
     NV_PROVIDES_SM_70,
@@ -521,6 +389,15 @@ __global__ void test_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::space_global_t, longlong2*, longlong2)>(cuda::ptx::st_L1_no_allocate));));
 #endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // st.global.L1::no_allocate.v4.b64 [addr], src;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t, longlong4*, longlong4)>(cuda::ptx::st_L1_no_allocate));));
+#endif // __cccl_ptx_isa >= 880
 
 #if __cccl_ptx_isa >= 740
   NV_IF_TARGET(
@@ -570,4 +447,14 @@ __global__ void test_st(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, longlong2*, longlong2, uint64_t)>(
             cuda::ptx::st_L1_no_allocate_L2_cache_hint));));
 #endif // __cccl_ptx_isa >= 830
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // st.global.L1::no_allocate.L2::cache_hint.v4.b64 [addr], src, cache_policy;
+        * fn_ptr++ =
+          reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, longlong4*, longlong4, uint64_t)>(
+            cuda::ptx::st_L1_no_allocate_L2_cache_hint));));
+#endif // __cccl_ptx_isa >= 880
 }

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_alloc.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_alloc.h
@@ -27,7 +27,7 @@ __global__ void test_tcgen05_alloc(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(
               static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t*, const uint32_t&)>(cuda::ptx::tcgen05_alloc));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.alloc.cta_group::1.sync.aligned.shared::cta.b32 [dst], nCols;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -48,7 +48,7 @@ __global__ void test_tcgen05_alloc(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(
               static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, const uint32_t&)>(cuda::ptx::tcgen05_dealloc));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.dealloc.cta_group::1.sync.aligned.b32 taddr, nCols;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -69,7 +69,7 @@ __global__ void test_tcgen05_alloc(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(
               static_cast<void (*)(cuda::ptx::cta_group_2_t)>(cuda::ptx::tcgen05_relinquish_alloc_permit));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;
         * fn_ptr++ = reinterpret_cast<void*>(

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_commit.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_commit.h
@@ -27,7 +27,7 @@ __global__ void test_tcgen05_commit(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(
               static_cast<void (*)(cuda::ptx::cta_group_2_t, uint64_t*)>(cuda::ptx::tcgen05_commit));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -49,7 +49,7 @@ __global__ void test_tcgen05_commit(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint64_t*, uint16_t)>(
               cuda::ptx::tcgen05_commit_multicast));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.multicast::cluster.b64 [smem_bar], ctaMask;
         * fn_ptr++ = reinterpret_cast<void*>(

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_cp.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_cp.h
@@ -27,7 +27,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(
               static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(cuda::ptx::tcgen05_cp_128x256b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.128x256b [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -48,7 +48,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(
               static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(cuda::ptx::tcgen05_cp_4x256b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -69,7 +69,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(
               static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(cuda::ptx::tcgen05_cp_128x128b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -90,7 +90,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -111,7 +111,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -132,7 +132,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_32x128b_warpx4));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -153,7 +153,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -174,7 +174,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -195,7 +195,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -216,7 +216,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -237,7 +237,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -258,7 +258,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -279,7 +279,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -300,7 +300,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -321,7 +321,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -342,7 +342,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -363,7 +363,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(
@@ -384,7 +384,7 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t, uint64_t)>(
               cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::cta_group_1_t, uint32_t, uint64_t)>(

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_fence.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_fence.h
@@ -23,7 +23,7 @@ __global__ void test_tcgen05_fence(void** fn_ptr)
         // tcgen05.fence::before_thread_sync;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)()>(cuda::ptx::tcgen05_fence_before_thread_sync));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.fence::before_thread_sync;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)()>(cuda::ptx::tcgen05_fence_before_thread_sync));));
@@ -36,7 +36,7 @@ __global__ void test_tcgen05_fence(void** fn_ptr)
         // tcgen05.fence::after_thread_sync;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)()>(cuda::ptx::tcgen05_fence_after_thread_sync));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.fence::after_thread_sync;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)()>(cuda::ptx::tcgen05_fence_after_thread_sync));));

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_ld.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_ld.h
@@ -22,7 +22,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x1.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[1], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x1.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -35,7 +35,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x1.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[1], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x1.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -48,7 +48,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x2.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[2], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x2.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -61,7 +61,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x2.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[2], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x2.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -74,7 +74,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x4.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[4], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x4.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -87,7 +87,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x4.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[4], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x4.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -100,7 +100,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x8.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[8], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x8.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -113,7 +113,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x8.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[8], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x8.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -126,7 +126,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x16.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[16], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x16.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -139,7 +139,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x16.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[16], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x16.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -152,7 +152,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x32.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[32], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x32.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -165,7 +165,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x32.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[32], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x32.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -178,7 +178,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x64.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[64], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x64.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -191,7 +191,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x64.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[64], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x64.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -204,7 +204,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x128.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[128], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x128.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -217,7 +217,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x64b.x128.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[128], uint32_t)>(cuda::ptx::tcgen05_ld_16x64b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x64b.x128.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -230,7 +230,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x1.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[2], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x1.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -243,7 +243,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x1.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[2], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x1.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -256,7 +256,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x2.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[4], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x2.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -269,7 +269,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x2.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[4], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x2.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -282,7 +282,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x4.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[8], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x4.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -295,7 +295,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x4.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[8], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x4.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -308,7 +308,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x8.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[16], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x8.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -321,7 +321,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x8.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[16], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x8.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -334,7 +334,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x16.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[32], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x16.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -347,7 +347,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x16.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[32], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x16.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -360,7 +360,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x32.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[64], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x32.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -373,7 +373,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x32.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[64], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x32.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -386,7 +386,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x64.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[128], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x64.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -399,7 +399,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x128b.x64.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[128], uint32_t)>(cuda::ptx::tcgen05_ld_16x128b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x128b.x64.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -412,7 +412,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x1.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[4], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x1.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -425,7 +425,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x1.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[4], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x1.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -438,7 +438,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x2.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[8], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x2.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -451,7 +451,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x2.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[8], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x2.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -464,7 +464,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x4.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[16], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x4.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -477,7 +477,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x4.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[16], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x4.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -490,7 +490,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x8.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[32], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x8.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -503,7 +503,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x8.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[32], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x8.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -516,7 +516,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x16.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[64], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x16.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -529,7 +529,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x16.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[64], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x16.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -542,7 +542,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x32.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[128], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x32.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -555,7 +555,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.16x256b.x32.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[128], uint32_t)>(cuda::ptx::tcgen05_ld_16x256b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.16x256b.x32.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -568,7 +568,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x1.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[1], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x1.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -581,7 +581,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x1.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[1], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x1.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -594,7 +594,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x2.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[2], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x2.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -607,7 +607,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x2.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[2], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x2.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -620,7 +620,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x4.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[4], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x4.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -633,7 +633,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x4.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[4], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x4.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -646,7 +646,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x8.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[8], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x8.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -659,7 +659,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x8.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[8], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x8.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -672,7 +672,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x16.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[16], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x16.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -685,7 +685,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x16.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[16], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x16.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -698,7 +698,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x32.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[32], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x32.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -711,7 +711,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x32.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[32], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x32.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -724,7 +724,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x64.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[64], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x64.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -737,7 +737,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x64.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[64], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x64.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -750,7 +750,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x128.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[128], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x128.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -763,7 +763,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
                    // tcgen05.ld.sync.aligned.32x32b.x128.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(int32_t (&out)[128], uint32_t)>(cuda::ptx::tcgen05_ld_32x32b_pack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.ld.sync.aligned.32x32b.x128.pack::16b.b32 out, [taddr];
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -778,7 +778,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(int32_t (&out)[1], uint32_t, cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_ld_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x1.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -793,7 +793,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[1], uint32_t, cuda::ptx::n32_t<0>)>(
           cuda::ptx::tcgen05_ld_16x32bx2_pack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x1.pack::16b.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[1], uint32_t, cuda::ptx::n32_t<0>)>(
@@ -808,7 +808,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(int32_t (&out)[2], uint32_t, cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_ld_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x2.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -823,7 +823,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[2], uint32_t, cuda::ptx::n32_t<0>)>(
           cuda::ptx::tcgen05_ld_16x32bx2_pack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x2.pack::16b.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[2], uint32_t, cuda::ptx::n32_t<0>)>(
@@ -838,7 +838,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(int32_t (&out)[4], uint32_t, cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_ld_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x4.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -853,7 +853,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[4], uint32_t, cuda::ptx::n32_t<0>)>(
           cuda::ptx::tcgen05_ld_16x32bx2_pack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x4.pack::16b.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[4], uint32_t, cuda::ptx::n32_t<0>)>(
@@ -868,7 +868,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(int32_t (&out)[8], uint32_t, cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_ld_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x8.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -883,7 +883,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[8], uint32_t, cuda::ptx::n32_t<0>)>(
           cuda::ptx::tcgen05_ld_16x32bx2_pack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x8.pack::16b.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[8], uint32_t, cuda::ptx::n32_t<0>)>(
@@ -898,7 +898,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(int32_t (&out)[16], uint32_t, cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_ld_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x16.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -913,7 +913,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[16], uint32_t, cuda::ptx::n32_t<0>)>(
           cuda::ptx::tcgen05_ld_16x32bx2_pack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x16.pack::16b.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[16], uint32_t, cuda::ptx::n32_t<0>)>(
@@ -928,7 +928,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(int32_t (&out)[32], uint32_t, cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_ld_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x32.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -943,7 +943,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[32], uint32_t, cuda::ptx::n32_t<0>)>(
           cuda::ptx::tcgen05_ld_16x32bx2_pack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x32.pack::16b.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[32], uint32_t, cuda::ptx::n32_t<0>)>(
@@ -958,7 +958,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(int32_t (&out)[64], uint32_t, cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_ld_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x64.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -973,7 +973,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[64], uint32_t, cuda::ptx::n32_t<0>)>(
           cuda::ptx::tcgen05_ld_16x32bx2_pack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x64.pack::16b.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[64], uint32_t, cuda::ptx::n32_t<0>)>(
@@ -988,7 +988,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(int32_t (&out)[128], uint32_t, cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_ld_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x128.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -1003,7 +1003,7 @@ __global__ void test_tcgen05_ld(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[128], uint32_t, cuda::ptx::n32_t<0>)>(
           cuda::ptx::tcgen05_ld_16x32bx2_pack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.ld.sync.aligned.16x32bx2.x128.pack::16b.b32 out, [taddr], immHalfSplitoff;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(int32_t (&out)[128], uint32_t, cuda::ptx::n32_t<0>)>(

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_mma.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_mma.h
@@ -121,7 +121,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    const uint32_t (&)[4],
                                    bool)>(cuda::ptx::tcgen05_mma));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -210,7 +210,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    const uint32_t (&)[8],
                                    bool)>(cuda::ptx::tcgen05_mma));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -345,7 +345,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                 cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -495,7 +495,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    const uint32_t (&)[4],
                                    bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -586,7 +586,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    const uint32_t (&)[8],
                                    bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -722,7 +722,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                 cuda::ptx::kind_i8_t, cuda::ptx::cta_group_2_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_tmem_a));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -795,7 +795,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -876,7 +876,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -957,7 +957,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1014,7 +1014,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1095,7 +1095,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1176,7 +1176,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1233,7 +1233,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1314,7 +1314,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1395,7 +1395,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1452,7 +1452,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1533,7 +1533,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1614,7 +1614,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1671,7 +1671,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1752,7 +1752,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1833,7 +1833,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1890,7 +1890,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -1971,7 +1971,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2052,7 +2052,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2109,7 +2109,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2190,7 +2190,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2271,7 +2271,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2328,7 +2328,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2409,7 +2409,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2490,7 +2490,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2547,7 +2547,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2628,7 +2628,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2709,7 +2709,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2766,7 +2766,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2847,7 +2847,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
@@ -2928,7 +2928,7 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                    uint32_t,
                                    bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_mma_ws.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_mma_ws.h
@@ -45,7 +45,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b0_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -99,7 +99,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b0_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -153,7 +153,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b0_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -208,7 +208,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b0_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -263,7 +263,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b0_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -317,7 +317,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b0_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::use [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -371,7 +371,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b0_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -426,7 +426,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b0_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -481,7 +481,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b0_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -537,7 +537,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b0_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -593,7 +593,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b0_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d, zero_column_mask_desc;
@@ -650,7 +650,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b0_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::lastuse [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d;
@@ -707,7 +707,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b0_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -763,7 +763,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b0_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -819,7 +819,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b0_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d, zero_column_mask_desc;
@@ -876,7 +876,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b0_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b0::discard [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d;
@@ -933,7 +933,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b1_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -987,7 +987,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b1_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -1041,7 +1041,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b1_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -1096,7 +1096,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b1_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -1151,7 +1151,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b1_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -1205,7 +1205,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b1_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::use [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -1259,7 +1259,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b1_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -1314,7 +1314,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b1_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -1369,7 +1369,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b1_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -1425,7 +1425,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b1_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -1481,7 +1481,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b1_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d, zero_column_mask_desc;
@@ -1538,7 +1538,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b1_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::lastuse [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d;
@@ -1595,7 +1595,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b1_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -1651,7 +1651,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b1_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -1707,7 +1707,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b1_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d, zero_column_mask_desc;
@@ -1764,7 +1764,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b1_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b1::discard [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d;
@@ -1821,7 +1821,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b2_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -1875,7 +1875,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b2_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -1929,7 +1929,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b2_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -1984,7 +1984,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b2_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -2039,7 +2039,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b2_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -2093,7 +2093,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b2_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::use [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -2147,7 +2147,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b2_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -2202,7 +2202,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b2_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -2257,7 +2257,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b2_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -2313,7 +2313,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b2_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -2369,7 +2369,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b2_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d, zero_column_mask_desc;
@@ -2426,7 +2426,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b2_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::lastuse [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d;
@@ -2483,7 +2483,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b2_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -2539,7 +2539,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b2_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -2595,7 +2595,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b2_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d, zero_column_mask_desc;
@@ -2652,7 +2652,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b2_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b2::discard [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d;
@@ -2709,7 +2709,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b3_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -2763,7 +2763,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b3_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::fill [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -2817,7 +2817,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b3_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -2872,7 +2872,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b3_fill));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::fill [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -2927,7 +2927,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b3_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -2981,7 +2981,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b3_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::use [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -3035,7 +3035,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b3_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -3090,7 +3090,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b3_use));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::use [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -3145,7 +3145,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b3_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -3201,7 +3201,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b3_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::lastuse [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -3257,7 +3257,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b3_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d, zero_column_mask_desc;
@@ -3314,7 +3314,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b3_lastuse));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::lastuse [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d;
@@ -3371,7 +3371,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b3_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d,
         // zero_column_mask_desc;
@@ -3427,7 +3427,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint64_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_collector_b3_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::discard [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -3483,7 +3483,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool, uint64_t)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b3_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d, zero_column_mask_desc;
@@ -3540,7 +3540,7 @@ __global__ void test_tcgen05_mma_ws(void** fn_ptr)
                 cuda::ptx::cta_group_1_t, cuda::ptx::kind_i8_t, uint32_t, uint32_t, uint64_t, uint32_t, bool)>(
                 cuda::ptx::tcgen05_mma_ws_tmem_a_collector_b3_discard));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.mma.ws.cta_group::1.kind::f16.collector::b3::discard [d_tmem], [a_tmem], b_desc, idesc,
         // enable_input_d;

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_shift.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_shift.h
@@ -27,7 +27,7 @@ __global__ void test_tcgen05_shift(void** fn_ptr)
             * fn_ptr++ = reinterpret_cast<void*>(
               static_cast<void (*)(cuda::ptx::cta_group_2_t, uint32_t)>(cuda::ptx::tcgen05_shift_down));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.shift.cta_group::1.down [taddr];
         * fn_ptr++ = reinterpret_cast<void*>(

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_st.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_st.h
@@ -22,7 +22,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x1.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[1])>(cuda::ptx::tcgen05_st_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x1.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -35,7 +35,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x1.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[1])>(cuda::ptx::tcgen05_st_16x64b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x1.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -48,7 +48,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x2.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[2])>(cuda::ptx::tcgen05_st_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x2.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -61,7 +61,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x2.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[2])>(cuda::ptx::tcgen05_st_16x64b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x2.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -74,7 +74,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x4.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[4])>(cuda::ptx::tcgen05_st_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x4.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -87,7 +87,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x4.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[4])>(cuda::ptx::tcgen05_st_16x64b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x4.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -100,7 +100,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x8.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[8])>(cuda::ptx::tcgen05_st_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x8.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -113,7 +113,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x8.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[8])>(cuda::ptx::tcgen05_st_16x64b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x8.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -126,7 +126,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x16.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[16])>(cuda::ptx::tcgen05_st_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x16.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -139,7 +139,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x16.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[16])>(
                      cuda::ptx::tcgen05_st_16x64b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x16.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[16])>(
@@ -152,7 +152,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x32.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[32])>(cuda::ptx::tcgen05_st_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x32.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -165,7 +165,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x32.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[32])>(
                      cuda::ptx::tcgen05_st_16x64b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x32.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[32])>(
@@ -178,7 +178,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x64.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[64])>(cuda::ptx::tcgen05_st_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x64.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -191,7 +191,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x64.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[64])>(
                      cuda::ptx::tcgen05_st_16x64b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x64.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[64])>(
@@ -204,7 +204,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x128.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[128])>(cuda::ptx::tcgen05_st_16x64b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x128.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -217,7 +217,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x64b.x128.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[128])>(
                      cuda::ptx::tcgen05_st_16x64b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x64b.x128.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[128])>(
@@ -230,7 +230,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x1.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[2])>(cuda::ptx::tcgen05_st_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x1.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -243,7 +243,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x1.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[2])>(
                      cuda::ptx::tcgen05_st_16x128b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x1.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[2])>(
@@ -256,7 +256,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x2.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[4])>(cuda::ptx::tcgen05_st_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x2.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -269,7 +269,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x2.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[4])>(
                      cuda::ptx::tcgen05_st_16x128b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x2.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[4])>(
@@ -282,7 +282,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x4.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[8])>(cuda::ptx::tcgen05_st_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x4.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -295,7 +295,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x4.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[8])>(
                      cuda::ptx::tcgen05_st_16x128b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x4.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[8])>(
@@ -308,7 +308,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x8.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[16])>(cuda::ptx::tcgen05_st_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x8.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -321,7 +321,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x8.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[16])>(
                      cuda::ptx::tcgen05_st_16x128b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x8.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[16])>(
@@ -334,7 +334,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x16.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[32])>(cuda::ptx::tcgen05_st_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x16.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -347,7 +347,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x16.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[32])>(
                      cuda::ptx::tcgen05_st_16x128b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x16.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[32])>(
@@ -360,7 +360,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x32.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[64])>(cuda::ptx::tcgen05_st_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x32.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -373,7 +373,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x32.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[64])>(
                      cuda::ptx::tcgen05_st_16x128b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x32.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[64])>(
@@ -386,7 +386,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x64.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[128])>(cuda::ptx::tcgen05_st_16x128b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x64.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -399,7 +399,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x128b.x64.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[128])>(
                      cuda::ptx::tcgen05_st_16x128b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x128b.x64.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[128])>(
@@ -412,7 +412,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x1.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[4])>(cuda::ptx::tcgen05_st_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x1.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -425,7 +425,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x1.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[4])>(
                      cuda::ptx::tcgen05_st_16x256b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x1.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[4])>(
@@ -438,7 +438,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x2.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[8])>(cuda::ptx::tcgen05_st_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x2.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -451,7 +451,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x2.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[8])>(
                      cuda::ptx::tcgen05_st_16x256b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x2.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[8])>(
@@ -464,7 +464,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x4.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[16])>(cuda::ptx::tcgen05_st_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x4.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -477,7 +477,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x4.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[16])>(
                      cuda::ptx::tcgen05_st_16x256b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x4.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[16])>(
@@ -490,7 +490,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x8.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[32])>(cuda::ptx::tcgen05_st_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x8.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -503,7 +503,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x8.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[32])>(
                      cuda::ptx::tcgen05_st_16x256b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x8.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[32])>(
@@ -516,7 +516,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x16.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[64])>(cuda::ptx::tcgen05_st_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x16.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -529,7 +529,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x16.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[64])>(
                      cuda::ptx::tcgen05_st_16x256b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x16.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[64])>(
@@ -542,7 +542,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x32.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[128])>(cuda::ptx::tcgen05_st_16x256b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x32.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -555,7 +555,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.16x256b.x32.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[128])>(
                      cuda::ptx::tcgen05_st_16x256b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.16x256b.x32.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[128])>(
@@ -568,7 +568,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x1.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[1])>(cuda::ptx::tcgen05_st_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x1.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -581,7 +581,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x1.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[1])>(cuda::ptx::tcgen05_st_32x32b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x1.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -594,7 +594,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x2.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[2])>(cuda::ptx::tcgen05_st_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x2.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -607,7 +607,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x2.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[2])>(cuda::ptx::tcgen05_st_32x32b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x2.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -620,7 +620,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x4.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[4])>(cuda::ptx::tcgen05_st_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x4.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -633,7 +633,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x4.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[4])>(cuda::ptx::tcgen05_st_32x32b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x4.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -646,7 +646,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x8.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[8])>(cuda::ptx::tcgen05_st_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x8.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -659,7 +659,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x8.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[8])>(cuda::ptx::tcgen05_st_32x32b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x8.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -672,7 +672,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x16.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[16])>(cuda::ptx::tcgen05_st_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x16.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -685,7 +685,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x16.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[16])>(
                      cuda::ptx::tcgen05_st_32x32b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x16.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[16])>(
@@ -698,7 +698,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x32.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[32])>(cuda::ptx::tcgen05_st_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x32.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -711,7 +711,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x32.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[32])>(
                      cuda::ptx::tcgen05_st_32x32b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x32.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[32])>(
@@ -724,7 +724,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x64.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[64])>(cuda::ptx::tcgen05_st_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x64.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -737,7 +737,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x64.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[64])>(
                      cuda::ptx::tcgen05_st_32x32b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x64.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[64])>(
@@ -750,7 +750,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x128.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(uint32_t, const int32_t (&)[128])>(cuda::ptx::tcgen05_st_32x32b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x128.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(
@@ -763,7 +763,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
                    // tcgen05.st.sync.aligned.32x32b.x128.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[128])>(
                      cuda::ptx::tcgen05_st_32x32b_unpack_16b));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.st.sync.aligned.32x32b.x128.unpack::16b.b32 [taddr], values;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, const int32_t (&)[128])>(
@@ -778,7 +778,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[1])>(
           cuda::ptx::tcgen05_st_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x1.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[1])>(
@@ -793,7 +793,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[1])>(
           cuda::ptx::tcgen05_st_16x32bx2_unpack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x1.unpack::16b.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[1])>(
@@ -808,7 +808,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[2])>(
           cuda::ptx::tcgen05_st_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x2.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[2])>(
@@ -823,7 +823,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[2])>(
           cuda::ptx::tcgen05_st_16x32bx2_unpack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x2.unpack::16b.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[2])>(
@@ -838,7 +838,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[4])>(
           cuda::ptx::tcgen05_st_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x4.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[4])>(
@@ -853,7 +853,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[4])>(
           cuda::ptx::tcgen05_st_16x32bx2_unpack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x4.unpack::16b.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[4])>(
@@ -868,7 +868,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[8])>(
           cuda::ptx::tcgen05_st_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x8.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[8])>(
@@ -883,7 +883,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[8])>(
           cuda::ptx::tcgen05_st_16x32bx2_unpack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x8.unpack::16b.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[8])>(
@@ -898,7 +898,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[16])>(
           cuda::ptx::tcgen05_st_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x16.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[16])>(
@@ -913,7 +913,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[16])>(
           cuda::ptx::tcgen05_st_16x32bx2_unpack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x16.unpack::16b.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[16])>(
@@ -928,7 +928,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[32])>(
           cuda::ptx::tcgen05_st_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x32.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[32])>(
@@ -943,7 +943,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[32])>(
           cuda::ptx::tcgen05_st_16x32bx2_unpack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x32.unpack::16b.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[32])>(
@@ -958,7 +958,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[64])>(
           cuda::ptx::tcgen05_st_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x64.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[64])>(
@@ -973,7 +973,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[64])>(
           cuda::ptx::tcgen05_st_16x32bx2_unpack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x64.unpack::16b.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[64])>(
@@ -989,7 +989,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[128])>(
             cuda::ptx::tcgen05_st_16x32bx2));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x128.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ =
@@ -1006,7 +1006,7 @@ __global__ void test_tcgen05_st(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(uint32_t, cuda::ptx::n32_t<0>, const int32_t (&)[128])>(
             cuda::ptx::tcgen05_st_16x32bx2_unpack_16b));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tcgen05.st.sync.aligned.16x32bx2.x128.unpack::16b.b32 [taddr], immHalfSplitoff, values;
         * fn_ptr++ =

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_wait.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_wait.h
@@ -21,7 +21,7 @@ __global__ void test_tcgen05_wait(void** fn_ptr)
                (
                    // tcgen05.wait::ld.sync.aligned;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)()>(cuda::ptx::tcgen05_wait_ld));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.wait::ld.sync.aligned;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)()>(cuda::ptx::tcgen05_wait_ld));));
@@ -32,7 +32,7 @@ __global__ void test_tcgen05_wait(void** fn_ptr)
                (
                    // tcgen05.wait::st.sync.aligned;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)()>(cuda::ptx::tcgen05_wait_st));));
-  NV_IF_TARGET(NV_HAS_FEATURE_SM_101a,
+  NV_IF_TARGET(NV_HAS_FEATURE_SM_110a,
                (
                    // tcgen05.wait::st.sync.aligned;
                    * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)()>(cuda::ptx::tcgen05_wait_st));));

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tensormap_replace.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tensormap_replace.h
@@ -30,7 +30,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, int64_t)>(
           cuda::ptx::tensormap_replace_global_address));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.global_address.global.b1024.b64 [tm_addr], new_val;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, int64_t)>(
@@ -51,7 +51,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, int64_t)>(
           cuda::ptx::tensormap_replace_global_address));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.global_address.shared::cta.b1024.b64 [tm_addr], new_val;
         * fn_ptr++ = reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, int64_t)>(
@@ -72,7 +72,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::space_global_t, void*, int32_t)>(cuda::ptx::tensormap_replace_rank));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.rank.global.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -93,7 +93,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::space_shared_t, void*, int32_t)>(cuda::ptx::tensormap_replace_rank));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.rank.shared::cta.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -116,7 +116,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, cuda::ptx::n32_t<0>, int32_t)>(
             cuda::ptx::tensormap_replace_box_dim));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.box_dim.global.b1024.b32 [tm_addr], ord, new_val;
         * fn_ptr++ =
@@ -140,7 +140,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, cuda::ptx::n32_t<0>, int32_t)>(
             cuda::ptx::tensormap_replace_box_dim));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.box_dim.shared::cta.b1024.b32 [tm_addr], ord, new_val;
         * fn_ptr++ =
@@ -164,7 +164,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, cuda::ptx::n32_t<0>, int32_t)>(
             cuda::ptx::tensormap_replace_global_dim));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.global_dim.global.b1024.b32 [tm_addr], ord, new_val;
         * fn_ptr++ =
@@ -188,7 +188,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, cuda::ptx::n32_t<0>, int32_t)>(
             cuda::ptx::tensormap_replace_global_dim));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.global_dim.shared::cta.b1024.b32 [tm_addr], ord, new_val;
         * fn_ptr++ =
@@ -212,7 +212,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, cuda::ptx::n32_t<0>, int64_t)>(
             cuda::ptx::tensormap_replace_global_stride));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.global_stride.global.b1024.b64 [tm_addr], ord, new_val;
         * fn_ptr++ =
@@ -236,7 +236,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, cuda::ptx::n32_t<0>, int64_t)>(
             cuda::ptx::tensormap_replace_global_stride));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.global_stride.shared::cta.b1024.b64 [tm_addr], ord, new_val;
         * fn_ptr++ =
@@ -260,7 +260,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, cuda::ptx::n32_t<0>, int32_t)>(
             cuda::ptx::tensormap_replace_element_stride));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.element_stride.global.b1024.b32 [tm_addr], ord, new_val;
         * fn_ptr++ =
@@ -284,7 +284,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, cuda::ptx::n32_t<0>, int32_t)>(
             cuda::ptx::tensormap_replace_element_stride));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.element_stride.shared::cta.b1024.b32 [tm_addr], ord, new_val;
         * fn_ptr++ =
@@ -308,7 +308,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, cuda::ptx::n32_t<0>, int32_t)>(
             cuda::ptx::tensormap_replace_element_size));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.element_stride.global.b1024.b32 [tm_addr], ord, new_val;
         * fn_ptr++ =
@@ -332,7 +332,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, cuda::ptx::n32_t<0>, int32_t)>(
             cuda::ptx::tensormap_replace_element_size));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.element_stride.shared::cta.b1024.b32 [tm_addr], ord, new_val;
         * fn_ptr++ =
@@ -356,7 +356,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, cuda::ptx::n32_t<0>)>(
             cuda::ptx::tensormap_replace_elemtype));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.elemtype.global.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ =
@@ -380,7 +380,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, cuda::ptx::n32_t<0>)>(
             cuda::ptx::tensormap_replace_elemtype));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.elemtype.shared::cta.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ =
@@ -404,7 +404,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, cuda::ptx::n32_t<0>)>(
             cuda::ptx::tensormap_replace_interleave_layout));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.interleave_layout.global.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ =
@@ -428,7 +428,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, cuda::ptx::n32_t<0>)>(
             cuda::ptx::tensormap_replace_interleave_layout));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.interleave_layout.shared::cta.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ =
@@ -452,7 +452,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, cuda::ptx::n32_t<0>)>(
             cuda::ptx::tensormap_replace_swizzle_mode));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.swizzle_mode.global.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ =
@@ -476,7 +476,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, cuda::ptx::n32_t<0>)>(
             cuda::ptx::tensormap_replace_swizzle_mode));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.swizzle_mode.shared::cta.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ =
@@ -500,7 +500,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, cuda::ptx::n32_t<0>)>(
             cuda::ptx::tensormap_replace_fill_mode));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.fill_mode.global.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ =
@@ -524,7 +524,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, cuda::ptx::n32_t<0>)>(
             cuda::ptx::tensormap_replace_fill_mode));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.fill_mode.shared::cta.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ =
@@ -541,7 +541,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_global_t, void*, cuda::ptx::n32_t<0>)>(
             cuda::ptx::tensormap_replace_swizzle_atomicity));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.swizzle_atomicity.global.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ =
@@ -558,7 +558,7 @@ __global__ void test_tensormap_replace(void** fn_ptr)
           reinterpret_cast<void*>(static_cast<void (*)(cuda::ptx::space_shared_t, void*, cuda::ptx::n32_t<0>)>(
             cuda::ptx::tensormap_replace_swizzle_atomicity));));
   NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_101a,
+    NV_HAS_FEATURE_SM_110a,
     (
         // tensormap.replace.tile.swizzle_atomicity.shared::cta.b1024.b32 [tm_addr], new_val;
         * fn_ptr++ =


### PR DESCRIPTION
## Description

Update `cuda::ptx` wrappers to align SM versions with https://github.com/NVIDIA/cccl/pull/5418.
No new instructions have been added.