### PR TITLE
Backport to 3.1: c.parallel: enable UBLKCP in transform (#4847) and Move TMA barrier in DeviceTransform into dynamic SMEM (#5414)

### DIFF
--- a/c/parallel/include/cccl/c/transform.h
+++ b/c/parallel/include/cccl/c/transform.h
@@ -29,6 +29,7 @@ typedef struct cccl_device_transform_build_result_t
   CUlibrary library;
   CUkernel transform_kernel;
   int loaded_bytes_per_iteration;
+  void* runtime_policy;
 } cccl_device_transform_build_result_t;
 
 CCCL_C_API CUresult cccl_device_unary_transform_build(

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -26,6 +26,7 @@
 #include "util/context.h"
 #include "util/errors.h"
 #include "util/indirect_arg.h"
+#include "util/runtime_policy.h"
 #include "util/types.h"
 #include <cccl/c/transform.h>
 #include <cccl/c/types.h> // cccl_type_info
@@ -51,75 +52,6 @@ constexpr auto input_iterator_name  = "input_iterator_t";
 constexpr auto input1_iterator_name = "input1_iterator_t";
 constexpr auto input2_iterator_name = "input2_iterator_t";
 constexpr auto output_iterator_name = "output_iterator_t";
-
-struct transform_runtime_tuning_policy
-{
-  int min_bif;
-  int block_threads;
-  int items_per_thread_no_input;
-  int min_items_per_thread;
-  int max_items_per_thread;
-  int items_per_thread_vectorized;
-  int load_store_word_size;
-
-  int MinBif() const
-  {
-    return min_bif;
-  }
-
-  // Note: when we extend transform to support UBLKCP, we may no longer
-  // be able to keep this constexpr:
-  static constexpr cub::detail::transform::Algorithm GetAlgorithm()
-  {
-    // FIXME(bgruber): this needs to incorporate the algorithm selection logic from CUB policy_hub
-    return cub::detail::transform::Algorithm::prefetch;
-  }
-
-  int BlockThreads() const
-  {
-    return block_threads;
-  }
-
-  int ItemsPerThreadNoInput() const
-  {
-    return items_per_thread_no_input;
-  }
-
-  int MinItemsPerThread() const
-  {
-    return min_items_per_thread;
-  }
-
-  int MaxItemsPerThread() const
-  {
-    return max_items_per_thread;
-  }
-
-  int ItemsPerThreadForVectorizedPath() const
-  {
-    return items_per_thread_vectorized;
-  }
-
-  int LoadStoreWordSize() const
-  {
-    return load_store_word_size;
-  }
-};
-
-transform_runtime_tuning_policy get_policy(int sm_arch)
-{
-  constexpr int load_store_word_size = 8; // TODO(bgruber): should be fused with the constant in CUB
-  constexpr int value_type_size = 4; // FIXME(bgruber): this should be derived from the value types of the iterators
-  constexpr int target_bytes_per_thread = 32; // TODO(bgruber): should be fused with the constant in CUB
-  return {
-    .min_bif                     = cub::detail::transform::arch_to_min_bytes_in_flight(sm_arch),
-    .block_threads               = 256,
-    .items_per_thread_no_input   = 2,
-    .min_items_per_thread        = 1,
-    .max_items_per_thread        = 32,
-    .items_per_thread_vectorized = ::cuda::round_up(target_bytes_per_thread, load_store_word_size) / value_type_size,
-    .load_store_word_size        = load_store_word_size};
-}
 
 template <typename StorageT>
 const std::string get_iterator_name(cccl_iterator_t iterator, const std::string& name)
@@ -180,36 +112,99 @@ get_kernel_name(cccl_iterator_t input1_it, cccl_iterator_t input2_it, cccl_itera
     input2_iterator_t); // 5
 }
 
-template <auto* GetPolicy>
-struct dynamic_transform_policy_t
+namespace cdt = cub::detail::transform;
+
+template <typename AgentPolicy>
+struct runtime_tuning_policy_variant
 {
-  using max_policy = dynamic_transform_policy_t;
+  using max_policy = runtime_tuning_policy_variant;
+
+  cdt::Algorithm algorithm;
+  int min_bif;
+  AgentPolicy algo_policy;
+
+  cdt::Algorithm Algorithm() const
+  {
+    return algorithm;
+  }
+
+  int MinBif() const
+  {
+    return min_bif;
+  }
+
+  AgentPolicy AlgorithmPolicy() const
+  {
+    return algo_policy;
+  }
 
   template <typename F>
-  cudaError_t Invoke(int device_ptx_version, F& op)
+  cudaError_t Invoke([[maybe_unused]] int device_ptx_version, F& op)
   {
-    return op.template Invoke<transform_runtime_tuning_policy>(GetPolicy(device_ptx_version));
+    return op.template Invoke<runtime_tuning_policy_variant>(*this);
   }
 };
 
+using runtime_tuning_policy =
+  std::variant<runtime_tuning_policy_variant<cdt::RuntimeTransformAgentPrefetchPolicy>,
+               runtime_tuning_policy_variant<cdt::RuntimeTransformAgentVectorizedPolicy>,
+               runtime_tuning_policy_variant<cdt::RuntimeTransformAgentAsyncPolicy>>;
+
+runtime_tuning_policy* make_runtime_tuning_policy(
+  cdt::Algorithm algorithm,
+  int min_bif,
+  std::variant<cdt::RuntimeTransformAgentPrefetchPolicy,
+               cdt::RuntimeTransformAgentVectorizedPolicy,
+               cdt::RuntimeTransformAgentAsyncPolicy> algo_policy)
+{
+  return new auto(std::visit(
+    [&](auto policy) -> runtime_tuning_policy {
+      return runtime_tuning_policy_variant{algorithm, min_bif, policy};
+    },
+    algo_policy));
+}
+
+template <int NumInputs>
 struct transform_kernel_source
 {
   cccl_device_transform_build_result_t& build;
+  std::array<cuda::std::pair<cuda::std::size_t, cuda::std::size_t>, NumInputs> it_value_sizes_alignments;
+
+  static constexpr bool CanCacheConfiguration()
+  {
+    return false;
+  }
 
   CUkernel TransformKernel() const
   {
     return build.transform_kernel;
   }
 
-  int LoadedBytesPerIteration()
+  int LoadedBytesPerIteration() const
   {
     return build.loaded_bytes_per_iteration;
   }
 
+  auto ItValueSizesAlignments() const
+  {
+    return cuda::std::span(it_value_sizes_alignments);
+  }
+
   template <typename It>
-  constexpr It MakeIteratorKernelArg(It it)
+  static constexpr It MakeIteratorKernelArg(It it)
   {
     return it;
+  }
+
+  static cdt::kernel_arg<char*> MakeAlignedBasePtrKernelArg(indirect_iterator_t it, int align)
+  {
+    _CCCL_ASSERT(it.value_size != 0, "a non-pointer iterator passed into MakeALignedBasePtrKernelArg");
+    return cdt::make_aligned_base_ptr_kernel_arg(*static_cast<char**>(it.ptr), align);
+  }
+
+  static auto IsPointerAligned(indirect_iterator_t it, int alignment)
+  {
+    return it.value_size != 0 && ::cuda::is_aligned(*static_cast<char**>(it.ptr), alignment);
   }
 };
 
@@ -234,7 +229,6 @@ CUresult cccl_device_unary_transform_build(
     const char* name = "test";
 
     const int cc                 = cc_major * 10 + cc_minor;
-    const auto policy            = transform::get_policy(cc * 10 /* convert to ptx version */);
     const auto input_it_value_t  = cccl_type_enum_to_name<input_storage_t>(input_it.value_type.type);
     const auto output_it_value_t = cccl_type_enum_to_name<output_storage_t>(output_it.value_type.type);
     const auto offset_t          = cccl_type_enum_to_name(cccl_type_enum::CCCL_INT64);
@@ -244,48 +238,82 @@ CUresult cccl_device_unary_transform_build(
       make_kernel_output_iterator(offset_t, transform::output_iterator_name, output_it_value_t, output_it);
     const std::string op_src = make_kernel_user_unary_operator(input_it_value_t, output_it_value_t, op);
 
-    constexpr std::string_view src_template = R"XXX(
-#include <cub/device/dispatch/kernels/transform.cuh>
+    const std::string ptx_arch = std::format("-arch=compute_{}{}", cc_major, cc_minor);
+
+    constexpr size_t ptx_num_args      = 5;
+    const char* ptx_args[ptx_num_args] = {ptx_arch.c_str(), cub_path, thrust_path, libcudacxx_path, "-rdc=true"};
+
+    std::string src = std::format(
+      R"XXX(
+#include <cub/device/dispatch/tuning/tuning_transform.cuh>
 struct __align__({1}) input_storage_t {{
   char data[{0}];
 }};
 struct __align__({3}) output_storage_t {{
   char data[{2}];
 }};
-{8}
-{9}
-struct prefetch_policy_t {{
-  static constexpr int block_threads = {4};
-  static constexpr int items_per_thread_no_input = {5};
-  static constexpr int min_items_per_thread      = {6};
-  static constexpr int max_items_per_thread      = {7};
-}};
-struct device_transform_policy {{
-  struct ActivePolicy {{
-    static constexpr auto algorithm = cub::detail::transform::Algorithm::prefetch;
-    using algo_policy = prefetch_policy_t;
-  }};
-}};
-{10}
-)XXX";
-
-    const std::string& src = std::format(
-      src_template,
+{4}
+{5}
+{6}
+)XXX",
       input_it.value_type.size, // 0
       input_it.value_type.alignment, // 1
       output_it.value_type.size, // 2
       output_it.value_type.alignment, // 3
-      policy.block_threads, // 4
-      policy.items_per_thread_no_input, // 5
-      policy.min_items_per_thread, // 6
-      policy.max_items_per_thread, // 7
-      input_iterator_src, // 8
-      output_iterator_src, // 9
-      op_src); // 10
+      input_iterator_src, // 4
+      output_iterator_src, // 5
+      op_src); // 6
+
+    nlohmann::json runtime_policy = get_policy(
+      std::format("cub::detail::transform::MakeTransformPolicyWrapper(cub::detail::transform::policy_hub<false, "
+                  "::cuda::std::tuple<{0}>, {1}>::max_policy::ActivePolicy{{}})",
+                  transform::get_iterator_name<input_storage_t>(input_it, transform::input_iterator_name),
+                  transform::get_iterator_name<output_storage_t>(output_it, transform::output_iterator_name)),
+      "#include <cub/device/dispatch/tuning/tuning_transform.cuh>\n" + src,
+      ptx_args);
+
+    auto algorithm = static_cast<transform::cdt::Algorithm>(runtime_policy["algorithm"].get<int>());
+    auto min_bif   = static_cast<int>(runtime_policy["min_bif"].get<int>());
+
+    auto [transform_policy, transform_policy_src] =
+      [&]() -> std::tuple<std::variant<transform::cdt::RuntimeTransformAgentPrefetchPolicy,
+                                       transform::cdt::RuntimeTransformAgentVectorizedPolicy,
+                                       transform::cdt::RuntimeTransformAgentAsyncPolicy>,
+                          std::string> {
+      switch (algorithm)
+      {
+        case transform::cdt::Algorithm::prefetch:
+          return transform::cdt::RuntimeTransformAgentPrefetchPolicy::from_json(runtime_policy, "algo_policy");
+        case transform::cdt::Algorithm::vectorized:
+          return transform::cdt::RuntimeTransformAgentVectorizedPolicy::from_json(runtime_policy, "algo_policy");
+        case transform::cdt::Algorithm::memcpy_async:
+          [[fallthrough]];
+        case transform::cdt::Algorithm::ublkcp:
+          return transform::cdt::RuntimeTransformAgentAsyncPolicy::from_json(runtime_policy, "algo_policy");
+      }
+      _CCCL_UNREACHABLE();
+    }();
+
+    std::string final_src = std::format(
+      R"XXX(
+#include <cub/device/dispatch/kernels/transform.cuh>
+{0}
+struct device_transform_policy {{
+  struct ActivePolicy {{
+    static constexpr auto algorithm = static_cast<cub::detail::transform::Algorithm>({1});
+    static constexpr int min_bif = {2};
+    {3}
+  }};
+}};
+)XXX",
+      src,
+      static_cast<int>(algorithm),
+      min_bif,
+      transform_policy_src);
 
 #if false // CCCL_DEBUGGING_SWITCH
     fflush(stderr);
-    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", src.c_str());
+    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", final_src.c_str());
     fflush(stdout);
 #endif
 
@@ -322,7 +350,7 @@ struct device_transform_policy {{
 
     nvrtc_link_result result =
       begin_linking_nvrtc_program(num_lto_args, lopts)
-        ->add_program(nvrtc_translation_unit{src.c_str(), name})
+        ->add_program(nvrtc_translation_unit{final_src.c_str(), name})
         ->add_expression({kernel_name})
         ->compile_program({args, num_args})
         ->get_name({kernel_name, kernel_lowered_name})
@@ -337,6 +365,7 @@ struct device_transform_policy {{
     build_ptr->cc                         = cc;
     build_ptr->cubin                      = (void*) result.data.release();
     build_ptr->cubin_size                 = result.size;
+    build_ptr->runtime_policy             = transform::make_runtime_tuning_policy(algorithm, min_bif, transform_policy);
   }
   catch (const std::exception& exc)
   {
@@ -365,21 +394,27 @@ CUresult cccl_device_unary_transform(
 
     CUdevice cu_device;
     check(cuCtxGetDevice(&cu_device));
-    auto cuda_error = cub::detail::transform::dispatch_t<
-      cub::detail::transform::requires_stable_address::no, // TODO implement yes
-      OffsetT,
-      ::cuda::std::tuple<indirect_arg_t>,
-      indirect_arg_t,
-      indirect_arg_t,
-      transform::dynamic_transform_policy_t<&transform::get_policy>,
-      transform::transform_kernel_source,
-      cub::detail::CudaDriverLauncherFactory>::
-      dispatch(d_in, d_out, num_items, op, stream, {build}, cub::detail::CudaDriverLauncherFactory{cu_device, build.cc});
-    if (cuda_error != cudaSuccess)
-    {
-      const char* errorString = cudaGetErrorString(cuda_error); // Get the error string
-      std::cerr << "CUDA error: " << errorString << std::endl;
-    }
+    error = static_cast<CUresult>(std::visit(
+      [&]<typename Policy>(Policy policy) {
+        return transform::cdt::dispatch_t<
+          transform::cdt::requires_stable_address::no, // TODO implement yes
+          OffsetT,
+          ::cuda::std::tuple<indirect_iterator_t>,
+          indirect_iterator_t,
+          indirect_arg_t,
+          Policy,
+          transform::transform_kernel_source<1>,
+          cub::detail::CudaDriverLauncherFactory>::
+          dispatch(d_in,
+                   d_out,
+                   num_items,
+                   op,
+                   stream,
+                   {build, {{{d_in.value_type.size, d_in.value_type.alignment}}}},
+                   cub::detail::CudaDriverLauncherFactory{cu_device, build.cc},
+                   policy);
+      },
+      *reinterpret_cast<transform::runtime_tuning_policy*>(build.runtime_policy)));
   }
   catch (const std::exception& exc)
   {
@@ -416,7 +451,6 @@ CUresult cccl_device_binary_transform_build(
     const char* name = "test";
 
     const int cc                 = cc_major * 10 + cc_minor;
-    const auto policy            = transform::get_policy(cc * 10 /* convert to ptx version */);
     const auto input1_it_value_t = cccl_type_enum_to_name<input1_storage_t>(input1_it.value_type.type);
     const auto input2_it_value_t = cccl_type_enum_to_name<input2_storage_t>(input2_it.value_type.type);
 
@@ -432,7 +466,13 @@ CUresult cccl_device_binary_transform_build(
     const std::string op_src =
       make_kernel_user_binary_operator(input1_it_value_t, input2_it_value_t, output_it_value_t, op);
 
-    constexpr std::string_view src_template = R"XXX(
+    const std::string ptx_arch = std::format("-arch=compute_{}{}", cc_major, cc_minor);
+
+    constexpr size_t ptx_num_args      = 5;
+    const char* ptx_args[ptx_num_args] = {ptx_arch.c_str(), cub_path, thrust_path, libcudacxx_path, "-rdc=true"};
+
+    std::string src = std::format(
+      R"XXX(
 #include <cub/device/dispatch/kernels/transform.cuh>
 struct __align__({1}) input1_storage_t {{
   char data[{0}];
@@ -444,47 +484,73 @@ struct __align__({3}) input2_storage_t {{
 struct __align__({5}) output_storage_t {{
   char data[{4}];
 }};
-
-{10}
-{11}
-{12}
-
-struct prefetch_policy_t {{
-  static constexpr int block_threads = {6};
-  static constexpr int items_per_thread_no_input = {7};
-  static constexpr int min_items_per_thread      = {8};
-  static constexpr int max_items_per_thread      = {9};
-}};
-
-struct device_transform_policy {{
-  struct ActivePolicy {{
-    static constexpr auto algorithm = cub::detail::transform::Algorithm::prefetch;
-    using algo_policy = prefetch_policy_t;
-  }};
-}};
-
-{13}
-)XXX";
-    const std::string& src                  = std::format(
-      src_template,
+{6}
+{7}
+{8}
+{9}
+)XXX",
       input1_it.value_type.size, // 0
       input1_it.value_type.alignment, // 1
       input2_it.value_type.size, // 2
       input2_it.value_type.alignment, // 3
       output_it.value_type.size, // 4
       output_it.value_type.alignment, // 5
-      policy.block_threads, // 6
-      policy.items_per_thread_no_input, // 7
-      policy.min_items_per_thread, // 8
-      policy.max_items_per_thread, // 9
-      input1_iterator_src, // 10
-      input2_iterator_src, // 11
-      output_iterator_src, // 12
-      op_src); // 13
+      input1_iterator_src, // 6
+      input2_iterator_src, // 7
+      output_iterator_src, // 8
+      op_src); // 9
+
+    nlohmann::json runtime_policy = get_policy(
+      std::format("cub::detail::transform::MakeTransformPolicyWrapper(cub::detail::transform::policy_hub<false, "
+                  "::cuda::std::tuple<{0}, {1}>, {2}>::max_policy::ActivePolicy{{}})",
+                  transform::get_iterator_name<input1_storage_t>(input1_it, transform::input1_iterator_name),
+                  transform::get_iterator_name<input2_storage_t>(input2_it, transform::input2_iterator_name),
+                  transform::get_iterator_name<output_storage_t>(output_it, transform::output_iterator_name)),
+      "#include <cub/device/dispatch/tuning/tuning_transform.cuh>\n" + src,
+      ptx_args);
+
+    auto algorithm = static_cast<transform::cdt::Algorithm>(runtime_policy["algorithm"].get<int>());
+    auto min_bif   = static_cast<int>(runtime_policy["min_bif"].get<int>());
+
+    auto [transform_policy, transform_policy_src] =
+      [&]() -> std::tuple<std::variant<transform::cdt::RuntimeTransformAgentPrefetchPolicy,
+                                       transform::cdt::RuntimeTransformAgentVectorizedPolicy,
+                                       transform::cdt::RuntimeTransformAgentAsyncPolicy>,
+                          std::string> {
+      switch (algorithm)
+      {
+        case transform::cdt::Algorithm::prefetch:
+          return transform::cdt::RuntimeTransformAgentPrefetchPolicy::from_json(runtime_policy, "algo_policy");
+        case transform::cdt::Algorithm::vectorized:
+          return transform::cdt::RuntimeTransformAgentVectorizedPolicy::from_json(runtime_policy, "algo_policy");
+        case transform::cdt::Algorithm::memcpy_async:
+          [[fallthrough]];
+        case transform::cdt::Algorithm::ublkcp:
+          return transform::cdt::RuntimeTransformAgentAsyncPolicy::from_json(runtime_policy, "algo_policy");
+      }
+      _CCCL_UNREACHABLE();
+    }();
+
+    std::string final_src = std::format(
+      R"XXX(
+#include <cub/device/dispatch/kernels/transform.cuh>
+{0}
+struct device_transform_policy {{
+  struct ActivePolicy {{
+    static constexpr auto algorithm = static_cast<cub::detail::transform::Algorithm>({1});
+    static constexpr int min_bif = {2};
+    {3}
+  }};
+}};
+)XXX",
+      src,
+      static_cast<int>(algorithm),
+      min_bif,
+      transform_policy_src);
 
 #if false // CCCL_DEBUGGING_SWITCH
     fflush(stderr);
-    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", src.c_str());
+    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", final_src.c_str());
     fflush(stdout);
 #endif
 
@@ -493,9 +559,17 @@ struct device_transform_policy {{
 
     const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
 
-    constexpr size_t num_args  = 8;
+    constexpr size_t num_args  = 9;
     const char* args[num_args] = {
-      arch.c_str(), cub_path, thrust_path, libcudacxx_path, ctk_path, "-rdc=true", "-dlto", "-default-device"};
+      arch.c_str(),
+      cub_path,
+      thrust_path,
+      libcudacxx_path,
+      ctk_path,
+      "-rdc=true",
+      "-dlto",
+      "-default-device",
+      "-DCUB_DISABLE_CDP"};
 
     constexpr size_t num_lto_args   = 2;
     const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
@@ -511,7 +585,7 @@ struct device_transform_policy {{
 
     nvrtc_link_result result =
       begin_linking_nvrtc_program(num_lto_args, lopts)
-        ->add_program(nvrtc_translation_unit{src.c_str(), name})
+        ->add_program(nvrtc_translation_unit{final_src.c_str(), name})
         ->add_expression({kernel_name})
         ->compile_program({args, num_args})
         ->get_name({kernel_name, kernel_lowered_name})
@@ -526,6 +600,7 @@ struct device_transform_policy {{
     build_ptr->cc                         = cc;
     build_ptr->cubin                      = (void*) result.data.release();
     build_ptr->cubin_size                 = result.size;
+    build_ptr->runtime_policy             = transform::make_runtime_tuning_policy(algorithm, min_bif, transform_policy);
   }
   catch (const std::exception& exc)
   {
@@ -556,24 +631,30 @@ CUresult cccl_device_binary_transform(
     CUdevice cu_device;
     check(cuCtxGetDevice(&cu_device));
 
-    auto exec_status = cub::detail::transform::dispatch_t<
-      cub::detail::transform::requires_stable_address::no, // TODO implement yes
-      OffsetT,
-      ::cuda::std::tuple<indirect_arg_t, indirect_arg_t>,
-      indirect_arg_t,
-      indirect_arg_t,
-      transform::dynamic_transform_policy_t<&transform::get_policy>,
-      transform::transform_kernel_source,
-      cub::detail::CudaDriverLauncherFactory>::
-      dispatch(::cuda::std::make_tuple<indirect_arg_t, indirect_arg_t>(d_in1, d_in2),
-               d_out,
-               num_items,
-               op,
-               stream,
-               {build},
-               cub::detail::CudaDriverLauncherFactory{cu_device, build.cc});
-
-    error = static_cast<CUresult>(exec_status);
+    error = static_cast<CUresult>(std::visit(
+      [&]<typename Policy>(Policy policy) {
+        return transform::cdt::dispatch_t<
+          transform::cdt::requires_stable_address::no, // TODO implement yes
+          OffsetT,
+          ::cuda::std::tuple<indirect_iterator_t, indirect_iterator_t>,
+          indirect_iterator_t,
+          indirect_arg_t,
+          Policy,
+          transform::transform_kernel_source<2>,
+          cub::detail::CudaDriverLauncherFactory>::
+          dispatch(
+            ::cuda::std::make_tuple<indirect_iterator_t, indirect_iterator_t>(d_in1, d_in2),
+            d_out,
+            num_items,
+            op,
+            stream,
+            {build,
+             {{{d_in1.value_type.size, d_in1.value_type.alignment},
+               {d_in2.value_type.size, d_in2.value_type.alignment}}}},
+            cub::detail::CudaDriverLauncherFactory{cu_device, build.cc},
+            policy);
+      },
+      *reinterpret_cast<transform::runtime_tuning_policy*>(build.runtime_policy)));
   }
   catch (const std::exception& exc)
   {
@@ -599,6 +680,8 @@ CUresult cccl_device_transform_cleanup(cccl_device_transform_build_result_t* bui
       return CUDA_ERROR_INVALID_VALUE;
     }
     std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
+    std::unique_ptr<transform::runtime_tuning_policy> rtp(
+      reinterpret_cast<transform::runtime_tuning_policy*>(build_ptr->runtime_policy));
     check(cuLibraryUnload(build_ptr->library));
   }
   catch (const std::exception& exc)

--- a/c/parallel/src/util/runtime_policy.cpp
+++ b/c/parallel/src/util/runtime_policy.cpp
@@ -29,7 +29,7 @@ get_policy(std::string_view policy_wrapper_expr, std::string_view translation_un
     "{0}\n"
      "__global__ void ptx_json_emitting_kernel()\n"
      "{{\n"
-     "  auto wrapped = {1};\n"
+     "  [[maybe_unused]] auto wrapped = {1};\n"
      "  ptx_json::id<ptx_json::string(\"{2}\")>() = wrapped.EncodedPolicy();\n"
      "}}\n",
     translation_unit,

--- a/c/parallel/test/test_transform.cpp
+++ b/c/parallel/test/test_transform.cpp
@@ -98,6 +98,56 @@ void binary_transform(
     cache, lookup_key, input1, input2, output, num_items, op);
 }
 
+C2H_TEST("Transform generates UBLKCP on SM90", "[transform][ublkcp]")
+{
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  // Only test for ublkcp when it is actually possible to get it.
+  if (build_info.get_cc_major() < 9)
+  {
+    return;
+  }
+
+  cccl_device_transform_build_result_t build;
+  operation_t op = make_operation("op", get_unary_op(get_type_info<int>().type));
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unary_transform_build(
+      &build,
+      pointer_t<int>(0),
+      pointer_t<int>(0),
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  std::string sass = inspect_sass(build.cubin, build.cubin_size);
+  CHECK(sass.find("UBLKCP") != std::string::npos);
+
+  op = make_operation("op", get_reduce_op(get_type_info<int>().type));
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_binary_transform_build(
+      &build,
+      pointer_t<int>(0),
+      pointer_t<int>(0),
+      pointer_t<int>(0),
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  sass = inspect_sass(build.cubin, build.cubin_size);
+  CHECK(sass.find("UBLKCP") != std::string::npos);
+}
+
 using integral_types = c2h::type_list<int32_t, uint32_t, int64_t, uint64_t>;
 struct Transform_IntegralTypes_Fixture_Tag;
 C2H_TEST("Transform works with integral types", "[transform]", integral_types)
@@ -125,6 +175,65 @@ C2H_TEST("Transform works with integral types", "[transform]", integral_types)
   {
     REQUIRE(expected == std::vector<T>(output_ptr));
   }
+}
+
+struct Transform_MisalignedInput_IntegerTypes_Fixture_Tag;
+C2H_TEST("Transform works with misaligned input with integral types", "[transform]", integral_types)
+{
+  using T = c2h::get<0, TestType>;
+
+  const std::size_t num_items = GENERATE(0, 42, take(4, random(1 << 12, 1 << 16)));
+  operation_t op              = make_operation("op", get_unary_op(get_type_info<T>().type));
+  const std::vector<T> input  = generate<T>(num_items + 1);
+  const std::vector<T> output(num_items, 0);
+  pointer_t<T> input_ptr_aligned(input);
+  pointer_t<T> input_ptr = input;
+  input_ptr.ptr += 1; // misalign by 1 from the guaranteed alignment of cudaMalloc, to maybe trip vectorized path
+  input_ptr.size -= 1;
+  pointer_t<T> output_ptr(output);
+
+  auto& build_cache    = get_cache<Transform_MisalignedInput_IntegerTypes_Fixture_Tag>();
+  const auto& test_key = make_key<T>();
+
+  unary_transform(input_ptr, output_ptr, num_items, op, build_cache, test_key);
+  input_ptr.ptr = nullptr; // avoid freeing the memory through this pointer
+
+  std::vector<T> expected(num_items, 0);
+  std::transform(input.begin() + 1, input.end(), expected.begin(), [](const T& x) {
+    return 2 * x;
+  });
+
+  REQUIRE(expected == std::vector<T>(output_ptr));
+}
+
+struct Transform_MisalignedOutput_IntegerTypes_Fixture_Tag;
+C2H_TEST("Transform works with misaligned output with integral types", "[transform]", integral_types)
+{
+  using T = c2h::get<0, TestType>;
+
+  const std::size_t num_items = GENERATE(1, 42, take(4, random(1 << 12, 1 << 16)));
+  operation_t op              = make_operation("op", get_unary_op(get_type_info<T>().type));
+  const std::vector<T> input  = generate<T>(num_items);
+  const std::vector<T> output(num_items + 1, 0);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr_aligned(output);
+  pointer_t<T> output_ptr = output;
+  output_ptr.ptr += 1; // misalign by 1 from the guaranteed alignment of cudaMalloc, to maybe trip vectorized path
+  output_ptr.size -= 1;
+
+  auto& build_cache    = get_cache<Transform_MisalignedOutput_IntegerTypes_Fixture_Tag>();
+  const auto& test_key = make_key<T>();
+
+  unary_transform(input_ptr, output_ptr, num_items, op, build_cache, test_key);
+
+  std::vector<T> expected(num_items, 0);
+  std::transform(input.begin(), input.end(), expected.begin(), [](const T& x) {
+    return 2 * x;
+  });
+
+  REQUIRE(expected == std::vector<T>(output_ptr));
+
+  output_ptr.ptr = nullptr; // avoid freeing the memory through this pointer
 }
 
 struct pair

--- a/cub/cub/config.cuh
+++ b/cub/cub/config.cuh
@@ -51,10 +51,3 @@
 #if !_CCCL_COMPILER(NVRTC)
 #  include <cuda/__nvtx/nvtx.h>
 #endif // !_CCCL_COMPILER(NVRTC)
-
-// cccl.c needs to weaken some compile-time branches to runtime branches in CUB
-#ifdef CCCL_C_EXPERIMENTAL
-#  define _CUB_WEAKEN_IF_CONSTEXPR_IF_COMPILED_FOR_CCCL_C if
-#else
-#  define _CUB_WEAKEN_IF_CONSTEXPR_IF_COMPILED_FOR_CCCL_C if constexpr
-#endif // CCCL_C_EXPERIMENTAL

--- a/cub/cub/detail/launcher/cuda_driver.cuh
+++ b/cub/cub/detail/launcher/cuda_driver.cuh
@@ -111,6 +111,12 @@ struct CudaDriverLauncherFactory
     return static_cast<cudaError_t>(cuDeviceGetAttribute(&max_grid_dim_x, CU_DEVICE_ATTRIBUTE_MAX_GRID_DIM_X, device));
   }
 
+  _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION cudaError_t MaxSharedMemory(int& max_shared_memory) const
+  {
+    return static_cast<cudaError_t>(
+      cuDeviceGetAttribute(&max_shared_memory, CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK, device));
+  }
+
   CUdevice device;
   int cc;
 };

--- a/cub/cub/detail/launcher/cuda_runtime.cuh
+++ b/cub/cub/detail/launcher/cuda_runtime.cuh
@@ -67,6 +67,20 @@ struct TripleChevronFactory
     // Get max grid dimension
     return cudaDeviceGetAttribute(&max_grid_dim_x, cudaDevAttrMaxGridDimX, device_ordinal);
   }
+
+  // TODO(bgruber): this is very similar to thrust::cuda_cub::core::get_max_shared_memory_per_block. We should unify
+  // this.
+  _CCCL_HIDE_FROM_ABI CUB_RUNTIME_FUNCTION cudaError_t MaxSharedMemory(int& max_shared_memory) const
+  {
+    int device = 0;
+    auto error = CubDebug(cudaGetDevice(&device));
+    if (error != cudaSuccess)
+    {
+      return error;
+    }
+
+    return cudaDeviceGetAttribute(&max_shared_memory, cudaDevAttrMaxSharedMemoryPerBlock, device);
+  }
 };
 
 } // namespace detail

--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -1085,7 +1085,7 @@ struct DispatchRadixSort
       return InvokeSingleTile(kernel_source.RadixSortSingleTileKernel(), wrapped_policy);
     }
 
-    _CUB_WEAKEN_IF_CONSTEXPR_IF_COMPILED_FOR_CCCL_C (wrapped_policy.IsOnesweep())
+    if CUB_DETAIL_CONSTEXPR_ISH (wrapped_policy.IsOnesweep())
     {
       return InvokeOnesweep(wrapped_policy);
     }

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -205,7 +205,7 @@ struct dispatch_t<StableAddress,
 
   template <typename ActivePolicy, typename SMemFunc>
   CUB_RUNTIME_FUNCTION _CCCL_VISIBILITY_HIDDEN _CCCL_FORCEINLINE auto
-  configure_async_kernel(int alignment, SMemFunc smem_for_tile_size, ActivePolicy policy = {}) -> cuda_expected<
+  configure_async_kernel(int alignment, SMemFunc dyn_smem_for_tile_size, ActivePolicy policy = {}) -> cuda_expected<
     ::cuda::std::tuple<decltype(launcher_factory(0, 0, 0, 0)), decltype(kernel_source.TransformKernel()), int>>
   {
     auto wrapped_policy = MakeTransformPolicyWrapper(policy);
@@ -222,15 +222,8 @@ struct dispatch_t<StableAddress,
     CUB_DETAIL_STATIC_ISH_ASSERT(min_items_per_thread <= max_items_per_thread, "invalid policy");
 
     auto determine_element_counts = [&]() -> cuda_expected<async_config> {
-      int max_smem = 0;
-      auto error   = CubDebug(launcher_factory.MaxSharedMemory(max_smem));
-      if (error != cudaSuccess)
-      {
-        return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
-      }
-
       int sm_count = 0;
-      error        = CubDebug(launcher_factory.MultiProcessorCount(sm_count));
+      auto error   = CubDebug(launcher_factory.MultiProcessorCount(sm_count));
       if (error != cudaSuccess)
       {
         return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
@@ -243,21 +236,20 @@ struct dispatch_t<StableAddress,
       async_config last_config{};
       for (int items_per_thread = +min_items_per_thread; items_per_thread <= +max_items_per_thread; ++items_per_thread)
       {
-        const int tile_size = block_threads * items_per_thread;
-        const int smem_size = smem_for_tile_size(tile_size, alignment);
-        if (smem_size > max_smem)
+        const int tile_size     = block_threads * items_per_thread;
+        const int dyn_smem_size = dyn_smem_for_tile_size(tile_size, alignment);
+        int max_occupancy       = 0;
+        error                   = CubDebug(launcher_factory.MaxSmOccupancy(
+          max_occupancy, kernel_source.TransformKernel(), block_threads, dyn_smem_size));
+        if (error != cudaSuccess)
+        {
+          return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
+        }
+        if (max_occupancy == 0)
         {
           // assert should be prevented by smem check in policy
           _CCCL_ASSERT(last_config.items_per_thread > 0, "min_items_per_thread exceeds available shared memory");
           return last_config;
-        }
-
-        int max_occupancy = 0;
-        error             = CubDebug(
-          launcher_factory.MaxSmOccupancy(max_occupancy, kernel_source.TransformKernel(), block_threads, smem_size));
-        if (error != cudaSuccess)
-        {
-          return ::cuda::std::unexpected<cudaError_t /* nvcc 12.0 fails CTAD here */>(error);
         }
 
         const auto config = async_config{items_per_thread, max_occupancy, sm_count};
@@ -297,15 +289,15 @@ struct dispatch_t<StableAddress,
 
     const int ipt =
       spread_out_items_per_thread(policy, config->items_per_thread, config->sm_count, config->max_occupancy);
-    const int tile_size = block_threads * ipt;
-    const int smem_size = smem_for_tile_size(tile_size, alignment);
-    _CCCL_ASSERT((sizeof...(RandomAccessIteratorsIn) == 0) != (smem_size != 0), ""); // logical xor
+    const int tile_size     = block_threads * ipt;
+    const int dyn_smem_size = dyn_smem_for_tile_size(tile_size, alignment);
+    _CCCL_ASSERT((sizeof...(RandomAccessIteratorsIn) == 0) != (dyn_smem_size != 0), ""); // logical xor
 
     const auto grid_dim = static_cast<unsigned int>(::cuda::ceil_div(num_items, Offset{tile_size}));
     // config->smem_size is 16 bytes larger than needed for UBLKCP because it's the total SMEM size, but 16 bytes are
     // occupied by static shared memory and padding. But let's not complicate things.
     return ::cuda::std::make_tuple(
-      launcher_factory(grid_dim, block_threads, smem_size, stream), kernel_source.TransformKernel(), ipt);
+      launcher_factory(grid_dim, block_threads, dyn_smem_size, stream), kernel_source.TransformKernel(), ipt);
   }
 
   // Avoid unnecessarily parsing these definitions when not needed.
@@ -327,9 +319,9 @@ struct dispatch_t<StableAddress,
 
   template <typename ActivePolicy, typename SMemFunc, std::size_t... Is>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_async_algorithm(
-    int alignment, SMemFunc smem_for_tile_size, cuda::std::index_sequence<Is...>, ActivePolicy policy = {})
+    int alignment, SMemFunc dyn_smem_for_tile_size, cuda::std::index_sequence<Is...>, ActivePolicy policy = {})
   {
-    auto ret = configure_async_kernel(alignment, smem_for_tile_size, policy);
+    auto ret = configure_async_kernel(alignment, dyn_smem_for_tile_size, policy);
     if (!ret)
     {
       return ret.error();
@@ -491,12 +483,8 @@ struct dispatch_t<StableAddress,
     {
       return invoke_async_algorithm(
         bulk_copy_align,
-        [this, wrapped_policy](int tile_size, int alignment) {
-          return bulk_copy_smem_for_tile_size(
-            kernel_source.ItValueSizesAlignments(),
-            tile_size,
-            wrapped_policy.AlgorithmPolicy().BlockThreads(),
-            alignment);
+        [this](int tile_size, int alignment) {
+          return bulk_copy_dyn_smem_for_tile_size(kernel_source.ItValueSizesAlignments(), tile_size, alignment);
         },
         seq,
         active_policy);
@@ -505,12 +493,8 @@ struct dispatch_t<StableAddress,
     {
       return invoke_async_algorithm(
         ldgsts_size_and_align,
-        [this, wrapped_policy](int tile_size, int alignment) {
-          return memcpy_async_smem_for_tile_size(
-            kernel_source.ItValueSizesAlignments(),
-            tile_size,
-            wrapped_policy.AlgorithmPolicy().BlockThreads(),
-            alignment);
+        [this](int tile_size, int alignment) {
+          return memcpy_async_dyn_smem_for_tile_size(kernel_source.ItValueSizesAlignments(), tile_size, alignment);
         },
         seq,
         active_policy);

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -28,8 +28,6 @@
 #include <cuda/std/cstdint>
 #include <cuda/std/expected>
 
-#include <cuda_pipeline_primitives.h>
-
 CUB_NAMESPACE_BEGIN
 
 namespace detail::transform
@@ -345,10 +343,19 @@ _CCCL_DEVICE void memcpy_async_aligned(void* dst, const void* src, unsigned int 
   for (unsigned int offset = threadIdx.x * ldgsts_size_and_align; offset < bytes_to_copy;
        offset += BlockThreads * ldgsts_size_and_align)
   {
-    __pipeline_memcpy_async(
-      static_cast<char*>(dst) + offset, static_cast<const char*>(src) + offset, ldgsts_size_and_align);
+    asm volatile(
+      "cp.async.cg.shared.global [%0], [%1], %2, %3;"
+      :
+      : "r"(static_cast<uint32_t>(__cvta_generic_to_shared(static_cast<char*>(dst) + offset))),
+        "l"(static_cast<const char*>(src) + offset),
+        "n"(ldgsts_size_and_align),
+        "n"(ldgsts_size_and_align)
+      : "memory");
+    // same as: __pipeline_memcpy_async(static_cast<char*>(dst) + offset, static_cast<const char*>(src) + offset,
+    //                                  ldgsts_size_and_align);
   }
-  __pipeline_commit();
+
+  asm volatile("cp.async.commit_group;"); // same as: __pipeline_commit();
 }
 
 template <int BlockThreads>
@@ -496,7 +503,8 @@ _CCCL_DEVICE void transform_kernel_ldgsts(
     (inner_blocks ? copy_and_return_smem_dst<block_threads>(aligned_ptrs, smem_offset, offset, smem, valid_items)
                   : copy_and_return_smem_dst_fallback<block_threads>(
                       aligned_ptrs, smem_offset, offset, smem, valid_items, tile_size))...};
-  __pipeline_wait_prior(0);
+
+  asm volatile("cp.async.wait_group %0;" : : "n"(0)); // same as: __pipeline_wait_prior(0);
   __syncthreads();
 
   // move the whole index and iterator to the block/thread index, to reduce arithmetic in the loops below

--- a/cub/cub/device/dispatch/kernels/transform.cuh
+++ b/cub/cub/device/dispatch/kernels/transform.cuh
@@ -23,6 +23,7 @@
 
 #include <cuda/__barrier/aligned_size.h> // cannot include <cuda/barrier> directly on CUDA_ARCH < 700
 #include <cuda/cmath>
+#include <cuda/memory>
 #include <cuda/ptx>
 #include <cuda/std/bit>
 #include <cuda/std/cstdint>
@@ -279,7 +280,7 @@ _CCCL_DEVICE void transform_kernel_vectorized(
 // copy a tile of data from an input buffer, we round down the pointer to the start of the tile to the next lower
 // address that is a multiple of 16 bytes. This introduces head padding. We also round up the total number of bytes to
 // copy (including head padding) to a multiple of 16 bytes, which introduces tail padding. For the bulk copy kernel, we
-// have to align to 128 bytes instead of 16 on Hopper.
+// should align to 128 bytes instead of 16 on Hopper.
 //
 // However, padding memory copies like that may access the input buffer out-of-bounds. Here are some thoughts:
 // * According to the CUDA programming guide
@@ -613,14 +614,6 @@ _CCCL_DEVICE void bulk_copy_maybe_unaligned(
   }
 }
 
-template <int Alignment>
-_CCCL_DEVICE auto round_up_smem_ptr(char* p) -> char*
-{
-  uint32_t smem32 = __cvta_generic_to_shared(p);
-  smem32          = ::cuda::round_up(smem32, Alignment);
-  return static_cast<char*>(_CCCL_BUILTIN_ASSUME_ALIGNED(__cvta_shared_to_generic(smem32), Alignment));
-}
-
 template <typename BulkCopyPolicy, typename Offset, typename F, typename RandomAccessIteratorOut, typename... InTs>
 _CCCL_DEVICE void transform_kernel_ublkcp(
   Offset num_items, int num_elem_per_thread, F f, RandomAccessIteratorOut out, aligned_base_ptr<InTs>... aligned_ptrs)
@@ -628,57 +621,49 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   constexpr int block_threads       = BulkCopyPolicy::block_threads;
   constexpr int bulk_copy_alignment = BulkCopyPolicy::bulk_copy_alignment;
 
-  constexpr int min_retained_alignment           = ::cuda::std::min({sizeof(InTs)...}) * block_threads;
-  constexpr int max_alignment                    = ::cuda::std::max({alignof(InTs)...});
-  constexpr bool tile_sizes_retain_max_alignment = max_alignment <= min_retained_alignment;
-
   // add padding after a tile in shared memory to make space for the next tile's head padding, and retain alignment
-  constexpr int tile_padding =
-    tile_sizes_retain_max_alignment ? ::cuda::std::max(bulk_copy_alignment, max_alignment) : bulk_copy_alignment;
+  constexpr int max_alignment = ::cuda::std::max({int{alignof(InTs)}...});
+  constexpr int tile_padding  = ::cuda::std::max(bulk_copy_alignment, max_alignment);
 
-  __shared__ uint64_t bar;
+  // We could use an attribute to align the shared memory. This is unfortunately not respected by nvcc in all cases and
+  // fails for example when compiling with -G or -rdc=true. See also NVBug 5093902, NVBug 5329745, and discussion in PR
+  // #5122.
+  //
+  // Also, because extern (__shared__) variables are injected from inside a function (template) scope into the enclosing
+  // namespace scope they must have the same type and (alignment) attributes for the same name. So we cannot specify a
+  // different alignment based on the template parameters (i.e. the iterator value types). We could use multiple extern
+  // __shared__ variables with different alignment and select the right one at compile time though. A variable template
+  // won't work, see NVBug 5420296.
+  //
+  // However, due to CUDA runtime implementation details, the alignment of dynamic shared memory affects the required
+  // *static* shared memory of *every* other kernel that is generated into the same TU (translation unit) as the
+  // transform kernel here, which causes all kinds of headaches for downstream users. So lets avoid alignment
+  // attributes. More internal information: https://github.com/NVIDIA/cccl_private/wiki/Dynamic-shared-memory-alignment.
+  //
+  // Because we put the barrier into the dynamic shared memory, we don't have any static shared memory, and the dynamic
+  // shared memory starts right at the beginning of the shared memory window, which usually has a high alignment (>
+  // 1KiB, depends on the GPU architecture). So we could just rely on this fact and don't specify an attribute to not
+  // mess with other kernels. This is also what cutlass does. But it is not guaranteed by CUDA. So let's align manually
+  // when we actually need it for correctness. That's when any value type's alignment is larger than 16. Hopper does
+  // benefit from 128 byte alignment, which is granted by the alignment of the shared memory window. In case this ever
+  // changes, it does not break the correctness and may entail up to 5% perf regression for TMA (the worst I have
+  // measured for a 16 byte aligned SMEM destination). So no manual alignment is needed to respect bulk_copy_alignment.
 
-  // We use an attribute to align the shared memory. This is not respected on all drivers though. The compiler correctly
-  // takes the alignment into account and even emits an alignment specifier into ptx. However, this sometimes randomly
-  // fails at runtime because the shared memory start pointer is not correctly provided by the driver/runtime. See also
-  // NVBug 5093902, NVBug 5329745, and discussion in PR #5122.
-  extern __shared__ char __align__(tile_padding) smem_base_unaligned[];
-
-  // However, any manual alignment of the shared memory start address outweighs the performance benefits of a faster
-  // bulk copy by introducing about 7 additional SASS instructions at the start of the kernel. This also has to be done
-  // carefully using a fake read on the address to prevent NVVM to pull the aligning deeper into the kernel.
-  //   extern __shared__ char smem_base[];
-  //   uint32_t smem32 = __cvta_generic_to_shared(smem_base);
-  //   smem32 = cuda::round_up(smem32, bulk_copy_alignment);
-  //   char* smem = static_cast<char*>(_CCCL_BUILTIN_ASSUME_ALIGNED(__cvta_shared_to_generic(smem32),
-  //                                                                bulk_copy_alignment));
-
-  // What gets closest to a working attribute is to rely on the following observations:
-  // * static shared memory is aligned to 1KiB
-  // * dynamic shared memory is aligned to 16 bytes and comes right after static shared memory
-  // In this case we could:
-  //   extern __shared__ char smem_base[];
-  //   uint32_t smem32 = __cvta_generic_to_shared(smem_base) + bulk_copy_alignment - 16;
-  //   asm("" : "+r"(smem32));
-  //   char* smem = static_cast<char*>(_CCCL_BUILTIN_ASSUME_ALIGNED(__cvta_shared_to_generic(smem32),
-  //                                                                bulk_copy_alignment));
-  // However, CUDA currently does not provide this guarantee.
-
-  // We cannot assert that shared memory is sufficiently aligned, since it fails on some systems (e.g. with driver
-  // 565.57.01 on RTX 2080 when cub::DeviceTransform is called from another kernel via CDP. See
-  // thrust.cpp.cuda.cpp20.test.cuda.transform.cdp_1). This will lead to slightly reduced performance of bulk copy, but
-  // correctness is maintained.
-  //_CCCL_ASSERT(::cuda::is_aligned(smem, bulk_copy_alignment), "");
-
-  char* smem_base = smem_base_unaligned;
-  // Since alignment via the attribute may not work, we have to align explicitly if it's larger than the default dynamic
-  // shared memory alignment (16). This is not needed when the tile size does not retain the alignment, since we align
-  // each tile separately later
-  if constexpr (tile_sizes_retain_max_alignment && max_alignment > 16)
+  extern __shared__ char smem_with_barrier_base[]; // aligned to 16 bytes by default
+  char* smem_with_barrier = smem_with_barrier_base;
+  if constexpr (max_alignment > 16)
   {
-    smem_base = round_up_smem_ptr<tile_padding>(smem_base);
-    asm("" : "+l"(smem_base)); // keep the compiler from pulling the alignment deeper into the kernel
+    // manual alignment is necessary for correctness
+    uint32_t smem32 = __cvta_generic_to_shared(smem_with_barrier);
+    smem32          = ::cuda::round_up(smem32, tile_padding);
+    asm("" : "+r"(smem32)); // avoid NVVM pulling the alignment code into the kernel, gains up to 8.7% some runs on H200
+    smem_with_barrier = static_cast<char*>(__cvta_shared_to_generic(smem32));
   }
+
+  uint64_t& bar = *reinterpret_cast<uint64_t*>(smem_with_barrier);
+  static_assert(tile_padding >= sizeof(uint64_t));
+  char* smem_base = smem_with_barrier + tile_padding;
+  _CCCL_ASSERT(::cuda::is_aligned(smem_base, tile_padding), "");
 
   namespace ptx = ::cuda::ptx;
 
@@ -703,11 +688,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       auto bulk_copy_tile = [&](auto aligned_ptr) {
         using T         = typename decltype(aligned_ptr)::value_type;
         const char* src = aligned_ptr.ptr + offset * unsigned{sizeof(T)}; // compute expression in U32 if Offset==I32
-        if constexpr (!tile_sizes_retain_max_alignment)
-        {
-          smem = round_up_smem_ptr<alignof(T)>(smem);
-        }
-        char* dst = smem;
+        char* dst       = smem;
         _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % bulk_copy_alignment == 0, "");
         _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % bulk_copy_alignment == 0, "");
 
@@ -761,10 +742,6 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
       const char* src = aligned_ptr.ptr + offset * unsigned{sizeof(T)} + head_padding; // compute expression in U32 if
                                                                                        // Offset==I32
-      if constexpr (!tile_sizes_retain_max_alignment)
-      {
-        smem = round_up_smem_ptr<alignof(T)>(smem);
-      }
       char* dst = smem + head_padding;
       _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % alignof(T) == 0, "");
       _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % alignof(T) == 0, "");
@@ -807,11 +784,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
         auto fetch_operand = [&](auto aligned_ptr) {
           using T                = typename decltype(aligned_ptr)::value_type;
           const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;
-          if constexpr (!tile_sizes_retain_max_alignment)
-          {
-            smem = round_up_smem_ptr<alignof(T)>(smem);
-          }
-          const char* src = smem + head_padding;
+          const char* src        = smem + head_padding;
           smem += tile_padding + int{sizeof(T)} * tile_size;
           return reinterpret_cast<const T*>(src)[idx];
         };

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -39,6 +39,7 @@
 
 #include <cub/detail/detect_cuda_runtime.cuh>
 #include <cub/util_device.cuh>
+#include <cub/util_type.cuh>
 
 #include <thrust/type_traits/is_contiguous_iterator.h>
 #include <thrust/type_traits/is_trivially_relocatable.h>
@@ -46,6 +47,7 @@
 #include <cuda/cmath>
 #include <cuda/numeric>
 #include <cuda/std/__cccl/execution_space.h>
+#include <cuda/std/__numeric/reduce.h>
 #include <cuda/std/bit>
 
 CUB_NAMESPACE_BEGIN
@@ -70,14 +72,39 @@ struct prefetch_policy_t
   static constexpr int items_per_thread_no_input = 2; // when there are no input iterators, the kernel is just filling
   static constexpr int min_items_per_thread      = 1;
   static constexpr int max_items_per_thread      = 32;
+
+  // TODO: remove with C++20
+  // The value of the below does not matter.
+  static constexpr int not_a_vectorized_policy = 0;
 };
+
+CUB_DETAIL_POLICY_WRAPPER_DEFINE(
+  TransformAgentPrefetchPolicy,
+  (always_true),
+  (block_threads, BlockThreads, int),
+  (items_per_thread_no_input, ItemsPerThreadNoInput, int),
+  (min_items_per_thread, MinItemsPerThread, int),
+  (max_items_per_thread, MaxItemsPerThread, int),
+  (not_a_vectorized_policy, NotAVectorizedPolicy, int) ) // TODO: remove with C++20
 
 template <int BlockThreads, int ItemsPerThread, int LoadStoreWordSize>
 struct vectorized_policy_t : prefetch_policy_t<BlockThreads>
 {
   static constexpr int items_per_thread_vectorized = ItemsPerThread;
   static constexpr int load_store_word_size        = LoadStoreWordSize;
+
+  using not_a_vectorized_policy = void; // TODO: remove with C++20, shadows the variable in prefetch_policy_t
 };
+
+CUB_DETAIL_POLICY_WRAPPER_DEFINE(
+  TransformAgentVectorizedPolicy,
+  (always_true), // TODO: restore with C++20: (TransformAgentPrefetchPolicy),
+  (block_threads, BlockThreads, int),
+  (items_per_thread_no_input, ItemsPerThreadNoInput, int),
+  (min_items_per_thread, MinItemsPerThread, int),
+  (max_items_per_thread, MaxItemsPerThread, int),
+  (items_per_thread_vectorized, ItemsPerThreadVectorized, int),
+  (load_store_word_size, LoadStoreWordSize, int) )
 
 template <int BlockThreads, int BulkCopyAlignment>
 struct async_copy_policy_t
@@ -90,6 +117,73 @@ struct async_copy_policy_t
   static constexpr int bulk_copy_alignment = BulkCopyAlignment;
 };
 
+CUB_DETAIL_POLICY_WRAPPER_DEFINE(
+  TransformAgentAsyncPolicy,
+  (always_true),
+  (block_threads, BlockThreads, int),
+  (min_items_per_thread, MinItemsPerThread, int),
+  (max_items_per_thread, MaxItemsPerThread, int),
+  (bulk_copy_alignment, BulkCopyAlignment, int) )
+
+_CCCL_TEMPLATE(typename PolicyT)
+_CCCL_REQUIRES((!TransformAgentPrefetchPolicy<PolicyT> && !TransformAgentAsyncPolicy<PolicyT>
+                && !TransformAgentVectorizedPolicy<PolicyT>) )
+__host__ __device__ constexpr PolicyT MakePolicyWrapper(PolicyT policy)
+{
+  return policy;
+}
+
+template <typename PolicyT, typename = void>
+struct TransformPolicyWrapper : PolicyT
+{
+  _CCCL_HOST_DEVICE TransformPolicyWrapper(PolicyT base)
+      : PolicyT(base)
+  {}
+};
+
+template <typename StaticPolicyT>
+struct TransformPolicyWrapper<
+  StaticPolicyT,
+  ::cuda::std::
+    void_t<decltype(StaticPolicyT::algorithm), decltype(StaticPolicyT::min_bif), typename StaticPolicyT::algo_policy>>
+    : StaticPolicyT
+{
+  _CCCL_HOST_DEVICE TransformPolicyWrapper(StaticPolicyT base)
+      : StaticPolicyT(base)
+  {}
+
+  _CCCL_HOST_DEVICE static constexpr Algorithm Algorithm()
+  {
+    return StaticPolicyT::algorithm;
+  }
+
+  _CCCL_HOST_DEVICE static constexpr int MinBif()
+  {
+    return StaticPolicyT::min_bif;
+  }
+
+  _CCCL_HOST_DEVICE static constexpr auto AlgorithmPolicy()
+  {
+    return MakePolicyWrapper(typename StaticPolicyT::algo_policy());
+  }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedPolicy()
+  {
+    using namespace ptx_json;
+    return object<key<"min_bif">()     = value<StaticPolicyT::min_bif>(),
+                  key<"algorithm">()   = value<static_cast<int>(StaticPolicyT::algorithm)>(),
+                  key<"algo_policy">() = AlgorithmPolicy().EncodedPolicy()>();
+  }
+#endif // CUB_ENABLE_POLICY_PTX_JSON
+};
+
+template <typename PolicyT>
+_CCCL_HOST_DEVICE TransformPolicyWrapper<PolicyT> MakeTransformPolicyWrapper(PolicyT base)
+{
+  return TransformPolicyWrapper<PolicyT>(base);
+}
+
 template <typename... Its>
 _CCCL_HOST_DEVICE constexpr auto loaded_bytes_per_iteration() -> int
 {
@@ -98,19 +192,23 @@ _CCCL_HOST_DEVICE constexpr auto loaded_bytes_per_iteration() -> int
 
 constexpr int ldgsts_size_and_align = 16;
 
-template <typename... RandomAccessIteratorsIn>
-_CCCL_HOST_DEVICE constexpr auto
-memcpy_async_smem_for_tile_size(int tile_size, int /*block_threads*/, int copy_alignment = ldgsts_size_and_align) -> int
+template <typename ItValueSizesAlignments>
+_CCCL_HOST_DEVICE constexpr auto memcpy_async_smem_for_tile_size(
+  ItValueSizesAlignments it_value_sizes_alignments,
+  int tile_size,
+  int /*block_threads*/,
+  int copy_alignment = ldgsts_size_and_align) -> int
 {
-  int smem_size                    = 0;
-  [[maybe_unused]] auto count_smem = [&](int vt_size, int vt_alignment) {
-    smem_size = ::cuda::round_up(smem_size, ::cuda::std::max(vt_alignment, copy_alignment));
+  int smem_size = 0;
+  for (auto&& [vt_size, vt_alignment] : it_value_sizes_alignments)
+  {
+    smem_size =
+      static_cast<int>(::cuda::round_up(smem_size, ::cuda::std::max(static_cast<int>(vt_alignment), copy_alignment)));
     // max head/tail padding is copy_alignment - sizeof(T) each
-    const int max_bytes_to_copy = vt_size * tile_size + ::cuda::std::max(copy_alignment - vt_size, 0) * 2;
+    const int max_bytes_to_copy =
+      static_cast<int>(vt_size) * tile_size + ::cuda::std::max(copy_alignment - static_cast<int>(vt_size), 0) * 2;
     smem_size += max_bytes_to_copy;
   };
-  // left to right evaluation!
-  (..., count_smem(sizeof(it_value_t<RandomAccessIteratorsIn>), alignof(it_value_t<RandomAccessIteratorsIn>)));
   return smem_size;
 }
 
@@ -121,20 +219,22 @@ _CCCL_HOST_DEVICE constexpr auto bulk_copy_alignment(int sm_arch) -> int
   return sm_arch < 1000 ? 128 : 16;
 }
 
-template <typename... RandomAccessIteratorsIn>
-_CCCL_HOST_DEVICE constexpr auto bulk_copy_smem_for_tile_size(int tile_size, int block_threads, int bulk_copy_align)
-  -> int
+template <typename ItValueSizesAlignments>
+_CCCL_HOST_DEVICE constexpr auto bulk_copy_smem_for_tile_size(
+  ItValueSizesAlignments it_value_sizes_alignments, int tile_size, int block_threads, int bulk_copy_align) -> int
 {
   // we rely on the tile_size being a multiple of alignments, so shifting offsets/pointers by it retains alignments
   _CCCL_ASSERT(tile_size % bulk_copy_align == 0, "");
   _CCCL_ASSERT(tile_size % bulk_copy_size_multiple == 0, "");
 
-  const int min_retained_alignment = ::cuda::std::min(
-    {(int{sizeof(it_value_t<RandomAccessIteratorsIn>)} * block_threads)...,
-     2 << 30 /* largest alignment that can fit into int */});
-  const int max_alignment = ::cuda::std::max({int{alignof(it_value_t<RandomAccessIteratorsIn>)}..., 1});
+  int min_retained_alignment = 2 << 30; // largest alignment that can fit into int
+  int max_alignment          = 1;
+  for (auto&& [vt_size, vt_alignment] : it_value_sizes_alignments)
+  {
+    min_retained_alignment = ::cuda::std::min(min_retained_alignment, static_cast<int>(vt_size) * block_threads);
+    max_alignment          = ::cuda::std::max(max_alignment, static_cast<int>(vt_alignment));
+  }
   const bool tile_sizes_retain_max_alignment = max_alignment <= min_retained_alignment;
-
   const int tile_padding =
     tile_sizes_retain_max_alignment ? ::cuda::std::max(bulk_copy_align, max_alignment) : bulk_copy_align;
 
@@ -142,16 +242,15 @@ _CCCL_HOST_DEVICE constexpr auto bulk_copy_smem_for_tile_size(int tile_size, int
   // So let's start at offset 16. This also hits the worst case scenario for types with alignment larger than 16,
   // needing the most padding before the first tile. From observation, dynamic shared memory starts at address 0x408
   // within the shared memory window of the current CTA.
-  int smem_size                    = ::cuda::round_up(int{sizeof(uint64_t)}, 16);
-  [[maybe_unused]] auto count_smem = [&](int vt_size, int vt_alignment) {
+  int smem_size = ::cuda::round_up(int{sizeof(uint64_t)}, 16);
+  for (auto&& [vt_size, vt_alignment] : it_value_sizes_alignments)
+  {
     if (!tile_sizes_retain_max_alignment)
     {
-      smem_size = ::cuda::round_up(smem_size, vt_alignment);
+      smem_size = ::cuda::round_up(smem_size, static_cast<int>(vt_alignment));
     }
-    smem_size += tile_padding + vt_size * tile_size;
-  };
-  // left to right evaluation!
-  (..., count_smem(sizeof(it_value_t<RandomAccessIteratorsIn>), alignof(it_value_t<RandomAccessIteratorsIn>)));
+    smem_size += tile_padding + static_cast<int>(vt_size) * tile_size;
+  }
   return smem_size;
 }
 
@@ -183,74 +282,18 @@ _CCCL_HOST_DEVICE constexpr bool all_equal()
   return true;
 }
 
-template <typename PolicyT, typename = void>
-struct TransformPolicyWrapper : PolicyT
-{
-  _CCCL_HOST_DEVICE TransformPolicyWrapper(PolicyT base)
-      : PolicyT(base)
-  {}
-};
-
-template <typename StaticPolicyT>
-struct TransformPolicyWrapper<StaticPolicyT, ::cuda::std::void_t<decltype(StaticPolicyT::algorithm)>> : StaticPolicyT
-{
-  _CCCL_HOST_DEVICE TransformPolicyWrapper(StaticPolicyT base)
-      : StaticPolicyT(base)
-  {}
-
-  _CCCL_HOST_DEVICE static constexpr int MinBif()
-  {
-    return StaticPolicyT::min_bif;
-  }
-
-  _CCCL_HOST_DEVICE static constexpr Algorithm GetAlgorithm()
-  {
-    return StaticPolicyT::algorithm;
-  }
-
-  _CCCL_HOST_DEVICE static constexpr int BlockThreads()
-  {
-    return StaticPolicyT::algo_policy::block_threads;
-  }
-
-  template <typename = void>
-  _CCCL_HOST_DEVICE static constexpr int ItemsPerThreadNoInput()
-  {
-    return StaticPolicyT::algo_policy::items_per_thread_no_input;
-  }
-
-  _CCCL_HOST_DEVICE static constexpr int MinItemsPerThread()
-  {
-    return StaticPolicyT::algo_policy::min_items_per_thread;
-  }
-
-  _CCCL_HOST_DEVICE static constexpr int MaxItemsPerThread()
-  {
-    return StaticPolicyT::algo_policy::max_items_per_thread;
-  }
-
-  template <typename = void>
-  _CCCL_HOST_DEVICE static constexpr int ItemsPerThreadForVectorizedPath()
-  {
-    return StaticPolicyT::algo_policy::items_per_thread_vectorized;
-  }
-
-  _CCCL_HOST_DEVICE static constexpr int LoadStoreWordSize()
-  {
-    return StaticPolicyT::algo_policy::load_store_word_size;
-  }
-};
-
-template <typename PolicyT>
-_CCCL_HOST_DEVICE TransformPolicyWrapper<PolicyT> MakeTransformPolicyWrapper(PolicyT base)
-{
-  return TransformPolicyWrapper<PolicyT>(base);
-}
-
 template <typename T, typename... Ts>
 _CCCL_HOST_DEVICE constexpr auto first_item(T head, Ts...) -> T
 {
   return head;
+}
+
+template <typename... RandomAccessIteratorsIn>
+_CCCL_HOST_DEVICE static constexpr auto make_sizes_alignments()
+{
+  return ::cuda::std::array<::cuda::std::pair<::cuda::std::size_t, ::cuda::std::size_t>,
+                            sizeof...(RandomAccessIteratorsIn)>{
+    {{sizeof(it_value_t<RandomAccessIteratorsIn>), alignof(it_value_t<RandomAccessIteratorsIn>)}...}};
 }
 
 template <bool RequiresStableAddress, typename RandomAccessIteratorTupleIn, typename RandomAccessIteratorOut>
@@ -301,8 +344,11 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
     // forward compatible. If a user compiled for sm_xxx and we assume the available SMEM for that architecture, but
     // then runs on the next architecture after that, which may have a smaller available SMEM, we get a crash.
     static constexpr bool exhaust_smem =
-      memcpy_async_smem_for_tile_size<RandomAccessIteratorsIn...>(
-        block_threads * async_policy::min_items_per_thread, block_threads, ldgsts_size_and_align)
+      memcpy_async_smem_for_tile_size(
+        make_sizes_alignments<RandomAccessIteratorsIn...>(),
+        block_threads* async_policy::min_items_per_thread,
+        block_threads,
+        ldgsts_size_and_align)
       > int{max_smem_per_block};
     static constexpr bool use_fallback =
       RequiresStableAddress || !can_memcpy_inputs || no_input_streams || exhaust_smem;
@@ -323,8 +369,11 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
     // forward compatible. If a user compiled for sm_xxx and we assume the available SMEM for that architecture, but
     // then runs on the next architecture after that, which may have a smaller available SMEM, we get a crash.
     static constexpr bool exhaust_smem =
-      bulk_copy_smem_for_tile_size<RandomAccessIteratorsIn...>(
-        AsyncBlockSize * async_policy::min_items_per_thread, AsyncBlockSize, alignment)
+      bulk_copy_smem_for_tile_size(
+        make_sizes_alignments<RandomAccessIteratorsIn...>(),
+        AsyncBlockSize* async_policy::min_items_per_thread,
+        AsyncBlockSize,
+        alignment)
       > int{max_smem_per_block};
     static constexpr bool use_fallback =
       RequiresStableAddress || !can_memcpy_inputs || no_input_streams || exhaust_smem;

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -193,11 +193,8 @@ _CCCL_HOST_DEVICE constexpr auto loaded_bytes_per_iteration() -> int
 constexpr int ldgsts_size_and_align = 16;
 
 template <typename ItValueSizesAlignments>
-_CCCL_HOST_DEVICE constexpr auto memcpy_async_smem_for_tile_size(
-  ItValueSizesAlignments it_value_sizes_alignments,
-  int tile_size,
-  int /*block_threads*/,
-  int copy_alignment = ldgsts_size_and_align) -> int
+_CCCL_HOST_DEVICE constexpr auto memcpy_async_dyn_smem_for_tile_size(
+  ItValueSizesAlignments it_value_sizes_alignments, int tile_size, int copy_alignment = ldgsts_size_and_align) -> int
 {
   int smem_size = 0;
   for (auto&& [vt_size, vt_alignment] : it_value_sizes_alignments)
@@ -220,35 +217,23 @@ _CCCL_HOST_DEVICE constexpr auto bulk_copy_alignment(int sm_arch) -> int
 }
 
 template <typename ItValueSizesAlignments>
-_CCCL_HOST_DEVICE constexpr auto bulk_copy_smem_for_tile_size(
-  ItValueSizesAlignments it_value_sizes_alignments, int tile_size, int block_threads, int bulk_copy_align) -> int
+_CCCL_HOST_DEVICE constexpr auto
+bulk_copy_dyn_smem_for_tile_size(ItValueSizesAlignments it_value_sizes_alignments, int tile_size, int bulk_copy_align)
+  -> int
 {
   // we rely on the tile_size being a multiple of alignments, so shifting offsets/pointers by it retains alignments
   _CCCL_ASSERT(tile_size % bulk_copy_align == 0, "");
   _CCCL_ASSERT(tile_size % bulk_copy_size_multiple == 0, "");
 
-  int min_retained_alignment = 2 << 30; // largest alignment that can fit into int
-  int max_alignment          = 1;
-  for (auto&& [vt_size, vt_alignment] : it_value_sizes_alignments)
+  int tile_padding = bulk_copy_align;
+  for (auto&& [_, vt_alignment] : it_value_sizes_alignments)
   {
-    min_retained_alignment = ::cuda::std::min(min_retained_alignment, static_cast<int>(vt_size) * block_threads);
-    max_alignment          = ::cuda::std::max(max_alignment, static_cast<int>(vt_alignment));
+    tile_padding = ::cuda::std::max(tile_padding, static_cast<int>(vt_alignment));
   }
-  const bool tile_sizes_retain_max_alignment = max_alignment <= min_retained_alignment;
-  const int tile_padding =
-    tile_sizes_retain_max_alignment ? ::cuda::std::max(bulk_copy_align, max_alignment) : bulk_copy_align;
 
-  // dynamic SMEM comes after static shared memory (which contains the 8-byte barrier) and is at least 16 bytes aligned.
-  // So let's start at offset 16. This also hits the worst case scenario for types with alignment larger than 16,
-  // needing the most padding before the first tile. From observation, dynamic shared memory starts at address 0x408
-  // within the shared memory window of the current CTA.
-  int smem_size = ::cuda::round_up(int{sizeof(uint64_t)}, 16);
-  for (auto&& [vt_size, vt_alignment] : it_value_sizes_alignments)
+  int smem_size = tile_padding; // for the barrier and padding
+  for (auto&& [vt_size, _] : it_value_sizes_alignments)
   {
-    if (!tile_sizes_retain_max_alignment)
-    {
-      smem_size = ::cuda::round_up(smem_size, static_cast<int>(vt_alignment));
-    }
     smem_size += tile_padding + static_cast<int>(vt_size) * tile_size;
   }
   return smem_size;
@@ -344,10 +329,9 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
     // forward compatible. If a user compiled for sm_xxx and we assume the available SMEM for that architecture, but
     // then runs on the next architecture after that, which may have a smaller available SMEM, we get a crash.
     static constexpr bool exhaust_smem =
-      memcpy_async_smem_for_tile_size(
+      memcpy_async_dyn_smem_for_tile_size(
         make_sizes_alignments<RandomAccessIteratorsIn...>(),
         block_threads* async_policy::min_items_per_thread,
-        block_threads,
         ldgsts_size_and_align)
       > int{max_smem_per_block};
     static constexpr bool use_fallback =
@@ -369,14 +353,23 @@ struct policy_hub<RequiresStableAddress, ::cuda::std::tuple<RandomAccessIterator
     // forward compatible. If a user compiled for sm_xxx and we assume the available SMEM for that architecture, but
     // then runs on the next architecture after that, which may have a smaller available SMEM, we get a crash.
     static constexpr bool exhaust_smem =
-      bulk_copy_smem_for_tile_size(
+      bulk_copy_dyn_smem_for_tile_size(
         make_sizes_alignments<RandomAccessIteratorsIn...>(),
         AsyncBlockSize* async_policy::min_items_per_thread,
-        AsyncBlockSize,
         alignment)
       > int{max_smem_per_block};
+
+    // if each tile size is a multiple of the bulk copy and maximum value type alignments, the alignment is retained if
+    // the base pointer is sufficiently aligned (the correct check would be if it's a multiple of all value types
+    // following the current tile). we would otherwise need to realign every SMEM tile individually, which is costly and
+    // complex, so let's fall back in this case.
+    static constexpr int max_alignment =
+      ::cuda::std::max({alignment, int{alignof(it_value_t<RandomAccessIteratorsIn>)}...});
+    static constexpr int tile_sizes_retain_alignment =
+      (((int{sizeof(it_value_t<RandomAccessIteratorsIn>)} * AsyncBlockSize) % max_alignment == 0) && ...);
+
     static constexpr bool use_fallback =
-      RequiresStableAddress || !can_memcpy_inputs || no_input_streams || exhaust_smem;
+      RequiresStableAddress || !can_memcpy_inputs || no_input_streams || exhaust_smem || !tile_sizes_retain_alignment;
 
   public:
     static constexpr int min_bif    = arch_to_min_bytes_in_flight(PtxVersion);

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -587,7 +587,7 @@ namespace detail
       from_json(const nlohmann::json& json, std::string_view subpolicy_name)                                           \
       {                                                                                                                \
         auto subpolicy = json[subpolicy_name];                                                                         \
-        assert(subpolicy);                                                                                             \
+        assert(!subpolicy.is_null());                                                                                  \
         Runtime##concept_name ap;                                                                                      \
         _CCCL_PP_FOR_EACH(CUB_DETAIL_POLICY_WRAPPER_GET_FIELD, __VA_ARGS__)                                            \
         return std::make_pair(                                                                                         \

--- a/cub/cub/util_macro.cuh
+++ b/cub/cub/util_macro.cuh
@@ -88,4 +88,12 @@ _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 #  define _CCCL_SORT_MAYBE_UNROLL() _CCCL_PRAGMA_UNROLL_FULL()
 #endif // !CCCL_AVOID_SORT_UNROLL
 
+#if defined(CUB_DEFINE_RUNTIME_POLICIES)
+#  define CUB_DETAIL_STATIC_ISH_ASSERT(expr, msg) _CCCL_ASSERT(expr, msg)
+#  define CUB_DETAIL_CONSTEXPR_ISH
+#else // ^^^ CUB_DEFINE_RUNTIME_POLICIES ^^^ / vvv !CUB_DEFINE_RUNTIME_POLICIES vvv
+#  define CUB_DETAIL_STATIC_ISH_ASSERT(expr, msg) static_assert(expr, msg);
+#  define CUB_DETAIL_CONSTEXPR_ISH                constexpr
+#endif // !(CUB_DEFINE_RUNTIME_POLICIES)
+
 CUB_NAMESPACE_END


### PR DESCRIPTION
I need to backport the UBLKCP enablement in c.parallel as well, since I get a lot of conflicts otherwise.