### PR TITLE
docs(thrust): document thrust::cuda::par_nosync and par (fixes #5453)

### DIFF
--- a/docs/thrust/api_docs/parallel_execution_policies.rst
+++ b/docs/thrust/api_docs/parallel_execution_policies.rst
@@ -5,6 +5,8 @@ Parallel Execution Policies
 
   - :cpp:struct:`thrust::host_execution_policy <thrust::host_execution_policy>`
   - :cpp:struct:`thrust::device_execution_policy <thrust::device_execution_policy>`
+  - :cpp:var:`thrust::cuda::par <thrust::cuda::par>`
+  - :cpp:var:`thrust::cuda::par_nosync <thrust::cuda::par_nosync>`
 
 .. toctree::
    :glob:

--- a/thrust/thrust/system/cuda/execution_policy.h
+++ b/thrust/thrust/system/cuda/execution_policy.h
@@ -37,3 +37,67 @@
 #endif // no system header
 #include <thrust/system/cuda/detail/execution_policy.h>
 #include <thrust/system/cuda/detail/par.h>
+
+// define these entities here for the purpose of Doxygenating them
+// they are actually defined elsewhere
+#if 0
+THRUST_NAMESPACE_BEGIN
+namespace cuda
+{
+
+/*! \addtogroup execution_policies
+ *  \{
+ */
+
+/*! \p thrust::cuda::par is the parallel execution policy associated with
+ *  Thrust's CUDA device backend.
+ *
+ *  Instead of relying on implicit algorithm dispatch through iterator system tags,
+ *  users may directly target Thrust's CUDA backend by providing \p thrust::cuda::par
+ *  as an algorithm parameter. The policy can be attached to a specific CUDA stream
+ *  using the `.on(stream)` helper.
+ *
+ *  The type of \p thrust::cuda::par is implementation-defined.
+ */
+static const unspecified par;
+
+/*! \p thrust::cuda::par_nosync is a parallel execution policy targeting
+ *  Thrust's CUDA device backend that allows algorithms to elide optional
+ *  stream synchronizations.
+ *
+ *  Similar to \p thrust::cuda::par, it allows execution of Thrust algorithms in
+ *  a specific CUDA stream via `.on(stream)`. In addition, \p thrust::cuda::par_nosync
+ *  indicates that an algorithm is free to avoid any synchronization of the associated
+ *  stream that is not strictly required for correctness. Algorithms may also return
+ *  before the corresponding kernels are completed (similar to asynchronous kernel launches).
+ *  The user must perform explicit synchronization when necessary.
+ *
+ *  Example:
+ *  \code
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/for_each.h>
+ *  #include <thrust/execution_policy.h>
+ *
+ *  struct IncFunctor{
+ *    __host__ __device__
+ *    void operator()(std::size_t& x){ x = x + 1; };
+ *  };
+ *
+ *  cudaStream_t stream;
+ *  cudaStreamCreate(&stream);
+ *  auto nosync = thrust::cuda::par_nosync.on(stream);
+ *
+ *  thrust::for_each(nosync, vec.begin(), vec.end(), IncFunctor{});
+ *  // ... do other host work ...
+ *  cudaStreamSynchronize(stream);
+ *  cudaStreamDestroy(stream);
+ *  \endcode
+ */
+static const unspecified par_nosync;
+
+/*! \}
+ */
+
+} // end cuda
+THRUST_NAMESPACE_END
+#endif


### PR DESCRIPTION
This adds user-visible documentation for  and  so these policies show up in the Thrust docs beyond the changelog.\n\n- Add Doxygen (guarded with ) declarations and API docs for  and  in , consistent with existing doc patterns in other backends.\n- Link both variables in  so they appear in the Parallel Execution Policies reference.\n\nThis addresses the missing docs reported in #5453.