### PR TITLE
Backport to 3.0: Fix grid dependency sync in cub::DeviceMergeSort (#5456)

### DIFF
--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -163,10 +163,10 @@ struct AgentBlockSort
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void Process()
   {
-    auto tile_idx     = static_cast<OffsetT>(blockIdx.x);
-    auto num_tiles    = static_cast<OffsetT>(gridDim.x);
-    auto tile_base    = tile_idx * ITEMS_PER_TILE;
-    int items_in_tile = (::cuda::std::min)(static_cast<int>(keys_count - tile_base), int{ITEMS_PER_TILE});
+    const auto tile_idx     = static_cast<OffsetT>(blockIdx.x);
+    const auto num_tiles    = static_cast<OffsetT>(gridDim.x);
+    const auto tile_base    = tile_idx * ITEMS_PER_TILE;
+    const int items_in_tile = (::cuda::std::min)(static_cast<int>(keys_count - tile_base), int{ITEMS_PER_TILE});
 
     if (tile_idx < num_tiles - 1)
     {
@@ -305,29 +305,6 @@ struct AgentPartition
   int items_per_tile;
   OffsetT num_partitions;
 
-  _CCCL_DEVICE _CCCL_FORCEINLINE AgentPartition(
-    bool ping,
-    KeyIteratorT keys_ping,
-    KeyT* keys_pong,
-    OffsetT keys_count,
-    OffsetT partition_idx,
-    OffsetT* merge_partitions,
-    CompareOpT compare_op,
-    OffsetT target_merged_tiles_number,
-    int items_per_tile,
-    OffsetT num_partitions)
-      : ping(ping)
-      , keys_ping(keys_ping)
-      , keys_pong(keys_pong)
-      , keys_count(keys_count)
-      , partition_idx(partition_idx)
-      , merge_partitions(merge_partitions)
-      , compare_op(compare_op)
-      , target_merged_tiles_number(target_merged_tiles_number)
-      , items_per_tile(items_per_tile)
-      , num_partitions(num_partitions)
-  {}
-
   _CCCL_DEVICE _CCCL_FORCEINLINE void Process()
   {
     const OffsetT merged_tiles_number = target_merged_tiles_number / 2;
@@ -378,6 +355,10 @@ struct AgentPartition
 
       merge_partitions[partition_idx] = keys1_beg + partition_diag;
     }
+
+    // TODO(bgruber): looking at SASS triggering the next launch here just generates a lot of noise and the PRE-EXIT
+    // just ends of right before EXIT anyway. So let's omit it.
+    // _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
   }
 };
 
@@ -508,6 +489,8 @@ struct AgentMerge
   template <bool IS_FULL_TILE>
   _CCCL_DEVICE _CCCL_FORCEINLINE void consume_tile(int tid, OffsetT tile_idx, OffsetT tile_base, int count)
   {
+    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+
     const OffsetT partition_beg = merge_partitions[tile_idx + 0];
     const OffsetT partition_end = merge_partitions[tile_idx + 1];
 
@@ -548,8 +531,6 @@ struct AgentMerge
     // number of keys per tile
     const int num_keys1 = static_cast<int>(keys1_end - keys1_beg);
     const int num_keys2 = static_cast<int>(keys2_end - keys2_beg);
-
-    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
 
     // load keys1 & keys2
     KeyT keys_local[ITEMS_PER_THREAD];

--- a/cub/cub/device/dispatch/kernels/merge_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/merge_sort.cuh
@@ -180,8 +180,6 @@ __launch_bounds__(
   VSmemHelperT::discard_temp_storage(temp_storage);
 }
 
-// TODO(bgruber): if we put a call to cudaTriggerProgrammaticLaunchCompletion inside this kernel, the tests fail with
-// cudaErrorIllegalAddress.
 template <typename KeyIteratorT, typename OffsetT, typename CompareOpT, typename KeyT>
 CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceMergeSortPartitionKernel(
   bool ping,
@@ -198,7 +196,7 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceMergeSortPartitionKernel(
 
   if (partition_idx < num_partitions)
   {
-    AgentPartition<KeyIteratorT, OffsetT, CompareOpT, KeyT> agent(
+    AgentPartition<KeyIteratorT, OffsetT, CompareOpT, KeyT>{
       ping,
       keys_ping,
       keys_pong,
@@ -208,9 +206,8 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void DeviceMergeSortPartitionKernel(
       compare_op,
       target_merged_tiles_number,
       items_per_tile,
-      num_partitions);
-
-    agent.Process();
+      num_partitions}
+      .Process();
   }
 }
 


### PR DESCRIPTION
The sync was too late and did not guard loading from merge_partitions, leading to a data race
