### PR TITLE
Drop all usages of `_CCCL_TRAIT`

### DIFF
--- a/cub/cub/detail/fast_modulo_division.cuh
+++ b/cub/cub/detail/fast_modulo_division.cuh
@@ -108,11 +108,11 @@ multiply_extract_higher_bits(T value, R multiplier)
 {
   static_assert(supported_integral<T>::value, "unsupported type");
   static_assert(supported_integral<R>::value, "unsupported type");
-  if constexpr (_CCCL_TRAIT(::cuda::std::is_signed, T))
+  if constexpr (::cuda::std::is_signed_v<T>)
   {
     _CCCL_ASSERT(value >= 0, "value must be non-negative");
   }
-  if constexpr (_CCCL_TRAIT(::cuda::std::is_signed, R))
+  if constexpr (::cuda::std::is_signed_v<R>)
   {
     _CCCL_ASSERT(multiplier >= 0, "multiplier must be non-negative");
   }

--- a/cub/cub/detail/type_traits.cuh
+++ b/cub/cub/detail/type_traits.cuh
@@ -34,7 +34,7 @@ namespace detail
 {
 
 template <typename T, typename... TArgs>
-inline constexpr bool is_one_of_v = (_CCCL_TRAIT(_CUDA_VSTD::is_same, T, TArgs) || ...);
+inline constexpr bool is_one_of_v = (_CUDA_VSTD::is_same_v<T, TArgs> || ...);
 
 template <typename T, typename V, typename = void>
 struct has_binary_call_operator : _CUDA_VSTD::false_type

--- a/cub/cub/warp/warp_reduce.cuh
+++ b/cub/cub/warp/warp_reduce.cuh
@@ -228,7 +228,7 @@ public:
   }
 
   _CCCL_TEMPLATE(typename InputType)
-  _CCCL_REQUIRES(_CCCL_TRAIT(detail::is_fixed_size_random_access_range, InputType))
+  _CCCL_REQUIRES(detail::is_fixed_size_random_access_range_v<InputType>)
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(const InputType& input)
   {
     auto thread_reduction = cub::ThreadReduce(input, _CUDA_VSTD::plus<>{});
@@ -242,7 +242,7 @@ public:
   }
 
   _CCCL_TEMPLATE(typename InputType)
-  _CCCL_REQUIRES(_CCCL_TRAIT(detail::is_fixed_size_random_access_range, InputType))
+  _CCCL_REQUIRES(detail::is_fixed_size_random_access_range_v<InputType>)
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T Max(const InputType& input)
   {
     auto thread_reduction = cub::ThreadReduce(input, ::cuda::maximum<>{});
@@ -256,7 +256,7 @@ public:
   }
 
   _CCCL_TEMPLATE(typename InputType)
-  _CCCL_REQUIRES(_CCCL_TRAIT(detail::is_fixed_size_random_access_range, InputType))
+  _CCCL_REQUIRES(detail::is_fixed_size_random_access_range_v<InputType>)
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T Min(const InputType& input)
   {
     auto thread_reduction = cub::ThreadReduce(input, ::cuda::minimum<>{});
@@ -497,7 +497,7 @@ public:
   }
 
   _CCCL_TEMPLATE(typename InputType, typename ReductionOp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(detail::is_fixed_size_random_access_range, InputType))
+  _CCCL_REQUIRES(detail::is_fixed_size_random_access_range_v<InputType>)
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(const InputType& input, ReductionOp reduction_op)
   {
     auto thread_reduction = cub::ThreadReduce(input, reduction_op);
@@ -726,7 +726,7 @@ public:
   }
 
   _CCCL_TEMPLATE(typename InputType)
-  _CCCL_REQUIRES(_CCCL_TRAIT(detail::is_fixed_size_random_access_range, InputType))
+  _CCCL_REQUIRES(detail::is_fixed_size_random_access_range_v<InputType>)
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T Sum(const InputType& input)
   {
     return cub::ThreadReduce(input, _CUDA_VSTD::plus<>{});
@@ -743,7 +743,7 @@ public:
   }
 
   _CCCL_TEMPLATE(typename InputType)
-  _CCCL_REQUIRES(_CCCL_TRAIT(detail::is_fixed_size_random_access_range, InputType))
+  _CCCL_REQUIRES(detail::is_fixed_size_random_access_range_v<InputType>)
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T Max(const InputType& input)
   {
     return cub::ThreadReduce(input, ::cuda::maximum<>{});
@@ -760,7 +760,7 @@ public:
   }
 
   _CCCL_TEMPLATE(typename InputType)
-  _CCCL_REQUIRES(_CCCL_TRAIT(detail::is_fixed_size_random_access_range, InputType))
+  _CCCL_REQUIRES(detail::is_fixed_size_random_access_range_v<InputType>)
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T Min(const InputType& input)
   {
     return cub::ThreadReduce(input, ::cuda::minimum<>{});
@@ -790,7 +790,7 @@ public:
   }
 
   _CCCL_TEMPLATE(typename InputType, typename ReductionOp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(detail::is_fixed_size_random_access_range, InputType))
+  _CCCL_REQUIRES(detail::is_fixed_size_random_access_range_v<InputType>)
   [[nodiscard]] _CCCL_DEVICE _CCCL_FORCEINLINE T Reduce(const InputType& input, ReductionOp reduction_op)
   {
     return cub::ThreadReduce(input, reduction_op);

--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -120,7 +120,7 @@ public:
   friend class async_buffer;
 
   // For now we require trivially copyable type to simplify the implementation
-  static_assert(_CCCL_TRAIT(_CUDA_VSTD::is_trivially_copyable, _Tp),
+  static_assert(_CUDA_VSTD::is_trivially_copyable_v<_Tp>,
                 "cuda::experimental::async_buffer requires T to be trivially copyable.");
 
   // At least one of the properties must signal an execution space

--- a/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
@@ -92,9 +92,7 @@ private:
   //! @brief Helper to check whether a different buffer still satisfies all properties of this one
   template <class... _OtherProperties>
   static constexpr bool __properties_match =
-    !_CCCL_TRAIT(_CUDA_VSTD::is_same,
-                 _CUDA_VSTD::__make_type_set<_Properties...>,
-                 _CUDA_VSTD::__make_type_set<_OtherProperties...>)
+    !_CUDA_VSTD::is_same_v<_CUDA_VSTD::__make_type_set<_Properties...>, _CUDA_VSTD::__make_type_set<_OtherProperties...>>
     && _CUDA_VSTD::__type_set_contains_v<_CUDA_VSTD::__make_type_set<_OtherProperties...>, _Properties...>;
 
   //! @brief Determines the allocation size given the alignment and size of `T`

--- a/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
@@ -81,9 +81,7 @@ private:
   //! @brief Helper to check whether a different buffer still satisfies all properties of this one
   template <class... _OtherProperties>
   static constexpr bool __properties_match =
-    !_CCCL_TRAIT(_CUDA_VSTD::is_same,
-                 _CUDA_VSTD::__make_type_set<_Properties...>,
-                 _CUDA_VSTD::__make_type_set<_OtherProperties...>)
+    !_CUDA_VSTD::is_same_v<_CUDA_VSTD::__make_type_set<_Properties...>, _CUDA_VSTD::__make_type_set<_OtherProperties...>>
     && _CUDA_VSTD::__type_set_contains_v<_CUDA_VSTD::__make_type_set<_OtherProperties...>, _Properties...>;
 
   //! @brief Determines the allocation size given the alignment and size of `T`

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -227,7 +227,7 @@ public:
   //! @brief Construct from an environment that has the right queries
   //! @param __env The environment we are querying for the required information
   _CCCL_TEMPLATE(class _Env)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(_CUDA_VSTD::is_same, _Env, env_t)) _CCCL_AND __is_compatible_env<_Env>)
+  _CCCL_REQUIRES((!_CUDA_VSTD::is_same_v<_Env, env_t>) _CCCL_AND __is_compatible_env<_Env>)
   _CCCL_HIDE_FROM_ABI env_t(const _Env& __env) noexcept
       : __mr_(__env.query(::cuda::mr::get_memory_resource))
       , __stream_(__env.query(::cuda::get_stream))

--- a/cudax/include/cuda/experimental/__execution/policy.cuh
+++ b/cudax/include/cuda/experimental/__execution/policy.cuh
@@ -133,14 +133,13 @@ struct get_execution_policy_t;
 
 template <class _Tp>
 _CCCL_CONCEPT __has_member_get_execution_policy = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)(
-  requires(_CCCL_TRAIT(_CUDA_VSTD::is_convertible, decltype(__t.get_execution_policy()), __execution_policy)));
+  requires(_CUDA_VSTD::is_convertible_v<decltype(__t.get_execution_policy()), __execution_policy>));
 
 template <class _Env>
 _CCCL_CONCEPT __has_query_get_execution_policy = _CCCL_REQUIRES_EXPR((_Env))(
   requires(!__has_member_get_execution_policy<_Env>),
-  requires(_CCCL_TRAIT(_CUDA_VSTD::is_convertible,
-                       _CUDA_STD_EXEC::__query_result_t<const _Env&, get_execution_policy_t>,
-                       __execution_policy)));
+  requires(_CUDA_VSTD::is_convertible_v<_CUDA_STD_EXEC::__query_result_t<const _Env&, get_execution_policy_t>,
+                                        __execution_policy>));
 
 struct get_execution_policy_t
 {

--- a/docs/cccl/development/macro.rst
+++ b/docs/cccl/development/macro.rst
@@ -253,8 +253,6 @@ The following macros are required only if the target C++ version does not suppor
 +------------------------+--------------------------------------------------------------------------------------------+
 | ``_CCCL_REQUIRES(X)``  | ``requires`` clause                                                                        |
 +------------------------+--------------------------------------------------------------------------------------------+
-| ``_CCCL_TRAIT(X)``     | Selects variable template ``is_meow_v<T>`` instead of ``is_meow<T>::value`` when available |
-+------------------------+--------------------------------------------------------------------------------------------+
 | ``_CCCL_AND``          | Traits conjunction only used with ``_CCCL_REQUIRES``                                       |
 +------------------------+--------------------------------------------------------------------------------------------+
 
@@ -263,12 +261,12 @@ Usage example:
 .. code-block:: c++
 
     _CCCL_TEMPLATE(typename T)
-    _CCCL_REQUIRES(_CCCL_TRAIT(is_integral, T) _CCCL_AND(sizeof(T) > 1))
+    _CCCL_REQUIRES(is_integral_v<T> _CCCL_AND(sizeof(T) > 1))
 
 .. code-block:: c++
 
     _CCCL_TEMPLATE(typename T)
-    _CCCL_REQUIRES(_CCCL_TRAIT(is_arithmetic, T) _CCCL_AND (!_CCCL_TRAIT(is_integral, T)))
+    _CCCL_REQUIRES(is_arithmetic_v<T> _CCCL_AND (!is_integral_v<T>))
 
 
 **Portable feature testing**:

--- a/docs/repo.toml
+++ b/docs/repo.toml
@@ -80,7 +80,6 @@ doxygen_predefined = [
     "_CCCL_SUPPRESS_DEPRECATED_PUSH=",
     "_CCCL_SUPPRESS_DEPRECATED_POP=",
     "_CCCL_TEMPLATE(x)=template<x, ",
-    "_CCCL_TRAIT(x, y)=x<y>::value",
     "_CCCL_TRAILING_REQUIRES(x)=-> x requires ",
     "_CCCL_TYPE_VISIBILITY_DEFAULT=",
     "_CCCL_API=inline",

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -42,7 +42,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_integral_v<_Tp> _CCCL_AND _CUDA_VSTD::is_integral_v<_Up>)
 [[nodiscard]] _CCCL_API constexpr _CUDA_VSTD::common_type_t<_Tp, _Up> ceil_div(const _Tp __a, const _Up __b) noexcept
 {
   _CCCL_ASSERT(__b > _Up{0}, "cuda::ceil_div: 'b' must be positive");
@@ -83,7 +83,7 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp) _CCCL_AND _CCCL_TRAIT(_
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_integral_v<_Tp> _CCCL_AND _CUDA_VSTD::is_enum_v<_Up>)
 [[nodiscard]] _CCCL_API constexpr _CUDA_VSTD::common_type_t<_Tp, _CUDA_VSTD::underlying_type_t<_Up>>
 ceil_div(const _Tp __a, const _Up __b) noexcept
 {
@@ -96,7 +96,7 @@ ceil_div(const _Tp __a, const _Up __b) noexcept
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_enum_v<_Tp> _CCCL_AND _CUDA_VSTD::is_integral_v<_Up>)
 [[nodiscard]] _CCCL_API constexpr _CUDA_VSTD::common_type_t<_CUDA_VSTD::underlying_type_t<_Tp>, _Up>
 ceil_div(const _Tp __a, const _Up __b) noexcept
 {
@@ -109,7 +109,7 @@ ceil_div(const _Tp __a, const _Up __b) noexcept
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_enum_v<_Tp> _CCCL_AND _CUDA_VSTD::is_enum_v<_Up>)
 [[nodiscard]]
 _CCCL_API constexpr _CUDA_VSTD::common_type_t<_CUDA_VSTD::underlying_type_t<_Tp>, _CUDA_VSTD::underlying_type_t<_Up>>
 ceil_div(const _Tp __a, const _Up __b) noexcept

--- a/libcudacxx/include/cuda/__cmath/ilog.h
+++ b/libcudacxx/include/cuda/__cmath/ilog.h
@@ -38,7 +38,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
 _CCCL_TEMPLATE(typename _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_cv_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_cv_integer_v<_Tp>)
 _CCCL_API constexpr int ilog2(_Tp __t) noexcept
 {
   using _Up = _CUDA_VSTD::make_unsigned_t<_Tp>;
@@ -49,7 +49,7 @@ _CCCL_API constexpr int ilog2(_Tp __t) noexcept
 }
 
 _CCCL_TEMPLATE(typename _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_cv_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_cv_integer_v<_Tp>)
 _CCCL_API constexpr int ceil_ilog2(_Tp __t) noexcept
 {
   using _Up = _CUDA_VSTD::make_unsigned_t<_Tp>;
@@ -143,7 +143,7 @@ _CCCL_API constexpr int ceil_ilog2(_Tp __t) noexcept
 #endif // _CCCL_HAS_INT128()
 
 _CCCL_TEMPLATE(typename _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_cv_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_cv_integer_v<_Tp>)
 _CCCL_API constexpr int ilog10(_Tp __t) noexcept
 {
   _CCCL_ASSERT(__t > 0, "ilog10() argument must be strictly positive");

--- a/libcudacxx/include/cuda/__cmath/isqrt.h
+++ b/libcudacxx/include/cuda/__cmath/isqrt.h
@@ -38,10 +38,10 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //! @return The square root of \p __v rounded down
 //! @warning If \p __v is negative, the behavior is undefined
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp isqrt(_Tp __v) noexcept
 {
-  if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))
+  if constexpr (_CUDA_VSTD::is_signed_v<_Tp>)
   {
     _CCCL_ASSERT(__v >= _Tp{0}, "cuda::isqrt requires non-negative input");
   }

--- a/libcudacxx/include/cuda/__cmath/pow2.h
+++ b/libcudacxx/include/cuda/__cmath/pow2.h
@@ -32,10 +32,10 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
 _CCCL_TEMPLATE(typename _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr bool is_power_of_two(_Tp __t) noexcept
 {
-  if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))
+  if constexpr (_CUDA_VSTD::is_signed_v<_Tp>)
   {
     _CCCL_ASSERT(__t >= _Tp{0}, "cuda::is_power_of_two requires non-negative input");
   }
@@ -44,10 +44,10 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
 }
 
 _CCCL_TEMPLATE(typename _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp next_power_of_two(_Tp __t) noexcept
 {
-  if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))
+  if constexpr (_CUDA_VSTD::is_signed_v<_Tp>)
   {
     _CCCL_ASSERT(__t >= _Tp{0}, "cuda::is_power_of_two requires non-negative input");
   }
@@ -56,10 +56,10 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
 }
 
 _CCCL_TEMPLATE(typename _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp prev_power_of_two(_Tp __t) noexcept
 {
-  if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))
+  if constexpr (_CUDA_VSTD::is_signed_v<_Tp>)
   {
     _CCCL_ASSERT(__t >= _Tp{0}, "cuda::is_power_of_two requires non-negative input");
   }

--- a/libcudacxx/include/cuda/__cmath/round_down.h
+++ b/libcudacxx/include/cuda/__cmath/round_down.h
@@ -40,7 +40,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_integral_v<_Tp> _CCCL_AND _CUDA_VSTD::is_integral_v<_Up>)
 [[nodiscard]] _CCCL_API constexpr _CUDA_VSTD::common_type_t<_Tp, _Up> round_down(const _Tp __a, const _Up __b) noexcept
 {
   _CCCL_ASSERT(__b > _Up{0}, "cuda::round_down: 'b' must be positive");
@@ -61,7 +61,7 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp) _CCCL_AND _CCCL_TRAIT(_
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_integral_v<_Tp> _CCCL_AND _CUDA_VSTD::is_enum_v<_Up>)
 [[nodiscard]] _CCCL_API constexpr _CUDA_VSTD::common_type_t<_Tp, _CUDA_VSTD::underlying_type_t<_Up>>
 round_down(const _Tp __a, const _Up __b) noexcept
 {
@@ -74,7 +74,7 @@ round_down(const _Tp __a, const _Up __b) noexcept
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_enum_v<_Tp> _CCCL_AND _CUDA_VSTD::is_integral_v<_Up>)
 [[nodiscard]] _CCCL_API constexpr _CUDA_VSTD::common_type_t<_CUDA_VSTD::underlying_type_t<_Tp>, _Up>
 round_down(const _Tp __a, const _Up __b) noexcept
 {
@@ -87,7 +87,7 @@ round_down(const _Tp __a, const _Up __b) noexcept
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_enum_v<_Tp> _CCCL_AND _CUDA_VSTD::is_enum_v<_Up>)
 [[nodiscard]]
 _CCCL_API constexpr _CUDA_VSTD::common_type_t<_CUDA_VSTD::underlying_type_t<_Tp>, _CUDA_VSTD::underlying_type_t<_Up>>
 round_down(const _Tp __a, const _Up __b) noexcept

--- a/libcudacxx/include/cuda/__cmath/round_up.h
+++ b/libcudacxx/include/cuda/__cmath/round_up.h
@@ -41,7 +41,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_integral_v<_Tp> _CCCL_AND _CUDA_VSTD::is_integral_v<_Up>)
 [[nodiscard]] _CCCL_API constexpr _CUDA_VSTD::common_type_t<_Tp, _Up> round_up(const _Tp __a, const _Up __b) noexcept
 {
   _CCCL_ASSERT(__b > _Up{0}, "cuda::round_up: 'b' must be positive");
@@ -63,7 +63,7 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp) _CCCL_AND _CCCL_TRAIT(_
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_integral, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_integral_v<_Tp> _CCCL_AND _CUDA_VSTD::is_enum_v<_Up>)
 [[nodiscard]] _CCCL_API constexpr _CUDA_VSTD::common_type_t<_Tp, _CUDA_VSTD::underlying_type_t<_Up>>
 round_up(const _Tp __a, const _Up __b) noexcept
 {
@@ -76,7 +76,7 @@ round_up(const _Tp __a, const _Up __b) noexcept
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_integral, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_enum_v<_Tp> _CCCL_AND _CUDA_VSTD::is_integral_v<_Up>)
 [[nodiscard]] _CCCL_API constexpr _CUDA_VSTD::common_type_t<_CUDA_VSTD::underlying_type_t<_Tp>, _Up>
 round_up(const _Tp __a, const _Up __b) noexcept
 {
@@ -89,7 +89,7 @@ round_up(const _Tp __a, const _Up __b) noexcept
 //! @pre \p __a must be non-negative
 //! @pre \p __b must be positive
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Tp) _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::is_enum, _Up))
+_CCCL_REQUIRES(_CUDA_VSTD::is_enum_v<_Tp> _CCCL_AND _CUDA_VSTD::is_enum_v<_Up>)
 [[nodiscard]]
 _CCCL_API constexpr _CUDA_VSTD::common_type_t<_CUDA_VSTD::underlying_type_t<_Tp>, _CUDA_VSTD::underlying_type_t<_Up>>
 round_up(const _Tp __a, const _Up __b) noexcept

--- a/libcudacxx/include/cuda/__cmath/uabs.h
+++ b/libcudacxx/include/cuda/__cmath/uabs.h
@@ -36,10 +36,10 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 //! @pre \p __v must be an integer type
 //! @return The unsigned absolute value of \p __v
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_cv_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_cv_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _CUDA_VSTD::make_unsigned_t<_Tp> uabs(_Tp __v) noexcept
 {
-  if constexpr (_CCCL_TRAIT(_CUDA_VSTD::is_signed, _Tp))
+  if constexpr (_CUDA_VSTD::is_signed_v<_Tp>)
   {
     using _Up = _CUDA_VSTD::make_unsigned_t<_Tp>;
     return (__v < _Tp(0)) ? static_cast<_Up>(::cuda::neg(__v)) : static_cast<_Up>(__v);

--- a/libcudacxx/include/cuda/__functional/address_stability.h
+++ b/libcudacxx/include/cuda/__functional/address_stability.h
@@ -75,8 +75,8 @@ struct proclaims_copyable_arguments<_CUDA_VSTD::__not_fn_t<_Fn>> : proclaims_cop
 
 template <typename _Tp>
 struct __has_builtin_operators
-    : _CUDA_VSTD::bool_constant<!_CCCL_TRAIT(_CUDA_VSTD::is_class, _Tp) && !_CCCL_TRAIT(_CUDA_VSTD::is_enum, _Tp)
-                                && !_CCCL_TRAIT(_CUDA_VSTD::is_void, _Tp)>
+    : _CUDA_VSTD::bool_constant<!_CUDA_VSTD::is_class_v<_Tp> && !_CUDA_VSTD::is_enum_v<_Tp>
+                                && !_CUDA_VSTD::is_void_v<_Tp>>
 {};
 
 #define _LIBCUDACXX_MARK_CAN_COPY_ARGUMENTS(functor)                                         \

--- a/libcudacxx/include/cuda/__mdspan/host_device_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/host_device_accessor.h
@@ -131,7 +131,7 @@ public:
   using element_type     = typename _Accessor::element_type;
 
   _CCCL_TEMPLATE(class _Accessor2 = _Accessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_default_constructible, _Accessor2))
+  _CCCL_REQUIRES(_CUDA_VSTD::is_default_constructible_v<_Accessor2>)
   _CCCL_API inline __host_accessor() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Accessor2>)
       : _Accessor{}
   {}
@@ -145,32 +145,32 @@ public:
   __host_accessor(const __device_accessor<_OtherAccessor>&) = delete;
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr __host_accessor(const __host_accessor<_OtherAccessor>& __acc) noexcept(noexcept(_Accessor{
     _CUDA_VSTD::declval<_OtherAccessor>()}))
       : _Accessor{__acc}
   {}
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr explicit __host_accessor(const __host_accessor<_OtherAccessor>& __acc) noexcept(
     noexcept(_Accessor{_CUDA_VSTD::declval<_OtherAccessor>()}))
       : _Accessor{__acc}
   {}
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr __host_accessor(const __managed_accessor<_OtherAccessor>& __acc) noexcept(noexcept(_Accessor{
     _CUDA_VSTD::declval<_OtherAccessor>()}))
       : _Accessor{__acc}
   {}
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr explicit __host_accessor(const __managed_accessor<_OtherAccessor>& __acc) noexcept(
     noexcept(_Accessor{_CUDA_VSTD::declval<_OtherAccessor>()}))
       : _Accessor{__acc}
@@ -263,7 +263,7 @@ public:
   using element_type     = typename _Accessor::element_type;
 
   _CCCL_TEMPLATE(typename _NotUsed = void)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_default_constructible, _Accessor))
+  _CCCL_REQUIRES(_CUDA_VSTD::is_default_constructible_v<_Accessor>)
   _CCCL_API inline __device_accessor() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Accessor>)
       : _Accessor{}
   {}
@@ -277,32 +277,32 @@ public:
   __device_accessor(const __host_accessor<_OtherAccessor>&) = delete;
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr __device_accessor(const __device_accessor<_OtherAccessor>& __acc) noexcept(
     _CUDA_VSTD::is_nothrow_copy_constructible_v<_Accessor>)
       : _Accessor{__acc}
   {}
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr explicit __device_accessor(const __device_accessor<_OtherAccessor>& __acc) noexcept(
     _CUDA_VSTD::is_nothrow_copy_constructible_v<_Accessor>)
       : _Accessor{__acc}
   {}
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr __device_accessor(const __managed_accessor<_OtherAccessor>& __acc) noexcept(noexcept(_Accessor{
     _CUDA_VSTD::declval<_OtherAccessor>()}))
       : _Accessor{__acc}
   {}
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr explicit __device_accessor(const __managed_accessor<_OtherAccessor>& __acc) noexcept(
     noexcept(_Accessor{_CUDA_VSTD::declval<_OtherAccessor>()}))
       : _Accessor{__acc}
@@ -376,7 +376,7 @@ public:
   using element_type     = typename _Accessor::element_type;
 
   _CCCL_TEMPLATE(typename _NotUsed = void)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_default_constructible, _Accessor))
+  _CCCL_REQUIRES(_CUDA_VSTD::is_default_constructible_v<_Accessor>)
   _CCCL_API inline __managed_accessor() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Accessor>)
       : _Accessor{}
   {}
@@ -393,16 +393,16 @@ public:
   __managed_accessor(const __device_accessor<_OtherAccessor>&) = delete;
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr __managed_accessor(const __managed_accessor<_OtherAccessor>& __acc) noexcept(noexcept(_Accessor{
     _CUDA_VSTD::declval<_OtherAccessor>()}))
       : _Accessor{__acc}
   {}
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr explicit __managed_accessor(const __managed_accessor<_OtherAccessor>& __acc) noexcept(
     noexcept(_Accessor{_CUDA_VSTD::declval<_OtherAccessor>()}))
       : _Accessor{__acc}

--- a/libcudacxx/include/cuda/__mdspan/restrict_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/restrict_accessor.h
@@ -76,7 +76,7 @@ public:
   using element_type     = typename _Accessor::element_type;
 
   _CCCL_TEMPLATE(class _Accessor2 = _Accessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_default_constructible, _Accessor2))
+  _CCCL_REQUIRES(_CUDA_VSTD::is_default_constructible_v<_Accessor2>)
   _CCCL_API inline __restrict_accessor() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Accessor2>)
       : _Accessor{}
   {}
@@ -87,16 +87,16 @@ public:
   {}
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr __restrict_accessor(const __restrict_accessor<_OtherAccessor>& __acc) noexcept(noexcept(_Accessor{
     _CUDA_VSTD::declval<_OtherAccessor>()}))
       : _Accessor{__acc}
   {}
 
   _CCCL_TEMPLATE(typename _OtherAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::is_constructible, _OtherAccessor)
-                   _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::is_constructible_v<_OtherAccessor> _CCCL_AND(!_CUDA_VSTD::is_convertible_v<_OtherAccessor, _Accessor>))
   _CCCL_API constexpr explicit __restrict_accessor(const __restrict_accessor<_OtherAccessor>& __acc) noexcept(
     noexcept(_Accessor{_CUDA_VSTD::declval<_OtherAccessor>()}))
       : _Accessor{__acc}

--- a/libcudacxx/include/cuda/__memcpy_async/is_local_smem_barrier.h
+++ b/libcudacxx/include/cuda/__memcpy_async/is_local_smem_barrier.h
@@ -37,7 +37,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 template <thread_scope _Sco,
           typename _CompF,
           bool _Is_mbarrier = (_Sco == thread_scope_block)
-                           && _CCCL_TRAIT(_CUDA_VSTD::is_same, _CompF, _CUDA_VSTD::__empty_completion)>
+                           && _CUDA_VSTD::is_same_v<_CompF, _CUDA_VSTD::__empty_completion>>
 _CCCL_API inline bool __is_local_smem_barrier(barrier<_Sco, _CompF>& __barrier)
 {
   NV_IF_ELSE_TARGET(

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async_barrier.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async_barrier.h
@@ -58,7 +58,7 @@ template <typename _Group, class _Tp, typename _Size, thread_scope _Sco, typenam
 _CCCL_API inline async_contract_fulfillment __memcpy_async_barrier(
   _Group const& __group, _Tp* __destination, _Tp const* __source, _Size __size, barrier<_Sco, _CompF>& __barrier)
 {
-  static_assert(_CCCL_TRAIT(_CUDA_VSTD::is_trivially_copyable, _Tp), "memcpy_async requires a trivially copyable type");
+  static_assert(_CUDA_VSTD::is_trivially_copyable_v<_Tp>, "memcpy_async requires a trivially copyable type");
 
   // 1. Determine which completion mechanisms can be used with the current
   // barrier. A local shared memory barrier, i.e., block-scope barrier in local

--- a/libcudacxx/include/cuda/__memory_resource/resource_ref.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource_ref.h
@@ -55,7 +55,7 @@ constexpr bool _IsSmall() noexcept
 {
   return (sizeof(_Resource) <= sizeof(_AnyResourceStorage)) //
       && (alignof(_AnyResourceStorage) % alignof(_Resource) == 0)
-      && _CCCL_TRAIT(_CUDA_VSTD::is_nothrow_move_constructible, _Resource);
+      && _CUDA_VSTD::is_nothrow_move_constructible_v<_Resource>;
 }
 
 template <class _Resource>

--- a/libcudacxx/include/cuda/__numeric/overflow_cast.h
+++ b/libcudacxx/include/cuda/__numeric/overflow_cast.h
@@ -41,8 +41,7 @@ inline constexpr bool __is_integer_representable_v =
 //! @return An overflow_result object containing the casted number and a boolean indicating whether an overflow
 //! occurred
 _CCCL_TEMPLATE(class _To, class _From)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_integer, _To)
-                 _CCCL_AND _CCCL_TRAIT(_CUDA_VSTD::__cccl_is_cv_integer, _From))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_integer_v<_To> _CCCL_AND _CUDA_VSTD::__cccl_is_cv_integer_v<_From>)
 [[nodiscard]] _CCCL_API constexpr overflow_result<_To> overflow_cast(const _From& __from) noexcept
 {
   bool __overflow = false;

--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -97,8 +97,8 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy,
           class _Tp,
           class _Up,
-          enable_if_t<_CCCL_TRAIT(is_same, remove_const_t<_Tp>, _Up), int> = 0,
-          enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>        = 0>
+          enable_if_t<is_same_v<remove_const_t<_Tp>, _Up>, int> = 0,
+          enable_if_t<is_trivially_copyable_v<_Up>, int>        = 0>
 _CCCL_API constexpr pair<_Tp*, _Up*> __copy(_Tp* __first, _Tp* __last, _Up* __result)
 {
   const ptrdiff_t __n = __last - __first;

--- a/libcudacxx/include/cuda/std/__algorithm/copy_backward.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy_backward.h
@@ -46,8 +46,8 @@ __copy_backward(_BidirectionalIterator __first, _BidirectionalIterator __last, _
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp,
           class _Up,
-          enable_if_t<_CCCL_TRAIT(is_same, remove_const_t<_Tp>, _Up), int> = 0,
-          enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>        = 0>
+          enable_if_t<is_same_v<remove_const_t<_Tp>, _Up>, int> = 0,
+          enable_if_t<is_trivially_copyable_v<_Up>, int>        = 0>
 _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _Up* __copy_backward(_Tp* __first, _Tp* __last, _Up* __result)
 {
   const ptrdiff_t __n = __last - __first;

--- a/libcudacxx/include/cuda/std/__algorithm/half_positive.h
+++ b/libcudacxx/include/cuda/std/__algorithm/half_positive.h
@@ -30,13 +30,13 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // Perform division by two quickly for positive integers (llvm.org/PR39129)
 
-template <class _Integral, enable_if_t<_CCCL_TRAIT(is_integral, _Integral), int> = 0>
+template <class _Integral, enable_if_t<is_integral_v<_Integral>, int> = 0>
 [[nodiscard]] _CCCL_API constexpr _Integral __half_positive(_Integral __value)
 {
   return static_cast<_Integral>(static_cast<make_unsigned_t<_Integral>>(__value) / 2);
 }
 
-template <class _Tp, enable_if_t<!_CCCL_TRAIT(is_integral, _Tp), int> = 0>
+template <class _Tp, enable_if_t<!is_integral_v<_Tp>, int> = 0>
 [[nodiscard]] _CCCL_API constexpr _Tp __half_positive(_Tp __value)
 {
   return __value / 2;

--- a/libcudacxx/include/cuda/std/__algorithm/move.h
+++ b/libcudacxx/include/cuda/std/__algorithm/move.h
@@ -50,8 +50,8 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy,
           class _Tp,
           class _Up,
-          enable_if_t<_CCCL_TRAIT(is_same, remove_const_t<_Tp>, _Up), int> = 0,
-          enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>        = 0>
+          enable_if_t<is_same_v<remove_const_t<_Tp>, _Up>, int> = 0,
+          enable_if_t<is_trivially_copyable_v<_Up>, int>        = 0>
 _CCCL_API constexpr pair<_Tp*, _Up*> __move(_Tp* __first, _Tp* __last, _Up* __result)
 {
   const ptrdiff_t __n = __last - __first;
@@ -72,9 +72,8 @@ _CCCL_API constexpr pair<_Tp*, _Up*> __move(_Tp* __first, _Tp* __last, _Up* __re
 template <class _InputIterator, class _OutputIterator>
 _CCCL_API constexpr _OutputIterator move(_InputIterator __first, _InputIterator __last, _OutputIterator __result)
 {
-  static_assert(_CCCL_TRAIT(is_copy_constructible, _InputIterator), "Iterators has to be copy constructible.");
-  static_assert(_CCCL_TRAIT(is_copy_constructible, _OutputIterator),
-                "The output iterator has to be copy constructible.");
+  static_assert(is_copy_constructible_v<_InputIterator>, "Iterators has to be copy constructible.");
+  static_assert(is_copy_constructible_v<_OutputIterator>, "The output iterator has to be copy constructible.");
   return _CUDA_VSTD::__move<_ClassicAlgPolicy>(
            _CUDA_VSTD::__unwrap_iter(__first), _CUDA_VSTD::__unwrap_iter(__last), _CUDA_VSTD::__unwrap_iter(__result))
     .second;

--- a/libcudacxx/include/cuda/std/__algorithm/move_backward.h
+++ b/libcudacxx/include/cuda/std/__algorithm/move_backward.h
@@ -49,8 +49,8 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _AlgPolicy,
           class _Tp,
           class _Up,
-          enable_if_t<_CCCL_TRAIT(is_same, remove_const_t<_Tp>, _Up), int> = 0,
-          enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _Up), int>        = 0>
+          enable_if_t<is_same_v<remove_const_t<_Tp>, _Up>, int> = 0,
+          enable_if_t<is_trivially_copyable_v<_Up>, int>        = 0>
 _CCCL_API constexpr pair<_Tp*, _Up*> __move_backward(_Tp* __first, _Tp* __last, _Up* __result)
 {
   const ptrdiff_t __n = __last - __first;

--- a/libcudacxx/include/cuda/std/__algorithm/partial_sort.h
+++ b/libcudacxx/include/cuda/std/__algorithm/partial_sort.h
@@ -81,8 +81,8 @@ template <class _RandomAccessIterator, class _Compare>
 _CCCL_API constexpr void partial_sort(
   _RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp)
 {
-  static_assert(_CCCL_TRAIT(is_copy_constructible, _RandomAccessIterator), "Iterators must be copy constructible.");
-  static_assert(_CCCL_TRAIT(is_copy_assignable, _RandomAccessIterator), "Iterators must be copy assignable.");
+  static_assert(is_copy_constructible_v<_RandomAccessIterator>, "Iterators must be copy constructible.");
+  static_assert(is_copy_assignable_v<_RandomAccessIterator>, "Iterators must be copy assignable.");
 
   (void) _CUDA_VSTD::__partial_sort<_ClassicAlgPolicy>(
     _CUDA_VSTD::move(__first), _CUDA_VSTD::move(__middle), _CUDA_VSTD::move(__last), __comp);

--- a/libcudacxx/include/cuda/std/__algorithm/rotate.h
+++ b/libcudacxx/include/cuda/std/__algorithm/rotate.h
@@ -165,7 +165,7 @@ _CCCL_API constexpr _ForwardIterator __rotate_impl(
   _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _CUDA_VSTD::forward_iterator_tag)
 {
   using value_type = typename iterator_traits<_ForwardIterator>::value_type;
-  if (_CCCL_TRAIT(is_trivially_move_assignable, value_type))
+  if (is_trivially_move_assignable_v<value_type>)
   {
     if (_IterOps<_AlgPolicy>::next(__first) == __middle)
     {
@@ -184,7 +184,7 @@ _CCCL_API constexpr _BidirectionalIterator __rotate_impl(
   bidirectional_iterator_tag)
 {
   using value_type = typename iterator_traits<_BidirectionalIterator>::value_type;
-  if (_CCCL_TRAIT(is_trivially_move_assignable, value_type))
+  if (is_trivially_move_assignable_v<value_type>)
   {
     if (_IterOps<_AlgPolicy>::next(__first) == __middle)
     {
@@ -207,7 +207,7 @@ _CCCL_API constexpr _RandomAccessIterator __rotate_impl(
   random_access_iterator_tag)
 {
   using value_type = typename iterator_traits<_RandomAccessIterator>::value_type;
-  if (_CCCL_TRAIT(is_trivially_move_assignable, value_type))
+  if (is_trivially_move_assignable_v<value_type>)
   {
     if (_IterOps<_AlgPolicy>::next(__first) == __middle)
     {

--- a/libcudacxx/include/cuda/std/__algorithm/sort_heap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/sort_heap.h
@@ -50,8 +50,8 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator, class _Compare>
 _CCCL_API constexpr void sort_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
 {
-  static_assert(_CCCL_TRAIT(is_copy_constructible, _RandomAccessIterator), "Iterators must be copy constructible.");
-  static_assert(_CCCL_TRAIT(is_copy_assignable, _RandomAccessIterator), "Iterators must be copy assignable.");
+  static_assert(is_copy_constructible_v<_RandomAccessIterator>, "Iterators must be copy constructible.");
+  static_assert(is_copy_assignable_v<_RandomAccessIterator>, "Iterators must be copy assignable.");
 
   _CUDA_VSTD::__sort_heap<_ClassicAlgPolicy>(_CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), __comp);
 }

--- a/libcudacxx/include/cuda/std/__algorithm/unique_copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unique_copy.h
@@ -128,13 +128,13 @@ template <class _InputIterator, class _OutputIterator, class _BinaryPredicate>
 _CCCL_API constexpr _OutputIterator
 unique_copy(_InputIterator __first, _InputIterator __last, _OutputIterator __result, _BinaryPredicate __pred)
 {
-  using __algo_tag = conditional_t<
-    _CCCL_TRAIT(is_base_of, forward_iterator_tag, __iterator_category_type<_InputIterator>),
-    __unique_copy_tags::__reread_from_input_tag,
-    conditional_t<_CCCL_TRAIT(is_base_of, forward_iterator_tag, __iterator_category_type<_OutputIterator>)
-                    && _CCCL_TRAIT(is_same, __iter_value_type<_InputIterator>, __iter_value_type<_OutputIterator>),
-                  __unique_copy_tags::__reread_from_output_tag,
-                  __unique_copy_tags::__read_from_tmp_value_tag>>;
+  using __algo_tag =
+    conditional_t<is_base_of_v<forward_iterator_tag, __iterator_category_type<_InputIterator>>,
+                  __unique_copy_tags::__reread_from_input_tag,
+                  conditional_t<is_base_of_v<forward_iterator_tag, __iterator_category_type<_OutputIterator>>
+                                  && is_same_v<__iter_value_type<_InputIterator>, __iter_value_type<_OutputIterator>>,
+                                __unique_copy_tags::__reread_from_output_tag,
+                                __unique_copy_tags::__read_from_tmp_value_tag>>;
   return _CUDA_VSTD::__unique_copy<_ClassicAlgPolicy>(
            _CUDA_VSTD::move(__first), _CUDA_VSTD::move(__last), _CUDA_VSTD::move(__result), __pred, __algo_tag())
     .second;

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated_helper.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated_helper.h
@@ -122,11 +122,11 @@ using __atomic_cuda_deduce_bitwise =
 
 template <class _Type>
 using __atomic_cuda_deduce_arithmetic = _If<
-  _CCCL_TRAIT(is_floating_point, _Type),
+  is_floating_point_v<_Type>,
   _If<sizeof(_Type) == 4,
       __atomic_cuda_operand_deduction<float, __atomic_cuda_operand_f32>,
       __atomic_cuda_operand_deduction<double, __atomic_cuda_operand_f64>>,
-  _If<_CCCL_TRAIT(is_signed, _Type),
+  _If<is_signed_v<_Type>,
       __type_switch<sizeof(_Type),
                     __type_case<1, __atomic_cuda_operand_deduction<int8_t, __atomic_cuda_operand_s8>>,
                     __type_case<2, __atomic_cuda_operand_deduction<int16_t, __atomic_cuda_operand_s16>>,
@@ -141,11 +141,11 @@ using __atomic_cuda_deduce_arithmetic = _If<
 
 template <class _Type>
 using __atomic_cuda_deduce_minmax = _If<
-  _CCCL_TRAIT(is_floating_point, _Type),
+  is_floating_point_v<_Type>,
   _If<sizeof(_Type) == 4,
       __atomic_cuda_operand_deduction<float, __atomic_cuda_operand_f32>,
       __atomic_cuda_operand_deduction<double, __atomic_cuda_operand_f64>>,
-  _If<_CCCL_TRAIT(is_signed, _Type),
+  _If<is_signed_v<_Type>,
       __type_switch<sizeof(_Type),
                     __type_case<1, __atomic_cuda_operand_deduction<int8_t, __atomic_cuda_operand_s8>>,
                     __type_case<2, __atomic_cuda_operand_deduction<int16_t, __atomic_cuda_operand_s16>>,
@@ -162,13 +162,13 @@ template <class _Type>
 using __atomic_enable_if_native_bitwise = bool;
 
 template <class _Type>
-using __atomic_enable_if_native_arithmetic = enable_if_t<_CCCL_TRAIT(is_scalar, _Type), bool>;
+using __atomic_enable_if_native_arithmetic = enable_if_t<is_scalar_v<_Type>, bool>;
 
 template <class _Type>
-using __atomic_enable_if_native_minmax = enable_if_t<_CCCL_TRAIT(is_integral, _Type), bool>;
+using __atomic_enable_if_native_minmax = enable_if_t<is_integral_v<_Type>, bool>;
 
 template <class _Type>
-using __atomic_enable_if_not_native_minmax = enable_if_t<!_CCCL_TRAIT(is_integral, _Type), bool>;
+using __atomic_enable_if_not_native_minmax = enable_if_t<!is_integral_v<_Type>, bool>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__atomic/types/base.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/base.h
@@ -36,8 +36,7 @@ struct __atomic_storage
   static constexpr __atomic_tag __tag = __atomic_tag::__atomic_base_tag;
 
 #if !_CCCL_COMPILER(GCC) || _CCCL_COMPILER(GCC, >=, 5)
-  static_assert(_CCCL_TRAIT(is_trivially_copyable, _Tp),
-                "std::atomic<Tp> requires that 'Tp' be a trivially copyable type");
+  static_assert(is_trivially_copyable_v<_Tp>, "std::atomic<Tp> requires that 'Tp' be a trivially copyable type");
 #endif
 
   _CCCL_ALIGNAS(sizeof(_Tp)) _Tp __a_value;

--- a/libcudacxx/include/cuda/std/__atomic/types/common.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/common.h
@@ -55,14 +55,13 @@ using __atomic_underlying_remove_cv_t = remove_cv_t<typename _Tp::__underlying_t
 // the default operator= in an object is not volatile, a byte-by-byte copy
 // is required.
 template <typename _Tp, typename _Tv>
-_CCCL_HOST_DEVICE enable_if_t<_CCCL_TRAIT(is_assignable, _Tp&, _Tv)>
-__atomic_assign_volatile(_Tp* __a_value, _Tv const& __val)
+_CCCL_HOST_DEVICE enable_if_t<is_assignable_v<_Tp&, _Tv>> __atomic_assign_volatile(_Tp* __a_value, _Tv const& __val)
 {
   *__a_value = __val;
 }
 
 template <typename _Tp, typename _Tv>
-_CCCL_HOST_DEVICE enable_if_t<_CCCL_TRAIT(is_assignable, _Tp&, _Tv)>
+_CCCL_HOST_DEVICE enable_if_t<is_assignable_v<_Tp&, _Tv>>
 __atomic_assign_volatile(_Tp volatile* __a_value, _Tv volatile const& __val)
 {
   volatile char* __to         = reinterpret_cast<volatile char*>(__a_value);

--- a/libcudacxx/include/cuda/std/__atomic/types/reference.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/reference.h
@@ -36,8 +36,7 @@ struct __atomic_ref_storage
   static constexpr __atomic_tag __tag = __atomic_tag::__atomic_base_tag;
 
 #if !_CCCL_COMPILER(GCC) || _CCCL_COMPILER(GCC, >=, 5)
-  static_assert(_CCCL_TRAIT(is_trivially_copyable, _Tp),
-                "std::atomic_ref<Tp> requires that 'Tp' be a trivially copyable type");
+  static_assert(is_trivially_copyable_v<_Tp>, "std::atomic_ref<Tp> requires that 'Tp' be a trivially copyable type");
 #endif
 
   _Tp* __a_value;

--- a/libcudacxx/include/cuda/std/__atomic/types/small.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/small.h
@@ -36,23 +36,23 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // manipulated by PTX without any performance overhead
 template <typename _Tp>
-using __atomic_small_proxy_t = _If<_CCCL_TRAIT(is_signed, _Tp), int32_t, uint32_t>;
+using __atomic_small_proxy_t = _If<is_signed_v<_Tp>, int32_t, uint32_t>;
 
 // Arithmetic conversions to/from proxy types
-template <class _Tp, enable_if_t<_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
+template <class _Tp, enable_if_t<is_arithmetic_v<_Tp>, int> = 0>
 _CCCL_HOST_DEVICE constexpr __atomic_small_proxy_t<_Tp> __atomic_small_to_32(_Tp __val)
 {
   return static_cast<__atomic_small_proxy_t<_Tp>>(__val);
 }
 
-template <class _Tp, enable_if_t<_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
+template <class _Tp, enable_if_t<is_arithmetic_v<_Tp>, int> = 0>
 _CCCL_HOST_DEVICE constexpr _Tp __atomic_small_from_32(__atomic_small_proxy_t<_Tp> __val)
 {
   return static_cast<_Tp>(__val);
 }
 
 // Non-arithmetic conversion to/from proxy types
-template <class _Tp, enable_if_t<!_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
+template <class _Tp, enable_if_t<!is_arithmetic_v<_Tp>, int> = 0>
 _CCCL_HOST_DEVICE inline __atomic_small_proxy_t<_Tp> __atomic_small_to_32(_Tp __val)
 {
   __atomic_small_proxy_t<_Tp> __temp{};
@@ -60,7 +60,7 @@ _CCCL_HOST_DEVICE inline __atomic_small_proxy_t<_Tp> __atomic_small_to_32(_Tp __
   return __temp;
 }
 
-template <class _Tp, enable_if_t<!_CCCL_TRAIT(is_arithmetic, _Tp), int> = 0>
+template <class _Tp, enable_if_t<!is_arithmetic_v<_Tp>, int> = 0>
 _CCCL_HOST_DEVICE inline _Tp __atomic_small_from_32(__atomic_small_proxy_t<_Tp> __val)
 {
   _Tp __temp{};

--- a/libcudacxx/include/cuda/std/__bit/bit_cast.h
+++ b/libcudacxx/include/cuda/std/__bit/bit_cast.h
@@ -44,18 +44,17 @@ _CCCL_DIAG_SUPPRESS_GCC("-Wclass-memaccess")
 #  endif // _CCCL_COMPILER(GCC, >=, 8)
 #endif // !_CCCL_BUILTIN_BIT_CAST
 
-template <
-  class _To,
-  class _From,
-  enable_if_t<(sizeof(_To) == sizeof(_From)), int>                                                                = 0,
-  enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _To) || _CCCL_TRAIT(__is_extended_floating_point, _To), int>     = 0,
-  enable_if_t<_CCCL_TRAIT(is_trivially_copyable, _From) || _CCCL_TRAIT(__is_extended_floating_point, _From), int> = 0>
+template <class _To,
+          class _From,
+          enable_if_t<(sizeof(_To) == sizeof(_From)), int>                                          = 0,
+          enable_if_t<is_trivially_copyable_v<_To> || __is_extended_floating_point_v<_To>, int>     = 0,
+          enable_if_t<is_trivially_copyable_v<_From> || __is_extended_floating_point_v<_From>, int> = 0>
 [[nodiscard]] _CCCL_API inline _CCCL_CONSTEXPR_BIT_CAST _To bit_cast(const _From& __from) noexcept
 {
 #if defined(_CCCL_BUILTIN_BIT_CAST)
   return _CCCL_BUILTIN_BIT_CAST(_To, __from);
 #else // ^^^ _CCCL_BUILTIN_BIT_CAST ^^^ / vvv !_CCCL_BUILTIN_BIT_CAST vvv
-  static_assert(_CCCL_TRAIT(is_trivially_default_constructible, _To),
+  static_assert(is_trivially_default_constructible_v<_To>,
                 "The compiler does not support __builtin_bit_cast, so bit_cast additionally requires the destination "
                 "type to be trivially constructible");
   _To __temp;

--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -163,7 +163,7 @@ template <class _Tp>
 #endif // _CCCL_HAS_INT128()
 
 _CCCL_TEMPLATE(class _Integer)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Integer))
+_CCCL_REQUIRES(is_integral_v<_Integer>)
 [[nodiscard]] _CCCL_API constexpr _Integer byteswap(_Integer __val) noexcept
 {
   if constexpr (sizeof(_Integer) > 1)

--- a/libcudacxx/include/cuda/std/__bit/countl.h
+++ b/libcudacxx/include/cuda/std/__bit/countl.h
@@ -118,7 +118,7 @@ template <typename _Tp>
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr int countl_zero(_Tp __v) noexcept
 {
   int __count{};
@@ -154,7 +154,7 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr int countl_one(_Tp __v) noexcept
 {
   return _CUDA_VSTD::countl_zero(static_cast<_Tp>(~__v));

--- a/libcudacxx/include/cuda/std/__bit/countr.h
+++ b/libcudacxx/include/cuda/std/__bit/countr.h
@@ -137,7 +137,7 @@ template <typename _Tp>
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr int countr_zero(_Tp __v) noexcept
 {
   int __count{};
@@ -172,7 +172,7 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr int countr_one(_Tp __t) noexcept
 {
   return _CUDA_VSTD::countr_zero(static_cast<_Tp>(~__t));

--- a/libcudacxx/include/cuda/std/__bit/has_single_bit.h
+++ b/libcudacxx/include/cuda/std/__bit/has_single_bit.h
@@ -30,7 +30,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr bool has_single_bit(_Tp __t) noexcept
 {
   return _CUDA_VSTD::popcount(__t) == 1;

--- a/libcudacxx/include/cuda/std/__bit/integral.h
+++ b/libcudacxx/include/cuda/std/__bit/integral.h
@@ -58,7 +58,7 @@ _CCCL_API constexpr uint32_t __bit_log2(_Tp __t) noexcept
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr int bit_width(_Tp __t) noexcept
 {
   // if __t == 0, __bit_log2(0) returns 0xFFFFFFFF. Since unsigned overflow is well-defined, the result is -1 + 1 = 0
@@ -68,7 +68,7 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp bit_ceil(_Tp __t) noexcept
 {
   using _Up = _If<sizeof(_Tp) <= 4, uint32_t, _Tp>;
@@ -94,7 +94,7 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp bit_floor(_Tp __t) noexcept
 {
   using _Up   = _If<sizeof(_Tp) <= 4, uint32_t, _Tp>;

--- a/libcudacxx/include/cuda/std/__bit/popcount.h
+++ b/libcudacxx/include/cuda/std/__bit/popcount.h
@@ -107,7 +107,7 @@ template <typename _Tp>
 template <typename _Tp>
 [[nodiscard]] _CCCL_API constexpr int __cccl_popcount_impl(_Tp __v) noexcept
 {
-  static_assert(_CCCL_TRAIT(is_same, _Tp, uint32_t) || _CCCL_TRAIT(is_same, _Tp, uint64_t));
+  static_assert(is_same_v<_Tp, uint32_t> || is_same_v<_Tp, uint64_t>);
 
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
@@ -119,7 +119,7 @@ template <typename _Tp>
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr int popcount(_Tp __v) noexcept
 {
   int __count{};

--- a/libcudacxx/include/cuda/std/__bit/rotate.h
+++ b/libcudacxx/include/cuda/std/__bit/rotate.h
@@ -64,7 +64,7 @@ template <typename _Tp>
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp rotl(_Tp __v, int __cnt) noexcept
 {
   if (__cnt < 0)
@@ -76,7 +76,7 @@ _CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(_CUDA_VSTD::__cccl_is_unsigned_integer, _Tp))
+_CCCL_REQUIRES(_CUDA_VSTD::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp rotr(_Tp __v, int __cnt) noexcept
 {
   if (__cnt < 0)

--- a/libcudacxx/include/cuda/std/__cccl/dialect.h
+++ b/libcudacxx/include/cuda/std/__cccl/dialect.h
@@ -106,9 +106,6 @@
 // Conditionally use certain language features depending on availability
 ///////////////////////////////////////////////////////////////////////////////
 
-// Variable templates are more efficient most of the time, so we want to use them rather than structs when possible
-#define _CCCL_TRAIT(__TRAIT, ...) __TRAIT##_v<__VA_ARGS__>
-
 // We need to treat host and device separately
 #if _CCCL_DEVICE_COMPILATION() && !_CCCL_CUDA_COMPILER(NVHPC)
 #  define _CCCL_GLOBAL_CONSTANT _CCCL_DEVICE constexpr

--- a/libcudacxx/include/cuda/std/__charconv/to_chars.h
+++ b/libcudacxx/include/cuda/std/__charconv/to_chars.h
@@ -93,14 +93,14 @@ _CCCL_API constexpr void __to_chars_int_generic(char* __last, _Tp __value, int _
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp))
+_CCCL_REQUIRES(__cccl_is_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr to_chars_result
 to_chars(char* __first, char* __last, _Tp __value, int __base = 10) noexcept
 {
   _CCCL_ASSERT(__base >= 2 && __base <= 36, "base must be in the range [2, 36]");
   _CCCL_ASSERT(__first <= __last, "output range must be a valid range");
 
-  if constexpr (_CCCL_TRAIT(is_signed, _Tp))
+  if constexpr (is_signed_v<_Tp>)
   {
     if (__value < _Tp{0} && __first < __last)
     {
@@ -129,7 +129,7 @@ to_chars(char* __first, char* __last, _Tp __value, int __base = 10) noexcept
 [[nodiscard]] _CCCL_API constexpr to_chars_result
 to_chars(char* __first, char* __last, char __value, int __base = 10) noexcept
 {
-  if constexpr (_CCCL_TRAIT(is_signed, char))
+  if constexpr (is_signed_v<char>)
   {
     return _CUDA_VSTD::to_chars(__first, __last, static_cast<signed char>(__value), __base);
   }

--- a/libcudacxx/include/cuda/std/__cmath/abs.h
+++ b/libcudacxx/include/cuda/std/__cmath/abs.h
@@ -158,7 +158,7 @@ template <class _Tp>
 #endif // _CCCL_HAS_NVFP4_E2M1()
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Tp))
+_CCCL_REQUIRES(is_integral_v<_Tp>)
 [[nodiscard]] _CCCL_API inline double fabs(_Tp __val) noexcept
 {
   return _CUDA_VSTD::fabs(static_cast<double>(__val));

--- a/libcudacxx/include/cuda/std/__cmath/exponential_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/exponential_functions.h
@@ -134,7 +134,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double exp(_Integer __x) noexcept
 {
   return _CUDA_VSTD::exp((double) __x);
@@ -216,7 +216,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double frexp(_Integer __x, int* __e) noexcept
 {
   return _CUDA_VSTD::frexp((double) __x, __e);
@@ -298,7 +298,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double ldexp(_Integer __x, int __e) noexcept
 {
   return _CUDA_VSTD::ldexp((double) __x, __e);
@@ -381,7 +381,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double exp2(_Integer __x) noexcept
 {
   return _CUDA_VSTD::exp2((double) __x);
@@ -463,7 +463,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double expm1(_Integer __x) noexcept
 {
   return _CUDA_VSTD::expm1((double) __x);
@@ -545,7 +545,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double scalbln(_Integer __x, long __y) noexcept
 {
   return _CUDA_VSTD::scalbln((double) __x, __y);
@@ -627,7 +627,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double scalbn(_Integer __x, int __y) noexcept
 {
   return _CUDA_VSTD::scalbn((double) __x, __y);
@@ -709,11 +709,11 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, _A2> pow(_A1 __x, _A2 __y) noexcept
 {
   using __result_type = __promote_t<_A1, _A2>;
-  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type>), "");
   return _CUDA_VSTD::pow((__result_type) __x, (__result_type) __y);
 }
 

--- a/libcudacxx/include/cuda/std/__cmath/fpclassify.h
+++ b/libcudacxx/include/cuda/std/__cmath/fpclassify.h
@@ -86,7 +86,7 @@ template <class _Tp>
       return FP_INFINITE;
     }
   }
-  if constexpr (_CCCL_TRAIT(is_floating_point, _Tp))
+  if constexpr (is_floating_point_v<_Tp>)
   {
     if (__x > -numeric_limits<_Tp>::min() && __x < numeric_limits<_Tp>::min())
     {
@@ -203,7 +203,7 @@ template <class _Tp>
 #endif // _CCCL_HAS_NVFP4_E2M1()
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Tp))
+_CCCL_REQUIRES(is_integral_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr int fpclassify(_Tp __x) noexcept
 {
   return (__x == 0) ? FP_ZERO : FP_NORMAL;

--- a/libcudacxx/include/cuda/std/__cmath/gamma.h
+++ b/libcudacxx/include/cuda/std/__cmath/gamma.h
@@ -111,7 +111,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double lgamma(_Integer __x) noexcept
 {
   return _CUDA_VSTD::lgamma((double) __x);
@@ -192,7 +192,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double tgamma(_Integer __x) noexcept
 {
   return _CUDA_VSTD::tgamma((double) __x);

--- a/libcudacxx/include/cuda/std/__cmath/hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/hyperbolic_functions.h
@@ -111,7 +111,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double cosh(_Integer __x) noexcept
 {
   return _CUDA_VSTD::cosh((double) __x);
@@ -192,7 +192,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double sinh(_Integer __x) noexcept
 {
   return _CUDA_VSTD::sinh((double) __x);
@@ -273,7 +273,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double tanh(_Integer __x) noexcept
 {
   return _CUDA_VSTD::tanh((double) __x);

--- a/libcudacxx/include/cuda/std/__cmath/hypot.h
+++ b/libcudacxx/include/cuda/std/__cmath/hypot.h
@@ -118,11 +118,11 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, _A2> hypot(_A1 __x, _A2 __y) noexcept
 {
   using __result_type = __promote_t<_A1, _A2>;
-  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type>), "");
   return _CUDA_VSTD::hypot((__result_type) __x, (__result_type) __y);
 }
 
@@ -206,14 +206,11 @@ template <class _Tp>
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
 _CCCL_TEMPLATE(class _A1, class _A2, class _A3)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_arithmetic, _A1) _CCCL_AND _CCCL_TRAIT(is_arithmetic, _A2)
-                 _CCCL_AND _CCCL_TRAIT(is_arithmetic, _A3))
+_CCCL_REQUIRES(is_arithmetic_v<_A1> _CCCL_AND is_arithmetic_v<_A2> _CCCL_AND is_arithmetic_v<_A3>)
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, _A2, _A3> hypot(_A1 __x, _A2 __y, _A3 __z) noexcept
 {
   using __result_type = __promote_t<_A1, _A2, _A3>;
-  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)
-                  && _CCCL_TRAIT(is_same, _A3, __result_type)),
-                "");
+  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type> && is_same_v<_A3, __result_type>), "");
   return _CUDA_VSTD::hypot((__result_type) __x, (__result_type) __y, (__result_type) __z);
 }
 

--- a/libcudacxx/include/cuda/std/__cmath/inverse_hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/inverse_hyperbolic_functions.h
@@ -111,7 +111,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double acosh(_Integer __x) noexcept
 {
   return _CUDA_VSTD::acosh((double) __x);
@@ -192,7 +192,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double asinh(_Integer __x) noexcept
 {
   return _CUDA_VSTD::asinh((double) __x);
@@ -273,7 +273,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double atanh(_Integer __x) noexcept
 {
   return _CUDA_VSTD::atanh((double) __x);

--- a/libcudacxx/include/cuda/std/__cmath/inverse_trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/inverse_trigonometric_functions.h
@@ -113,7 +113,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double acos(_Integer __x) noexcept
 {
   return _CUDA_VSTD::acos((double) __x);
@@ -194,7 +194,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double asin(_Integer __x) noexcept
 {
   return _CUDA_VSTD::asin((double) __x);
@@ -275,7 +275,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double atan(_Integer __x) noexcept
 {
   return _CUDA_VSTD::atan((double) __x);
@@ -356,11 +356,11 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, _A2> atan2(_A1 __x, _A2 __y) noexcept
 {
   using __result_type = __promote_t<_A1, _A2>;
-  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type>), "");
   return _CUDA_VSTD::atan2((__result_type) __x, (__result_type) __y);
 }
 

--- a/libcudacxx/include/cuda/std/__cmath/isfinite.h
+++ b/libcudacxx/include/cuda/std/__cmath/isfinite.h
@@ -44,7 +44,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isfinite_impl(_Tp __x) noexcept
 {
-  static_assert(_CCCL_TRAIT(is_floating_point, _Tp), "Only standard floating-point types are supported");
+  static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
     return ::isfinite(__x);
@@ -154,7 +154,7 @@ template <class _Tp>
 #endif // _CCCL_HAS_NVFP4_E2M1()
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Tp))
+_CCCL_REQUIRES(is_integral_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr bool isfinite(_Tp) noexcept
 {
   return true;

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -45,7 +45,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isinf_impl(_Tp __x) noexcept
 {
-  static_assert(_CCCL_TRAIT(is_floating_point, _Tp), "Only standard floating-point types are supported");
+  static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
     return ::isinf(__x);
@@ -192,7 +192,7 @@ template <class _Tp>
 #endif // _CCCL_HAS_NVFP4_E2M1()
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Tp))
+_CCCL_REQUIRES(is_integral_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr bool isinf(_Tp) noexcept
 {
   return false;

--- a/libcudacxx/include/cuda/std/__cmath/isnan.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnan.h
@@ -43,7 +43,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr bool __isnan_impl(_Tp __x) noexcept
 {
-  static_assert(_CCCL_TRAIT(is_floating_point, _Tp), "Only standard floating-point types are supported");
+  static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   if (!_CUDA_VSTD::__cccl_default_is_constant_evaluated())
   {
     return ::isnan(__x);
@@ -167,7 +167,7 @@ template <class _Tp>
 #endif // _CCCL_HAS_FLOAT128()
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Tp))
+_CCCL_REQUIRES(is_integral_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr bool isnan(_Tp) noexcept
 {
   return false;

--- a/libcudacxx/include/cuda/std/__cmath/isnormal.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnormal.h
@@ -125,7 +125,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 #endif // _CCCL_HAS_NVFP4_E2M1()
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Tp))
+_CCCL_REQUIRES(is_integral_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr bool isnormal(_Tp __x) noexcept
 {
   return __x != 0;

--- a/libcudacxx/include/cuda/std/__cmath/lerp.h
+++ b/libcudacxx/include/cuda/std/__cmath/lerp.h
@@ -85,15 +85,12 @@ template <typename _Fp>
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
 template <class _A1, class _A2, class _A3>
-[[nodiscard]] _CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2) && _CCCL_TRAIT(is_arithmetic, _A3),
-  __promote_t<_A1, _A2, _A3>>
-lerp(_A1 __a, _A2 __b, _A3 __t) noexcept
+[[nodiscard]]
+_CCCL_API constexpr enable_if_t<is_arithmetic_v<_A1> && is_arithmetic_v<_A2> && is_arithmetic_v<_A3>,
+                                __promote_t<_A1, _A2, _A3>> lerp(_A1 __a, _A2 __b, _A3 __t) noexcept
 {
   using __result_type = __promote_t<_A1, _A2, _A3>;
-  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)
-                  && _CCCL_TRAIT(is_same, _A3, __result_type)),
-                "");
+  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type> && is_same_v<_A3, __result_type>), "");
   return _CUDA_VSTD::__lerp((__result_type) __a, (__result_type) __b, (__result_type) __t);
 }
 

--- a/libcudacxx/include/cuda/std/__cmath/logarithms.h
+++ b/libcudacxx/include/cuda/std/__cmath/logarithms.h
@@ -130,7 +130,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double log(_Integer __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LOG)
@@ -218,7 +218,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double log10(_Integer __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LOG10)
@@ -305,7 +305,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline int ilogb(_Integer __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_ILOGB)
@@ -391,7 +391,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double log1p(_Integer __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LOG1P)
@@ -479,7 +479,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double log2(_Integer __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LOG2)
@@ -565,7 +565,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double logb(_Integer __x) noexcept
 {
 #if defined(_CCCL_BUILTIN_LOGB)

--- a/libcudacxx/include/cuda/std/__cmath/min_max.h
+++ b/libcudacxx/include/cuda/std/__cmath/min_max.h
@@ -98,13 +98,13 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
                     (return ::__hmax(__x, __y);),
                     (return __float2half(_CUDA_VSTD::fmaxf(__half2float(__x), __half2float(__y)));))
 }
-template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<is_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<float, _A1> fmax(__half __x, _A1 __y) noexcept
 {
   return _CUDA_VSTD::fmaxf(__half2float(__x), __y);
 }
 
-template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<is_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, float> fmax(_A1 __x, __half __y) noexcept
 {
   return _CUDA_VSTD::fmaxf(__x, __half2float(__y));
@@ -118,24 +118,24 @@ template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
                     (return ::__hmax(__x, __y);),
                     (return __float2bfloat16(_CUDA_VSTD::fmaxf(__bfloat162float(__x), __bfloat162float(__y)));))
 }
-template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<is_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<float, _A1> fmax(__nv_bfloat16 __x, _A1 __y) noexcept
 {
   return _CUDA_VSTD::fmaxf(__bfloat162float(__x), __y);
 }
 
-template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<is_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, float> fmax(_A1 __x, __nv_bfloat16 __y) noexcept
 {
   return _CUDA_VSTD::fmaxf(__x, __bfloat162float(__y));
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, _A2> fmax(_A1 __x, _A2 __y) noexcept
 {
   using __result_type = __promote_t<_A1, _A2>;
-  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type>), "");
   return _CUDA_VSTD::fmax((__result_type) __x, (__result_type) __y);
 }
 
@@ -200,13 +200,13 @@ template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _
                     (return ::__hmin(__x, __y);),
                     (return __float2half(_CUDA_VSTD::fminf(__half2float(__x), __half2float(__y)));))
 }
-template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<is_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<float, _A1> fmin(__half __x, _A1 __y) noexcept
 {
   return _CUDA_VSTD::fminf(__half2float(__x), __y);
 }
 
-template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<is_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, float> fmin(_A1 __x, __half __y) noexcept
 {
   return _CUDA_VSTD::fminf(__x, __half2float(__y));
@@ -220,24 +220,24 @@ template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
                     (return ::__hmin(__x, __y);),
                     (return __float2bfloat16(_CUDA_VSTD::fminf(__bfloat162float(__x), __bfloat162float(__y)));))
 }
-template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<is_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<float, _A1> fmin(__nv_bfloat16 __x, _A1 __y) noexcept
 {
   return _CUDA_VSTD::fminf(__bfloat162float(__x), __y);
 }
 
-template <class _A1, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<is_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, float> fmin(_A1 __x, __nv_bfloat16 __y) noexcept
 {
   return _CUDA_VSTD::fminf(__x, __bfloat162float(__y));
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline __promote_t<_A1, _A2> fmin(_A1 __x, _A2 __y) noexcept
 {
   using __result_type = __promote_t<_A1, _A2>;
-  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type>), "");
   return _CUDA_VSTD::fmin((__result_type) __x, (__result_type) __y);
 }
 

--- a/libcudacxx/include/cuda/std/__cmath/roots.h
+++ b/libcudacxx/include/cuda/std/__cmath/roots.h
@@ -104,7 +104,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double sqrt(_Integer __x) noexcept
 {
   return _CUDA_VSTD::sqrt((double) __x);
@@ -186,7 +186,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double cbrt(_Integer __x) noexcept
 {
   return _CUDA_VSTD::cbrt((double) __x);

--- a/libcudacxx/include/cuda/std/__cmath/rounding_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/rounding_functions.h
@@ -106,7 +106,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double ceil(_Integer __x) noexcept
 {
   return _CUDA_VSTD::ceil((double) __x);
@@ -182,7 +182,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double floor(_Integer __x) noexcept
 {
   return _CUDA_VSTD::floor((double) __x);
@@ -264,7 +264,7 @@ _CCCL_API inline long long llrintl(long double __x) noexcept
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 _CCCL_API inline long long llrint(_Integer __x) noexcept
 {
   return _CUDA_VSTD::llrint((double) __x);
@@ -346,7 +346,7 @@ _CCCL_API inline long long llroundl(long double __x) noexcept
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 _CCCL_API inline long long llround(_Integer __x) noexcept
 {
   return _CUDA_VSTD::llround((double) __x);
@@ -428,7 +428,7 @@ _CCCL_API inline long lrintl(long double __x) noexcept
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 _CCCL_API inline long lrint(_Integer __x) noexcept
 {
   return _CUDA_VSTD::lrint((double) __x);
@@ -510,7 +510,7 @@ _CCCL_API inline long lroundl(long double __x) noexcept
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 _CCCL_API inline long lround(_Integer __x) noexcept
 {
   return _CUDA_VSTD::lround((double) __x);
@@ -585,7 +585,7 @@ _CCCL_API inline long lround(_Integer __x) noexcept
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double nearbyint(_Integer __x) noexcept
 {
   return _CUDA_VSTD::nearbyint((double) __x);
@@ -667,11 +667,11 @@ _CCCL_API inline long double nextafterl(long double __x, long double __y) noexce
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _A1, class _A2, enable_if_t<_CCCL_TRAIT(is_arithmetic, _A1) && _CCCL_TRAIT(is_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<is_arithmetic_v<_A1> && is_arithmetic_v<_A2>, int> = 0>
 _CCCL_API inline __promote_t<_A1, _A2> nextafter(_A1 __x, _A2 __y) noexcept
 {
   using __result_type = __promote_t<_A1, _A2>;
-  static_assert(!(_CCCL_TRAIT(is_same, _A1, __result_type) && _CCCL_TRAIT(is_same, _A2, __result_type)), "");
+  static_assert(!(is_same_v<_A1, __result_type> && is_same_v<_A2, __result_type>), "");
   return _CUDA_VSTD::nextafter(static_cast<__result_type>(__x), static_cast<__result_type>(__y));
 }
 
@@ -743,7 +743,7 @@ _CCCL_API inline long double nexttowardl(long double __x, long double __y) noexc
 }
 #  endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 _CCCL_API inline double nexttoward(_Integer __x, long double __y) noexcept
 {
   return _CUDA_VSTD::nexttoward((double) __x, __y);
@@ -820,7 +820,7 @@ _CCCL_API inline double nexttoward(_Integer __x, long double __y) noexcept
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double rint(_Integer __x) noexcept
 {
   return _CUDA_VSTD::rint((double) __x);
@@ -895,7 +895,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double round(_Integer __x) noexcept
 {
   return _CUDA_VSTD::round((double) __x);
@@ -971,7 +971,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double trunc(_Integer __x) noexcept
 {
   return _CUDA_VSTD::trunc((double) __x);

--- a/libcudacxx/include/cuda/std/__cmath/traits.h
+++ b/libcudacxx/include/cuda/std/__cmath/traits.h
@@ -39,7 +39,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // isgreater
 
-template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI bool __device_isgreater(_A1 __x, _A1 __y) noexcept
 {
   if (_CUDA_VSTD::isnan(__x) || _CUDA_VSTD::isnan(__y))
@@ -49,9 +49,7 @@ template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int
   return __x > __y;
 }
 
-template <class _A1,
-          class _A2,
-          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<__is_extended_arithmetic_v<_A1> && __is_extended_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline bool isgreater(_A1 __x, _A2 __y) noexcept
 {
   using type = __promote_t<_A1, _A2>;
@@ -62,7 +60,7 @@ template <class _A1,
 
 // isgreaterequal
 
-template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI bool __device_isgreaterequal(_A1 __x, _A1 __y) noexcept
 {
   if (_CUDA_VSTD::isnan(__x) || _CUDA_VSTD::isnan(__y))
@@ -72,9 +70,7 @@ template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int
   return __x >= __y;
 }
 
-template <class _A1,
-          class _A2,
-          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<__is_extended_arithmetic_v<_A1> && __is_extended_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline bool isgreaterequal(_A1 __x, _A2 __y) noexcept
 {
   using type = __promote_t<_A1, _A2>;
@@ -85,7 +81,7 @@ template <class _A1,
 
 // isless
 
-template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI bool __device_isless(_A1 __x, _A1 __y) noexcept
 {
   if (_CUDA_VSTD::isnan(__x) || _CUDA_VSTD::isnan(__y))
@@ -95,9 +91,7 @@ template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int
   return __x < __y;
 }
 
-template <class _A1,
-          class _A2,
-          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<__is_extended_arithmetic_v<_A1> && __is_extended_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline bool isless(_A1 __x, _A2 __y) noexcept
 {
   using type = __promote_t<_A1, _A2>;
@@ -108,7 +102,7 @@ template <class _A1,
 
 // islessequal
 
-template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI bool __device_islessequal(_A1 __x, _A1 __y) noexcept
 {
   if (_CUDA_VSTD::isnan(__x) || _CUDA_VSTD::isnan(__y))
@@ -118,9 +112,7 @@ template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int
   return __x <= __y;
 }
 
-template <class _A1,
-          class _A2,
-          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<__is_extended_arithmetic_v<_A1> && __is_extended_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline bool islessequal(_A1 __x, _A2 __y) noexcept
 {
   using type = __promote_t<_A1, _A2>;
@@ -131,7 +123,7 @@ template <class _A1,
 
 // islessgreater
 
-template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int> = 0>
+template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI bool __device_islessgreater(_A1 __x, _A1 __y) noexcept
 {
   if (_CUDA_VSTD::isnan(__x) || _CUDA_VSTD::isnan(__y))
@@ -141,9 +133,7 @@ template <class _A1, enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1), int
   return __x < __y || __x > __y;
 }
 
-template <class _A1,
-          class _A2,
-          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<__is_extended_arithmetic_v<_A1> && __is_extended_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline bool islessgreater(_A1 __x, _A2 __y) noexcept
 {
   using type = __promote_t<_A1, _A2>;
@@ -154,9 +144,7 @@ template <class _A1,
 
 // isunordered
 
-template <class _A1,
-          class _A2,
-          enable_if_t<_CCCL_TRAIT(__is_extended_arithmetic, _A1) && _CCCL_TRAIT(__is_extended_arithmetic, _A2), int> = 0>
+template <class _A1, class _A2, enable_if_t<__is_extended_arithmetic_v<_A1> && __is_extended_arithmetic_v<_A2>, int> = 0>
 [[nodiscard]] _CCCL_API inline bool isunordered(_A1 __x, _A2 __y) noexcept
 {
   using type = __promote_t<_A1, _A2>;

--- a/libcudacxx/include/cuda/std/__cmath/trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/trigonometric_functions.h
@@ -130,7 +130,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double cos(_Integer __x) noexcept
 {
   return _CUDA_VSTD::cos((double) __x);
@@ -234,7 +234,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double sin(_Integer __x) noexcept
 {
   return _CUDA_VSTD::sin((double) __x);
@@ -315,7 +315,7 @@ template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> =
 }
 #endif // _LIBCUDACXX_HAS_NVBF16()
 
-template <class _Integer, enable_if_t<_CCCL_TRAIT(is_integral, _Integer), int> = 0>
+template <class _Integer, enable_if_t<is_integral_v<_Integer>, int> = 0>
 [[nodiscard]] _CCCL_API inline double tan(_Integer __x) noexcept
 {
   return _CUDA_VSTD::tan((double) __x);

--- a/libcudacxx/include/cuda/std/__complex/complex.h
+++ b/libcudacxx/include/cuda/std/__complex/complex.h
@@ -88,7 +88,7 @@ public:
 
   template <class _Up,
             enable_if_t<!__cccl_internal::__is_non_narrowing_convertible<_Tp, _Up>::value, int> = 0,
-            enable_if_t<_CCCL_TRAIT(is_constructible, _Tp, _Up), int>                           = 0>
+            enable_if_t<is_constructible_v<_Tp, _Up>, int>                                      = 0>
   _CCCL_API explicit constexpr complex(const complex<_Up>& __c)
       : __re_(static_cast<_Tp>(__c.real()))
       , __im_(static_cast<_Tp>(__c.imag()))
@@ -606,7 +606,7 @@ template <class _Tp>
 
 // 26.3.7 values:
 
-template <class _Tp, bool = _CCCL_TRAIT(is_integral, _Tp), bool = _CCCL_TRAIT(is_floating_point, _Tp)>
+template <class _Tp, bool = is_integral_v<_Tp>, bool = is_floating_point_v<_Tp>>
 struct __cccl_complex_overload_traits
 {};
 

--- a/libcudacxx/include/cuda/std/__complex/math.h
+++ b/libcudacxx/include/cuda/std/__complex/math.h
@@ -97,7 +97,7 @@ template <class _Tp>
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES((_CCCL_TRAIT(is_floating_point, _Tp) || _CCCL_TRAIT(__is_extended_floating_point, _Tp)))
+_CCCL_REQUIRES((is_floating_point_v<_Tp> || __is_extended_floating_point_v<_Tp>) )
 [[nodiscard]] _CCCL_API inline __cccl_complex_complex_type<_Tp> proj(_Tp __re)
 {
   if (_CUDA_VSTD::isinf(__re))
@@ -108,7 +108,7 @@ _CCCL_REQUIRES((_CCCL_TRAIT(is_floating_point, _Tp) || _CCCL_TRAIT(__is_extended
 }
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Tp))
+_CCCL_REQUIRES(is_integral_v<_Tp>)
 [[nodiscard]] _CCCL_API inline __cccl_complex_complex_type<_Tp> proj(_Tp __re)
 {
   return __cccl_complex_complex_type<_Tp>(__re);

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -125,7 +125,7 @@ public:
 
   template <class _Up,
             enable_if_t<!__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0,
-            enable_if_t<_CCCL_TRAIT(is_constructible, value_type, _Up), int>                           = 0>
+            enable_if_t<is_constructible_v<value_type, _Up>, int>                                      = 0>
   _CCCL_API inline explicit complex(const complex<_Up>& __c)
       : __repr_(__convert_to_bfloat16(__c.real()), __convert_to_bfloat16(__c.imag()))
   {}

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -125,7 +125,7 @@ public:
 
   template <class _Up,
             enable_if_t<!__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0,
-            enable_if_t<_CCCL_TRAIT(is_constructible, value_type, _Up), int>                           = 0>
+            enable_if_t<is_constructible_v<value_type, _Up>, int>                                      = 0>
   _CCCL_API inline explicit complex(const complex<_Up>& __c)
       : __repr_(__convert_to_half(__c.real()), __convert_to_half(__c.imag()))
   {}

--- a/libcudacxx/include/cuda/std/__complex/vector_support.h
+++ b/libcudacxx/include/cuda/std/__complex/vector_support.h
@@ -32,8 +32,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-inline constexpr bool __is_complex_float_v =
-  _CCCL_TRAIT(is_floating_point, _Tp) || _CCCL_TRAIT(__is_extended_floating_point, _Tp);
+inline constexpr bool __is_complex_float_v = is_floating_point_v<_Tp> || __is_extended_floating_point_v<_Tp>;
 
 template <class _Tp>
 inline constexpr size_t __complex_alignment_v = 2 * sizeof(_Tp);

--- a/libcudacxx/include/cuda/std/__concepts/arithmetic.h
+++ b/libcudacxx/include/cuda/std/__concepts/arithmetic.h
@@ -35,16 +35,16 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 // [concepts.arithmetic], arithmetic concepts
 
 template <class _Tp>
-_CCCL_CONCEPT integral = _CCCL_TRAIT(is_integral, _Tp);
+_CCCL_CONCEPT integral = is_integral_v<_Tp>;
 
 template <class _Tp>
-_CCCL_CONCEPT signed_integral = integral<_Tp> && _CCCL_TRAIT(is_signed, _Tp);
+_CCCL_CONCEPT signed_integral = integral<_Tp> && is_signed_v<_Tp>;
 
 template <class _Tp>
 _CCCL_CONCEPT unsigned_integral = integral<_Tp> && !signed_integral<_Tp>;
 
 template <class _Tp>
-_CCCL_CONCEPT floating_point = _CCCL_TRAIT(is_floating_point, _Tp);
+_CCCL_CONCEPT floating_point = is_floating_point_v<_Tp>;
 
 template <class _Tp>
 _CCCL_CONCEPT __cccl_signed_integer = __cccl_is_signed_integer_v<_Tp>;

--- a/libcudacxx/include/cuda/std/__concepts/assignable.h
+++ b/libcudacxx/include/cuda/std/__concepts/assignable.h
@@ -48,7 +48,7 @@ template <class _Lhs, class _Rhs>
 _CCCL_CONCEPT_FRAGMENT(
   __assignable_from_,
   requires(_Lhs __lhs,
-           _Rhs&& __rhs)(requires(_CCCL_TRAIT(is_lvalue_reference, _Lhs)),
+           _Rhs&& __rhs)(requires(is_lvalue_reference_v<_Lhs>),
                          requires(common_reference_with<__make_const_lvalue_ref<_Lhs>, __make_const_lvalue_ref<_Rhs>>),
                          requires(same_as<_Lhs, decltype(__lhs = _CUDA_VSTD::forward<_Rhs>(__rhs))>)));
 

--- a/libcudacxx/include/cuda/std/__concepts/class_or_enum.h
+++ b/libcudacxx/include/cuda/std/__concepts/class_or_enum.h
@@ -31,13 +31,12 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-_CCCL_CONCEPT __class_or_enum = _CCCL_TRAIT(is_class, _Tp) || _CCCL_TRAIT(is_union, _Tp) || _CCCL_TRAIT(is_enum, _Tp);
+_CCCL_CONCEPT __class_or_enum = is_class_v<_Tp> || is_union_v<_Tp> || is_enum_v<_Tp>;
 
 // Work around Clang bug https://llvm.org/PR52970
 // TODO: remove this workaround once libc++ no longer has to support Clang 13 (it was fixed in Clang 14).
 template <class _Tp>
-_CCCL_CONCEPT __workaround_52970 =
-  _CCCL_TRAIT(is_class, remove_cvref_t<_Tp>) || _CCCL_TRAIT(is_union, remove_cvref_t<_Tp>);
+_CCCL_CONCEPT __workaround_52970 = is_class_v<remove_cvref_t<_Tp>> || is_union_v<remove_cvref_t<_Tp>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__concepts/constructible.h
+++ b/libcudacxx/include/cuda/std/__concepts/constructible.h
@@ -58,7 +58,7 @@ concept copy_constructible =
 
 template <class _Tp, class... _Args>
 _CCCL_CONCEPT_FRAGMENT(__constructible_from_,
-                       requires()(requires(destructible<_Tp>), requires(_CCCL_TRAIT(is_constructible, _Tp, _Args...))));
+                       requires()(requires(destructible<_Tp>), requires(is_constructible_v<_Tp, _Args...>)));
 
 template <class _Tp, class... _Args>
 _CCCL_CONCEPT constructible_from = _CCCL_FRAGMENT(__constructible_from_, _Tp, _Args...);

--- a/libcudacxx/include/cuda/std/__concepts/convertible_to.h
+++ b/libcudacxx/include/cuda/std/__concepts/convertible_to.h
@@ -50,9 +50,8 @@ template <class _From, class _To>
 _CCCL_CONCEPT __test_conversion = _CCCL_FRAGMENT(__test_conversion_, _From, _To);
 
 template <class _From, class _To>
-_CCCL_CONCEPT_FRAGMENT(
-  __convertible_to_,
-  requires()(requires(_CCCL_TRAIT(is_convertible, _From, _To)), requires(__test_conversion<_From, _To>)));
+_CCCL_CONCEPT_FRAGMENT(__convertible_to_,
+                       requires()(requires(is_convertible_v<_From, _To>), requires(__test_conversion<_From, _To>)));
 
 template <class _From, class _To>
 _CCCL_CONCEPT convertible_to = _CCCL_FRAGMENT(__convertible_to_, _From, _To);

--- a/libcudacxx/include/cuda/std/__concepts/derived_from.h
+++ b/libcudacxx/include/cuda/std/__concepts/derived_from.h
@@ -41,9 +41,8 @@ concept derived_from = is_base_of_v<_Bp, _Dp> && is_convertible_v<const volatile
 template <class _Dp, class _Bp>
 _CCCL_CONCEPT_FRAGMENT(
   __derived_from_,
-  requires()(
-    requires(_CCCL_TRAIT(is_base_of, _Bp, _Dp)),
-    requires(_CCCL_TRAIT(is_convertible, add_pointer_t<const volatile _Dp>, add_pointer_t<const volatile _Bp>))));
+  requires()(requires(is_base_of_v<_Bp, _Dp>),
+             requires(is_convertible_v<add_pointer_t<const volatile _Dp>, add_pointer_t<const volatile _Bp>>)));
 
 template <class _Dp, class _Bp>
 _CCCL_CONCEPT derived_from = _CCCL_FRAGMENT(__derived_from_, _Dp, _Bp);

--- a/libcudacxx/include/cuda/std/__concepts/destructible.h
+++ b/libcudacxx/include/cuda/std/__concepts/destructible.h
@@ -44,9 +44,9 @@ inline constexpr bool __destructible_impl = false;
 
 template <class _Tp>
 inline constexpr bool __destructible_impl<_Tp,
-                                          enable_if_t<_CCCL_TRAIT(is_object, _Tp)>,
+                                          enable_if_t<is_object_v<_Tp>>,
 #  if _CCCL_COMPILER(GCC)
-                                          enable_if_t<_CCCL_TRAIT(is_destructible, _Tp)>>
+                                          enable_if_t<is_destructible_v<_Tp>>>
 #  else // ^^^ _CCCL_COMPILER(GCC) ^^^ / vvv !_CCCL_COMPILER(GCC) vvv
                                           void_t<decltype(_CUDA_VSTD::declval<_Tp>().~_Tp())>>
 #  endif // !_CCCL_COMPILER(GCC)

--- a/libcudacxx/include/cuda/std/__concepts/swappable.h
+++ b/libcudacxx/include/cuda/std/__concepts/swappable.h
@@ -129,7 +129,7 @@ struct __fn
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__exchangeable<_Tp>)
   _CCCL_API constexpr void operator()(_Tp& __x, _Tp& __y) const
-    noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Tp) && _CCCL_TRAIT(is_nothrow_move_assignable, _Tp))
+    noexcept(is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_assignable_v<_Tp>)
   {
     __y = _CUDA_VSTD::exchange(__x, _CUDA_VSTD::move(__y));
   }
@@ -141,7 +141,7 @@ _CCCL_CONCEPT_FRAGMENT(
   __swappable_arrays_,
   requires(_Tp (&__t)[_Size::value], _Up (&__u)[_Size::value], const __fn& __swap)(
     requires(!__unqualified_swappable_with<_Tp (&)[_Size::value], _Up (&)[_Size::value]>),
-    requires(_CCCL_TRAIT(extent, _Tp) == _CCCL_TRAIT(extent, _Up)),
+    requires(extent_v<_Tp> == extent_v<_Up>),
     (__swap(__t[0], __u[0]))));
 
 template <class _Tp, class _Up, size_t _Size>

--- a/libcudacxx/include/cuda/std/__cstddef/byte.h
+++ b/libcudacxx/include/cuda/std/__cstddef/byte.h
@@ -72,35 +72,35 @@ _CCCL_API constexpr byte operator~(byte __b) noexcept
 }
 
 _CCCL_TEMPLATE(class _Integer)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Integer))
+_CCCL_REQUIRES(is_integral_v<_Integer>)
 _CCCL_API constexpr byte& operator<<=(byte& __lhs, _Integer __shift) noexcept
 {
   return __lhs = __lhs << __shift;
 }
 
 _CCCL_TEMPLATE(class _Integer)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Integer))
+_CCCL_REQUIRES(is_integral_v<_Integer>)
 _CCCL_API constexpr byte operator<<(byte __lhs, _Integer __shift) noexcept
 {
   return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) << __shift));
 }
 
 _CCCL_TEMPLATE(class _Integer)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Integer))
+_CCCL_REQUIRES(is_integral_v<_Integer>)
 _CCCL_API constexpr byte& operator>>=(byte& __lhs, _Integer __shift) noexcept
 {
   return __lhs = __lhs >> __shift;
 }
 
 _CCCL_TEMPLATE(class _Integer)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Integer))
+_CCCL_REQUIRES(is_integral_v<_Integer>)
 _CCCL_API constexpr byte operator>>(byte __lhs, _Integer __shift) noexcept
 {
   return static_cast<byte>(static_cast<unsigned char>(static_cast<unsigned int>(__lhs) >> __shift));
 }
 
 _CCCL_TEMPLATE(class _Integer)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_integral, _Integer))
+_CCCL_REQUIRES(is_integral_v<_Integer>)
 _CCCL_API constexpr _Integer to_integer(byte __b) noexcept
 {
   return static_cast<_Integer>(__b);

--- a/libcudacxx/include/cuda/std/__expected/expected.h
+++ b/libcudacxx/include/cuda/std/__expected/expected.h
@@ -73,9 +73,9 @@ namespace __expected
 {
 template <class _Tp, class _Err>
 inline constexpr bool __valid_expected =
-  !_CCCL_TRAIT(is_reference, _Tp) && !_CCCL_TRAIT(is_function, _Tp)
-  && !_CCCL_TRAIT(is_same, remove_cv_t<_Tp>, in_place_t) && !_CCCL_TRAIT(is_same, remove_cv_t<_Tp>, unexpect_t)
-  && !__unexpected::__is_unexpected<remove_cv_t<_Tp>> && __unexpected::__valid_unexpected<_Err>;
+  !is_reference_v<_Tp> && !is_function_v<_Tp> && !is_same_v<remove_cv_t<_Tp>, in_place_t>
+  && !is_same_v<remove_cv_t<_Tp>, unexpect_t> && !__unexpected::__is_unexpected<remove_cv_t<_Tp>>
+  && __unexpected::__valid_unexpected<_Err>;
 
 template <class _Tp>
 inline constexpr bool __is_expected = false;
@@ -91,13 +91,11 @@ inline constexpr bool __is_expected_nonvoid<expected<void, _Err>> = false;
 
 template <class _Tp, class _Err>
 inline constexpr bool __can_swap =
-  _CCCL_TRAIT(is_swappable, _Tp) && _CCCL_TRAIT(is_swappable, _Err) && _CCCL_TRAIT(is_move_constructible, _Tp)
-  && _CCCL_TRAIT(is_move_constructible, _Err)
-  && (_CCCL_TRAIT(is_nothrow_move_constructible, _Tp) || _CCCL_TRAIT(is_nothrow_move_constructible, _Err));
+  is_swappable_v<_Tp> && is_swappable_v<_Err> && is_move_constructible_v<_Tp> && is_move_constructible_v<_Err>
+  && (is_nothrow_move_constructible_v<_Tp> || is_nothrow_move_constructible_v<_Err>);
 
 template <class _Err>
-inline constexpr bool __can_swap<void, _Err> =
-  _CCCL_TRAIT(is_swappable, _Err) && _CCCL_TRAIT(is_move_constructible, _Err);
+inline constexpr bool __can_swap<void, _Err> = is_swappable_v<_Err> && is_move_constructible_v<_Err>;
 } // namespace __expected
 
 template <class _Tp, class _Err>
@@ -125,8 +123,8 @@ public:
 
   // [expected.object.ctor], constructors
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_default_constructible, _Tp2))
-  _CCCL_API constexpr expected() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _Tp2))
+  _CCCL_REQUIRES(is_default_constructible_v<_Tp2>)
+  _CCCL_API constexpr expected() noexcept(is_nothrow_default_constructible_v<_Tp2>)
       : __base(true)
   {}
 
@@ -155,11 +153,10 @@ private:
 
 public:
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&>::value _CCCL_AND _CCCL_TRAIT(
-    is_convertible, const _Up&, _Tp) _CCCL_AND _CCCL_TRAIT(is_convertible, const _OtherErr&, _Err))
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&>::value _CCCL_AND
+                   is_convertible_v<const _Up&, _Tp> _CCCL_AND is_convertible_v<const _OtherErr&, _Err>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 expected(const expected<_Up, _OtherErr>& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, const _Up&)
-    && _CCCL_TRAIT(is_nothrow_constructible, _Err, const _OtherErr&)) // strengthened
+    is_nothrow_constructible_v<_Tp, const _Up&> && is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
       : __base(__other.__has_val_)
   {
     if (__other.__has_val_)
@@ -174,10 +171,9 @@ public:
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
   _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&>::value _CCCL_AND(
-    !_CCCL_TRAIT(is_convertible, const _Up&, _Tp) || !_CCCL_TRAIT(is_convertible, const _OtherErr&, _Err)))
+    !is_convertible_v<const _Up&, _Tp> || !is_convertible_v<const _OtherErr&, _Err>))
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit expected(const expected<_Up, _OtherErr>& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, const _Up&)
-    && _CCCL_TRAIT(is_nothrow_constructible, _Err, const _OtherErr&)) // strengthened
+    is_nothrow_constructible_v<_Tp, const _Up&> && is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
       : __base(__other.__has_val_)
   {
     if (__other.__has_val_)
@@ -191,11 +187,10 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _Up, _OtherErr>::value _CCCL_AND _CCCL_TRAIT(is_convertible, _Up, _Tp)
-                   _CCCL_AND _CCCL_TRAIT(is_convertible, _OtherErr, _Err))
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _Up, _OtherErr>::value _CCCL_AND is_convertible_v<_Up, _Tp> _CCCL_AND
+                   is_convertible_v<_OtherErr, _Err>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 expected(expected<_Up, _OtherErr>&& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up)
-    && _CCCL_TRAIT(is_nothrow_constructible, _Err, _OtherErr)) // strengthened
+    is_nothrow_constructible_v<_Tp, _Up> && is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
       : __base(__other.__has_val_)
   {
     if (__other.__has_val_)
@@ -212,10 +207,9 @@ public:
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
   _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _Up, _OtherErr>::value _CCCL_AND(
-    !_CCCL_TRAIT(is_convertible, _Up, _Tp) || !_CCCL_TRAIT(is_convertible, _OtherErr, _Err)))
+    !is_convertible_v<_Up, _Tp> || !is_convertible_v<_OtherErr, _Err>))
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit expected(expected<_Up, _OtherErr>&& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up)
-    && _CCCL_TRAIT(is_nothrow_constructible, _Err, _OtherErr)) // strengthened
+    is_nothrow_constructible_v<_Tp, _Up> && is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
       : __base(__other.__has_val_)
   {
     if (__other.__has_val_)
@@ -231,84 +225,74 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up = _Tp)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, in_place_t)) _CCCL_AND(
-    !_CCCL_TRAIT(is_same, expected, remove_cvref_t<_Up>)) _CCCL_AND(!__unexpected::__is_unexpected<remove_cvref_t<_Up>>)
-                   _CCCL_AND _CCCL_TRAIT(is_constructible, _Tp, _Up) _CCCL_AND _CCCL_TRAIT(is_convertible, _Up, _Tp))
-  _CCCL_API constexpr expected(_Up&& __u) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up)) // strengthened
+  _CCCL_REQUIRES((!is_same_v<remove_cvref_t<_Up>, in_place_t>) _CCCL_AND(!is_same_v<expected, remove_cvref_t<_Up>>)
+                   _CCCL_AND(!__unexpected::__is_unexpected<remove_cvref_t<_Up>>)
+                     _CCCL_AND is_constructible_v<_Tp, _Up> _CCCL_AND is_convertible_v<_Up, _Tp>)
+  _CCCL_API constexpr expected(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>) // strengthened
       : __base(in_place, _CUDA_VSTD::forward<_Up>(__u))
   {}
 
   _CCCL_TEMPLATE(class _Up = _Tp)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, in_place_t)) _CCCL_AND(
-    !_CCCL_TRAIT(is_same, expected, remove_cvref_t<_Up>)) _CCCL_AND(!__unexpected::__is_unexpected<remove_cvref_t<_Up>>)
-                   _CCCL_AND _CCCL_TRAIT(is_constructible, _Tp, _Up) _CCCL_AND(!_CCCL_TRAIT(is_convertible, _Up, _Tp)))
-  _CCCL_API constexpr explicit expected(_Up&& __u) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up)) // strengthened
+  _CCCL_REQUIRES((!is_same_v<remove_cvref_t<_Up>, in_place_t>) _CCCL_AND(!is_same_v<expected, remove_cvref_t<_Up>>)
+                   _CCCL_AND(!__unexpected::__is_unexpected<remove_cvref_t<_Up>>)
+                     _CCCL_AND is_constructible_v<_Tp, _Up> _CCCL_AND(!is_convertible_v<_Up, _Tp>))
+  _CCCL_API constexpr explicit expected(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>) // strengthened
       : __base(in_place, _CUDA_VSTD::forward<_Up>(__u))
   {}
 
   _CCCL_TEMPLATE(class _OtherErr)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, const _OtherErr&)
-                   _CCCL_AND _CCCL_TRAIT(is_convertible, const _OtherErr&, _Err))
+  _CCCL_REQUIRES(is_constructible_v<_Err, const _OtherErr&> _CCCL_AND is_convertible_v<const _OtherErr&, _Err>)
   _CCCL_API constexpr expected(const unexpected<_OtherErr>& __unex) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, const _OtherErr&)) // strengthened
+    is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
       : __base(unexpect, __unex.error())
   {}
 
   _CCCL_TEMPLATE(class _OtherErr)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, const _OtherErr&)
-                   _CCCL_AND(!_CCCL_TRAIT(is_convertible, const _OtherErr&, _Err)))
+  _CCCL_REQUIRES(is_constructible_v<_Err, const _OtherErr&> _CCCL_AND(!is_convertible_v<const _OtherErr&, _Err>))
   _CCCL_API constexpr explicit expected(const unexpected<_OtherErr>& __unex) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, const _OtherErr&)) // strengthened
+    is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
       : __base(unexpect, __unex.error())
   {}
 
   _CCCL_TEMPLATE(class _OtherErr)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, _OtherErr) _CCCL_AND _CCCL_TRAIT(is_convertible, _OtherErr, _Err))
+  _CCCL_REQUIRES(is_constructible_v<_Err, _OtherErr> _CCCL_AND is_convertible_v<_OtherErr, _Err>)
   _CCCL_API constexpr expected(unexpected<_OtherErr>&& __unex) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _OtherErr)) // strengthened
+    is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
       : __base(unexpect, _CUDA_VSTD::move(__unex.error()))
   {}
 
   _CCCL_TEMPLATE(class _OtherErr)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, _OtherErr)
-                   _CCCL_AND(!_CCCL_TRAIT(is_convertible, _OtherErr, _Err)))
+  _CCCL_REQUIRES(is_constructible_v<_Err, _OtherErr> _CCCL_AND(!is_convertible_v<_OtherErr, _Err>))
   _CCCL_API constexpr explicit expected(unexpected<_OtherErr>&& __unex) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _OtherErr)) // strengthened
+    is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
       : __base(unexpect, _CUDA_VSTD::move(__unex.error()))
   {}
 
   _CCCL_TEMPLATE(class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Tp, _Args...))
+  _CCCL_REQUIRES(is_constructible_v<_Tp, _Args...>)
   _CCCL_API constexpr explicit expected(in_place_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...)) // strengthened
+    is_nothrow_constructible_v<_Tp, _Args...>) // strengthened
       : __base(in_place, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class _Up, class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Tp, initializer_list<_Up>&, _Args...))
-  _CCCL_API constexpr explicit expected(in_place_t, initializer_list<_Up> __il, _Args&&... __args) noexcept(_CCCL_TRAIT(
-    is_nothrow_constructible,
-    _Tp,
-    initializer_list<_Up>&,
-    _Args...)) // strengthened
+  _CCCL_REQUIRES(is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>)
+  _CCCL_API constexpr explicit expected(in_place_t, initializer_list<_Up> __il, _Args&&... __args) noexcept(
+    is_nothrow_constructible_v<_Tp, initializer_list<_Up>&, _Args...>) // strengthened
       : __base(in_place, __il, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, _Args...))
+  _CCCL_REQUIRES(is_constructible_v<_Err, _Args...>)
   _CCCL_API constexpr explicit expected(unexpect_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...)) // strengthened
+    is_nothrow_constructible_v<_Err, _Args...>) // strengthened
       : __base(unexpect, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class _Up, class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, initializer_list<_Up>&, _Args...))
-  _CCCL_API constexpr explicit expected(unexpect_t, initializer_list<_Up> __il, _Args&&... __args) noexcept(_CCCL_TRAIT(
-    is_nothrow_constructible,
-    _Err,
-    initializer_list<_Up>&,
-    _Args...)) // strengthened
+  _CCCL_REQUIRES(is_constructible_v<_Err, initializer_list<_Up>&, _Args...>)
+  _CCCL_API constexpr explicit expected(unexpect_t, initializer_list<_Up> __il, _Args&&... __args) noexcept(
+    is_nothrow_constructible_v<_Err, initializer_list<_Up>&, _Args...>) // strengthened
       : __base(unexpect, __il, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
@@ -318,7 +302,7 @@ private:
     __expected_construct_from_invoke_tag,
     in_place_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __base(__expected_construct_from_invoke_tag{},
                in_place,
                _CUDA_VSTD::forward<_Fun>(__fun),
@@ -330,7 +314,7 @@ private:
     __expected_construct_from_invoke_tag,
     unexpect_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
       : __base(__expected_construct_from_invoke_tag{},
                unexpect,
                _CUDA_VSTD::forward<_Fun>(__fun),
@@ -342,10 +326,10 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Up = _Tp)
   _CCCL_REQUIRES(
-    (!_CCCL_TRAIT(is_same, expected, remove_cvref_t<_Up>)) _CCCL_AND(!__unexpected::__is_unexpected<remove_cvref_t<_Up>>)
-      _CCCL_AND _CCCL_TRAIT(is_constructible, _Tp, _Up) _CCCL_AND _CCCL_TRAIT(is_assignable, _Tp&, _Up)
-        _CCCL_AND(_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up) || _CCCL_TRAIT(is_nothrow_move_constructible, _Tp)
-                  || _CCCL_TRAIT(is_nothrow_move_constructible, _Err)))
+    (!is_same_v<expected, remove_cvref_t<_Up>>) _CCCL_AND(!__unexpected::__is_unexpected<remove_cvref_t<_Up>>)
+      _CCCL_AND is_constructible_v<_Tp, _Up> _CCCL_AND is_assignable_v<_Tp&, _Up> _CCCL_AND(
+        is_nothrow_constructible_v<_Tp, _Up> || is_nothrow_move_constructible_v<_Tp>
+        || is_nothrow_move_constructible_v<_Err>))
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 expected& operator=(_Up&& __v)
   {
     if (this->__has_val_)
@@ -406,7 +390,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+  _CCCL_REQUIRES(is_nothrow_constructible_v<_Tp, _Args...>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _Tp& emplace(_Args&&... __args) noexcept
   {
     if (this->__has_val_)
@@ -423,7 +407,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up, class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_nothrow_constructible, _Tp, initializer_list<_Up>&, _Args...))
+  _CCCL_REQUIRES(is_nothrow_constructible_v<_Tp, initializer_list<_Up>&, _Args...>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _Tp& emplace(initializer_list<_Up> __il, _Args&&... __args) noexcept
   {
     if (this->__has_val_)
@@ -444,8 +428,8 @@ public:
   _CCCL_TEMPLATE(class _Tp2 = _Tp, class _Err2 = _Err)
   _CCCL_REQUIRES(__expected::__can_swap<_Tp2, _Err2>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void swap(expected<_Tp2, _Err>& __rhs) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_constructible, _Tp2) && _CCCL_TRAIT(is_nothrow_swappable, _Tp2)
-    && _CCCL_TRAIT(is_nothrow_move_constructible, _Err) && _CCCL_TRAIT(is_nothrow_swappable, _Err))
+    is_nothrow_move_constructible_v<_Tp2> && is_nothrow_swappable_v<_Tp2> && is_nothrow_move_constructible_v<_Err>
+    && is_nothrow_swappable_v<_Err>)
   {
     if (this->__has_val_)
     {
@@ -475,9 +459,8 @@ public:
 
   template <class _Tp2 = _Tp, class _Err2 = _Err>
   friend _CCCL_API inline _CCCL_CONSTEXPR_CXX20 auto swap(expected& __x, expected& __y) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_constructible, _Tp2) && _CCCL_TRAIT(is_nothrow_swappable, _Tp2)
-    && _CCCL_TRAIT(is_nothrow_move_constructible, _Err2) && _CCCL_TRAIT(is_nothrow_swappable, _Err2))
-    _CCCL_TRAILING_REQUIRES(void)(__expected::__can_swap<_Tp2, _Err2>)
+    is_nothrow_move_constructible_v<_Tp2> && is_nothrow_swappable_v<_Tp2> && is_nothrow_move_constructible_v<_Err2>
+    && is_nothrow_swappable_v<_Err2>) _CCCL_TRAILING_REQUIRES(void)(__expected::__can_swap<_Tp2, _Err2>)
   {
     return __x.swap(__y); // some compiler warn about non void function without return
   }
@@ -531,8 +514,7 @@ public:
 
   _CCCL_API constexpr const _Tp& value() const&
   {
-    static_assert(_CCCL_TRAIT(is_copy_constructible, _Err),
-                  "expected::value() const& requires is_copy_constructible_v<E>");
+    static_assert(is_copy_constructible_v<_Err>, "expected::value() const& requires is_copy_constructible_v<E>");
     if (!this->__has_val_)
     {
       __throw_bad_expected_access<_Err>(this->__union_.__unex_);
@@ -542,7 +524,7 @@ public:
 
   _CCCL_API constexpr _Tp& value() &
   {
-    static_assert(_CCCL_TRAIT(is_copy_constructible, _Err), "expected::value() & requires is_copy_constructible_v<E>");
+    static_assert(is_copy_constructible_v<_Err>, "expected::value() & requires is_copy_constructible_v<E>");
     if (!this->__has_val_)
     {
       __throw_bad_expected_access<_Err>(_CUDA_VSTD::as_const(this->__union_.__unex_));
@@ -552,9 +534,8 @@ public:
 
   _CCCL_API constexpr const _Tp&& value() const&&
   {
-    static_assert(_CCCL_TRAIT(is_copy_constructible, _Err),
-                  "expected::value() const&& requires is_copy_constructible_v<E>");
-    static_assert(_CCCL_TRAIT(is_constructible, _Err, decltype(_CUDA_VSTD::move(error()))),
+    static_assert(is_copy_constructible_v<_Err>, "expected::value() const&& requires is_copy_constructible_v<E>");
+    static_assert(is_constructible_v<_Err, decltype(_CUDA_VSTD::move(error()))>,
                   "expected::value() const&& requires is_constructible_v<E, decltype(_CUDA_VSTD::move(error()))>");
     if (!this->__has_val_)
     {
@@ -565,8 +546,8 @@ public:
 
   _CCCL_API constexpr _Tp&& value() &&
   {
-    static_assert(_CCCL_TRAIT(is_copy_constructible, _Err), "expected::value() && requires is_copy_constructible_v<E>");
-    static_assert(_CCCL_TRAIT(is_constructible, _Err, decltype(_CUDA_VSTD::move(error()))),
+    static_assert(is_copy_constructible_v<_Err>, "expected::value() && requires is_copy_constructible_v<E>");
+    static_assert(is_constructible_v<_Err, decltype(_CUDA_VSTD::move(error()))>,
                   "expected::value() && requires is_constructible_v<E, decltype(_CUDA_VSTD::move(error()))>");
     if (!this->__has_val_)
     {
@@ -602,28 +583,28 @@ public:
   template <class _Up>
   _CCCL_API constexpr _Tp value_or(_Up&& __v) const&
   {
-    static_assert(_CCCL_TRAIT(is_copy_constructible, _Tp), "value_type has to be copy constructible");
-    static_assert(_CCCL_TRAIT(is_convertible, _Up, _Tp), "argument has to be convertible to value_type");
+    static_assert(is_copy_constructible_v<_Tp>, "value_type has to be copy constructible");
+    static_assert(is_convertible_v<_Up, _Tp>, "argument has to be convertible to value_type");
     return this->__has_val_ ? this->__union_.__val_ : static_cast<_Tp>(_CUDA_VSTD::forward<_Up>(__v));
   }
 
   template <class _Up>
   _CCCL_API constexpr _Tp value_or(_Up&& __v) &&
   {
-    static_assert(_CCCL_TRAIT(is_move_constructible, _Tp), "value_type has to be move constructible");
-    static_assert(_CCCL_TRAIT(is_convertible, _Up, _Tp), "argument has to be convertible to value_type");
+    static_assert(is_move_constructible_v<_Tp>, "value_type has to be move constructible");
+    static_assert(is_convertible_v<_Up, _Tp>, "argument has to be convertible to value_type");
     return this->__has_val_ ? _CUDA_VSTD::move(this->__union_.__val_) : static_cast<_Tp>(_CUDA_VSTD::forward<_Up>(__v));
   }
 
   // [expected.object.monadic]
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&))
+  _CCCL_REQUIRES(is_constructible_v<_Err2, _Err2&>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) &
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun, _Tp&>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
+    static_assert(is_same_v<typename _Res::error_type, _Err>,
                   "The error type of the result of f(value()) must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -637,13 +618,13 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2))
+  _CCCL_REQUIRES(is_copy_constructible_v<_Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) const&
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun, const _Tp&>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
+    static_assert(is_same_v<typename _Res::error_type, _Err>,
                   "The error type of the result of f(value()) must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -657,13 +638,13 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2))
+  _CCCL_REQUIRES(is_move_constructible_v<_Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) &&
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun, _Tp>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
+    static_assert(is_same_v<typename _Res::error_type, _Err>,
                   "The error type of the result of f(value()) must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -677,13 +658,13 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2))
+  _CCCL_REQUIRES(is_constructible_v<_Err2, const _Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) const&&
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun, const _Tp>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
+    static_assert(is_same_v<typename _Res::error_type, _Err>,
                   "The error type of the result of f(value()) must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -697,14 +678,14 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Tp2, _Tp2&))
+  _CCCL_REQUIRES(is_constructible_v<_Tp2, _Tp2&>)
   _CCCL_API constexpr auto or_else(_Fun&& __fun) &
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun, _Err&>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::value_type, _Tp),
+    static_assert(is_same_v<typename _Res::value_type, _Tp>,
                   "The value type of the result of std::expected::or_else must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -718,14 +699,14 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Tp2))
+  _CCCL_REQUIRES(is_copy_constructible_v<_Tp2>)
   _CCCL_API constexpr auto or_else(_Fun&& __fun) const&
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun, const _Err&>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::value_type, _Tp),
+    static_assert(is_same_v<typename _Res::value_type, _Tp>,
                   "The value type of the result of std::expected::or_else must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -739,14 +720,14 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Tp2))
+  _CCCL_REQUIRES(is_move_constructible_v<_Tp2>)
   _CCCL_API constexpr auto or_else(_Fun&& __fun) &&
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun, _Err>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::value_type, _Tp),
+    static_assert(is_same_v<typename _Res::value_type, _Tp>,
                   "The value type of the result of std::expected::or_else must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -760,14 +741,14 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Tp2, const _Tp2))
+  _CCCL_REQUIRES(is_constructible_v<_Tp2, const _Tp2>)
   _CCCL_API constexpr auto or_else(_Fun&& __fun) const&&
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun, const _Err>>;
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::value_type, _Tp),
+    static_assert(is_same_v<typename _Res::value_type, _Tp>,
                   "The value type of the result of std::expected::or_else must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -781,8 +762,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&)
-                   _CCCL_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void))
+  _CCCL_REQUIRES(is_constructible_v<_Err2, _Err2&> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun, _Tp&>, "std::expected::transform requires that F must be invocable with T.");
@@ -800,8 +780,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&)
-                   _CCCL_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void)))
+  _CCCL_REQUIRES(
+    is_constructible_v<_Err2, _Err2&> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun, _Tp2&>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun, _Tp&>, "std::expected::transform requires that F must be invocable with T.");
@@ -826,8 +806,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2)
-                   _CCCL_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void))
+  _CCCL_REQUIRES(
+    is_copy_constructible_v<_Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&
   {
     static_assert(invocable<_Fun, const _Tp&>, "std::expected::transform requires that F must be invocable with T.");
@@ -845,8 +825,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2)
-                   _CCCL_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void)))
+  _CCCL_REQUIRES(
+    is_copy_constructible_v<_Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun, const _Tp2&>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&
   {
     static_assert(invocable<_Fun, const _Tp&>, "std::expected::transform requires that F must be invocable with T");
@@ -871,8 +851,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2)
-                   _CCCL_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void))
+  _CCCL_REQUIRES(is_move_constructible_v<_Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun, _Tp>, "std::expected::transform requires that F must be invocable with T.");
@@ -889,8 +868,7 @@ public:
     }
   }
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2)
-                   _CCCL_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void)))
+  _CCCL_REQUIRES(is_move_constructible_v<_Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun, _Tp2>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun, _Tp>, "std::expected::transform requires that F must be invocable with T");
@@ -918,8 +896,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2)
-                   _CCCL_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void))
+  _CCCL_REQUIRES(
+    is_constructible_v<_Err2, const _Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&&
   {
     static_assert(invocable<_Fun, const _Tp>, "std::expected::transform requires that F must be invocable with T.");
@@ -937,8 +915,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2)
-                   _CCCL_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void)))
+  _CCCL_REQUIRES(
+    is_constructible_v<_Err2, const _Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun, const _Tp2>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&&
   {
     static_assert(invocable<_Fun, const _Tp>, "std::expected::transform requires that F must be invocable with T");
@@ -966,7 +944,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Tp2, _Tp2&))
+  _CCCL_REQUIRES(is_constructible_v<_Tp2, _Tp2&>)
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun, _Err&>, "std::expected::transform_error requires that F must be invocable with E");
@@ -991,7 +969,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Tp2))
+  _CCCL_REQUIRES(is_copy_constructible_v<_Tp2>)
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) const&
   {
     static_assert(invocable<_Fun, const _Err&>,
@@ -1017,7 +995,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Tp2))
+  _CCCL_REQUIRES(is_move_constructible_v<_Tp2>)
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun, _Err>, "std::expected::transform_error requires that F must be invocable with E");
@@ -1045,7 +1023,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Tp2, const _Tp2))
+  _CCCL_REQUIRES(is_constructible_v<_Tp2, const _Tp2>)
   _CCCL_API constexpr auto transform_error(_Fun&& __fun) const&&
   {
     static_assert(invocable<_Fun, const _Err>,
@@ -1104,7 +1082,7 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T2, class _E2)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_void, _T2)))
+  _CCCL_REQUIRES((!is_void_v<_T2>) )
   friend _CCCL_API constexpr bool operator==(const expected& __x, const expected<_T2, _E2>& __y)
   {
     if (__x.__has_val_ != __y.has_value())
@@ -1127,7 +1105,7 @@ public:
 #if _CCCL_STD_VER < 2020
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T2, class _E2)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_void, _T2)))
+  _CCCL_REQUIRES((!is_void_v<_T2>) )
   friend _CCCL_API constexpr bool operator!=(const expected& __x, const expected<_T2, _E2>& __y)
   {
     return !(__x == __y);
@@ -1229,49 +1207,48 @@ public:
   _CCCL_HIDE_FROM_ABI constexpr expected& operator=(expected&&)      = default;
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _OtherErr&>::value _CCCL_AND _CCCL_TRAIT(
-    is_convertible, const _OtherErr&, _Err))
+  _CCCL_REQUIRES(
+    __can_convert<_Up, _OtherErr, const _OtherErr&>::value _CCCL_AND is_convertible_v<const _OtherErr&, _Err>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 expected(const expected<_Up, _OtherErr>& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, const _OtherErr&)) // strengthened
+    is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
       : __base(__other.__has_val_)
   {
     if (!__other.__has_val_)
     {
       _CUDA_VSTD::__construct_at(_CUDA_VSTD::addressof(this->__union_.__unex_), __other.__union_.__unex_);
-    }
-  }
-
-  _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _OtherErr&>::value _CCCL_AND(
-    !_CCCL_TRAIT(is_convertible, const _OtherErr&, _Err)))
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit expected(const expected<_Up, _OtherErr>& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, const _OtherErr&)) // strengthened
-      : __base(__other.__has_val_)
-  {
-    if (!__other.__has_val_)
-    {
-      _CUDA_VSTD::__construct_at(_CUDA_VSTD::addressof(this->__union_.__unex_), __other.__union_.__unex_);
-    }
-  }
-
-  _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _OtherErr>::value _CCCL_AND _CCCL_TRAIT(is_convertible, _OtherErr, _Err))
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 expected(expected<_Up, _OtherErr>&& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _OtherErr)) // strengthened
-      : __base(__other.__has_val_)
-  {
-    if (!__other.__has_val_)
-    {
-      _CUDA_VSTD::__construct_at(
-        _CUDA_VSTD::addressof(this->__union_.__unex_), _CUDA_VSTD::move(__other.__union_.__unex_));
     }
   }
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
   _CCCL_REQUIRES(
-    __can_convert<_Up, _OtherErr, _OtherErr>::value _CCCL_AND(!_CCCL_TRAIT(is_convertible, _OtherErr, _Err)))
+    __can_convert<_Up, _OtherErr, const _OtherErr&>::value _CCCL_AND(!is_convertible_v<const _OtherErr&, _Err>))
+  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit expected(const expected<_Up, _OtherErr>& __other) noexcept(
+    is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
+      : __base(__other.__has_val_)
+  {
+    if (!__other.__has_val_)
+    {
+      _CUDA_VSTD::__construct_at(_CUDA_VSTD::addressof(this->__union_.__unex_), __other.__union_.__unex_);
+    }
+  }
+
+  _CCCL_TEMPLATE(class _Up, class _OtherErr)
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _OtherErr>::value _CCCL_AND is_convertible_v<_OtherErr, _Err>)
+  _CCCL_API inline _CCCL_CONSTEXPR_CXX20
+  expected(expected<_Up, _OtherErr>&& __other) noexcept(is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
+      : __base(__other.__has_val_)
+  {
+    if (!__other.__has_val_)
+    {
+      _CUDA_VSTD::__construct_at(
+        _CUDA_VSTD::addressof(this->__union_.__unex_), _CUDA_VSTD::move(__other.__union_.__unex_));
+    }
+  }
+
+  _CCCL_TEMPLATE(class _Up, class _OtherErr)
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _OtherErr>::value _CCCL_AND(!is_convertible_v<_OtherErr, _Err>))
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit expected(expected<_Up, _OtherErr>&& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _OtherErr)) // strengthened
+    is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
       : __base(__other.__has_val_)
   {
     if (!__other.__has_val_)
@@ -1282,33 +1259,30 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherErr)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, const _OtherErr&)
-                   _CCCL_AND _CCCL_TRAIT(is_convertible, const _OtherErr&, _Err))
+  _CCCL_REQUIRES(is_constructible_v<_Err, const _OtherErr&> _CCCL_AND is_convertible_v<const _OtherErr&, _Err>)
   _CCCL_API constexpr expected(const unexpected<_OtherErr>& __unex) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, const _OtherErr&)) // strengthened
+    is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
       : __base(unexpect, __unex.error())
   {}
 
   _CCCL_TEMPLATE(class _OtherErr)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, const _OtherErr&)
-                   _CCCL_AND(!_CCCL_TRAIT(is_convertible, const _OtherErr&, _Err)))
+  _CCCL_REQUIRES(is_constructible_v<_Err, const _OtherErr&> _CCCL_AND(!is_convertible_v<const _OtherErr&, _Err>))
   _CCCL_API constexpr explicit expected(const unexpected<_OtherErr>& __unex) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, const _OtherErr&)) // strengthened
+    is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
       : __base(unexpect, __unex.error())
   {}
 
   _CCCL_TEMPLATE(class _OtherErr)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, _OtherErr) _CCCL_AND _CCCL_TRAIT(is_convertible, _OtherErr, _Err))
+  _CCCL_REQUIRES(is_constructible_v<_Err, _OtherErr> _CCCL_AND is_convertible_v<_OtherErr, _Err>)
   _CCCL_API constexpr expected(unexpected<_OtherErr>&& __unex) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _OtherErr)) // strengthened
+    is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
       : __base(unexpect, _CUDA_VSTD::move(__unex.error()))
   {}
 
   _CCCL_TEMPLATE(class _OtherErr)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, _OtherErr)
-                   _CCCL_AND(!_CCCL_TRAIT(is_convertible, _OtherErr, _Err)))
+  _CCCL_REQUIRES(is_constructible_v<_Err, _OtherErr> _CCCL_AND(!is_convertible_v<_OtherErr, _Err>))
   _CCCL_API constexpr explicit expected(unexpected<_OtherErr>&& __unex) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _OtherErr)) // strengthened
+    is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
       : __base(unexpect, _CUDA_VSTD::move(__unex.error()))
   {}
 
@@ -1317,19 +1291,16 @@ public:
   {}
 
   _CCCL_TEMPLATE(class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, _Args...))
+  _CCCL_REQUIRES(is_constructible_v<_Err, _Args...>)
   _CCCL_API constexpr explicit expected(unexpect_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...)) // strengthened
+    is_nothrow_constructible_v<_Err, _Args...>) // strengthened
       : __base(unexpect, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class _Up, class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, initializer_list<_Up>&, _Args...))
-  _CCCL_API constexpr explicit expected(unexpect_t, initializer_list<_Up> __il, _Args&&... __args) noexcept(_CCCL_TRAIT(
-    is_nothrow_constructible,
-    _Err,
-    initializer_list<_Up>,
-    _Args...)) // strengthened
+  _CCCL_REQUIRES(is_constructible_v<_Err, initializer_list<_Up>&, _Args...>)
+  _CCCL_API constexpr explicit expected(unexpect_t, initializer_list<_Up> __il, _Args&&... __args) noexcept(
+    is_nothrow_constructible_v<_Err, initializer_list<_Up>, _Args...>) // strengthened
       : __base(unexpect, __il, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
@@ -1339,7 +1310,7 @@ private:
     __expected_construct_from_invoke_tag,
     unexpect_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
       : __base(__expected_construct_from_invoke_tag{},
                unexpect,
                _CUDA_VSTD::forward<_Fun>(__fun),
@@ -1351,11 +1322,10 @@ public:
   // [expected.void.assign], assignment
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherErr)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, const _OtherErr&)
-                   _CCCL_AND _CCCL_TRAIT(is_assignable, _Err&, const _OtherErr&))
+  _CCCL_REQUIRES(is_constructible_v<_Err, const _OtherErr&> _CCCL_AND is_assignable_v<_Err&, const _OtherErr&>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 expected& operator=(const unexpected<_OtherErr>& __un) noexcept(
-    _CCCL_TRAIT(is_nothrow_assignable, _Err&, const _OtherErr&)
-    && _CCCL_TRAIT(is_nothrow_constructible, _Err, const _OtherErr&)) // strengthened
+    is_nothrow_assignable_v<_Err&, const _OtherErr&>
+    && is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
   {
     if (this->__has_val_)
     {
@@ -1371,9 +1341,9 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherErr)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, _OtherErr) _CCCL_AND _CCCL_TRAIT(is_assignable, _Err&, _OtherErr))
+  _CCCL_REQUIRES(is_constructible_v<_Err, _OtherErr> _CCCL_AND is_assignable_v<_Err&, _OtherErr>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 expected& operator=(unexpected<_OtherErr>&& __un) noexcept(
-    _CCCL_TRAIT(is_nothrow_assignable, _Err&, _OtherErr) && _CCCL_TRAIT(is_nothrow_constructible, _Err, _OtherErr))
+    is_nothrow_assignable_v<_Err&, _OtherErr> && is_nothrow_constructible_v<_Err, _OtherErr>)
   {
     if (this->__has_val_)
     {
@@ -1399,8 +1369,8 @@ public:
   // [expected.void.swap], swap
   _CCCL_TEMPLATE(class _Err2 = _Err)
   _CCCL_REQUIRES(__expected::__can_swap<void, _Err2>)
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void swap(expected<void, _Err2>& __rhs) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_constructible, _Err2) && _CCCL_TRAIT(is_nothrow_swappable, _Err2))
+  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void
+  swap(expected<void, _Err2>& __rhs) noexcept(is_nothrow_move_constructible_v<_Err2> && is_nothrow_swappable_v<_Err2>)
   {
     if (this->__has_val_)
     {
@@ -1424,8 +1394,8 @@ public:
   }
 
   template <class _Err2 = _Err>
-  friend _CCCL_API inline _CCCL_CONSTEXPR_CXX20 auto swap(expected& __x, expected& __y) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_constructible, _Err2) && _CCCL_TRAIT(is_nothrow_swappable, _Err2))
+  friend _CCCL_API inline _CCCL_CONSTEXPR_CXX20 auto
+  swap(expected& __x, expected& __y) noexcept(is_nothrow_move_constructible_v<_Err2> && is_nothrow_swappable_v<_Err2>)
     _CCCL_TRAILING_REQUIRES(void)(__expected::__can_swap<void, _Err2>)
   {
     return __x.swap(__y); // some compiler warn about non void function without return
@@ -1449,8 +1419,7 @@ public:
 
   _CCCL_API constexpr void value() const&
   {
-    static_assert(_CCCL_TRAIT(is_copy_constructible, _Err),
-                  "expected::value() const& requires is_copy_constructible_v<E>");
+    static_assert(is_copy_constructible_v<_Err>, "expected::value() const& requires is_copy_constructible_v<E>");
     if (!this->__has_val_)
     {
       __throw_bad_expected_access<_Err>(this->__union_.__unex_);
@@ -1459,8 +1428,8 @@ public:
 
   _CCCL_API constexpr void value() &&
   {
-    static_assert(_CCCL_TRAIT(is_copy_constructible, _Err), "expected::value() && requires is_copy_constructible_v<E>");
-    static_assert(_CCCL_TRAIT(is_move_constructible, _Err), "expected::value() && requires is_move_constructible_v<E>");
+    static_assert(is_copy_constructible_v<_Err>, "expected::value() && requires is_copy_constructible_v<E>");
+    static_assert(is_move_constructible_v<_Err>, "expected::value() && requires is_move_constructible_v<E>");
     if (!this->__has_val_)
     {
       __throw_bad_expected_access<_Err>(_CUDA_VSTD::move(this->__union_.__unex_));
@@ -1493,13 +1462,13 @@ public:
 
   // [expected.void.monadic]
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&))
+  _CCCL_REQUIRES(is_constructible_v<_Err2, _Err2&>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) &
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
+    static_assert(is_same_v<typename _Res::error_type, _Err>,
                   "The error type of the result of f(value()) must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -1513,13 +1482,13 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2))
+  _CCCL_REQUIRES(is_copy_constructible_v<_Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) const&
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
+    static_assert(is_same_v<typename _Res::error_type, _Err>,
                   "The error type of the result of f(value()) must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -1533,13 +1502,13 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2))
+  _CCCL_REQUIRES(is_move_constructible_v<_Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) &&
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
+    static_assert(is_same_v<typename _Res::error_type, _Err>,
                   "The error type of the result of f(value()) must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -1553,13 +1522,13 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2))
+  _CCCL_REQUIRES(is_constructible_v<_Err2, const _Err2>)
   _CCCL_API constexpr auto and_then(_Fun&& __fun) const&&
   {
     using _Res = remove_cvref_t<invoke_result_t<_Fun>>;
 
     static_assert(__expected::__is_expected<_Res>, "Result of f(value()) must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::error_type, _Err),
+    static_assert(is_same_v<typename _Res::error_type, _Err>,
                   "The error type of the result of f(value()) must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -1579,7 +1548,7 @@ public:
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::value_type, void),
+    static_assert(is_same_v<typename _Res::value_type, void>,
                   "The value type of the result of std::expected::or_else must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -1599,7 +1568,7 @@ public:
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::value_type, void),
+    static_assert(is_same_v<typename _Res::value_type, void>,
                   "The value type of the result of std::expected::or_else must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -1619,7 +1588,7 @@ public:
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::value_type, void),
+    static_assert(is_same_v<typename _Res::value_type, void>,
                   "The value type of the result of std::expected::or_else must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -1639,7 +1608,7 @@ public:
 
     static_assert(__expected::__is_expected<_Res>,
                   "Result of std::expected::or_else must be a specialization of std::expected");
-    static_assert(_CCCL_TRAIT(is_same, typename _Res::value_type, void),
+    static_assert(is_same_v<typename _Res::value_type, void>,
                   "The value type of the result of std::expected::or_else must be the same as that of std::expected");
 
     if (this->__has_val_)
@@ -1653,8 +1622,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&)
-                   _CCCL_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void))
+  _CCCL_REQUIRES(is_constructible_v<_Err2, _Err2&> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T.");
@@ -1670,8 +1638,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, _Err2&)
-                   _CCCL_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void)))
+  _CCCL_REQUIRES(is_constructible_v<_Err2, _Err2&> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) &
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T.");
@@ -1695,8 +1662,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2)
-                   _CCCL_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void))
+  _CCCL_REQUIRES(is_copy_constructible_v<_Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T.");
@@ -1712,8 +1678,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_copy_constructible, _Err2)
-                   _CCCL_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void)))
+  _CCCL_REQUIRES(is_copy_constructible_v<_Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T");
@@ -1737,8 +1702,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2)
-                   _CCCL_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void))
+  _CCCL_REQUIRES(is_move_constructible_v<_Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T.");
@@ -1753,8 +1717,7 @@ public:
     }
   }
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_move_constructible, _Err2)
-                   _CCCL_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void)))
+  _CCCL_REQUIRES(is_move_constructible_v<_Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) &&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T");
@@ -1778,8 +1741,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2)
-                   _CCCL_AND _CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void))
+  _CCCL_REQUIRES(is_constructible_v<_Err2, const _Err2> _CCCL_AND is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>)
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T.");
@@ -1795,8 +1757,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Fun, class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err2, const _Err2)
-                   _CCCL_AND(!_CCCL_TRAIT(is_same, remove_cv_t<invoke_result_t<_Fun>>, void)))
+  _CCCL_REQUIRES(is_constructible_v<_Err2, const _Err2> _CCCL_AND(!is_same_v<remove_cv_t<invoke_result_t<_Fun>>, void>))
   _CCCL_API constexpr auto transform(_Fun&& __fun) const&&
   {
     static_assert(invocable<_Fun>, "std::expected::transform requires that F must be invocable with T");

--- a/libcudacxx/include/cuda/std/__expected/expected_base.h
+++ b/libcudacxx/include/cuda/std/__expected/expected_base.h
@@ -63,9 +63,7 @@ struct __expected_construct_from_invoke_tag
   _CCCL_HIDE_FROM_ABI explicit __expected_construct_from_invoke_tag() = default;
 };
 
-template <class _Tp,
-          class _Err,
-          bool = _CCCL_TRAIT(is_trivially_destructible, _Tp) && _CCCL_TRAIT(is_trivially_destructible, _Err)>
+template <class _Tp, class _Err, bool = is_trivially_destructible_v<_Tp> && is_trivially_destructible_v<_Err>>
 union __expected_union_t
 {
   struct __empty_t
@@ -73,29 +71,29 @@ union __expected_union_t
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_default_constructible, _Tp2))
-  _CCCL_API constexpr __expected_union_t() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _Tp2))
+  _CCCL_REQUIRES(is_default_constructible_v<_Tp2>)
+  _CCCL_API constexpr __expected_union_t() noexcept(is_nothrow_default_constructible_v<_Tp2>)
       : __val_()
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_default_constructible, _Tp2)))
+  _CCCL_REQUIRES((!is_default_constructible_v<_Tp2>) )
   _CCCL_API constexpr __expected_union_t() noexcept
       : __empty_()
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args>
-  _CCCL_API constexpr __expected_union_t(in_place_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+  _CCCL_API constexpr __expected_union_t(in_place_t,
+                                         _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : __val_(_CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args>
-  _CCCL_API constexpr __expected_union_t(unexpect_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+  _CCCL_API constexpr __expected_union_t(unexpect_t,
+                                         _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
       : __unex_(_CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
@@ -105,7 +103,7 @@ union __expected_union_t
     __expected_construct_from_invoke_tag,
     in_place_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __val_(_CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Fun>(__fun), _CUDA_VSTD::forward<_Args>(__args)...))
   {}
 
@@ -115,7 +113,7 @@ union __expected_union_t
     __expected_construct_from_invoke_tag,
     unexpect_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
       : __unex_(_CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Fun>(__fun), _CUDA_VSTD::forward<_Args>(__args)...))
   {}
 
@@ -136,29 +134,29 @@ union __expected_union_t<_Tp, _Err, true>
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_default_constructible, _Tp2))
-  _CCCL_API constexpr __expected_union_t() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _Tp2))
+  _CCCL_REQUIRES(is_default_constructible_v<_Tp2>)
+  _CCCL_API constexpr __expected_union_t() noexcept(is_nothrow_default_constructible_v<_Tp2>)
       : __val_()
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_default_constructible, _Tp2)))
+  _CCCL_REQUIRES((!is_default_constructible_v<_Tp2>) )
   _CCCL_API constexpr __expected_union_t() noexcept
       : __empty_()
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args>
-  _CCCL_API constexpr __expected_union_t(in_place_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+  _CCCL_API constexpr __expected_union_t(in_place_t,
+                                         _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : __val_(_CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args>
-  _CCCL_API constexpr __expected_union_t(unexpect_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+  _CCCL_API constexpr __expected_union_t(unexpect_t,
+                                         _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
       : __unex_(_CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
@@ -168,7 +166,7 @@ union __expected_union_t<_Tp, _Err, true>
     __expected_construct_from_invoke_tag,
     in_place_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __val_(_CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Fun>(__fun), _CUDA_VSTD::forward<_Args>(__args)...))
   {}
 
@@ -178,7 +176,7 @@ union __expected_union_t<_Tp, _Err, true>
     __expected_construct_from_invoke_tag,
     unexpect_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
       : __unex_(_CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Fun>(__fun), _CUDA_VSTD::forward<_Args>(__args)...))
   {}
 
@@ -187,10 +185,7 @@ union __expected_union_t<_Tp, _Err, true>
   _CCCL_NO_UNIQUE_ADDRESS _Err __unex_;
 };
 
-template <class _Tp,
-          class _Err,
-          bool = _CCCL_TRAIT(is_trivially_destructible, _Tp),
-          bool = _CCCL_TRAIT(is_trivially_destructible, _Err)>
+template <class _Tp, class _Err, bool = is_trivially_destructible_v<_Tp>, bool = is_trivially_destructible_v<_Err>>
 struct __expected_destruct;
 
 template <class _Tp, class _Err>
@@ -201,21 +196,20 @@ struct __expected_destruct<_Tp, _Err, false, false>
 
   _CCCL_HIDE_FROM_ABI constexpr __expected_destruct() = default;
 
-  _CCCL_API constexpr __expected_destruct(const bool __has_val) noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Tp))
+  _CCCL_API constexpr __expected_destruct(const bool __has_val) noexcept(is_nothrow_default_constructible_v<_Tp>)
       : __has_val_(__has_val)
   {}
 
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(in_place_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+  _CCCL_API constexpr __expected_destruct(in_place_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : __union_(in_place, _CUDA_VSTD::forward<_Args>(__args)...)
       , __has_val_(true)
   {}
 
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(unexpect_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+  _CCCL_API constexpr __expected_destruct(unexpect_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
       : __union_(unexpect, _CUDA_VSTD::forward<_Args>(__args)...)
       , __has_val_(false)
   {}
@@ -225,7 +219,7 @@ struct __expected_destruct<_Tp, _Err, false, false>
     __expected_construct_from_invoke_tag,
     in_place_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
                  in_place,
                  _CUDA_VSTD::forward<_Fun>(__fun),
@@ -238,7 +232,7 @@ struct __expected_destruct<_Tp, _Err, false, false>
     __expected_construct_from_invoke_tag,
     unexpect_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
                  unexpect,
                  _CUDA_VSTD::forward<_Fun>(__fun),
@@ -268,21 +262,20 @@ struct __expected_destruct<_Tp, _Err, true, false>
 
   _CCCL_HIDE_FROM_ABI constexpr __expected_destruct() = default;
 
-  _CCCL_API constexpr __expected_destruct(const bool __has_val) noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Tp))
+  _CCCL_API constexpr __expected_destruct(const bool __has_val) noexcept(is_nothrow_default_constructible_v<_Tp>)
       : __has_val_(__has_val)
   {}
 
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(in_place_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+  _CCCL_API constexpr __expected_destruct(in_place_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : __union_(in_place, _CUDA_VSTD::forward<_Args>(__args)...)
       , __has_val_(true)
   {}
 
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(unexpect_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+  _CCCL_API constexpr __expected_destruct(unexpect_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
       : __union_(unexpect, _CUDA_VSTD::forward<_Args>(__args)...)
       , __has_val_(false)
   {}
@@ -292,7 +285,7 @@ struct __expected_destruct<_Tp, _Err, true, false>
     __expected_construct_from_invoke_tag,
     in_place_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
                  in_place,
                  _CUDA_VSTD::forward<_Fun>(__fun),
@@ -305,7 +298,7 @@ struct __expected_destruct<_Tp, _Err, true, false>
     __expected_construct_from_invoke_tag,
     unexpect_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
                  unexpect,
                  _CUDA_VSTD::forward<_Fun>(__fun),
@@ -331,21 +324,20 @@ struct __expected_destruct<_Tp, _Err, false, true>
 
   _CCCL_HIDE_FROM_ABI constexpr __expected_destruct() = default;
 
-  _CCCL_API constexpr __expected_destruct(const bool __has_val) noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Tp))
+  _CCCL_API constexpr __expected_destruct(const bool __has_val) noexcept(is_nothrow_default_constructible_v<_Tp>)
       : __has_val_(__has_val)
   {}
 
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(in_place_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+  _CCCL_API constexpr __expected_destruct(in_place_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : __union_(in_place, _CUDA_VSTD::forward<_Args>(__args)...)
       , __has_val_(true)
   {}
 
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(unexpect_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+  _CCCL_API constexpr __expected_destruct(unexpect_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
       : __union_(unexpect, _CUDA_VSTD::forward<_Args>(__args)...)
       , __has_val_(false)
   {}
@@ -355,7 +347,7 @@ struct __expected_destruct<_Tp, _Err, false, true>
     __expected_construct_from_invoke_tag,
     in_place_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
                  in_place,
                  _CUDA_VSTD::forward<_Fun>(__fun),
@@ -368,7 +360,7 @@ struct __expected_destruct<_Tp, _Err, false, true>
     __expected_construct_from_invoke_tag,
     unexpect_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
                  unexpect,
                  _CUDA_VSTD::forward<_Fun>(__fun),
@@ -395,21 +387,20 @@ struct __expected_destruct<_Tp, _Err, true, true>
 
   _CCCL_HIDE_FROM_ABI constexpr __expected_destruct() = default;
 
-  _CCCL_API constexpr __expected_destruct(const bool __has_val) noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Tp))
+  _CCCL_API constexpr __expected_destruct(const bool __has_val) noexcept(is_nothrow_default_constructible_v<_Tp>)
       : __has_val_(__has_val)
   {}
 
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(in_place_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+  _CCCL_API constexpr __expected_destruct(in_place_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : __union_(in_place, _CUDA_VSTD::forward<_Args>(__args)...)
       , __has_val_(true)
   {}
 
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(unexpect_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+  _CCCL_API constexpr __expected_destruct(unexpect_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
       : __union_(unexpect, _CUDA_VSTD::forward<_Args>(__args)...)
       , __has_val_(false)
   {}
@@ -419,7 +410,7 @@ struct __expected_destruct<_Tp, _Err, true, true>
     __expected_construct_from_invoke_tag,
     in_place_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
                  in_place,
                  _CUDA_VSTD::forward<_Fun>(__fun),
@@ -432,7 +423,7 @@ struct __expected_destruct<_Tp, _Err, true, true>
     __expected_construct_from_invoke_tag,
     unexpect_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
                  unexpect,
                  _CUDA_VSTD::forward<_Fun>(__fun),
@@ -450,7 +441,7 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T1, class _T2, class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_nothrow_constructible, _T1, _Args...))
+  _CCCL_REQUIRES(is_nothrow_constructible_v<_T1, _Args...>)
   static _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void
   __reinit_expected(_T1& __newval, _T2& __oldval, _Args&&... __args) noexcept
   {
@@ -460,8 +451,7 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T1, class _T2, class... _Args)
-  _CCCL_REQUIRES(
-    (!_CCCL_TRAIT(is_nothrow_constructible, _T1, _Args...)) _CCCL_AND _CCCL_TRAIT(is_nothrow_move_constructible, _T1))
+  _CCCL_REQUIRES((!is_nothrow_constructible_v<_T1, _Args...>) _CCCL_AND is_nothrow_move_constructible_v<_T1>)
   static _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void __reinit_expected(_T1& __newval, _T2& __oldval, _Args&&... __args)
   {
     _T1 __tmp(_CUDA_VSTD::forward<_Args>(__args)...);
@@ -471,12 +461,11 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T1, class _T2, class... _Args)
-  _CCCL_REQUIRES(
-    (!_CCCL_TRAIT(is_nothrow_constructible, _T1, _Args...)) _CCCL_AND(!_CCCL_TRAIT(is_nothrow_move_constructible, _T1)))
+  _CCCL_REQUIRES((!is_nothrow_constructible_v<_T1, _Args...>) _CCCL_AND(!is_nothrow_move_constructible_v<_T1>))
   static _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void __reinit_expected(_T1& __newval, _T2& __oldval, _Args&&... __args)
   {
     static_assert(
-      _CCCL_TRAIT(is_nothrow_move_constructible, _T2),
+      is_nothrow_move_constructible_v<_T2>,
       "To provide strong exception guarantee, T2 has to satisfy `is_nothrow_move_constructible_v` so that it can "
       "be reverted to the previous state in case an exception is thrown during the assignment.");
     _T2 __tmp(_CUDA_VSTD::move(__oldval));
@@ -490,7 +479,7 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_nothrow_move_constructible, _Err2))
+  _CCCL_REQUIRES(is_nothrow_move_constructible_v<_Err2>)
   static _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void
   __swap_val_unex_impl(__expected_storage<_Tp, _Err2>& __with_val, __expected_storage& __with_err)
   {
@@ -510,11 +499,11 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Err2 = _Err)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_nothrow_move_constructible, _Err2)))
+  _CCCL_REQUIRES((!is_nothrow_move_constructible_v<_Err2>) )
   static _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void
   __swap_val_unex_impl(__expected_storage<_Tp, _Err2>& __with_val, __expected_storage& __with_err)
   {
-    static_assert(_CCCL_TRAIT(is_nothrow_move_constructible, _Tp),
+    static_assert(is_nothrow_move_constructible_v<_Tp>,
                   "To provide strong exception guarantee, Tp has to satisfy `is_nothrow_move_constructible_v` so "
                   "that it can be reverted to the previous state in case an exception is thrown during swap.");
     _Tp __tmp(_CUDA_VSTD::move(__with_val.__union_.__val_));
@@ -534,11 +523,9 @@ struct __expected_storage : __expected_destruct<_Tp, _Err>
 
 template <class _Tp, class _Err>
 inline constexpr __smf_availability __expected_can_copy_construct =
-  (_CCCL_TRAIT(is_trivially_copy_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_trivially_copy_constructible, _Err)
+  (is_trivially_copy_constructible_v<_Tp> || is_same_v<_Tp, void>) && is_trivially_copy_constructible_v<_Err>
     ? __smf_availability::__trivial
-  : (_CCCL_TRAIT(is_copy_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_copy_constructible, _Err)
+  : (is_copy_constructible_v<_Tp> || is_same_v<_Tp, void>) && is_copy_constructible_v<_Err>
     ? __smf_availability::__available
     : __smf_availability::__deleted;
 
@@ -554,7 +541,7 @@ struct __expected_copy<_Tp, _Err, __smf_availability::__available> : __expected_
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__expected_copy, __expected_storage, _Tp, _Err);
 
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 __expected_copy(const __expected_copy& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_copy_constructible, _Tp) && _CCCL_TRAIT(is_nothrow_copy_constructible, _Err))
+    is_nothrow_copy_constructible_v<_Tp> && is_nothrow_copy_constructible_v<_Err>)
       : __base(__other.__has_val_)
   {
     if (__other.__has_val_)
@@ -585,11 +572,9 @@ struct __expected_copy<_Tp, _Err, __smf_availability::__deleted> : __expected_st
 
 template <class _Tp, class _Err>
 inline constexpr __smf_availability __expected_can_move_construct =
-  (_CCCL_TRAIT(is_trivially_move_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_trivially_move_constructible, _Err)
+  (is_trivially_move_constructible_v<_Tp> || is_same_v<_Tp, void>) && is_trivially_move_constructible_v<_Err>
     ? __smf_availability::__trivial
-  : (_CCCL_TRAIT(is_move_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_move_constructible, _Err)
+  : (is_move_constructible_v<_Tp> || is_same_v<_Tp, void>) && is_move_constructible_v<_Err>
     ? __smf_availability::__available
     : __smf_availability::__deleted;
 
@@ -607,7 +592,7 @@ struct __expected_move<_Tp, _Err, __smf_availability::__available> : __expected_
   _CCCL_HIDE_FROM_ABI __expected_move(const __expected_move&) = default;
 
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 __expected_move(__expected_move&& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_constructible, _Tp) && _CCCL_TRAIT(is_nothrow_move_constructible, _Err))
+    is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_constructible_v<_Err>)
       : __base(__other.__has_val_)
   {
     if (__other.__has_val_)
@@ -640,21 +625,14 @@ struct __expected_move<_Tp, _Err, __smf_availability::__deleted> : __expected_co
 // Need to also check against is_nothrow_move_constructible in the trivial case as that is stupidly in the constraints
 template <class _Tp, class _Err>
 inline constexpr __smf_availability __expected_can_copy_assign =
-  (_CCCL_TRAIT(is_trivially_destructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_trivially_destructible, _Err)
-      && (_CCCL_TRAIT(is_trivially_copy_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_trivially_copy_constructible, _Err)
-      && (_CCCL_TRAIT(is_trivially_copy_assignable, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_trivially_copy_assignable, _Err)
-      && (_CCCL_TRAIT(is_nothrow_move_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void)
-          || _CCCL_TRAIT(is_nothrow_move_constructible, _Err))
+  (is_trivially_destructible_v<_Tp> || is_same_v<_Tp, void>) && is_trivially_destructible_v<_Err>
+      && (is_trivially_copy_constructible_v<_Tp> || is_same_v<_Tp, void>) && is_trivially_copy_constructible_v<_Err>
+      && (is_trivially_copy_assignable_v<_Tp> || is_same_v<_Tp, void>) && is_trivially_copy_assignable_v<_Err>
+      && (is_nothrow_move_constructible_v<_Tp> || is_same_v<_Tp, void> || is_nothrow_move_constructible_v<_Err>)
     ? __smf_availability::__trivial
-  : (_CCCL_TRAIT(is_copy_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_copy_constructible, _Err)
-      && (_CCCL_TRAIT(is_copy_assignable, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_copy_assignable, _Err)
-      && (_CCCL_TRAIT(is_nothrow_move_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void)
-          || _CCCL_TRAIT(is_nothrow_move_constructible, _Err))
+  : (is_copy_constructible_v<_Tp> || is_same_v<_Tp, void>) && is_copy_constructible_v<_Err>
+      && (is_copy_assignable_v<_Tp> || is_same_v<_Tp, void>) && is_copy_assignable_v<_Err>
+      && (is_nothrow_move_constructible_v<_Tp> || is_same_v<_Tp, void> || is_nothrow_move_constructible_v<_Err>)
     ? __smf_availability::__available
     : __smf_availability::__deleted;
 
@@ -675,9 +653,8 @@ struct __expected_copy_assign<_Tp, _Err, __smf_availability::__available> : __ex
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 __expected_copy_assign&
   operator=(const __expected_copy_assign& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_copy_assignable, _Tp) && _CCCL_TRAIT(is_nothrow_copy_constructible, _Tp)
-    && _CCCL_TRAIT(is_nothrow_copy_assignable, _Err)
-    && _CCCL_TRAIT(is_nothrow_copy_constructible, _Err)) // strengthened
+    is_nothrow_copy_assignable_v<_Tp> && is_nothrow_copy_constructible_v<_Tp> && is_nothrow_copy_assignable_v<_Err>
+    && is_nothrow_copy_constructible_v<_Err>) // strengthened
   {
     if (this->__has_val_ && __other.__has_val_)
     {
@@ -716,19 +693,13 @@ struct __expected_copy_assign<_Tp, _Err, __smf_availability::__deleted> : __expe
 
 template <class _Tp, class _Err>
 inline constexpr __smf_availability __expected_can_move_assign =
-  (_CCCL_TRAIT(is_trivially_destructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_trivially_destructible, _Err)
-      && (_CCCL_TRAIT(is_trivially_move_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_trivially_move_constructible, _Err)
-      && (_CCCL_TRAIT(is_trivially_move_assignable, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_trivially_move_assignable, _Err)
+  (is_trivially_destructible_v<_Tp> || is_same_v<_Tp, void>) && is_trivially_destructible_v<_Err>
+      && (is_trivially_move_constructible_v<_Tp> || is_same_v<_Tp, void>) && is_trivially_move_constructible_v<_Err>
+      && (is_trivially_move_assignable_v<_Tp> || is_same_v<_Tp, void>) && is_trivially_move_assignable_v<_Err>
     ? __smf_availability::__trivial
-  : (_CCCL_TRAIT(is_move_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_move_constructible, _Err)
-      && (_CCCL_TRAIT(is_move_assignable, _Tp) || _CCCL_TRAIT(is_same, _Tp, void))
-      && _CCCL_TRAIT(is_move_assignable, _Err)
-      && (_CCCL_TRAIT(is_nothrow_move_constructible, _Tp) || _CCCL_TRAIT(is_same, _Tp, void)
-          || _CCCL_TRAIT(is_nothrow_move_constructible, _Err))
+  : (is_move_constructible_v<_Tp> || is_same_v<_Tp, void>) && is_move_constructible_v<_Err>
+      && (is_move_assignable_v<_Tp> || is_same_v<_Tp, void>) && is_move_assignable_v<_Err>
+      && (is_nothrow_move_constructible_v<_Tp> || is_same_v<_Tp, void> || is_nothrow_move_constructible_v<_Err>)
     ? __smf_availability::__available
     : __smf_availability::__deleted;
 
@@ -749,9 +720,8 @@ struct __expected_move_assign<_Tp, _Err, __smf_availability::__available> : __ex
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 __expected_move_assign& operator=(__expected_move_assign&& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_assignable, _Tp) && _CCCL_TRAIT(is_nothrow_move_constructible, _Tp)
-    && _CCCL_TRAIT(is_nothrow_move_assignable, _Err)
-    && _CCCL_TRAIT(is_nothrow_move_constructible, _Err)) // strengthened
+    is_nothrow_move_assignable_v<_Tp> && is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_assignable_v<_Err>
+    && is_nothrow_move_constructible_v<_Err>) // strengthened
   {
     if (this->__has_val_ && __other.__has_val_)
     {
@@ -805,8 +775,8 @@ struct __expected_destruct<void, _Err, false, false>
 
     _CCCL_EXEC_CHECK_DISABLE
     template <class... _Args>
-    _CCCL_API constexpr __expected_union_t(unexpect_t, _Args&&... __args) noexcept(
-      _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+    _CCCL_API constexpr __expected_union_t(unexpect_t,
+                                           _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
         : __unex_(_CUDA_VSTD::forward<_Args>(__args)...)
     {}
 
@@ -816,7 +786,7 @@ struct __expected_destruct<void, _Err, false, false>
       __expected_construct_from_invoke_tag,
       unexpect_t,
       _Fun&& __fun,
-      _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+      _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
         : __unex_(_CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Fun>(__fun), _CUDA_VSTD::forward<_Args>(__args)...))
     {}
 
@@ -837,8 +807,8 @@ struct __expected_destruct<void, _Err, false, false>
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(unexpect_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+  _CCCL_API constexpr __expected_destruct(unexpect_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
       : __union_(unexpect, _CUDA_VSTD::forward<_Args>(__args)...)
       , __has_val_(false)
   {}
@@ -849,7 +819,7 @@ struct __expected_destruct<void, _Err, false, false>
     __expected_construct_from_invoke_tag,
     unexpect_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
                  unexpect,
                  _CUDA_VSTD::forward<_Fun>(__fun),
@@ -882,8 +852,8 @@ struct __expected_destruct<void, _Err, false, true>
 
     _CCCL_EXEC_CHECK_DISABLE
     template <class... _Args>
-    _CCCL_API constexpr __expected_union_t(unexpect_t, _Args&&... __args) noexcept(
-      _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+    _CCCL_API constexpr __expected_union_t(unexpect_t,
+                                           _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
         : __unex_(_CUDA_VSTD::forward<_Args>(__args)...)
     {}
 
@@ -893,7 +863,7 @@ struct __expected_destruct<void, _Err, false, true>
       __expected_construct_from_invoke_tag,
       unexpect_t,
       _Fun&& __fun,
-      _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+      _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
         : __unex_(_CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Fun>(__fun), _CUDA_VSTD::forward<_Args>(__args)...))
     {}
 
@@ -906,15 +876,15 @@ struct __expected_destruct<void, _Err, false, true>
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(in_place_t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+  _CCCL_API constexpr __expected_destruct(in_place_t) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
       : __union_()
       , __has_val_(true)
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Args>
-  _CCCL_API constexpr __expected_destruct(unexpect_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+  _CCCL_API constexpr __expected_destruct(unexpect_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
       : __union_(unexpect, _CUDA_VSTD::forward<_Args>(__args)...)
       , __has_val_(false)
   {}
@@ -925,7 +895,7 @@ struct __expected_destruct<void, _Err, false, true>
     __expected_construct_from_invoke_tag,
     unexpect_t,
     _Fun&& __fun,
-    _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, invoke_result_t<_Fun, _Args...>))
+    _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, invoke_result_t<_Fun, _Args...>>)
       : __union_(__expected_construct_from_invoke_tag{},
                  unexpect,
                  _CUDA_VSTD::forward<_Fun>(__fun),
@@ -947,8 +917,7 @@ struct __expected_storage<void, _Err> : __expected_destruct<void, _Err>
 
   _CCCL_EXEC_CHECK_DISABLE
   static _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void __swap_val_unex_impl(
-    __expected_storage& __with_val,
-    __expected_storage& __with_err) noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Err))
+    __expected_storage& __with_val, __expected_storage& __with_err) noexcept(is_nothrow_move_constructible_v<_Err>)
   {
     _CUDA_VSTD::__construct_at(
       _CUDA_VSTD::addressof(__with_val.__union_.__unex_), _CUDA_VSTD::move(__with_err.__union_.__unex_));
@@ -964,7 +933,7 @@ struct __expected_copy<void, _Err, __smf_availability::__available> : __expected
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__expected_copy, __expected_storage, void, _Err);
 
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20
-  __expected_copy(const __expected_copy& __other) noexcept(_CCCL_TRAIT(is_nothrow_copy_constructible, _Err))
+  __expected_copy(const __expected_copy& __other) noexcept(is_nothrow_copy_constructible_v<_Err>)
       : __base(__other.__has_val_)
   {
     if (!__other.__has_val_)
@@ -986,7 +955,7 @@ struct __expected_move<void, _Err, __smf_availability::__available> : __expected
   _CCCL_HIDE_FROM_ABI __expected_move(const __expected_move&) = default;
 
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20
-  __expected_move(__expected_move&& __other) noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Err))
+  __expected_move(__expected_move&& __other) noexcept(is_nothrow_move_constructible_v<_Err>)
       : __base(__other.__has_val_)
   {
     if (!__other.__has_val_)
@@ -1011,7 +980,7 @@ struct __expected_copy_assign<void, _Err, __smf_availability::__available> : __e
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 __expected_copy_assign&
   operator=(const __expected_copy_assign& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_copy_assignable, _Err) && _CCCL_TRAIT(is_nothrow_copy_constructible, _Err)) // strengthened
+    is_nothrow_copy_assignable_v<_Err> && is_nothrow_copy_constructible_v<_Err>) // strengthened
   {
     if (this->__has_val_ && __other.__has_val_)
     {
@@ -1048,7 +1017,7 @@ struct __expected_move_assign<void, _Err, __smf_availability::__available> : __e
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 __expected_move_assign& operator=(__expected_move_assign&& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_assignable, _Err) && _CCCL_TRAIT(is_nothrow_move_constructible, _Err)) // strengthened
+    is_nothrow_move_assignable_v<_Err> && is_nothrow_move_constructible_v<_Err>) // strengthened
   {
     if (this->__has_val_ && __other.__has_val_)
     {

--- a/libcudacxx/include/cuda/std/__expected/unexpected.h
+++ b/libcudacxx/include/cuda/std/__expected/unexpected.h
@@ -53,8 +53,7 @@ inline constexpr bool __is_unexpected<unexpected<_Err>> = true;
 
 template <class _Tp>
 inline constexpr bool __valid_unexpected =
-  _CCCL_TRAIT(is_object, _Tp) && !_CCCL_TRAIT(is_array, _Tp) && !__is_unexpected<_Tp> && !_CCCL_TRAIT(is_const, _Tp)
-  && !_CCCL_TRAIT(is_volatile, _Tp);
+  is_object_v<_Tp> && !is_array_v<_Tp> && !__is_unexpected<_Tp> && !is_const_v<_Tp> && !is_volatile_v<_Tp>;
 } // namespace __unexpected
 
 // [expected.un.general]
@@ -75,26 +74,25 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Error = _Err)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_same, remove_cvref_t<_Error>, unexpected)
-                  && !_CCCL_TRAIT(is_same, remove_cvref_t<_Error>, in_place_t)
-                  && _CCCL_TRAIT(is_constructible, _Err, _Error)))
-  _CCCL_API constexpr explicit unexpected(_Error&& __error) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Err, _Error))
+  _CCCL_REQUIRES((!is_same_v<remove_cvref_t<_Error>, unexpected> && !is_same_v<remove_cvref_t<_Error>, in_place_t>
+                  && is_constructible_v<_Err, _Error>) )
+  _CCCL_API constexpr explicit unexpected(_Error&& __error) noexcept(is_nothrow_constructible_v<_Err, _Error>)
       : __unex_(_CUDA_VSTD::forward<_Error>(__error))
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, _Args...))
-  _CCCL_API constexpr explicit unexpected(in_place_t, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, _Args...))
+  _CCCL_REQUIRES(is_constructible_v<_Err, _Args...>)
+  _CCCL_API constexpr explicit unexpected(in_place_t,
+                                          _Args&&... __args) noexcept(is_nothrow_constructible_v<_Err, _Args...>)
       : __unex_(_CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Up, class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Err, initializer_list<_Up>&, _Args...))
+  _CCCL_REQUIRES(is_constructible_v<_Err, initializer_list<_Up>&, _Args...>)
   _CCCL_API constexpr explicit unexpected(in_place_t, initializer_list<_Up> __il, _Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Err, initializer_list<_Up>&, _Args...))
+    is_nothrow_constructible_v<_Err, initializer_list<_Up>&, _Args...>)
       : __unex_(__il, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
@@ -124,18 +122,17 @@ public:
 
   // [expected.un.swap]
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr void swap(unexpected& __other) noexcept(_CCCL_TRAIT(is_nothrow_swappable, _Err))
+  _CCCL_API constexpr void swap(unexpected& __other) noexcept(is_nothrow_swappable_v<_Err>)
   {
-    static_assert(_CCCL_TRAIT(is_swappable, _Err), "E must be swappable");
+    static_assert(is_swappable_v<_Err>, "E must be swappable");
     using _CUDA_VSTD::swap;
     swap(__unex_, __other.__unex_);
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Err2 = _Err)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_swappable, _Err2))
-  friend _CCCL_API constexpr void
-  swap(unexpected& __lhs, unexpected& __rhs) noexcept(_CCCL_TRAIT(is_nothrow_swappable, _Err2))
+  _CCCL_REQUIRES(is_swappable_v<_Err2>)
+  friend _CCCL_API constexpr void swap(unexpected& __lhs, unexpected& __rhs) noexcept(is_nothrow_swappable_v<_Err2>)
   {
     __lhs.swap(__rhs);
     return;

--- a/libcudacxx/include/cuda/std/__floating_point/cast.h
+++ b/libcudacxx/include/cuda/std/__floating_point/cast.h
@@ -33,66 +33,66 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _To, class _From>
 [[nodiscard]] _CCCL_API inline constexpr _To __fp_cast(_From __v) noexcept
 {
-  if constexpr (_CCCL_TRAIT(is_same, _From, float))
+  if constexpr (is_same_v<_From, float>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return __v;
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return static_cast<double>(__v);
     }
 #if _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return static_cast<long double>(__v);
     }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 #if _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return ::__float2half(__v);
     }
 #endif // _CCCL_HAS_NVFP16()
 #if _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return ::__float2bfloat16(__v);
     }
 #endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e4m3>(::__nv_cvt_float_to_fp8(__v, __NV_NOSAT, __NV_E4M3));
     }
 #endif // _CCCL_HAS_NVFP8_E4M3()
 #if _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e5m2>(::__nv_cvt_float_to_fp8(__v, __NV_NOSAT, __NV_E5M2));
     }
 #endif // _CCCL_HAS_NVFP8_E5M2()
 #if _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e8m0>(::__nv_cvt_float_to_e8m0(__v, __NV_NOSAT, cudaRoundZero));
     }
 #endif // _CCCL_HAS_NVFP8_E8M0()
 #if _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp6_e2m3>(::__nv_cvt_float_to_fp6(__v, __NV_E2M3, cudaRoundNearest));
     }
 #endif // _CCCL_HAS_NVFP6_E2M3()
 #if _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp6_e3m2>(::__nv_cvt_float_to_fp6(__v, __NV_E3M2, cudaRoundNearest));
     }
 #endif // _CCCL_HAS_NVFP6_E3M2()
 #if _CCCL_HAS_NVFP4_E2M1()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp4_e2m1>(::__nv_cvt_float_to_fp4(__v, __NV_E2M1, cudaRoundNearest));
     }
@@ -102,66 +102,66 @@ template <class _To, class _From>
       static_assert(__always_false_v<_To>, "Unsupported floating point format");
     }
   }
-  else if constexpr (_CCCL_TRAIT(is_same, _From, double))
+  else if constexpr (is_same_v<_From, double>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return static_cast<float>(__v);
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return __v;
     }
 #if _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return static_cast<long double>(__v);
     }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 #if _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return ::__double2half(__v);
     }
 #endif // _CCCL_HAS_NVFP16()
 #if _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return ::__double2bfloat16(__v);
     }
 #endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e4m3>(::__nv_cvt_double_to_fp8(__v, __NV_NOSAT, __NV_E4M3));
     }
 #endif // _CCCL_HAS_NVFP8_E4M3()
 #if _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e5m2>(::__nv_cvt_double_to_fp8(__v, __NV_NOSAT, __NV_E5M2));
     }
 #endif // _CCCL_HAS_NVFP8_E5M2()
 #if _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e8m0>(::__nv_cvt_double_to_e8m0(__v, __NV_NOSAT, cudaRoundZero));
     }
 #endif // _CCCL_HAS_NVFP8_E8M0()
 #if _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp6_e2m3>(::__nv_cvt_double_to_fp6(__v, __NV_E2M3, cudaRoundNearest));
     }
 #endif // _CCCL_HAS_NVFP6_E2M3()
 #if _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp6_e3m2>(::__nv_cvt_double_to_fp6(__v, __NV_E3M2, cudaRoundNearest));
     }
 #endif // _CCCL_HAS_NVFP6_E3M2()
 #if _CCCL_HAS_NVFP4_E2M1()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp4_e2m1>(::__nv_cvt_double_to_fp4(__v, __NV_E2M1, cudaRoundNearest));
     }
@@ -172,64 +172,64 @@ template <class _To, class _From>
     }
   }
 #if _CCCL_HAS_LONG_DOUBLE()
-  else if constexpr (_CCCL_TRAIT(is_same, _From, long double))
+  else if constexpr (is_same_v<_From, long double>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return static_cast<float>(__v);
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return static_cast<double>(__v);
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return __v;
     }
 #  if _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return _CUDA_VSTD::__fp_cast<__half>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP16()
 #  if _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_bfloat16>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVBF16()
 #  if _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e4m3>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E4M3()
 #  if _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e5m2>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E5M2()
 #  if _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e8m0>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E8M0()
 #  if _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e2m3>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E2M3()
 #  if _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e3m2>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E3M2()
 #  if _CCCL_HAS_NVFP4_E2M1()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp4_e2m1>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
@@ -241,64 +241,64 @@ template <class _To, class _From>
   }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 #if _CCCL_HAS_NVFP16()
-  else if constexpr (_CCCL_TRAIT(is_same, _From, __half))
+  else if constexpr (is_same_v<_From, __half>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return ::__half2float(__v);
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return _CUDA_VSTD::__fp_cast<double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  if _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return _CUDA_VSTD::__fp_cast<long double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return __v;
     }
 #  if _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_bfloat16>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP16()
 #  if _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e4m3>(::__nv_cvt_halfraw_to_fp8(__v, __NV_NOSAT, __NV_E4M3));
     }
 #  endif // _CCCL_HAS_NVFP8_E4M3()
 #  if _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e5m2>(::__nv_cvt_halfraw_to_fp8(__v, __NV_NOSAT, __NV_E5M2));
     }
 #  endif // _CCCL_HAS_NVFP8_E5M2()
 #  if _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e8m0>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E8M0()
 #  if _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp6_e2m3>(::__nv_cvt_halfraw_to_fp6(__v, __NV_E2M3, cudaRoundNearest));
     }
 #  endif // _CCCL_HAS_NVFP6_E2M3()
 #  if _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp6_e3m2>(::__nv_cvt_halfraw_to_fp6(__v, __NV_E3M2, cudaRoundNearest));
     }
 #  endif // _CCCL_HAS_NVFP6_E3M2()
 #  if _CCCL_HAS_NVFP4_E2M1()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp4_e2m1>(::__nv_cvt_halfraw_to_fp4(__v, __NV_E2M1, cudaRoundNearest));
     }
@@ -310,67 +310,67 @@ template <class _To, class _From>
   }
 #endif // _CCCL_HAS_NVFP16()
 #if _CCCL_HAS_NVBF16()
-  else if constexpr (_CCCL_TRAIT(is_same, _From, __nv_bfloat16))
+  else if constexpr (is_same_v<_From, __nv_bfloat16>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return ::__bfloat162float(__v);
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return _CUDA_VSTD::__fp_cast<double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  if _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return _CUDA_VSTD::__fp_cast<long double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_LONG_DOUBLE()
 #  if _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return _CUDA_VSTD::__fp_cast<__half>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return __v;
     }
 #  if _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e4m3>(::__nv_cvt_bfloat16raw_to_fp8(__v, __NV_NOSAT, __NV_E4M3));
     }
 #  endif // _CCCL_HAS_NVFP8_E4M3()
 #  if _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e5m2>(::__nv_cvt_bfloat16raw_to_fp8(__v, __NV_NOSAT, __NV_E5M2));
     }
 #  endif // _CCCL_HAS_NVFP8_E5M2()
 #  if _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp8_e8m0>(
         ::__nv_cvt_bfloat16raw_to_e8m0(__v, __NV_NOSAT, cudaRoundZero));
     }
 #  endif // _CCCL_HAS_NVFP8_E8M0()
 #  if _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp6_e2m3>(
         ::__nv_cvt_bfloat16raw_to_fp6(__v, __NV_E2M3, cudaRoundNearest));
     }
 #  endif // _CCCL_HAS_NVFP6_E2M3()
 #  if _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp6_e3m2>(
         ::__nv_cvt_bfloat16raw_to_fp6(__v, __NV_E3M2, cudaRoundNearest));
     }
 #  endif // _CCCL_HAS_NVFP6_E3M2()
 #  if _CCCL_HAS_NVFP4_E2M1()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return _CUDA_VSTD::__fp_from_storage<__nv_fp4_e2m1>(
         ::__nv_cvt_bfloat16raw_to_fp4(__v, __NV_E2M1, cudaRoundNearest));
@@ -383,64 +383,64 @@ template <class _To, class _From>
   }
 #endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
-  else if constexpr (_CCCL_TRAIT(is_same, _From, __nv_fp8_e4m3))
+  else if constexpr (is_same_v<_From, __nv_fp8_e4m3>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return _CUDA_VSTD::__fp_cast<float>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return _CUDA_VSTD::__fp_cast<double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  if _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return _CUDA_VSTD::__fp_cast<long double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_LONG_DOUBLE()
 #  if _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return ::__nv_cvt_fp8_to_halfraw(__v.__x, __NV_E4M3);
     }
 #  endif // _CCCL_HAS_NVFP16()
 #  if _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_bfloat16>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return __v;
     }
 #  if _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e5m2>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E4M3()
 #  if _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e8m0>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E8M0()
 #  if _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e2m3>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E2M3()
 #  if _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e3m2>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E3M2()
 #  if _CCCL_HAS_NVFP4_E2M1()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp4_e2m1>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
@@ -452,64 +452,64 @@ template <class _To, class _From>
   }
 #endif // _CCCL_HAS_NVFP8_E4M3()
 #if _CCCL_HAS_NVFP8_E5M2()
-  else if constexpr (_CCCL_TRAIT(is_same, _From, __nv_fp8_e5m2))
+  else if constexpr (is_same_v<_From, __nv_fp8_e5m2>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return _CUDA_VSTD::__fp_cast<float>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return _CUDA_VSTD::__fp_cast<double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  if _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return _CUDA_VSTD::__fp_cast<long double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_LONG_DOUBLE()
 #  if _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return ::__nv_cvt_fp8_to_halfraw(__v.__x, __NV_E5M2);
     }
 #  endif // _CCCL_HAS_NVFP16()
 #  if _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_bfloat16>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVBF16()
 #  if _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e4m3>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return __v;
     }
 #  if _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e8m0>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E8M0()
 #  if _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e2m3>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E2M3()
 #  if _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e3m2>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E3M2()
 #  if _CCCL_HAS_NVFP4_E2M1()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp4_e2m1>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
@@ -521,64 +521,64 @@ template <class _To, class _From>
   }
 #endif // _CCCL_HAS_NVFP8_E5M2()
 #if _CCCL_HAS_NVFP8_E8M0()
-  else if constexpr (_CCCL_TRAIT(is_same, _From, __nv_fp8_e8m0))
+  else if constexpr (is_same_v<_From, __nv_fp8_e8m0>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return _CUDA_VSTD::__fp_cast<float>(_CUDA_VSTD::__fp_cast<__nv_bfloat16>(__v));
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return _CUDA_VSTD::__fp_cast<double>(_CUDA_VSTD::__fp_cast<__nv_bfloat16>(__v));
     }
 #  if _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return _CUDA_VSTD::__fp_cast<long double>(_CUDA_VSTD::__fp_cast<__nv_bfloat16>(__v));
     }
 #  endif // _CCCL_HAS_LONG_DOUBLE()
 #  if _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return _CUDA_VSTD::__fp_cast<__half>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP16()
 #  if _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return ::__nv_cvt_e8m0_to_bf16raw(__v.__x);
     }
 #  endif // _CCCL_HAS_NVBF16()
 #  if _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e4m3>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E4M3()
 #  if _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e5m2>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return __v;
     }
 #  if _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e2m3>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E2M3()
 #  if _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e3m2>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E3M2()
 #  if _CCCL_HAS_NVFP4_E2M1()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp4_e2m1>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
@@ -590,64 +590,64 @@ template <class _To, class _From>
   }
 #endif // _CCCL_HAS_NVFP8_E8M0()
 #if _CCCL_HAS_NVFP6_E2M3()
-  else if constexpr (_CCCL_TRAIT(is_same, _From, __nv_fp6_e2m3))
+  else if constexpr (is_same_v<_From, __nv_fp6_e2m3>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return _CUDA_VSTD::__fp_cast<float>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return _CUDA_VSTD::__fp_cast<double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  if _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return _CUDA_VSTD::__fp_cast<long double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_LONG_DOUBLE()
 #  if _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return ::__nv_cvt_fp6_to_halfraw(__v.__x, __NV_E2M3);
     }
 #  endif // _CCCL_HAS_NVFP16()
 #  if _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_bfloat16>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVBF16()
 #  if _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e4m3>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E4M3()
 #  if _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e5m2>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E5M2()
 #  if _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e8m0>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return __v;
     }
 #  if _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e3m2>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E3M2()
 #  if _CCCL_HAS_NVFP4_E2M1()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp4_e2m1>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
@@ -659,64 +659,64 @@ template <class _To, class _From>
   }
 #endif // _CCCL_HAS_NVFP6_E2M3()
 #if _CCCL_HAS_NVFP6_E3M2()
-  else if constexpr (_CCCL_TRAIT(is_same, _From, __nv_fp6_e3m2))
+  else if constexpr (is_same_v<_From, __nv_fp6_e3m2>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return _CUDA_VSTD::__fp_cast<float>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return _CUDA_VSTD::__fp_cast<double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  if _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return _CUDA_VSTD::__fp_cast<long double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_LONG_DOUBLE()
 #  if _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return ::__nv_cvt_fp6_to_halfraw(__v.__x, __NV_E3M2);
     }
 #  endif // _CCCL_HAS_NVFP16()
 #  if _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_bfloat16>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVBF16()
 #  if _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e4m3>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E4M3()
 #  if _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e5m2>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E5M2()
 #  if _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e8m0>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E8M0()
 #  if _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e2m3>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return __v;
     }
 #  if _CCCL_HAS_NVFP4_E2M1()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp4_e2m1>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
@@ -728,65 +728,65 @@ template <class _To, class _From>
   }
 #endif // _CCCL_HAS_NVFP6_E3M2()
 #if _CCCL_HAS_NVFP4_E2M1()
-  else if constexpr (_CCCL_TRAIT(is_same, _From, __nv_fp4_e2m1))
+  else if constexpr (is_same_v<_From, __nv_fp4_e2m1>)
   {
-    if constexpr (_CCCL_TRAIT(is_same, _To, float))
+    if constexpr (is_same_v<_To, float>)
     {
       return _CUDA_VSTD::__fp_cast<float>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
-    else if constexpr (_CCCL_TRAIT(is_same, _To, double))
+    else if constexpr (is_same_v<_To, double>)
     {
       return _CUDA_VSTD::__fp_cast<double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  if _CCCL_HAS_LONG_DOUBLE()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, long double))
+    else if constexpr (is_same_v<_To, long double>)
     {
       return _CUDA_VSTD::__fp_cast<long double>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_LONG_DOUBLE()
 #  if _CCCL_HAS_NVFP16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __half))
+    else if constexpr (is_same_v<_To, __half>)
     {
       return ::__nv_cvt_fp4_to_halfraw(__v.__x, __NV_E2M1);
     }
 #  endif // _CCCL_HAS_NVFP16()
 #  if _CCCL_HAS_NVBF16()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_bfloat16))
+    else if constexpr (is_same_v<_To, __nv_bfloat16>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_bfloat16>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVBF16()
 #  if _CCCL_HAS_NVFP8_E4M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e4m3))
+    else if constexpr (is_same_v<_To, __nv_fp8_e4m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e4m3>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E4M3()
 #  if _CCCL_HAS_NVFP8_E5M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e5m2))
+    else if constexpr (is_same_v<_To, __nv_fp8_e5m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e5m2>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E5M2()
 #  if _CCCL_HAS_NVFP8_E8M0()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp8_e8m0))
+    else if constexpr (is_same_v<_To, __nv_fp8_e8m0>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp8_e8m0>(_CUDA_VSTD::__fp_cast<float>(__v));
     }
 #  endif // _CCCL_HAS_NVFP8_E8M0()
 #  if _CCCL_HAS_NVFP6_E2M3()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e2m3))
+    else if constexpr (is_same_v<_To, __nv_fp6_e2m3>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e2m3>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E2M3()
 #  if _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp6_e3m2))
+    else if constexpr (is_same_v<_To, __nv_fp6_e3m2>)
     {
       return _CUDA_VSTD::__fp_cast<__nv_fp6_e3m2>(_CUDA_VSTD::__fp_cast<__half>(__v));
     }
 #  endif // _CCCL_HAS_NVFP6_E3M2()
-    else if constexpr (_CCCL_TRAIT(is_same, _To, __nv_fp4_e2m1))
+    else if constexpr (is_same_v<_To, __nv_fp4_e2m1>)
     {
       return __v;
     }

--- a/libcudacxx/include/cuda/std/__floating_point/common_type.h
+++ b/libcudacxx/include/cuda/std/__floating_point/common_type.h
@@ -38,8 +38,7 @@ using __fp_common_type_t =
 
 template <class _Lhs, class _Rhs>
 using __fp_int_ext_common_type_t =
-  __fp_common_type_t<conditional_t<_CCCL_TRAIT(is_integral, _Lhs), double, _Lhs>,
-                     conditional_t<_CCCL_TRAIT(is_integral, _Rhs), double, _Rhs>>;
+  __fp_common_type_t<conditional_t<is_integral_v<_Lhs>, double, _Lhs>, conditional_t<is_integral_v<_Rhs>, double, _Rhs>>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__floating_point/conversion_rank_order.h
+++ b/libcudacxx/include/cuda/std/__floating_point/conversion_rank_order.h
@@ -48,11 +48,11 @@ template <class _Lhs, class _Rhs>
     // If double and long double have the same properties, long double has the higher subrank
     if constexpr (__fp_is_subset_of_v<long double, double>)
     {
-      if constexpr (_CCCL_TRAIT(is_same, _Lhs, long double) && !_CCCL_TRAIT(is_same, _Rhs, long double))
+      if constexpr (is_same_v<_Lhs, long double> && !is_same_v<_Rhs, long double>)
       {
         return __fp_conv_rank_order::__greater;
       }
-      else if constexpr (!_CCCL_TRAIT(is_same, _Lhs, long double) && _CCCL_TRAIT(is_same, _Rhs, long double))
+      else if constexpr (!is_same_v<_Lhs, long double> && is_same_v<_Rhs, long double>)
       {
         return __fp_conv_rank_order::__less;
       }
@@ -82,16 +82,16 @@ template <class _Lhs, class _Rhs>
 }
 
 _CCCL_TEMPLATE(class _Lhs, class _Rhs)
-_CCCL_REQUIRES(_CCCL_TRAIT(__is_fp, _Lhs) && _CCCL_TRAIT(__is_fp, _Rhs))
+_CCCL_REQUIRES(__is_fp_v<_Lhs>&& __is_fp_v<_Rhs>)
 inline constexpr __fp_conv_rank_order __fp_conv_rank_order_v = __fp_conv_rank_order_v_impl<_Lhs, _Rhs>();
 
 template <class _Lhs, class _Rhs>
 inline constexpr __fp_conv_rank_order __fp_conv_rank_order_int_ext_v =
-  __fp_conv_rank_order_v<conditional_t<_CCCL_TRAIT(is_integral, _Lhs), double, _Lhs>,
-                         conditional_t<_CCCL_TRAIT(is_integral, _Rhs), double, _Rhs>>;
+  __fp_conv_rank_order_v<conditional_t<is_integral_v<_Lhs>, double, _Lhs>,
+                         conditional_t<is_integral_v<_Rhs>, double, _Rhs>>;
 
 _CCCL_TEMPLATE(class _From, class _To)
-_CCCL_REQUIRES(_CCCL_TRAIT(__is_fp, _From) && _CCCL_TRAIT(__is_fp, _To))
+_CCCL_REQUIRES(__is_fp_v<_From>&& __is_fp_v<_To>)
 inline constexpr bool __fp_is_implicit_conversion_v =
   __fp_conv_rank_order_v<_From, _To> == __fp_conv_rank_order::__less
   || __fp_conv_rank_order_v<_From, _To> == __fp_conv_rank_order::__equal;

--- a/libcudacxx/include/cuda/std/__floating_point/format.h
+++ b/libcudacxx/include/cuda/std/__floating_point/format.h
@@ -51,16 +51,16 @@ enum class __fp_format
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr __fp_format __fp_format_of_v_impl() noexcept
 {
-  if constexpr (_CCCL_TRAIT(is_same, _Tp, float))
+  if constexpr (is_same_v<_Tp, float>)
   {
     return __fp_format::__binary32;
   }
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, double))
+  else if constexpr (is_same_v<_Tp, double>)
   {
     return __fp_format::__binary64;
   }
 #if _CCCL_HAS_LONG_DOUBLE()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, long double))
+  else if constexpr (is_same_v<_Tp, long double>)
   {
     if (LDBL_MIN_EXP == -1021 && LDBL_MAX_EXP == 1024 && LDBL_MANT_DIG == 53)
     {
@@ -81,55 +81,55 @@ template <class _Tp>
   }
 #endif // _CCCL_HAS_LONG_DOUBLE()
 #if _CCCL_HAS_NVFP16()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __half))
+  else if constexpr (is_same_v<_Tp, __half>)
   {
     return __fp_format::__binary16;
   }
 #endif // _CCCL_HAS_NVFP16()
 #if _CCCL_HAS_NVBF16()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_bfloat16))
+  else if constexpr (is_same_v<_Tp, __nv_bfloat16>)
   {
     return __fp_format::__bfloat16;
   }
 #endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp8_e4m3))
+  else if constexpr (is_same_v<_Tp, __nv_fp8_e4m3>)
   {
     return __fp_format::__fp8_nv_e4m3;
   }
 #endif // _CCCL_HAS_NVFP8_E4M3()
 #if _CCCL_HAS_NVFP8_E5M2()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp8_e5m2))
+  else if constexpr (is_same_v<_Tp, __nv_fp8_e5m2>)
   {
     return __fp_format::__fp8_nv_e5m2;
   }
 #endif // _CCCL_HAS_NVFP8_E5M2()
 #if _CCCL_HAS_NVFP8_E8M0()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp8_e8m0))
+  else if constexpr (is_same_v<_Tp, __nv_fp8_e8m0>)
   {
     return __fp_format::__fp8_nv_e8m0;
   }
 #endif // _CCCL_HAS_NVFP8_E8M0()
 #if _CCCL_HAS_NVFP6_E2M3()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp6_e2m3))
+  else if constexpr (is_same_v<_Tp, __nv_fp6_e2m3>)
   {
     return __fp_format::__fp6_nv_e2m3;
   }
 #endif // _CCCL_HAS_NVFP6_E2M3()
 #if _CCCL_HAS_NVFP6_E3M2()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp6_e3m2))
+  else if constexpr (is_same_v<_Tp, __nv_fp6_e3m2>)
   {
     return __fp_format::__fp6_nv_e3m2;
   }
 #endif // _CCCL_HAS_NVFP6_E3M2()
 #if _CCCL_HAS_NVFP4_E2M1()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp4_e2m1))
+  else if constexpr (is_same_v<_Tp, __nv_fp4_e2m1>)
   {
     return __fp_format::__fp4_nv_e2m1;
   }
 #endif // _CCCL_HAS_NVFP4_E2M1()
 #if _CCCL_HAS_FLOAT128()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __float128))
+  else if constexpr (is_same_v<_Tp, __float128>)
   {
     return __fp_format::__binary128;
   }

--- a/libcudacxx/include/cuda/std/__floating_point/native_type.h
+++ b/libcudacxx/include/cuda/std/__floating_point/native_type.h
@@ -69,7 +69,7 @@ template <__fp_format _Fmt>
 using __fp_native_type_t = decltype(__fp_native_type_impl<_Fmt>());
 
 template <__fp_format _Fmt>
-inline constexpr bool __fp_has_native_type_v = !_CCCL_TRAIT(is_void, __fp_native_type_t<_Fmt>);
+inline constexpr bool __fp_has_native_type_v = !is_void_v<__fp_native_type_t<_Fmt>>;
 
 template <class _Tp>
 inline constexpr bool __fp_is_native_type_v = __is_std_fp_v<_Tp> || __is_ext_compiler_fp_v<_Tp>;

--- a/libcudacxx/include/cuda/std/__floating_point/storage.h
+++ b/libcudacxx/include/cuda/std/__floating_point/storage.h
@@ -89,18 +89,18 @@ struct __cccl_nvbf16_manip_helper : __nv_bfloat16
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __fp_from_storage(__fp_storage_of_t<_Tp> __v) noexcept
 {
-  if constexpr (_CCCL_TRAIT(__is_std_fp, _Tp) || _CCCL_TRAIT(__is_ext_compiler_fp, _Tp))
+  if constexpr (__is_std_fp_v<_Tp> || __is_ext_compiler_fp_v<_Tp>)
   {
     return _CUDA_VSTD::bit_cast<_Tp>(__v);
   }
-  else if constexpr (_CCCL_TRAIT(__is_ext_cccl_fp, _Tp))
+  else if constexpr (__is_ext_cccl_fp_v<_Tp>)
   {
     _Tp __ret{};
     __ret.__storage_ = __v;
     return __ret;
   }
 #if _CCCL_HAS_NVFP16()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __half))
+  else if constexpr (is_same_v<_Tp, __half>)
   {
     __cccl_nvfp16_manip_helper __helper{};
     __helper.__x = __v;
@@ -108,7 +108,7 @@ template <class _Tp>
   }
 #endif // _CCCL_HAS_NVFP16()
 #if _CCCL_HAS_NVBF16()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_bfloat16))
+  else if constexpr (is_same_v<_Tp, __nv_bfloat16>)
   {
     __cccl_nvbf16_manip_helper __helper{};
     __helper.__x = __v;
@@ -116,7 +116,7 @@ template <class _Tp>
   }
 #endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp8_e4m3))
+  else if constexpr (is_same_v<_Tp, __nv_fp8_e4m3>)
   {
     __nv_fp8_e4m3 __ret{};
     __ret.__x = __v;
@@ -124,7 +124,7 @@ template <class _Tp>
   }
 #endif // _CCCL_HAS_NVFP8_E4M3()
 #if _CCCL_HAS_NVFP8_E5M2()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp8_e5m2))
+  else if constexpr (is_same_v<_Tp, __nv_fp8_e5m2>)
   {
     __nv_fp8_e5m2 __ret{};
     __ret.__x = __v;
@@ -132,7 +132,7 @@ template <class _Tp>
   }
 #endif // _CCCL_HAS_NVFP8_E5M2()
 #if _CCCL_HAS_NVFP8_E8M0()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp8_e8m0))
+  else if constexpr (is_same_v<_Tp, __nv_fp8_e8m0>)
   {
     __nv_fp8_e8m0 __ret{};
     __ret.__x = __v;
@@ -140,7 +140,7 @@ template <class _Tp>
   }
 #endif // _CCCL_HAS_NVFP8_E8M0()
 #if _CCCL_HAS_NVFP6_E2M3()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp6_e2m3))
+  else if constexpr (is_same_v<_Tp, __nv_fp6_e2m3>)
   {
     _CCCL_ASSERT((__v & 0xc0u) == 0u, "Invalid __nv_fp6_e2m3 storage value");
     __nv_fp6_e2m3 __ret{};
@@ -149,7 +149,7 @@ template <class _Tp>
   }
 #endif // _CCCL_HAS_NVFP6_E2M3()
 #if _CCCL_HAS_NVFP6_E3M2()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp6_e3m2))
+  else if constexpr (is_same_v<_Tp, __nv_fp6_e3m2>)
   {
     _CCCL_ASSERT((__v & 0xc0u) == 0u, "Invalid __nv_fp6_e3m2 storage value");
     __nv_fp6_e3m2 __ret{};
@@ -158,7 +158,7 @@ template <class _Tp>
   }
 #endif // _CCCL_HAS_NVFP6_E3M2()
 #if _CCCL_HAS_NVFP4_E2M1()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp4_e2m1))
+  else if constexpr (is_same_v<_Tp, __nv_fp4_e2m1>)
   {
     _CCCL_ASSERT((__v & 0xf0u) == 0u, "Invalid __nv_fp4_e2m1 storage value");
     __nv_fp4_e2m1 __ret{};
@@ -173,64 +173,64 @@ template <class _Tp>
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES((!_CCCL_TRAIT(is_same, _Up, __fp_storage_of_t<_Tp>)))
+_CCCL_REQUIRES((!is_same_v<_Up, __fp_storage_of_t<_Tp>>) )
 _CCCL_API constexpr _Tp __fp_from_storage(const _Up& __v) noexcept = delete;
 
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr __fp_storage_of_t<_Tp> __fp_get_storage(_Tp __v) noexcept
 {
-  if constexpr (_CCCL_TRAIT(__is_std_fp, _Tp) || _CCCL_TRAIT(__is_ext_compiler_fp, _Tp))
+  if constexpr (__is_std_fp_v<_Tp> || __is_ext_compiler_fp_v<_Tp>)
   {
     return _CUDA_VSTD::bit_cast<__fp_storage_of_t<_Tp>>(__v);
   }
-  else if constexpr (_CCCL_TRAIT(__is_ext_cccl_fp, _Tp))
+  else if constexpr (__is_ext_cccl_fp_v<_Tp>)
   {
     return __v.__storage_;
   }
 #if _CCCL_HAS_NVFP16()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __half))
+  else if constexpr (is_same_v<_Tp, __half>)
   {
     return __cccl_nvfp16_manip_helper{__v}.__x;
   }
 #endif // _CCCL_HAS_NVFP16()
 #if _CCCL_HAS_NVBF16()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_bfloat16))
+  else if constexpr (is_same_v<_Tp, __nv_bfloat16>)
   {
     return __cccl_nvbf16_manip_helper{__v}.__x;
   }
 #endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp8_e4m3))
+  else if constexpr (is_same_v<_Tp, __nv_fp8_e4m3>)
   {
     return __v.__x;
   }
 #endif // _CCCL_HAS_NVFP8_E4M3()
 #if _CCCL_HAS_NVFP8_E5M2()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp8_e5m2))
+  else if constexpr (is_same_v<_Tp, __nv_fp8_e5m2>)
   {
     return __v.__x;
   }
 #endif // _CCCL_HAS_NVFP8_E5M2()
 #if _CCCL_HAS_NVFP8_E8M0()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp8_e8m0))
+  else if constexpr (is_same_v<_Tp, __nv_fp8_e8m0>)
   {
     return __v.__x;
   }
 #endif // _CCCL_HAS_NVFP8_E8M0()
 #if _CCCL_HAS_NVFP6_E2M3()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp6_e2m3))
+  else if constexpr (is_same_v<_Tp, __nv_fp6_e2m3>)
   {
     return __v.__x;
   }
 #endif // _CCCL_HAS_NVFP6_E2M3()
 #if _CCCL_HAS_NVFP6_E3M2()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp6_e3m2))
+  else if constexpr (is_same_v<_Tp, __nv_fp6_e3m2>)
   {
     return __v.__x;
   }
 #endif // _CCCL_HAS_NVFP6_E3M2()
 #if _CCCL_HAS_NVFP4_E2M1()
-  else if constexpr (_CCCL_TRAIT(is_same, _Tp, __nv_fp4_e2m1))
+  else if constexpr (is_same_v<_Tp, __nv_fp4_e2m1>)
   {
     return __v.__x;
   }

--- a/libcudacxx/include/cuda/std/__functional/invoke.h
+++ b/libcudacxx/include/cuda/std/__functional/invoke.h
@@ -533,15 +533,14 @@ using invoke_result_t = typename invoke_result<_Fn, _Args...>::type;
 
 template <class _Fn, class... _Args>
 _CCCL_API constexpr invoke_result_t<_Fn, _Args...>
-invoke(_Fn&& __f, _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_invocable, _Fn, _Args...))
+invoke(_Fn&& __f, _Args&&... __args) noexcept(is_nothrow_invocable_v<_Fn, _Args...>)
 {
   return _CUDA_VSTD::__invoke(_CUDA_VSTD::forward<_Fn>(__f), _CUDA_VSTD::forward<_Args>(__args)...);
 }
 
 _CCCL_TEMPLATE(class _Ret, class _Fn, class... _Args)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_invocable_r, _Ret, _Fn, _Args...))
-_CCCL_API constexpr _Ret invoke_r(_Fn&& __f,
-                                  _Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_invocable_r, _Ret, _Fn, _Args...))
+_CCCL_REQUIRES(is_invocable_r_v<_Ret, _Fn, _Args...>)
+_CCCL_API constexpr _Ret invoke_r(_Fn&& __f, _Args&&... __args) noexcept(is_nothrow_invocable_r_v<_Ret, _Fn, _Args...>)
 {
   return __invoke_void_return_wrapper<_Ret>::__call(
     _CUDA_VSTD::forward<_Fn>(__f), _CUDA_VSTD::forward<_Args>(__args)...);

--- a/libcudacxx/include/cuda/std/__functional/perfect_forward.h
+++ b/libcudacxx/include/cuda/std/__functional/perfect_forward.h
@@ -46,8 +46,7 @@ private:
   tuple<_BoundArgs...> __bound_args_;
 
   template <class... _Args>
-  static constexpr bool __noexcept_constructible =
-    _CCCL_TRAIT(is_nothrow_constructible, tuple<_BoundArgs...>, _Args&&...);
+  static constexpr bool __noexcept_constructible = is_nothrow_constructible_v<tuple<_BoundArgs...>, _Args&&...>;
 
 public:
   _CCCL_TEMPLATE(class... _Args)

--- a/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
@@ -68,7 +68,7 @@ public:
   // invoke
   template <class... _ArgTypes>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 typename __invoke_of<type&, _ArgTypes...>::type
-  operator()(_ArgTypes&&... __args) const noexcept(_CCCL_TRAIT(is_nothrow_invocable, _Tp&, _ArgTypes...))
+  operator()(_ArgTypes&&... __args) const noexcept(is_nothrow_invocable_v<_Tp&, _ArgTypes...>)
   {
     return _CUDA_VSTD::__invoke(get(), _CUDA_VSTD::forward<_ArgTypes>(__args)...);
   }

--- a/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
@@ -94,7 +94,7 @@ struct incrementable_traits
 {};
 
 template <class _Tp>
-struct incrementable_traits<_Tp*, enable_if_t<_CCCL_TRAIT(is_object, _Tp)>>
+struct incrementable_traits<_Tp*, enable_if_t<is_object_v<_Tp>>>
 {
   using difference_type = ptrdiff_t;
 };
@@ -121,17 +121,15 @@ inline constexpr bool
     integral<decltype(_CUDA_VSTD::declval<const _Tp&>() - _CUDA_VSTD::declval<const _Tp&>())>;
 
 template <class _Tp>
-struct incrementable_traits<
-  _Tp,
-  enable_if_t<!_CCCL_TRAIT(is_pointer, _Tp) && !_CCCL_TRAIT(is_const, _Tp) && __has_member_difference_type<_Tp>>>
+struct incrementable_traits<_Tp, enable_if_t<!is_pointer_v<_Tp> && !is_const_v<_Tp> && __has_member_difference_type<_Tp>>>
 {
   using difference_type = typename _Tp::difference_type;
 };
 
 template <class _Tp>
-struct incrementable_traits<_Tp,
-                            enable_if_t<!_CCCL_TRAIT(is_pointer, _Tp) && !_CCCL_TRAIT(is_const, _Tp)
-                                        && !__has_member_difference_type<_Tp> && __has_integral_minus<_Tp>>>
+struct incrementable_traits<
+  _Tp,
+  enable_if_t<!is_pointer_v<_Tp> && !is_const_v<_Tp> && !__has_member_difference_type<_Tp> && __has_integral_minus<_Tp>>>
 {
   using difference_type = make_signed_t<decltype(declval<_Tp>() - declval<_Tp>())>;
 };

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -558,7 +558,7 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(convertible_to<decltype(__i++), _Ip const&>),
     requires(same_as<iter_reference_t<_Ip>, decltype(*__i++)>),
     requires(constructible_from<_Ip>),
-    requires(_CCCL_TRAIT(is_lvalue_reference, iter_reference_t<_Ip>)),
+    requires(is_lvalue_reference_v<iter_reference_t<_Ip>>),
     requires(same_as<remove_cvref_t<iter_reference_t<_Ip>>, typename indirectly_readable_traits<_Ip>::value_type>)));
 
 template <class _Ip>

--- a/libcudacxx/include/cuda/std/__iterator/readable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/readable_traits.h
@@ -112,7 +112,7 @@ struct __cond_value_type
 {};
 
 template <class _Tp>
-struct __cond_value_type<_Tp, enable_if_t<_CCCL_TRAIT(is_object, _Tp)>>
+struct __cond_value_type<_Tp, enable_if_t<is_object_v<_Tp>>>
 {
   using value_type = remove_cv_t<_Tp>;
 };
@@ -134,7 +134,7 @@ struct indirectly_readable_traits
 {};
 
 template <class _Ip>
-struct indirectly_readable_traits<_Ip, enable_if_t<!_CCCL_TRAIT(is_const, _Ip) && _CCCL_TRAIT(is_array, _Ip)>>
+struct indirectly_readable_traits<_Ip, enable_if_t<!is_const_v<_Ip> && is_array_v<_Ip>>>
 {
   using value_type = remove_cv_t<remove_extent_t<_Ip>>;
 };
@@ -150,21 +150,21 @@ struct indirectly_readable_traits<_Tp*> : __cond_value_type<_Tp>
 template <class _Tp>
 struct indirectly_readable_traits<
   _Tp,
-  enable_if_t<!_CCCL_TRAIT(is_const, _Tp) && __has_member_value_type<_Tp> && !__has_member_element_type<_Tp>>>
+  enable_if_t<!is_const_v<_Tp> && __has_member_value_type<_Tp> && !__has_member_element_type<_Tp>>>
     : __cond_value_type<typename _Tp::value_type>
 {};
 
 template <class _Tp>
 struct indirectly_readable_traits<
   _Tp,
-  enable_if_t<!_CCCL_TRAIT(is_const, _Tp) && !__has_member_value_type<_Tp> && __has_member_element_type<_Tp>>>
+  enable_if_t<!is_const_v<_Tp> && !__has_member_value_type<_Tp> && __has_member_element_type<_Tp>>>
     : __cond_value_type<typename _Tp::element_type>
 {};
 
 template <class _Tp>
 struct indirectly_readable_traits<
   _Tp,
-  enable_if_t<!_CCCL_TRAIT(is_const, _Tp) && __has_member_value_type<_Tp> && __has_member_element_type<_Tp>
+  enable_if_t<!is_const_v<_Tp> && __has_member_value_type<_Tp> && __has_member_element_type<_Tp>
               && same_as<remove_cv_t<typename _Tp::element_type>, remove_cv_t<typename _Tp::value_type>>>>
     : __cond_value_type<typename _Tp::value_type>
 {};

--- a/libcudacxx/include/cuda/std/__limits/numeric_limits.h
+++ b/libcudacxx/include/cuda/std/__limits/numeric_limits.h
@@ -59,15 +59,15 @@ enum class __numeric_limits_type
 template <class _Tp>
 _CCCL_API constexpr __numeric_limits_type __make_numeric_limits_type()
 {
-  if constexpr (_CCCL_TRAIT(is_same, _Tp, bool))
+  if constexpr (is_same_v<_Tp, bool>)
   {
     return __numeric_limits_type::__bool;
   }
-  else if constexpr (_CCCL_TRAIT(is_integral, _Tp))
+  else if constexpr (is_integral_v<_Tp>)
   {
     return __numeric_limits_type::__integral;
   }
-  else if constexpr (_CCCL_TRAIT(is_floating_point, _Tp) || _CCCL_TRAIT(__is_extended_floating_point, _Tp))
+  else if constexpr (is_floating_point_v<_Tp> || __is_extended_floating_point_v<_Tp>)
   {
     return __numeric_limits_type::__floating_point;
   }

--- a/libcudacxx/include/cuda/std/__linalg/conjugated.h
+++ b/libcudacxx/include/cuda/std/__linalg/conjugated.h
@@ -63,15 +63,15 @@ public:
   {}
 
   _CCCL_TEMPLATE(class _OtherNestedAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _NestedAccessor, const _OtherNestedAccessor&)
-                   _CCCL_AND _CCCL_TRAIT(is_convertible, _OtherNestedAccessor, _NestedAccessor))
+  _CCCL_REQUIRES(is_constructible_v<_NestedAccessor, const _OtherNestedAccessor&> _CCCL_AND
+                   is_convertible_v<_OtherNestedAccessor, _NestedAccessor>)
   _CCCL_API constexpr conjugated_accessor(const conjugated_accessor<_OtherNestedAccessor>& __other)
       : __nested_accessor_(__other.nested_accessor())
   {}
 
   _CCCL_TEMPLATE(class _OtherNestedAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _NestedAccessor, const _OtherNestedAccessor&)
-                   _CCCL_AND(!_CCCL_TRAIT(is_convertible, _OtherNestedAccessor, _NestedAccessor)))
+  _CCCL_REQUIRES(is_constructible_v<_NestedAccessor, const _OtherNestedAccessor&> _CCCL_AND(
+    !is_convertible_v<_OtherNestedAccessor, _NestedAccessor>))
   _CCCL_API explicit constexpr conjugated_accessor(const conjugated_accessor<_OtherNestedAccessor>& __other)
       : __nested_accessor_(__other.nested_accessor())
   {}

--- a/libcudacxx/include/cuda/std/__linalg/scaled.h
+++ b/libcudacxx/include/cuda/std/__linalg/scaled.h
@@ -55,18 +55,18 @@ public:
   _CCCL_HIDE_FROM_ABI constexpr scaled_accessor() = default;
 
   _CCCL_TEMPLATE(class _OtherScalingFactor, class _OtherNestedAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _NestedAccessor, const _OtherNestedAccessor&)
-                   _CCCL_AND _CCCL_TRAIT(is_constructible, _ScalingFactor, _OtherScalingFactor)
-                     _CCCL_AND(!_CCCL_TRAIT(is_convertible, _OtherNestedAccessor, _NestedAccessor)))
+  _CCCL_REQUIRES(is_constructible_v<_NestedAccessor, const _OtherNestedAccessor&> _CCCL_AND
+                   is_constructible_v<_ScalingFactor, _OtherScalingFactor> _CCCL_AND(
+                     !is_convertible_v<_OtherNestedAccessor, _NestedAccessor>))
   _CCCL_API explicit constexpr scaled_accessor(const scaled_accessor<_OtherScalingFactor, _OtherNestedAccessor>& __other)
       : __scaling_factor_(__other.scaling_factor())
       , __nested_accessor_(__other.nested_accessor())
   {}
 
   _CCCL_TEMPLATE(class _OtherScalingFactor, class _OtherNestedAccessor)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _NestedAccessor, const _OtherNestedAccessor&)
-                   _CCCL_AND _CCCL_TRAIT(is_constructible, _ScalingFactor, _OtherScalingFactor)
-                     _CCCL_AND _CCCL_TRAIT(is_convertible, _OtherNestedAccessor, _NestedAccessor))
+  _CCCL_REQUIRES(is_constructible_v<_NestedAccessor, const _OtherNestedAccessor&> _CCCL_AND
+                   is_constructible_v<_ScalingFactor, _OtherScalingFactor> _CCCL_AND
+                     is_convertible_v<_OtherNestedAccessor, _NestedAccessor>)
   _CCCL_API constexpr scaled_accessor(const scaled_accessor<_OtherScalingFactor, _OtherNestedAccessor>& __other)
       : __scaling_factor_(__other.scaling_factor())
       , __nested_accessor_(__other.nested_accessor())

--- a/libcudacxx/include/cuda/std/__linalg/transposed.h
+++ b/libcudacxx/include/cuda/std/__linalg/transposed.h
@@ -134,8 +134,7 @@ public:
     }
 
     _CCCL_TEMPLATE(class _IndexType0, class _IndexType1)
-    _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, _IndexType0, index_type)
-                     _CCCL_AND _CCCL_TRAIT(is_convertible, _IndexType1, index_type))
+    _CCCL_REQUIRES(is_convertible_v<_IndexType0, index_type> _CCCL_AND is_convertible_v<_IndexType1, index_type>)
     _CCCL_API constexpr index_type operator()(_IndexType0 __i, _IndexType1 __j) const
     {
       return __nested_mapping_(__j, __i);

--- a/libcudacxx/include/cuda/std/__mdspan/aligned_accessor.h
+++ b/libcudacxx/include/cuda/std/__mdspan/aligned_accessor.h
@@ -52,8 +52,7 @@ public:
 
   static_assert(byte_alignment >= alignof(_ElementType), "Insufficient byte alignment for _ElementType");
 
-  static_assert(_CCCL_TRAIT(is_object, _ElementType) && !_CCCL_TRAIT(is_abstract, _ElementType)
-                  && !_CCCL_TRAIT(is_array, _ElementType),
+  static_assert(is_object_v<_ElementType> && !is_abstract_v<_ElementType> && !is_array_v<_ElementType>,
                 "_ElementType must be a complete object type that is neither an abstract class type nor an array "
                 "type.");
 
@@ -65,16 +64,16 @@ public:
   _CCCL_HIDE_FROM_ABI aligned_accessor() noexcept = default;
 
   _CCCL_TEMPLATE(class _OtherElementType, size_t _OtherByteAlignment)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, _OtherElementType (*)[], element_type (*)[])
-                   _CCCL_AND((_OtherByteAlignment >= byte_alignment)))
+  _CCCL_REQUIRES(
+    is_convertible_v<_OtherElementType (*)[], element_type (*)[]> _CCCL_AND((_OtherByteAlignment >= byte_alignment)))
   _CCCL_API constexpr aligned_accessor(aligned_accessor<_OtherElementType, _OtherByteAlignment>) noexcept {}
 
   _CCCL_TEMPLATE(class _OtherElementType)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, _OtherElementType (*)[], element_type (*)[]))
+  _CCCL_REQUIRES(is_convertible_v<_OtherElementType (*)[], element_type (*)[]>)
   _CCCL_API constexpr explicit aligned_accessor(default_accessor<_OtherElementType>) noexcept {}
 
   _CCCL_TEMPLATE(class _OtherElementType)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, _OtherElementType (*)[], element_type (*)[]))
+  _CCCL_REQUIRES(is_convertible_v<_OtherElementType (*)[], element_type (*)[]>)
   _CCCL_API constexpr operator default_accessor<_OtherElementType>() const noexcept
   {
     return {};

--- a/libcudacxx/include/cuda/std/__mdspan/concepts.h
+++ b/libcudacxx/include/cuda/std/__mdspan/concepts.h
@@ -67,16 +67,16 @@ inline constexpr bool __is_extents_v = __is_extents<_Tp>::value;
 // [mdspan.layout.general]/2
 template <class _Layout, class _Mapping>
 inline constexpr bool __is_mapping_of =
-  _CCCL_TRAIT(is_same, typename _Layout::template mapping<typename _Mapping::extents_type>, _Mapping);
+  is_same_v<typename _Layout::template mapping<typename _Mapping::extents_type>, _Mapping>;
 
 // [mdspan.layout.reqmts]/1
 template <class _Mapping>
 _CCCL_CONCEPT __layout_mapping_req_type = _CCCL_REQUIRES_EXPR((_Mapping))(
   requires(copyable<_Mapping>),
   requires(equality_comparable<_Mapping>),
-  requires(_CCCL_TRAIT(is_nothrow_move_constructible, _Mapping)),
-  requires(_CCCL_TRAIT(is_move_assignable, _Mapping)),
-  requires(_CCCL_TRAIT(is_nothrow_swappable, _Mapping)));
+  requires(is_nothrow_move_constructible_v<_Mapping>),
+  requires(is_move_assignable_v<_Mapping>),
+  requires(is_nothrow_swappable_v<_Mapping>));
 
 // [mdspan.layout.reqmts]/2-4
 template <class _Mapping>
@@ -115,8 +115,8 @@ _CCCL_CONCEPT __layout_mapping_alike = _CCCL_REQUIRES_EXPR((_Mapping))(
 
 template <class _IndexType, class... _Indices>
 _CCCL_CONCEPT __all_convertible_to_index_type =
-  (_CCCL_TRAIT(is_convertible, _Indices, _IndexType) && ... && true)
-  && (_CCCL_TRAIT(is_nothrow_constructible, _IndexType, _Indices) && ... && true);
+  (is_convertible_v<_Indices, _IndexType> && ... && true)
+  && (is_nothrow_constructible_v<_IndexType, _Indices> && ... && true);
 
 } // namespace __mdspan_detail
 
@@ -129,8 +129,7 @@ _CCCL_CONCEPT __index_pair_like = _CCCL_REQUIRES_EXPR((_Tp, _IndexType))(
 // [mdspan.submdspan.strided.slice]/3
 
 template <class _Tp>
-_CCCL_CONCEPT __index_like =
-  _CCCL_TRAIT(is_signed, _Tp) || _CCCL_TRAIT(is_unsigned, _Tp) || __integral_constant_like<_Tp>;
+_CCCL_CONCEPT __index_like = is_signed_v<_Tp> || is_unsigned_v<_Tp> || __integral_constant_like<_Tp>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__mdspan/default_accessor.h
+++ b/libcudacxx/include/cuda/std/__mdspan/default_accessor.h
@@ -42,9 +42,8 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _ElementType>
 struct default_accessor
 {
-  static_assert(!_CCCL_TRAIT(is_array, _ElementType), "default_accessor: template argument may not be an array type");
-  static_assert(!_CCCL_TRAIT(is_abstract, _ElementType),
-                "default_accessor: template argument may not be an abstract class");
+  static_assert(!is_array_v<_ElementType>, "default_accessor: template argument may not be an array type");
+  static_assert(!is_abstract_v<_ElementType>, "default_accessor: template argument may not be an abstract class");
 
   using offset_policy    = default_accessor;
   using element_type     = _ElementType;
@@ -54,7 +53,7 @@ struct default_accessor
   _CCCL_HIDE_FROM_ABI constexpr default_accessor() noexcept = default;
 
   _CCCL_TEMPLATE(class _OtherElementType)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, _OtherElementType (*)[], element_type (*)[]))
+  _CCCL_REQUIRES(is_convertible_v<_OtherElementType (*)[], element_type (*)[]>)
   _CCCL_API constexpr default_accessor(default_accessor<_OtherElementType>) noexcept {}
 
   [[nodiscard]] _CCCL_API constexpr reference access(data_handle_type __p, size_t __i) const noexcept

--- a/libcudacxx/include/cuda/std/__mdspan/empty_base.h
+++ b/libcudacxx/include/cuda/std/__mdspan/empty_base.h
@@ -33,23 +33,22 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-template <size_t _Index, class _Elem, bool = _CCCL_TRAIT(is_empty, _Elem)>
+template <size_t _Index, class _Elem, bool = is_empty_v<_Elem>>
 struct _CCCL_DECLSPEC_EMPTY_BASES __mdspan_ebco_impl
 {
   _Elem __elem_;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Elem_ = _Elem)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_default_constructible, _Elem_))
-  _CCCL_API constexpr __mdspan_ebco_impl() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _Elem_))
+  _CCCL_REQUIRES(is_default_constructible_v<_Elem_>)
+  _CCCL_API constexpr __mdspan_ebco_impl() noexcept(is_nothrow_default_constructible_v<_Elem_>)
       : __elem_()
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class... _Args)
-  _CCCL_REQUIRES((sizeof...(_Args) != 0) _CCCL_AND _CCCL_TRAIT(is_constructible, _Elem, _Args...))
-  _CCCL_API constexpr __mdspan_ebco_impl(_Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Elem, _Args...))
+  _CCCL_REQUIRES((sizeof...(_Args) != 0) _CCCL_AND is_constructible_v<_Elem, _Args...>)
+  _CCCL_API constexpr __mdspan_ebco_impl(_Args&&... __args) noexcept(is_nothrow_constructible_v<_Elem, _Args...>)
       : __elem_(_CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
@@ -68,16 +67,15 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __mdspan_ebco_impl<_Index, _Elem, true> : _Ele
 {
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Elem_ = _Elem)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_default_constructible, _Elem_))
-  _CCCL_API constexpr __mdspan_ebco_impl() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _Elem_))
+  _CCCL_REQUIRES(is_default_constructible_v<_Elem_>)
+  _CCCL_API constexpr __mdspan_ebco_impl() noexcept(is_nothrow_default_constructible_v<_Elem_>)
       : _Elem()
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class... _Args)
-  _CCCL_REQUIRES((sizeof...(_Args) != 0) _CCCL_AND _CCCL_TRAIT(is_constructible, _Elem, _Args...))
-  _CCCL_API constexpr __mdspan_ebco_impl(_Args&&... __args) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Elem, _Args...))
+  _CCCL_REQUIRES((sizeof...(_Args) != 0) _CCCL_AND is_constructible_v<_Elem, _Args...>)
+  _CCCL_API constexpr __mdspan_ebco_impl(_Args&&... __args) noexcept(is_nothrow_constructible_v<_Elem, _Args...>)
       : _Elem(_CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
@@ -101,15 +99,15 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __mdspan_ebco<_Elem1> : __mdspan_ebco_impl<0, 
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Elem1_ = _Elem1)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_default_constructible, _Elem1_))
-  _CCCL_API constexpr __mdspan_ebco() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _Elem1_))
+  _CCCL_REQUIRES(is_default_constructible_v<_Elem1_>)
+  _CCCL_API constexpr __mdspan_ebco() noexcept(is_nothrow_default_constructible_v<_Elem1_>)
       : __base1()
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class... _Args)
-  _CCCL_REQUIRES((sizeof...(_Args) != 0) _CCCL_AND _CCCL_TRAIT(is_constructible, _Elem1, _Args...))
-  _CCCL_API constexpr __mdspan_ebco(_Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Elem1, _Args...))
+  _CCCL_REQUIRES((sizeof...(_Args) != 0) _CCCL_AND is_constructible_v<_Elem1, _Args...>)
+  _CCCL_API constexpr __mdspan_ebco(_Args&&... __args) noexcept(is_nothrow_constructible_v<_Elem1, _Args...>)
       : __base1(_CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
@@ -144,21 +142,20 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __mdspan_ebco<_Elem1, _Elem2>
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Elem1_ = _Elem1, class _Elem2_ = _Elem2)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_default_constructible, _Elem1_)
-                   _CCCL_AND _CCCL_TRAIT(is_default_constructible, _Elem2_))
-  _CCCL_API constexpr __mdspan_ebco() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _Elem1_)
-                                               && _CCCL_TRAIT(is_nothrow_default_constructible, _Elem2_))
+  _CCCL_REQUIRES(is_default_constructible_v<_Elem1_> _CCCL_AND is_default_constructible_v<_Elem2_>)
+  _CCCL_API constexpr __mdspan_ebco() noexcept(is_nothrow_default_constructible_v<_Elem1_>
+                                               && is_nothrow_default_constructible_v<_Elem2_>)
       : __base1()
       , __base2()
   {}
 
   template <class _Arg1>
   static constexpr bool __is_constructible_from_one_arg =
-    _CCCL_TRAIT(is_constructible, _Elem1, _Arg1) && _CCCL_TRAIT(is_default_constructible, _Elem2);
+    is_constructible_v<_Elem1, _Arg1> && is_default_constructible_v<_Elem2>;
 
   template <class _Arg1>
   static constexpr bool __is_nothrow_constructible_from_one_arg =
-    _CCCL_TRAIT(is_nothrow_constructible, _Elem1, _Arg1) && _CCCL_TRAIT(is_nothrow_default_constructible, _Elem2);
+    is_nothrow_constructible_v<_Elem1, _Arg1> && is_nothrow_default_constructible_v<_Elem2>;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Arg1)
@@ -170,11 +167,11 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __mdspan_ebco<_Elem1, _Elem2>
 
   template <class _Arg1, class _Arg2>
   static constexpr bool __is_constructible_from_two_args =
-    _CCCL_TRAIT(is_constructible, _Elem1, _Arg1) && _CCCL_TRAIT(is_constructible, _Elem2, _Arg2);
+    is_constructible_v<_Elem1, _Arg1> && is_constructible_v<_Elem2, _Arg2>;
 
   template <class _Arg1, class _Arg2>
   static constexpr bool __is_nothrow_constructible_from_two_args =
-    _CCCL_TRAIT(is_nothrow_constructible, _Elem1, _Arg1) && _CCCL_TRAIT(is_nothrow_constructible, _Elem2, _Arg2);
+    is_nothrow_constructible_v<_Elem1, _Arg1> && is_nothrow_constructible_v<_Elem2, _Arg2>;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Arg1, class _Arg2)
@@ -235,11 +232,11 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __mdspan_ebco<_Elem1, _Elem2, _Elem3>
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Elem1_ = _Elem1, class _Elem2_ = _Elem2, class _Elem3_ = _Elem3)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_default_constructible, _Elem1_) _CCCL_AND _CCCL_TRAIT(is_default_constructible, _Elem2_)
-                   _CCCL_AND _CCCL_TRAIT(is_default_constructible, _Elem3_))
+  _CCCL_REQUIRES(is_default_constructible_v<_Elem1_> _CCCL_AND is_default_constructible_v<_Elem2_> _CCCL_AND
+                   is_default_constructible_v<_Elem3_>)
   _CCCL_API constexpr __mdspan_ebco() noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Elem1_) && _CCCL_TRAIT(is_nothrow_default_constructible, _Elem2_)
-    && _CCCL_TRAIT(is_nothrow_default_constructible, _Elem3_))
+    is_nothrow_default_constructible_v<_Elem1_> && is_nothrow_default_constructible_v<_Elem2_>
+    && is_nothrow_default_constructible_v<_Elem3_>)
       : __base1()
       , __base2()
       , __base3()
@@ -247,13 +244,12 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __mdspan_ebco<_Elem1, _Elem2, _Elem3>
 
   template <class _Arg1>
   static constexpr bool __is_constructible_from_one_arg =
-    _CCCL_TRAIT(is_constructible, _Elem1, _Arg1) && _CCCL_TRAIT(is_default_constructible, _Elem2)
-    && _CCCL_TRAIT(is_default_constructible, _Elem3);
+    is_constructible_v<_Elem1, _Arg1> && is_default_constructible_v<_Elem2> && is_default_constructible_v<_Elem3>;
 
   template <class _Arg1>
   static constexpr bool __is_nothrow_constructible_from_one_arg =
-    _CCCL_TRAIT(is_nothrow_constructible, _Elem1, _Arg1) && _CCCL_TRAIT(is_nothrow_default_constructible, _Elem2)
-    && _CCCL_TRAIT(is_nothrow_default_constructible, _Elem3);
+    is_nothrow_constructible_v<_Elem1, _Arg1> && is_nothrow_default_constructible_v<_Elem2>
+    && is_nothrow_default_constructible_v<_Elem3>;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Arg1)
@@ -266,13 +262,12 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __mdspan_ebco<_Elem1, _Elem2, _Elem3>
 
   template <class _Arg1, class _Arg2>
   static constexpr bool __is_constructible_from_two_args =
-    _CCCL_TRAIT(is_constructible, _Elem1, _Arg1) && _CCCL_TRAIT(is_constructible, _Elem2, _Arg2)
-    && _CCCL_TRAIT(is_default_constructible, _Elem3);
+    is_constructible_v<_Elem1, _Arg1> && is_constructible_v<_Elem2, _Arg2> && is_default_constructible_v<_Elem3>;
 
   template <class _Arg1, class _Arg2>
   static constexpr bool __is_nothrow_constructible_from_two_args =
-    _CCCL_TRAIT(is_nothrow_constructible, _Elem1, _Arg1) && _CCCL_TRAIT(is_nothrow_constructible, _Elem2, _Arg2)
-    && _CCCL_TRAIT(is_nothrow_default_constructible, _Elem3);
+    is_nothrow_constructible_v<_Elem1, _Arg1> && is_nothrow_constructible_v<_Elem2, _Arg2>
+    && is_nothrow_default_constructible_v<_Elem3>;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Arg1, class _Arg2)
@@ -286,13 +281,12 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __mdspan_ebco<_Elem1, _Elem2, _Elem3>
 
   template <class _Arg1, class _Arg2, class _Arg3>
   static constexpr bool __is_constructible_from_three_args =
-    _CCCL_TRAIT(is_constructible, _Elem1, _Arg1) && _CCCL_TRAIT(is_constructible, _Elem2, _Arg2)
-    && _CCCL_TRAIT(is_constructible, _Elem3, _Arg3);
+    is_constructible_v<_Elem1, _Arg1> && is_constructible_v<_Elem2, _Arg2> && is_constructible_v<_Elem3, _Arg3>;
 
   template <class _Arg1, class _Arg2, class _Arg3>
   static constexpr bool __is_nothrow_constructible_from_three_args =
-    _CCCL_TRAIT(is_nothrow_constructible, _Elem1, _Arg1) && _CCCL_TRAIT(is_nothrow_constructible, _Elem2, _Arg2)
-    && _CCCL_TRAIT(is_nothrow_constructible, _Elem3, _Arg3);
+    is_nothrow_constructible_v<_Elem1, _Arg1> && is_nothrow_constructible_v<_Elem2, _Arg2>
+    && is_nothrow_constructible_v<_Elem3, _Arg3>;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Arg1, class _Arg2, class _Arg3)

--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -178,9 +178,9 @@ template <class _TDynamic, class _TStatic, _TStatic _DynTag, _TStatic... _Values
 struct __maybe_static_array
     : private __possibly_empty_array<_TDynamic, __count_dynamic_v<_TStatic, _DynTag, _Values...>>
 {
-  static_assert(_CCCL_TRAIT(is_convertible, _TStatic, _TDynamic),
+  static_assert(is_convertible_v<_TStatic, _TDynamic>,
                 "__maybe_static_array: _TStatic must be convertible to _TDynamic");
-  static_assert(_CCCL_TRAIT(is_convertible, _TDynamic, _TStatic),
+  static_assert(is_convertible_v<_TDynamic, _TStatic>,
                 "__maybe_static_array: _TDynamic must be convertible to _TStatic");
 
 private:
@@ -327,7 +327,7 @@ _CCCL_REQUIRES(integral<_To>)
 {
   if constexpr (integral<_From>)
   {
-    if constexpr (_CCCL_TRAIT(is_signed, _From))
+    if constexpr (is_signed_v<_From>)
     {
       if constexpr (__potentially_narrowing<_To, _From>)
       {
@@ -344,7 +344,7 @@ _CCCL_REQUIRES(integral<_To>)
         return __value >= 0;
       }
     }
-    else // !_CCCL_TRAIT(is_signed, _From)
+    else // !is_signed_v<_From>
     {
       if constexpr (__potentially_narrowing<_To, _From>)
       {
@@ -360,11 +360,11 @@ _CCCL_REQUIRES(integral<_To>)
   }
   else // !integral<_From>
   {
-    if constexpr (_CCCL_TRAIT(is_signed, _To))
+    if constexpr (is_signed_v<_To>)
     {
       return static_cast<_To>(__value) >= 0;
     }
-    else // !_CCCL_TRAIT(is_signed, _To)
+    else // !is_signed_v<_To>
     {
       return true;
     }
@@ -415,7 +415,7 @@ public:
   using size_type  = make_unsigned_t<index_type>;
   using rank_type  = size_t;
 
-  static_assert(_CCCL_TRAIT(is_integral, index_type) && !_CCCL_TRAIT(is_same, index_type, bool),
+  static_assert(is_integral_v<index_type> && !is_same_v<index_type, bool>,
                 "extents::index_type must be a signed or unsigned integer type");
   static_assert(
     __all<(__mdspan_detail::__is_representable_as<index_type>(_Extents) || (_Extents == dynamic_extent))...>::value,
@@ -468,8 +468,8 @@ public:
 
   template <class _OtherIndexType>
   static constexpr bool __is_convertible_to_index_type =
-    _CCCL_TRAIT(is_convertible, const _OtherIndexType&, index_type)
-    && _CCCL_TRAIT(is_nothrow_constructible, index_type, const _OtherIndexType&);
+    is_convertible_v<const _OtherIndexType&, index_type>
+    && is_nothrow_constructible_v<index_type, const _OtherIndexType&>;
 
   _CCCL_TEMPLATE(class _OtherIndexType, size_t _Size)
   _CCCL_REQUIRES((_Size == __rank_dynamic_) _CCCL_AND __is_convertible_to_index_type<_OtherIndexType>)
@@ -701,7 +701,7 @@ _CCCL_REQUIRES(integral<_IndexType>)
 {
   if constexpr (integral<_From>)
   {
-    if constexpr (_CCCL_TRAIT(is_signed, _From))
+    if constexpr (is_signed_v<_From>)
     {
       if (__value < 0)
       {
@@ -718,7 +718,7 @@ _CCCL_REQUIRES(integral<_IndexType>)
   }
   else
   {
-    if constexpr (_CCCL_TRAIT(is_signed, _From))
+    if constexpr (is_signed_v<_From>)
     {
       if (static_cast<_IndexType>(__value) < 0)
       {

--- a/libcudacxx/include/cuda/std/__mdspan/layout_left.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_left.h
@@ -104,8 +104,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, extents_type, _OtherExtents)
-                   _CCCL_AND _CCCL_TRAIT(is_convertible, _OtherExtents, extents_type))
+  _CCCL_REQUIRES(is_constructible_v<extents_type, _OtherExtents> _CCCL_AND is_convertible_v<_OtherExtents, extents_type>)
   _CCCL_API constexpr mapping(const mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {
@@ -117,8 +116,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, extents_type, _OtherExtents)
-                   _CCCL_AND(!_CCCL_TRAIT(is_convertible, _OtherExtents, extents_type)))
+  _CCCL_REQUIRES(
+    is_constructible_v<extents_type, _OtherExtents> _CCCL_AND(!is_convertible_v<_OtherExtents, extents_type>))
   _CCCL_API explicit constexpr mapping(const mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {
@@ -130,8 +129,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES((_OtherExtents::rank() <= 1) _CCCL_AND _CCCL_TRAIT(is_constructible, extents_type, _OtherExtents)
-                   _CCCL_AND _CCCL_TRAIT(is_convertible, _OtherExtents, extents_type))
+  _CCCL_REQUIRES((_OtherExtents::rank() <= 1) _CCCL_AND is_constructible_v<extents_type, _OtherExtents> _CCCL_AND
+                   is_convertible_v<_OtherExtents, extents_type>)
   _CCCL_API constexpr mapping(const layout_right::mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {
@@ -147,8 +146,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES((_OtherExtents::rank() <= 1) _CCCL_AND _CCCL_TRAIT(is_constructible, extents_type, _OtherExtents)
-                   _CCCL_AND(!_CCCL_TRAIT(is_convertible, _OtherExtents, extents_type)))
+  _CCCL_REQUIRES((_OtherExtents::rank() <= 1) _CCCL_AND is_constructible_v<extents_type, _OtherExtents> _CCCL_AND(
+    !is_convertible_v<_OtherExtents, extents_type>))
   _CCCL_API explicit constexpr mapping(const layout_right::mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {
@@ -179,7 +178,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, extents_type, _OtherExtents) _CCCL_AND(extents_type::rank() > 0))
+  _CCCL_REQUIRES(is_constructible_v<extents_type, _OtherExtents> _CCCL_AND(extents_type::rank() > 0))
   _CCCL_API explicit constexpr mapping(const layout_stride::mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {
@@ -191,7 +190,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, extents_type, _OtherExtents) _CCCL_AND(extents_type::rank() == 0))
+  _CCCL_REQUIRES(is_constructible_v<extents_type, _OtherExtents> _CCCL_AND(extents_type::rank() == 0))
   _CCCL_API constexpr mapping(const layout_stride::mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {}

--- a/libcudacxx/include/cuda/std/__mdspan/layout_right.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_right.h
@@ -105,8 +105,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, extents_type, _OtherExtents)
-                   _CCCL_AND _CCCL_TRAIT(is_convertible, _OtherExtents, extents_type))
+  _CCCL_REQUIRES(is_constructible_v<extents_type, _OtherExtents> _CCCL_AND is_convertible_v<_OtherExtents, extents_type>)
   _CCCL_API constexpr mapping(const mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {
@@ -118,8 +117,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, extents_type, _OtherExtents)
-                   _CCCL_AND(!_CCCL_TRAIT(is_convertible, _OtherExtents, extents_type)))
+  _CCCL_REQUIRES(
+    is_constructible_v<extents_type, _OtherExtents> _CCCL_AND(!is_convertible_v<_OtherExtents, extents_type>))
   _CCCL_API explicit constexpr mapping(const mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {
@@ -131,8 +130,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES((_OtherExtents::rank() <= 1) _CCCL_AND _CCCL_TRAIT(is_constructible, extents_type, _OtherExtents)
-                   _CCCL_AND _CCCL_TRAIT(is_convertible, _OtherExtents, extents_type))
+  _CCCL_REQUIRES((_OtherExtents::rank() <= 1) _CCCL_AND is_constructible_v<extents_type, _OtherExtents> _CCCL_AND
+                   is_convertible_v<_OtherExtents, extents_type>)
   _CCCL_API constexpr mapping(const layout_left::mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {
@@ -148,8 +147,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES((_OtherExtents::rank() <= 1) _CCCL_AND _CCCL_TRAIT(is_constructible, extents_type, _OtherExtents)
-                   _CCCL_AND(!_CCCL_TRAIT(is_convertible, _OtherExtents, extents_type)))
+  _CCCL_REQUIRES((_OtherExtents::rank() <= 1) _CCCL_AND is_constructible_v<extents_type, _OtherExtents> _CCCL_AND(
+    !is_convertible_v<_OtherExtents, extents_type>))
   _CCCL_API explicit constexpr mapping(const layout_left::mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {
@@ -180,7 +179,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, extents_type, _OtherExtents) _CCCL_AND(extents_type::rank() > 0))
+  _CCCL_REQUIRES(is_constructible_v<extents_type, _OtherExtents> _CCCL_AND(extents_type::rank() > 0))
   _CCCL_API explicit constexpr mapping(const layout_stride::mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {
@@ -192,7 +191,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _OtherExtents)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, extents_type, _OtherExtents) _CCCL_AND(extents_type::rank() == 0))
+  _CCCL_REQUIRES(is_constructible_v<extents_type, _OtherExtents> _CCCL_AND(extents_type::rank() == 0))
   _CCCL_API constexpr mapping(const layout_stride::mapping<_OtherExtents>& __other) noexcept
       : __base(__other.extents())
   {}

--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -56,13 +56,13 @@ _CCCL_CONCEPT __can_convert = _CCCL_REQUIRES_EXPR((_StridedLayoutMapping, _Exten
   requires(__mdspan_detail::__layout_mapping_alike<_StridedLayoutMapping>),
   requires(_StridedLayoutMapping::is_always_unique()),
   requires(_StridedLayoutMapping::is_always_strided()),
-  requires(_CCCL_TRAIT(is_constructible, _Extents, typename _StridedLayoutMapping::extents_type)));
+  requires(is_constructible_v<_Extents, typename _StridedLayoutMapping::extents_type>));
 
 struct __constraints
 {
   template <class _StridedLayoutMapping, class _Extents>
   static constexpr bool __converts_implicit =
-    _CCCL_TRAIT(is_convertible, typename _StridedLayoutMapping::extents_type, _Extents)
+    is_convertible_v<typename _StridedLayoutMapping::extents_type, _Extents>
     && (__mdspan_detail::__is_mapping_of<layout_left, _StridedLayoutMapping>
         || __mdspan_detail::__is_mapping_of<layout_right, _StridedLayoutMapping>
         || __mdspan_detail::__is_mapping_of<layout_stride, _StridedLayoutMapping>);
@@ -130,7 +130,7 @@ private:
   __conversion_may_overflow([[maybe_unused]] _OtherIndexType __stride) noexcept
   {
     // nvcc believes stride is unused here
-    if constexpr (_CCCL_TRAIT(is_integral, _OtherIndexType))
+    if constexpr (is_integral_v<_OtherIndexType>)
     {
       using _CommonType = common_type_t<index_type, _OtherIndexType>;
       return static_cast<_CommonType>(__stride) > static_cast<_CommonType>((numeric_limits<index_type>::max)());
@@ -239,7 +239,7 @@ public:
     [[maybe_unused]] span<_OtherIndexType, extents_type::rank()> __strides, index_sequence<_Pos...>) noexcept
   {
     // nvcc believes strides is unused here
-    if constexpr (_CCCL_TRAIT(is_integral, _OtherIndexType))
+    if constexpr (is_integral_v<_OtherIndexType>)
     {
       return ((__strides[_Pos] > _OtherIndexType{0}) && ... && true);
     }
@@ -301,8 +301,8 @@ public:
 
   // nvcc cannot deduce this constructor when using _CCCL_REQUIRES
   template <class _OtherIndexType,
-            enable_if_t<_CCCL_TRAIT(is_constructible, index_type, const _OtherIndexType&), int> = 0,
-            enable_if_t<_CCCL_TRAIT(is_convertible, const _OtherIndexType&, index_type), int>   = 0>
+            enable_if_t<is_constructible_v<index_type, const _OtherIndexType&>, int> = 0,
+            enable_if_t<is_convertible_v<const _OtherIndexType&, index_type>, int>   = 0>
   _CCCL_API constexpr mapping(const extents_type& __ext, span<_OtherIndexType, extents_type::rank()> __strides) noexcept
       : __base(__ext, __to_strides_array(__strides, __rank_sequence))
   {
@@ -316,8 +316,8 @@ public:
 
   // nvcc cannot deduce this constructor when using _CCCL_REQUIRES
   template <class _OtherIndexType,
-            enable_if_t<_CCCL_TRAIT(is_constructible, index_type, const _OtherIndexType&), int> = 0,
-            enable_if_t<_CCCL_TRAIT(is_convertible, const _OtherIndexType&, index_type), int>   = 0>
+            enable_if_t<is_constructible_v<index_type, const _OtherIndexType&>, int> = 0,
+            enable_if_t<is_convertible_v<const _OtherIndexType&, index_type>, int>   = 0>
   _CCCL_API constexpr mapping(const extents_type& __ext,
                               const array<_OtherIndexType, extents_type::rank()>& __strides) noexcept
       : mapping(__ext, span<const _OtherIndexType, extents_type::rank()>(__strides))

--- a/libcudacxx/include/cuda/std/__mdspan/submdspan_extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/submdspan_extents.h
@@ -171,7 +171,7 @@ struct __get_subextent
 template <class _IndexType, class _SliceType>
 inline constexpr bool __is_valid_subextents =
   convertible_to<_SliceType, _IndexType> || __index_pair_like<_SliceType, _IndexType>
-  || _CCCL_TRAIT(is_convertible, _SliceType, full_extent_t) || __is_strided_slice<remove_cv_t<_SliceType>>;
+  || is_convertible_v<_SliceType, full_extent_t> || __is_strided_slice<remove_cv_t<_SliceType>>;
 
 _CCCL_TEMPLATE(class _Extents, class... _Slices)
 _CCCL_REQUIRES((_Extents::rank() == sizeof...(_Slices)))

--- a/libcudacxx/include/cuda/std/__mdspan/submdspan_helper.h
+++ b/libcudacxx/include/cuda/std/__mdspan/submdspan_helper.h
@@ -102,7 +102,7 @@ _CCCL_REQUIRES(__integral_constant_like<_Tp>)
 template <class _IndexType, class _From>
 [[nodiscard]] _CCCL_API constexpr auto __index_cast(_From&& __from) noexcept
 {
-  if constexpr (_CCCL_TRAIT(is_integral, _From) && !_CCCL_TRAIT(is_same, _From, bool))
+  if constexpr (is_integral_v<_From> && !is_same_v<_From, bool>)
   {
     return __from;
   }
@@ -124,7 +124,7 @@ using __get_slice_type = tuple_element_t<_Index, __tuple_types<_Slices...>>;
 template <class _IndexType, size_t _Index, class... _Slices>
 [[nodiscard]] _CCCL_API constexpr _IndexType __first_extent_from_slice(_Slices... __slices) noexcept
 {
-  static_assert(_CCCL_TRAIT(is_signed, _IndexType) || _CCCL_TRAIT(is_unsigned, _IndexType),
+  static_assert(is_signed_v<_IndexType> || is_unsigned_v<_IndexType>,
                 "[mdspan.sub.helpers] mandates IndexType to be a signed or unsigned integral");
   using _SliceType                     = __get_slice_type<_Index, _Slices...>;
   [[maybe_unused]] _SliceType& __slice = _CUDA_VSTD::__get_slice_at<_Index>(__slices...);
@@ -154,7 +154,7 @@ template <size_t _Index, class _Extents, class... _Slices>
 [[nodiscard]] _CCCL_API constexpr typename _Extents::index_type
 __last_extent_from_slice(const _Extents& __src, _Slices... __slices) noexcept
 {
-  static_assert(_CCCL_TRAIT(__mdspan_detail::__is_extents, _Extents),
+  static_assert(__mdspan_detail::__is_extents_v<_Extents>,
                 "[mdspan.sub.helpers] mandates Extents to be a specialization of extents");
   using _IndexType                     = typename _Extents::index_type;
   using _SliceType                     = __get_slice_type<_Index, _Slices...>;

--- a/libcudacxx/include/cuda/std/__mdspan/submdspan_mapping.h
+++ b/libcudacxx/include/cuda/std/__mdspan/submdspan_mapping.h
@@ -158,7 +158,7 @@ _CCCL_API constexpr bool __is_unit_stride_slice()
     return true;
   }
   // [mdspan.sub.map.common-9.3]
-  else if constexpr (_CCCL_TRAIT(is_convertible, _SliceType, full_extent_t))
+  else if constexpr (is_convertible_v<_SliceType, full_extent_t>)
   {
     return true;
   }
@@ -184,7 +184,7 @@ _CCCL_API constexpr bool __can_layout_left()
     return _CUDA_VSTD::__is_unit_stride_slice<_LayoutMapping, _Slice>();
   }
   // [mdspan.sub.map.left-1.3.1]
-  else if constexpr (_CCCL_TRAIT(is_convertible, _Slice, full_extent_t))
+  else if constexpr (is_convertible_v<_Slice, full_extent_t>)
   {
     return _CUDA_VSTD::__can_layout_left<_LayoutMapping, _SubExtents, _OtherSlices...>();
   }
@@ -244,7 +244,7 @@ _CCCL_API constexpr bool __can_layout_right()
     return _CUDA_VSTD::__is_unit_stride_slice<_LayoutMapping, _Slice>();
   }
   // [mdspan.sub.map.right-1.3.1]
-  else if constexpr (_CCCL_TRAIT(is_convertible, _Slice, full_extent_t))
+  else if constexpr (is_convertible_v<_Slice, full_extent_t>)
   {
     return _CUDA_VSTD::__can_layout_left<_LayoutMapping, _SubExtents, _OtherSlices...>();
   }

--- a/libcudacxx/include/cuda/std/__memory/allocator.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator.h
@@ -104,9 +104,9 @@ struct __non_trivial_if<true, _Unique>
 //       allocator<void> trivial in C++20.
 
 template <class _Tp>
-class _CCCL_TYPE_VISIBILITY_DEFAULT allocator : private __non_trivial_if<!_CCCL_TRAIT(is_void, _Tp), allocator<_Tp>>
+class _CCCL_TYPE_VISIBILITY_DEFAULT allocator : private __non_trivial_if<!is_void_v<_Tp>, allocator<_Tp>>
 {
-  static_assert(!_CCCL_TRAIT(is_volatile, _Tp), "std::allocator does not support volatile types");
+  static_assert(!is_volatile_v<_Tp>, "std::allocator does not support volatile types");
 
 public:
   using size_type                              = size_t;
@@ -208,9 +208,9 @@ public:
 
 template <class _Tp>
 class _CCCL_TYPE_VISIBILITY_DEFAULT
-allocator<const _Tp> : private __non_trivial_if<!_CCCL_TRAIT(is_void, _Tp), allocator<const _Tp>>
+allocator<const _Tp> : private __non_trivial_if<!is_void_v<_Tp>, allocator<const _Tp>>
 {
-  static_assert(!_CCCL_TRAIT(is_volatile, _Tp), "std::allocator does not support volatile types");
+  static_assert(!is_volatile_v<_Tp>, "std::allocator does not support volatile types");
 
 public:
   using size_type                              = size_t;

--- a/libcudacxx/include/cuda/std/__memory/allocator_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_traits.h
@@ -53,10 +53,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // __pointer
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_pointer, pointer)
-template <class _Tp,
-          class _Alloc,
-          class _RawAlloc = remove_reference_t<_Alloc>,
-          bool            = _CCCL_TRAIT(__has_pointer, _RawAlloc)>
+template <class _Tp, class _Alloc, class _RawAlloc = remove_reference_t<_Alloc>, bool = __has_pointer_v<_RawAlloc>>
 struct __pointer
 {
   using type _CCCL_NODEBUG_ALIAS = typename _RawAlloc::pointer;
@@ -69,7 +66,7 @@ struct __pointer<_Tp, _Alloc, _RawAlloc, false>
 
 // __const_pointer
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_const_pointer, const_pointer)
-template <class _Tp, class _Ptr, class _Alloc, bool = _CCCL_TRAIT(__has_const_pointer, _Alloc)>
+template <class _Tp, class _Ptr, class _Alloc, bool = __has_const_pointer_v<_Alloc>>
 struct __const_pointer
 {
   using type _CCCL_NODEBUG_ALIAS = typename _Alloc::const_pointer;
@@ -82,7 +79,7 @@ struct __const_pointer<_Tp, _Ptr, _Alloc, false>
 
 // __void_pointer
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_void_pointer, void_pointer)
-template <class _Ptr, class _Alloc, bool = _CCCL_TRAIT(__has_void_pointer, _Alloc)>
+template <class _Ptr, class _Alloc, bool = __has_void_pointer_v<_Alloc>>
 struct __void_pointer
 {
   using type _CCCL_NODEBUG_ALIAS = typename _Alloc::void_pointer;
@@ -95,7 +92,7 @@ struct __void_pointer<_Ptr, _Alloc, false>
 
 // __const_void_pointer
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_const_void_pointer, const_void_pointer)
-template <class _Ptr, class _Alloc, bool = _CCCL_TRAIT(__has_const_void_pointer, _Alloc)>
+template <class _Ptr, class _Alloc, bool = __has_const_void_pointer_v<_Alloc>>
 struct __const_void_pointer
 {
   using type _CCCL_NODEBUG_ALIAS = typename _Alloc::const_void_pointer;
@@ -108,7 +105,7 @@ struct __const_void_pointer<_Ptr, _Alloc, false>
 
 // __size_type
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_size_type, size_type)
-template <class _Alloc, class _DiffType, bool = _CCCL_TRAIT(__has_size_type, _Alloc)>
+template <class _Alloc, class _DiffType, bool = __has_size_type_v<_Alloc>>
 struct __size_type : make_unsigned<_DiffType>
 {};
 template <class _Alloc, class _DiffType>
@@ -119,7 +116,7 @@ struct __size_type<_Alloc, _DiffType, true>
 
 // __alloc_traits_difference_type
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_alloc_traits_difference_type, difference_type)
-template <class _Alloc, class _Ptr, bool = _CCCL_TRAIT(__has_alloc_traits_difference_type, _Alloc)>
+template <class _Alloc, class _Ptr, bool = __has_alloc_traits_difference_type_v<_Alloc>>
 struct __alloc_traits_difference_type
 {
   using type _CCCL_NODEBUG_ALIAS = typename pointer_traits<_Ptr>::difference_type;
@@ -133,7 +130,7 @@ struct __alloc_traits_difference_type<_Alloc, _Ptr, true>
 // __propagate_on_container_copy_assignment
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_propagate_on_container_copy_assignment,
                                      propagate_on_container_copy_assignment)
-template <class _Alloc, bool = _CCCL_TRAIT(__has_propagate_on_container_copy_assignment, _Alloc)>
+template <class _Alloc, bool = __has_propagate_on_container_copy_assignment_v<_Alloc>>
 struct __propagate_on_container_copy_assignment : false_type
 {};
 template <class _Alloc>
@@ -145,7 +142,7 @@ struct __propagate_on_container_copy_assignment<_Alloc, true>
 // __propagate_on_container_move_assignment
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_propagate_on_container_move_assignment,
                                      propagate_on_container_move_assignment)
-template <class _Alloc, bool = _CCCL_TRAIT(__has_propagate_on_container_move_assignment, _Alloc)>
+template <class _Alloc, bool = __has_propagate_on_container_move_assignment_v<_Alloc>>
 struct __propagate_on_container_move_assignment : false_type
 {};
 template <class _Alloc>
@@ -156,7 +153,7 @@ struct __propagate_on_container_move_assignment<_Alloc, true>
 
 // __propagate_on_container_swap
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_propagate_on_container_swap, propagate_on_container_swap)
-template <class _Alloc, bool = _CCCL_TRAIT(__has_propagate_on_container_swap, _Alloc)>
+template <class _Alloc, bool = __has_propagate_on_container_swap_v<_Alloc>>
 struct __propagate_on_container_swap : false_type
 {};
 template <class _Alloc>
@@ -167,7 +164,7 @@ struct __propagate_on_container_swap<_Alloc, true>
 
 // __is_always_equal
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_is_always_equal, is_always_equal)
-template <class _Alloc, bool = _CCCL_TRAIT(__has_is_always_equal, _Alloc)>
+template <class _Alloc, bool = __has_is_always_equal_v<_Alloc>>
 struct __is_always_equal : is_empty<_Alloc>
 {};
 template <class _Alloc>

--- a/libcudacxx/include/cuda/std/__memory/compressed_pair.h
+++ b/libcudacxx/include/cuda/std/__memory/compressed_pair.h
@@ -50,7 +50,7 @@ struct __default_init_tag
 struct __value_init_tag
 {};
 
-template <class _Tp, int _Idx, bool _CanBeEmptyBase = _CCCL_TRAIT(is_empty, _Tp) && !_CCCL_TRAIT(is_final, _Tp)>
+template <class _Tp, int _Idx, bool _CanBeEmptyBase = is_empty_v<_Tp> && !is_final_v<_Tp>>
 struct __compressed_pair_elem
 {
   using _ParamT         = _Tp;
@@ -58,16 +58,14 @@ struct __compressed_pair_elem
   using const_reference = const _Tp&;
 
   _CCCL_API constexpr explicit __compressed_pair_elem(__default_init_tag) noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Tp))
+    is_nothrow_default_constructible_v<_Tp>)
   {}
-  _CCCL_API constexpr explicit __compressed_pair_elem(__value_init_tag) noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Tp))
+  _CCCL_API constexpr explicit __compressed_pair_elem(__value_init_tag) noexcept(is_nothrow_default_constructible_v<_Tp>)
       : __value_()
   {}
 
-  template <class _Up, enable_if_t<!_CCCL_TRAIT(is_same, __compressed_pair_elem, decay_t<_Up>), int> = 0>
-  _CCCL_API constexpr explicit __compressed_pair_elem(_Up&& __u) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up))
+  template <class _Up, enable_if_t<!is_same_v<__compressed_pair_elem, decay_t<_Up>>, int> = 0>
+  _CCCL_API constexpr explicit __compressed_pair_elem(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>)
       : __value_(_CUDA_VSTD::forward<_Up>(__u))
   {}
 
@@ -75,7 +73,7 @@ struct __compressed_pair_elem
   _CCCL_API constexpr explicit __compressed_pair_elem(
     piecewise_construct_t,
     tuple<_Args...> __args,
-    __tuple_indices<_Indices...>) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+    __tuple_indices<_Indices...>) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : __value_(_CUDA_VSTD::forward<_Args>(_CUDA_VSTD::get<_Indices>(__args))...)
   {}
 
@@ -103,16 +101,14 @@ struct __compressed_pair_elem<_Tp, _Idx, true> : private _Tp
   _CCCL_HIDE_FROM_ABI explicit constexpr __compressed_pair_elem() = default;
 
   _CCCL_API constexpr explicit __compressed_pair_elem(__default_init_tag) noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Tp))
+    is_nothrow_default_constructible_v<_Tp>)
   {}
-  _CCCL_API constexpr explicit __compressed_pair_elem(__value_init_tag) noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Tp))
+  _CCCL_API constexpr explicit __compressed_pair_elem(__value_init_tag) noexcept(is_nothrow_default_constructible_v<_Tp>)
       : __value_type()
   {}
 
-  template <class _Up, enable_if_t<!_CCCL_TRAIT(is_same, __compressed_pair_elem, decay_t<_Up>), int> = 0>
-  _CCCL_API constexpr explicit __compressed_pair_elem(_Up&& __u) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up))
+  template <class _Up, enable_if_t<!is_same_v<__compressed_pair_elem, decay_t<_Up>>, int> = 0>
+  _CCCL_API constexpr explicit __compressed_pair_elem(_Up&& __u) noexcept(is_nothrow_constructible_v<_Tp, _Up>)
       : __value_type(_CUDA_VSTD::forward<_Up>(__u))
   {}
 
@@ -120,7 +116,7 @@ struct __compressed_pair_elem<_Tp, _Idx, true> : private _Tp
   _CCCL_API constexpr __compressed_pair_elem(
     piecewise_construct_t,
     tuple<_Args...> __args,
-    __tuple_indices<_Indices...>) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+    __tuple_indices<_Indices...>) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
       : __value_type(_CUDA_VSTD::forward<_Args>(_CUDA_VSTD::get<_Indices>(__args))...)
   {}
 
@@ -144,7 +140,7 @@ public:
   // is *almost never* used in a scenario where it's possible for T1 == T2.
   // (The exception is std::function where it is possible that the function
   //  object and the allocator have the same type).
-  static_assert((!_CCCL_TRAIT(is_same, _T1, _T2)),
+  static_assert((!is_same_v<_T1, _T2>),
                 "__compressed_pair cannot be instantiated when T1 and T2 are the same type; "
                 "The current implementation is NOT ABI-compatible with the previous implementation for this "
                 "configuration");
@@ -156,14 +152,14 @@ public:
             class       = enable_if_t<__dependent_type<is_default_constructible<_T1>, _Dummy>::value
                                       && __dependent_type<is_default_constructible<_T2>, _Dummy>::value>>
   _CCCL_API constexpr explicit __compressed_pair() noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _T1) && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
+    is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : _Base1(__value_init_tag())
       , _Base2(__value_init_tag())
   {}
 
   template <class _U1, class _U2>
   _CCCL_API constexpr explicit __compressed_pair(_U1&& __t1, _U2&& __t2) noexcept(
-    _CCCL_TRAIT(is_constructible, _T1, _U1) && _CCCL_TRAIT(is_constructible, _T2, _U2))
+    is_constructible_v<_T1, _U1> && is_constructible_v<_T2, _U2>)
       : _Base1(_CUDA_VSTD::forward<_U1>(__t1))
       , _Base2(_CUDA_VSTD::forward<_U2>(__t2))
   {}
@@ -172,8 +168,7 @@ public:
   _CCCL_API constexpr explicit __compressed_pair(
     piecewise_construct_t __pc,
     tuple<_Args1...> __first_args,
-    tuple<_Args2...> __second_args) noexcept(_CCCL_TRAIT(is_constructible, _T1, _Args1...)
-                                             && _CCCL_TRAIT(is_constructible, _T2, _Args2...))
+    tuple<_Args2...> __second_args) noexcept(is_constructible_v<_T1, _Args1...> && is_constructible_v<_T2, _Args2...>)
       : _Base1(__pc, _CUDA_VSTD::move(__first_args), typename __make_tuple_indices<sizeof...(_Args1)>::type())
       , _Base2(__pc, _CUDA_VSTD::move(__second_args), typename __make_tuple_indices<sizeof...(_Args2)>::type())
   {}

--- a/libcudacxx/include/cuda/std/__memory/unique_ptr.h
+++ b/libcudacxx/include/cuda/std/__memory/unique_ptr.h
@@ -59,13 +59,13 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete
 {
-  static_assert(!_CCCL_TRAIT(is_function, _Tp), "default_delete cannot be instantiated for function types");
+  static_assert(!is_function_v<_Tp>, "default_delete cannot be instantiated for function types");
 
   _CCCL_HIDE_FROM_ABI constexpr default_delete() noexcept = default;
 
   template <class _Up>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20
-  default_delete(const default_delete<_Up>&, enable_if_t<_CCCL_TRAIT(is_convertible, _Up*, _Tp*), int> = 0) noexcept
+  default_delete(const default_delete<_Up>&, enable_if_t<is_convertible_v<_Up*, _Tp*>, int> = 0) noexcept
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -83,13 +83,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete<_Tp[]>
   _CCCL_HIDE_FROM_ABI constexpr default_delete() noexcept = default;
 
   template <class _Up>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 default_delete(
-    const default_delete<_Up[]>&, enable_if_t<_CCCL_TRAIT(is_convertible, _Up (*)[], _Tp (*)[]), int> = 0) noexcept
+  _CCCL_API inline _CCCL_CONSTEXPR_CXX20
+  default_delete(const default_delete<_Up[]>&, enable_if_t<is_convertible_v<_Up (*)[], _Tp (*)[]>, int> = 0) noexcept
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Up>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<_CCCL_TRAIT(is_convertible, _Up (*)[], _Tp (*)[]), void>
+  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<is_convertible_v<_Up (*)[], _Tp (*)[]>, void>
   operator()(_Up* __ptr) const noexcept
   {
     static_assert(sizeof(_Up) >= 0, "cannot delete an incomplete type");
@@ -100,7 +100,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete<_Tp[]>
 template <class _Deleter>
 struct __unique_ptr_deleter_sfinae
 {
-  static_assert(!_CCCL_TRAIT(is_reference, _Deleter), "incorrect specialization");
+  static_assert(!is_reference_v<_Deleter>, "incorrect specialization");
   typedef const _Deleter& __lval_ref_type;
   typedef _Deleter&& __good_rval_ref_type;
   typedef true_type __enable_rval_overload;
@@ -136,8 +136,7 @@ public:
   typedef _Dp deleter_type;
   typedef _CCCL_NODEBUG_ALIAS typename __pointer<_Tp, deleter_type>::type pointer;
 
-  static_assert(!_CCCL_TRAIT(is_rvalue_reference, deleter_type),
-                "the specified deleter type cannot be an rvalue reference");
+  static_assert(!is_rvalue_reference_v<deleter_type>, "the specified deleter type cannot be an rvalue reference");
 
 private:
   __compressed_pair<pointer, deleter_type> __ptr_;

--- a/libcudacxx/include/cuda/std/__memory/uses_allocator.h
+++ b/libcudacxx/include/cuda/std/__memory/uses_allocator.h
@@ -35,18 +35,17 @@ inline constexpr bool __has_allocator_type_v = false;
 template <class _Tp>
 inline constexpr bool __has_allocator_type_v<_Tp, void_t<typename _Tp::allocator_type>> = true;
 
-template <class _Tp, class _Alloc, bool = _CCCL_TRAIT(__has_allocator_type, _Tp)>
+template <class _Tp, class _Alloc, bool = __has_allocator_type_v<_Tp>>
 inline constexpr bool __uses_allocator_v = false;
 template <class _Tp, class _Alloc>
 inline constexpr bool __uses_allocator_v<_Tp, _Alloc, true> = is_convertible_v<_Alloc, typename _Tp::allocator_type>;
 
 template <class _Tp, class _Alloc>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-uses_allocator : public integral_constant<bool, _CCCL_TRAIT(__uses_allocator, _Tp, _Alloc)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT uses_allocator : public integral_constant<bool, __uses_allocator_v<_Tp, _Alloc>>
 {};
 
 template <class _Tp, class _Alloc>
-inline constexpr bool uses_allocator_v = _CCCL_TRAIT(__uses_allocator, _Tp, _Alloc);
+inline constexpr bool uses_allocator_v = __uses_allocator_v<_Tp, _Alloc>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__new/launder.h
+++ b/libcudacxx/include/cuda/std/__new/launder.h
@@ -33,8 +33,8 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp* launder(_Tp* __p) noexcept
 {
-  static_assert(!_CCCL_TRAIT(is_function, _Tp), "can't launder functions");
-  static_assert(!_CCCL_TRAIT(is_same, void, remove_cv_t<_Tp>), "can't launder cv-void");
+  static_assert(!is_function_v<_Tp>, "can't launder functions");
+  static_assert(!is_same_v<void, remove_cv_t<_Tp>>, "can't launder cv-void");
 #if defined(_CCCL_BUILTIN_LAUNDER)
   return _CCCL_BUILTIN_LAUNDER(__p);
 #else

--- a/libcudacxx/include/cuda/std/__numeric/gcd_lcm.h
+++ b/libcudacxx/include/cuda/std/__numeric/gcd_lcm.h
@@ -37,17 +37,16 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 template <class _Tp>
 constexpr _CCCL_API inline _Tp __gcd(_Tp __m, _Tp __n)
 {
-  static_assert((!_CCCL_TRAIT(is_signed, _Tp)), "");
+  static_assert((!is_signed_v<_Tp>), "");
   return __n == 0 ? __m : _CUDA_VSTD::__gcd<_Tp>(__n, __m % __n);
 }
 
 template <class _Tp, class _Up>
 constexpr _CCCL_API inline common_type_t<_Tp, _Up> gcd(_Tp __m, _Up __n)
 {
-  static_assert((_CCCL_TRAIT(is_integral, _Tp) && _CCCL_TRAIT(is_integral, _Up)),
-                "Arguments to gcd must be integer types");
-  static_assert((!_CCCL_TRAIT(is_same, remove_cv_t<_Tp>, bool)), "First argument to gcd cannot be bool");
-  static_assert((!_CCCL_TRAIT(is_same, remove_cv_t<_Up>, bool)), "Second argument to gcd cannot be bool");
+  static_assert((is_integral_v<_Tp> && is_integral_v<_Up>), "Arguments to gcd must be integer types");
+  static_assert((!is_same_v<remove_cv_t<_Tp>, bool>), "First argument to gcd cannot be bool");
+  static_assert((!is_same_v<remove_cv_t<_Up>, bool>), "Second argument to gcd cannot be bool");
   using _Rp = common_type_t<_Tp, _Up>;
   using _Wp = make_unsigned_t<_Rp>;
   return static_cast<_Rp>(_CUDA_VSTD::__gcd(static_cast<_Wp>(::cuda::uabs(__m)), static_cast<_Wp>(::cuda::uabs(__n))));
@@ -56,10 +55,9 @@ constexpr _CCCL_API inline common_type_t<_Tp, _Up> gcd(_Tp __m, _Up __n)
 template <class _Tp, class _Up>
 constexpr _CCCL_API inline common_type_t<_Tp, _Up> lcm(_Tp __m, _Up __n)
 {
-  static_assert((_CCCL_TRAIT(is_integral, _Tp) && _CCCL_TRAIT(is_integral, _Up)),
-                "Arguments to lcm must be integer types");
-  static_assert((!_CCCL_TRAIT(is_same, remove_cv_t<_Tp>, bool)), "First argument to lcm cannot be bool");
-  static_assert((!_CCCL_TRAIT(is_same, remove_cv_t<_Up>, bool)), "Second argument to lcm cannot be bool");
+  static_assert((is_integral_v<_Tp> && is_integral_v<_Up>), "Arguments to lcm must be integer types");
+  static_assert((!is_same_v<remove_cv_t<_Tp>, bool>), "First argument to lcm cannot be bool");
+  static_assert((!is_same_v<remove_cv_t<_Up>, bool>), "Second argument to lcm cannot be bool");
   if (__m == 0 || __n == 0)
   {
     return 0;

--- a/libcudacxx/include/cuda/std/__numeric/midpoint.h
+++ b/libcudacxx/include/cuda/std/__numeric/midpoint.h
@@ -38,9 +38,8 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _Tp>
-[[nodiscard]] _CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_integral, _Tp) && !_CCCL_TRAIT(is_same, bool, _Tp) && !_CCCL_TRAIT(is_null_pointer, _Tp),
-  _Tp>
+[[nodiscard]]
+_CCCL_API constexpr enable_if_t<is_integral_v<_Tp> && !is_same_v<bool, _Tp> && !is_null_pointer_v<_Tp>, _Tp>
 midpoint(_Tp __a, _Tp __b) noexcept
 {
   using _Up = make_unsigned_t<_Tp>;
@@ -57,8 +56,7 @@ midpoint(_Tp __a, _Tp __b) noexcept
   }
 }
 
-template <class _Tp,
-          enable_if_t<_CCCL_TRAIT(is_object, _Tp) && !_CCCL_TRAIT(is_void, _Tp) && (sizeof(_Tp) > 0), int> = 0>
+template <class _Tp, enable_if_t<is_object_v<_Tp> && !is_void_v<_Tp> && (sizeof(_Tp) > 0), int> = 0>
 [[nodiscard]] _CCCL_API constexpr _Tp* midpoint(_Tp* __a, _Tp* __b) noexcept
 {
   return __a + _CUDA_VSTD::midpoint(ptrdiff_t(0), __b - __a);
@@ -77,8 +75,7 @@ template <typename _Fp>
 }
 
 template <class _Fp>
-[[nodiscard]] _CCCL_API constexpr enable_if_t<_CCCL_TRAIT(is_floating_point, _Fp), _Fp>
-midpoint(_Fp __a, _Fp __b) noexcept
+[[nodiscard]] _CCCL_API constexpr enable_if_t<is_floating_point_v<_Fp>, _Fp> midpoint(_Fp __a, _Fp __b) noexcept
 {
   constexpr _Fp __lo = numeric_limits<_Fp>::min() * 2;
   constexpr _Fp __hi = numeric_limits<_Fp>::max() / 2;

--- a/libcudacxx/include/cuda/std/__optional/make_optional.h
+++ b/libcudacxx/include/cuda/std/__optional/make_optional.h
@@ -34,21 +34,21 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 _CCCL_TEMPLATE(class _Tp = nullopt_t::__secret_tag, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_same, _Tp, nullopt_t::__secret_tag))
+_CCCL_REQUIRES(is_same_v<_Tp, nullopt_t::__secret_tag>)
 _CCCL_API constexpr optional<decay_t<_Up>> make_optional(_Up&& __v)
 {
   return optional<decay_t<_Up>>(_CUDA_VSTD::forward<_Up>(__v));
 }
 
 _CCCL_TEMPLATE(class _Tp, class... _Args)
-_CCCL_REQUIRES((!_CCCL_TRAIT(is_reference, _Tp)))
+_CCCL_REQUIRES((!is_reference_v<_Tp>) )
 _CCCL_API constexpr optional<_Tp> make_optional(_Args&&... __args)
 {
   return optional<_Tp>(in_place, _CUDA_VSTD::forward<_Args>(__args)...);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up, class... _Args)
-_CCCL_REQUIRES((!_CCCL_TRAIT(is_reference, _Tp)))
+_CCCL_REQUIRES((!is_reference_v<_Tp>) )
 _CCCL_API constexpr optional<_Tp> make_optional(initializer_list<_Up> __il, _Args&&... __args)
 {
   return optional<_Tp>(in_place, __il, _CUDA_VSTD::forward<_Args>(__args)...);

--- a/libcudacxx/include/cuda/std/__optional/optional.h
+++ b/libcudacxx/include/cuda/std/__optional/optional.h
@@ -70,33 +70,29 @@ using __opt_check_assignable_from_opt =
       is_assignable<_Tp&, _Opt const&&>>;
 
 template <class _Tp, class _Up>
-inline constexpr bool __opt_is_implictly_constructible =
-  _CCCL_TRAIT(is_constructible, _Tp, _Up) && _CCCL_TRAIT(is_convertible, _Up, _Tp);
+inline constexpr bool __opt_is_implictly_constructible = is_constructible_v<_Tp, _Up> && is_convertible_v<_Up, _Tp>;
 
 template <class _Tp, class _Up>
-inline constexpr bool __opt_is_explictly_constructible =
-  _CCCL_TRAIT(is_constructible, _Tp, _Up) && !_CCCL_TRAIT(is_convertible, _Up, _Tp);
+inline constexpr bool __opt_is_explictly_constructible = is_constructible_v<_Tp, _Up> && !is_convertible_v<_Up, _Tp>;
 
 template <class _Tp, class _Up>
 inline constexpr bool __opt_is_constructible_from_U =
-  !_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, in_place_t) && !_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, optional<_Tp>);
+  !is_same_v<remove_cvref_t<_Up>, in_place_t> && !is_same_v<remove_cvref_t<_Up>, optional<_Tp>>;
 
 template <class _Tp, class _Up>
 inline constexpr bool __opt_is_constructible_from_opt =
-  !_CCCL_TRAIT(is_same, _Up, _Tp) && !__opt_check_constructible_from_opt<_Tp, _Up>::value;
+  !is_same_v<_Up, _Tp> && !__opt_check_constructible_from_opt<_Tp, _Up>::value;
 
 template <class _Tp, class _Up>
-inline constexpr bool __opt_is_assignable =
-  _CCCL_TRAIT(is_constructible, _Tp, _Up) && _CCCL_TRAIT(is_assignable, _Tp&, _Up);
+inline constexpr bool __opt_is_assignable = is_constructible_v<_Tp, _Up> && is_assignable_v<_Tp&, _Up>;
 
 template <class _Tp, class _Up>
 inline constexpr bool __opt_is_assignable_from_U =
-  !_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, optional<_Tp>)
-  && (!_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, _Tp) || !_CCCL_TRAIT(is_scalar, _Tp));
+  !is_same_v<remove_cvref_t<_Up>, optional<_Tp>> && (!is_same_v<remove_cvref_t<_Up>, _Tp> || !is_scalar_v<_Tp>);
 
 template <class _Tp, class _Up>
 inline constexpr bool __opt_is_assignable_from_opt =
-  !_CCCL_TRAIT(is_same, _Up, _Tp) && !__opt_check_constructible_from_opt<_Tp, _Up>::value
+  !is_same_v<_Up, _Tp> && !__opt_check_constructible_from_opt<_Tp, _Up>::value
   && !__opt_check_assignable_from_opt<_Tp, _Up>::value;
 
 template <class _Tp>
@@ -112,16 +108,15 @@ public:
 
 private:
   // Disable the reference extension using this static assert.
-  static_assert(!_CCCL_TRAIT(is_same, remove_cvref_t<value_type>, in_place_t),
+  static_assert(!is_same_v<remove_cvref_t<value_type>, in_place_t>,
                 "instantiation of optional with in_place_t is ill-formed");
-  static_assert(!_CCCL_TRAIT(is_same, remove_cvref_t<value_type>, nullopt_t),
+  static_assert(!is_same_v<remove_cvref_t<value_type>, nullopt_t>,
                 "instantiation of optional with nullopt_t is ill-formed");
-  static_assert(!_CCCL_TRAIT(is_reference, value_type),
+  static_assert(!is_reference_v<value_type>,
                 "instantiation of optional with a reference type is ill-formed. Define "
                 "CCCL_ENABLE_OPTIONAL_REF to enable it as a non-standard extension");
-  static_assert(_CCCL_TRAIT(is_destructible, value_type),
-                "instantiation of optional with a non-destructible type is ill-formed");
-  static_assert(!_CCCL_TRAIT(is_array, value_type), "instantiation of optional with an array type is ill-formed");
+  static_assert(is_destructible_v<value_type>, "instantiation of optional with a non-destructible type is ill-formed");
+  static_assert(!is_array_v<value_type>, "instantiation of optional with an array type is ill-formed");
 
 public:
   _CCCL_API constexpr optional() noexcept {}
@@ -130,14 +125,13 @@ public:
   _CCCL_API constexpr optional(nullopt_t) noexcept {}
 
   _CCCL_TEMPLATE(class _In_place_t, class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_same, _In_place_t, in_place_t)
-                   _CCCL_AND _CCCL_TRAIT(is_constructible, value_type, _Args...))
+  _CCCL_REQUIRES(is_same_v<_In_place_t, in_place_t> _CCCL_AND is_constructible_v<value_type, _Args...>)
   _CCCL_API constexpr explicit optional(_In_place_t, _Args&&... __args)
       : __base(in_place, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
 
   _CCCL_TEMPLATE(class _Up, class... _Args)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, value_type, initializer_list<_Up>&, _Args...))
+  _CCCL_REQUIRES(is_constructible_v<value_type, initializer_list<_Up>&, _Args...>)
   _CCCL_API constexpr explicit optional(in_place_t, initializer_list<_Up> __il, _Args&&... __args)
       : __base(in_place, __il, _CUDA_VSTD::forward<_Args>(__args)...)
   {}
@@ -170,7 +164,7 @@ public:
 
 #ifdef CCCL_ENABLE_OPTIONAL_REF
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES((_CCCL_TRAIT(is_same, remove_cv_t<_Tp>, bool) || __opt_is_constructible_from_opt<_Tp, _Up>)
+  _CCCL_REQUIRES((is_same_v<remove_cv_t<_Tp>, bool> || __opt_is_constructible_from_opt<_Tp, _Up>)
                    _CCCL_AND __opt_is_implictly_constructible<_Tp, const _Up&>)
   _CCCL_API constexpr optional(const optional<_Up&>& __v)
   {
@@ -178,7 +172,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES((_CCCL_TRAIT(is_same, remove_cv_t<_Tp>, bool) || __opt_is_constructible_from_opt<_Tp, _Up>)
+  _CCCL_REQUIRES((is_same_v<remove_cv_t<_Tp>, bool> || __opt_is_constructible_from_opt<_Tp, _Up>)
                    _CCCL_AND __opt_is_explictly_constructible<_Tp, const _Up&>)
   _CCCL_API constexpr explicit optional(const optional<_Up&>& __v)
   {
@@ -187,7 +181,7 @@ public:
 
   _CCCL_TEMPLATE(class _Up)
   _CCCL_REQUIRES(__opt_is_constructible_from_opt<_Tp, _Up> _CCCL_AND
-                   __opt_is_implictly_constructible<_Tp, _Up> _CCCL_AND(!_CCCL_TRAIT(is_reference, _Up)))
+                   __opt_is_implictly_constructible<_Tp, _Up> _CCCL_AND(!is_reference_v<_Up>))
   _CCCL_API constexpr optional(optional<_Up>&& __v)
   {
     this->__construct_from(_CUDA_VSTD::move(__v));
@@ -195,7 +189,7 @@ public:
 
   _CCCL_TEMPLATE(class _Up)
   _CCCL_REQUIRES(__opt_is_constructible_from_opt<_Tp, _Up> _CCCL_AND
-                   __opt_is_explictly_constructible<_Tp, _Up> _CCCL_AND(!_CCCL_TRAIT(is_reference, _Up)))
+                   __opt_is_explictly_constructible<_Tp, _Up> _CCCL_AND(!is_reference_v<_Up>))
   _CCCL_API constexpr explicit optional(optional<_Up>&& __v)
   {
     this->__construct_from(_CUDA_VSTD::move(__v));
@@ -251,7 +245,7 @@ public:
 
 #ifdef CCCL_ENABLE_OPTIONAL_REF
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_reference, _Up))
+  _CCCL_REQUIRES((!is_reference_v<_Up>)
                    _CCCL_AND __opt_is_assignable_from_opt<_Tp, _Up> _CCCL_AND __opt_is_assignable<_Tp, const _Up&>)
   _CCCL_API constexpr optional& operator=(const optional<_Up>& __v)
   {
@@ -260,8 +254,8 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_reference, _Up)
-                   _CCCL_AND __opt_is_assignable_from_opt<_Tp, _Up&> _CCCL_AND __opt_is_assignable<_Tp, _Up&>)
+  _CCCL_REQUIRES(
+    is_reference_v<_Up> _CCCL_AND __opt_is_assignable_from_opt<_Tp, _Up&> _CCCL_AND __opt_is_assignable<_Tp, _Up&>)
   _CCCL_API constexpr optional& operator=(const optional<_Up>& __v)
   {
     this->__assign_from(__v);
@@ -285,7 +279,7 @@ public:
     return *this;
   }
 
-  template <class... _Args, enable_if_t<_CCCL_TRAIT(is_constructible, value_type, _Args...), int> = 0>
+  template <class... _Args, enable_if_t<is_constructible_v<value_type, _Args...>, int> = 0>
   _CCCL_API constexpr _Tp& emplace(_Args&&... __args)
   {
     reset();
@@ -295,7 +289,7 @@ public:
 
   template <class _Up,
             class... _Args,
-            enable_if_t<_CCCL_TRAIT(is_constructible, value_type, initializer_list<_Up>&, _Args...), int> = 0>
+            enable_if_t<is_constructible_v<value_type, initializer_list<_Up>&, _Args...>, int> = 0>
   _CCCL_API constexpr _Tp& emplace(initializer_list<_Up> __il, _Args&&... __args)
   {
     reset();
@@ -304,8 +298,8 @@ public:
   }
 
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr void swap(optional& __opt) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_constructible, value_type) && _CCCL_TRAIT(is_nothrow_swappable, value_type))
+  _CCCL_API constexpr void
+  swap(optional& __opt) noexcept(is_nothrow_move_constructible_v<value_type> && is_nothrow_swappable_v<value_type>)
   {
     if (this->has_value() == __opt.has_value())
     {
@@ -413,18 +407,16 @@ public:
   template <class _Up>
   _CCCL_API constexpr value_type value_or(_Up&& __v) const&
   {
-    static_assert(_CCCL_TRAIT(is_copy_constructible, value_type),
-                  "optional<T>::value_or: T must be copy constructible");
-    static_assert(_CCCL_TRAIT(is_convertible, _Up, value_type), "optional<T>::value_or: U must be convertible to T");
+    static_assert(is_copy_constructible_v<value_type>, "optional<T>::value_or: T must be copy constructible");
+    static_assert(is_convertible_v<_Up, value_type>, "optional<T>::value_or: U must be convertible to T");
     return this->has_value() ? this->__get() : static_cast<value_type>(_CUDA_VSTD::forward<_Up>(__v));
   }
 
   template <class _Up>
   _CCCL_API constexpr value_type value_or(_Up&& __v) &&
   {
-    static_assert(_CCCL_TRAIT(is_move_constructible, value_type),
-                  "optional<T>::value_or: T must be move constructible");
-    static_assert(_CCCL_TRAIT(is_convertible, _Up, value_type), "optional<T>::value_or: U must be convertible to T");
+    static_assert(is_move_constructible_v<value_type>, "optional<T>::value_or: T must be move constructible");
+    static_assert(is_convertible_v<_Up, value_type>, "optional<T>::value_or: U must be convertible to T");
     return this->has_value() ? _CUDA_VSTD::move(this->__get()) : static_cast<value_type>(_CUDA_VSTD::forward<_Up>(__v));
   }
 
@@ -484,10 +476,10 @@ public:
   _CCCL_API constexpr auto transform(_Func&& __f) &
   {
     using _Up = remove_cv_t<invoke_result_t<_Func, value_type&>>;
-    static_assert(!_CCCL_TRAIT(is_array, _Up), "Result of f(value()) should not be an Array");
-    static_assert(!_CCCL_TRAIT(is_same, _Up, in_place_t), "Result of f(value()) should not be std::in_place_t");
-    static_assert(!_CCCL_TRAIT(is_same, _Up, nullopt_t), "Result of f(value()) should not be std::nullopt_t");
-    static_assert(_CCCL_TRAIT(is_object, _Up), "Result of f(value()) should be an object type");
+    static_assert(!is_array_v<_Up>, "Result of f(value()) should not be an Array");
+    static_assert(!is_same_v<_Up, in_place_t>, "Result of f(value()) should not be std::in_place_t");
+    static_assert(!is_same_v<_Up, nullopt_t>, "Result of f(value()) should not be std::nullopt_t");
+    static_assert(is_object_v<_Up>, "Result of f(value()) should be an object type");
     if (this->__engaged_)
     {
       return optional<_Up>(__optional_construct_from_invoke_tag{}, _CUDA_VSTD::forward<_Func>(__f), this->__get());
@@ -499,10 +491,10 @@ public:
   _CCCL_API constexpr auto transform(_Func&& __f) const&
   {
     using _Up = remove_cv_t<invoke_result_t<_Func, const value_type&>>;
-    static_assert(!_CCCL_TRAIT(is_array, _Up), "Result of f(value()) should not be an Array");
-    static_assert(!_CCCL_TRAIT(is_same, _Up, in_place_t), "Result of f(value()) should not be std::in_place_t");
-    static_assert(!_CCCL_TRAIT(is_same, _Up, nullopt_t), "Result of f(value()) should not be std::nullopt_t");
-    static_assert(_CCCL_TRAIT(is_object, _Up), "Result of f(value()) should be an object type");
+    static_assert(!is_array_v<_Up>, "Result of f(value()) should not be an Array");
+    static_assert(!is_same_v<_Up, in_place_t>, "Result of f(value()) should not be std::in_place_t");
+    static_assert(!is_same_v<_Up, nullopt_t>, "Result of f(value()) should not be std::nullopt_t");
+    static_assert(is_object_v<_Up>, "Result of f(value()) should be an object type");
     if (this->__engaged_)
     {
       return optional<_Up>(__optional_construct_from_invoke_tag{}, _CUDA_VSTD::forward<_Func>(__f), this->__get());
@@ -514,12 +506,10 @@ public:
   _CCCL_API constexpr auto transform(_Func&& __f) &&
   {
     using _Up = remove_cv_t<invoke_result_t<_Func, value_type&&>>;
-    static_assert(!_CCCL_TRAIT(is_array, _Up), "Result of f(std::move(value())) should not be an Array");
-    static_assert(!_CCCL_TRAIT(is_same, _Up, in_place_t),
-                  "Result of f(std::move(value())) should not be std::in_place_t");
-    static_assert(!_CCCL_TRAIT(is_same, _Up, nullopt_t),
-                  "Result of f(std::move(value())) should not be std::nullopt_t");
-    static_assert(_CCCL_TRAIT(is_object, _Up), "Result of f(std::move(value())) should be an object type");
+    static_assert(!is_array_v<_Up>, "Result of f(std::move(value())) should not be an Array");
+    static_assert(!is_same_v<_Up, in_place_t>, "Result of f(std::move(value())) should not be std::in_place_t");
+    static_assert(!is_same_v<_Up, nullopt_t>, "Result of f(std::move(value())) should not be std::nullopt_t");
+    static_assert(is_object_v<_Up>, "Result of f(std::move(value())) should be an object type");
     if (this->__engaged_)
     {
       return optional<_Up>(
@@ -532,12 +522,10 @@ public:
   _CCCL_API constexpr auto transform(_Func&& __f) const&&
   {
     using _Up = remove_cvref_t<invoke_result_t<_Func, const value_type&&>>;
-    static_assert(!_CCCL_TRAIT(is_array, _Up), "Result of f(std::move(value())) should not be an Array");
-    static_assert(!_CCCL_TRAIT(is_same, _Up, in_place_t),
-                  "Result of f(std::move(value())) should not be std::in_place_t");
-    static_assert(!_CCCL_TRAIT(is_same, _Up, nullopt_t),
-                  "Result of f(std::move(value())) should not be std::nullopt_t");
-    static_assert(_CCCL_TRAIT(is_object, _Up), "Result of f(std::move(value())) should be an object type");
+    static_assert(!is_array_v<_Up>, "Result of f(std::move(value())) should not be an Array");
+    static_assert(!is_same_v<_Up, in_place_t>, "Result of f(std::move(value())) should not be std::in_place_t");
+    static_assert(!is_same_v<_Up, nullopt_t>, "Result of f(std::move(value())) should not be std::nullopt_t");
+    static_assert(is_object_v<_Up>, "Result of f(std::move(value())) should be an object type");
     if (this->__engaged_)
     {
       return optional<_Up>(
@@ -547,10 +535,10 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Func, class _Tp2 = _Tp)
-  _CCCL_REQUIRES(invocable<_Func> _CCCL_AND _CCCL_TRAIT(is_copy_constructible, _Tp2))
+  _CCCL_REQUIRES(invocable<_Func> _CCCL_AND is_copy_constructible_v<_Tp2>)
   _CCCL_API constexpr optional or_else(_Func&& __f) const&
   {
-    static_assert(_CCCL_TRAIT(is_same, remove_cvref_t<invoke_result_t<_Func>>, optional),
+    static_assert(is_same_v<remove_cvref_t<invoke_result_t<_Func>>, optional>,
                   "Result of f() should be the same type as this optional");
     if (this->__engaged_)
     {
@@ -560,10 +548,10 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Func, class _Tp2 = _Tp)
-  _CCCL_REQUIRES(invocable<_Func> _CCCL_AND _CCCL_TRAIT(is_move_constructible, _Tp2))
+  _CCCL_REQUIRES(invocable<_Func> _CCCL_AND is_move_constructible_v<_Tp2>)
   _CCCL_API constexpr optional or_else(_Func&& __f) &&
   {
-    static_assert(_CCCL_TRAIT(is_same, remove_cvref_t<invoke_result_t<_Func>>, optional),
+    static_assert(is_same_v<remove_cvref_t<invoke_result_t<_Func>>, optional>,
                   "Result of f() should be the same type as this optional");
     if (this->__engaged_)
     {
@@ -581,9 +569,7 @@ _CCCL_HOST_DEVICE optional(_Tp) -> optional<_Tp>;
 // Comparisons between optionals
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() == declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() == declval<const _Up&>()), bool>, bool>
 operator==(const optional<_Tp>& __x, const optional<_Up>& __y)
 {
   if (static_cast<bool>(__x) != static_cast<bool>(__y))
@@ -599,9 +585,7 @@ operator==(const optional<_Tp>& __x, const optional<_Up>& __y)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() != declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() != declval<const _Up&>()), bool>, bool>
 operator!=(const optional<_Tp>& __x, const optional<_Up>& __y)
 {
   if (static_cast<bool>(__x) != static_cast<bool>(__y))
@@ -617,9 +601,7 @@ operator!=(const optional<_Tp>& __x, const optional<_Up>& __y)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() < declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() < declval<const _Up&>()), bool>, bool>
 operator<(const optional<_Tp>& __x, const optional<_Up>& __y)
 {
   if (!static_cast<bool>(__y))
@@ -635,9 +617,7 @@ operator<(const optional<_Tp>& __x, const optional<_Up>& __y)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() > declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() > declval<const _Up&>()), bool>, bool>
 operator>(const optional<_Tp>& __x, const optional<_Up>& __y)
 {
   if (!static_cast<bool>(__x))
@@ -653,9 +633,7 @@ operator>(const optional<_Tp>& __x, const optional<_Up>& __y)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() <= declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() <= declval<const _Up&>()), bool>, bool>
 operator<=(const optional<_Tp>& __x, const optional<_Up>& __y)
 {
   if (!static_cast<bool>(__x))
@@ -671,9 +649,7 @@ operator<=(const optional<_Tp>& __x, const optional<_Up>& __y)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() >= declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() >= declval<const _Up&>()), bool>, bool>
 operator>=(const optional<_Tp>& __x, const optional<_Up>& __y)
 {
   if (!static_cast<bool>(__y))
@@ -763,9 +739,7 @@ _CCCL_API constexpr bool operator>=(nullopt_t, const optional<_Tp>& __x) noexcep
 // Comparisons with T
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() == declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() == declval<const _Up&>()), bool>, bool>
 operator==(const optional<_Tp>& __x, const _Up& __v)
 {
   return static_cast<bool>(__x) ? *__x == __v : false;
@@ -773,9 +747,7 @@ operator==(const optional<_Tp>& __x, const _Up& __v)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() == declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() == declval<const _Up&>()), bool>, bool>
 operator==(const _Tp& __v, const optional<_Up>& __x)
 {
   return static_cast<bool>(__x) ? __v == *__x : false;
@@ -783,9 +755,7 @@ operator==(const _Tp& __v, const optional<_Up>& __x)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() != declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() != declval<const _Up&>()), bool>, bool>
 operator!=(const optional<_Tp>& __x, const _Up& __v)
 {
   return static_cast<bool>(__x) ? *__x != __v : true;
@@ -793,9 +763,7 @@ operator!=(const optional<_Tp>& __x, const _Up& __v)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() != declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() != declval<const _Up&>()), bool>, bool>
 operator!=(const _Tp& __v, const optional<_Up>& __x)
 {
   return static_cast<bool>(__x) ? __v != *__x : true;
@@ -803,9 +771,7 @@ operator!=(const _Tp& __v, const optional<_Up>& __x)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() < declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() < declval<const _Up&>()), bool>, bool>
 operator<(const optional<_Tp>& __x, const _Up& __v)
 {
   return static_cast<bool>(__x) ? *__x < __v : true;
@@ -813,9 +779,7 @@ operator<(const optional<_Tp>& __x, const _Up& __v)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() < declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() < declval<const _Up&>()), bool>, bool>
 operator<(const _Tp& __v, const optional<_Up>& __x)
 {
   return static_cast<bool>(__x) ? __v < *__x : false;
@@ -823,9 +787,7 @@ operator<(const _Tp& __v, const optional<_Up>& __x)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() <= declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() <= declval<const _Up&>()), bool>, bool>
 operator<=(const optional<_Tp>& __x, const _Up& __v)
 {
   return static_cast<bool>(__x) ? *__x <= __v : true;
@@ -833,9 +795,7 @@ operator<=(const optional<_Tp>& __x, const _Up& __v)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() <= declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() <= declval<const _Up&>()), bool>, bool>
 operator<=(const _Tp& __v, const optional<_Up>& __x)
 {
   return static_cast<bool>(__x) ? __v <= *__x : false;
@@ -843,9 +803,7 @@ operator<=(const _Tp& __v, const optional<_Up>& __x)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() > declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() > declval<const _Up&>()), bool>, bool>
 operator>(const optional<_Tp>& __x, const _Up& __v)
 {
   return static_cast<bool>(__x) ? *__x > __v : false;
@@ -853,9 +811,7 @@ operator>(const optional<_Tp>& __x, const _Up& __v)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() > declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() > declval<const _Up&>()), bool>, bool>
 operator>(const _Tp& __v, const optional<_Up>& __x)
 {
   return static_cast<bool>(__x) ? __v > *__x : true;
@@ -863,9 +819,7 @@ operator>(const _Tp& __v, const optional<_Up>& __x)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() >= declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() >= declval<const _Up&>()), bool>, bool>
 operator>=(const optional<_Tp>& __x, const _Up& __v)
 {
   return static_cast<bool>(__x) ? *__x >= __v : false;
@@ -873,9 +827,7 @@ operator>=(const optional<_Tp>& __x, const _Up& __v)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp, class _Up>
-_CCCL_API constexpr enable_if_t<
-  _CCCL_TRAIT(is_convertible, decltype(declval<const _Tp&>() >= declval<const _Up&>()), bool),
-  bool>
+_CCCL_API constexpr enable_if_t<is_convertible_v<decltype(declval<const _Tp&>() >= declval<const _Up&>()), bool>, bool>
 operator>=(const _Tp& __v, const optional<_Up>& __x)
 {
   return static_cast<bool>(__x) ? __v >= *__x : true;
@@ -884,9 +836,9 @@ operator>=(const _Tp& __v, const optional<_Up>& __x)
 template <class _Tp>
 _CCCL_API constexpr enable_if_t<
 #ifdef CCCL_ENABLE_OPTIONAL_REF
-  _CCCL_TRAIT(is_reference, _Tp) ||
+  is_reference_v<_Tp> ||
 #endif // CCCL_ENABLE_OPTIONAL_REF
-    (_CCCL_TRAIT(is_move_constructible, _Tp) && _CCCL_TRAIT(is_swappable, _Tp)),
+    (is_move_constructible_v<_Tp> && is_swappable_v<_Tp>),
   void>
 swap(optional<_Tp>& __x, optional<_Tp>& __y) noexcept(noexcept(__x.swap(__y)))
 {

--- a/libcudacxx/include/cuda/std/__optional/optional_base.h
+++ b/libcudacxx/include/cuda/std/__optional/optional_base.h
@@ -59,8 +59,7 @@ template <class _Tp>
 struct __optional_destruct_base<_Tp, false>
 {
   using value_type = _Tp;
-  static_assert(_CCCL_TRAIT(is_object, value_type),
-                "instantiation of optional with a non-object type is undefined behavior");
+  static_assert(is_object_v<value_type>, "instantiation of optional with a non-object type is undefined behavior");
   union __storage
   {
     char __null_state_;
@@ -128,8 +127,7 @@ template <class _Tp>
 struct __optional_destruct_base<_Tp, true>
 {
   using value_type = _Tp;
-  static_assert(_CCCL_TRAIT(is_object, value_type),
-                "instantiation of optional with a non-object type is undefined behavior");
+  static_assert(is_object_v<value_type>, "instantiation of optional with a non-object type is undefined behavior");
   union __storage
   {
     char __null_state_;
@@ -255,8 +253,8 @@ struct __optional_storage_base : __optional_destruct_base<_Tp>
 
 template <class _Tp>
 inline constexpr __smf_availability __optional_can_copy_construct =
-  _CCCL_TRAIT(is_trivially_copy_constructible, _Tp) ? __smf_availability::__trivial
-  : _CCCL_TRAIT(is_copy_constructible, _Tp)
+  is_trivially_copy_constructible_v<_Tp> ? __smf_availability::__trivial
+  : is_copy_constructible_v<_Tp>
     ? __smf_availability::__available
     : __smf_availability::__deleted;
 
@@ -298,8 +296,8 @@ struct __optional_copy_base<_Tp, __smf_availability::__deleted> : __optional_sto
 
 template <class _Tp>
 inline constexpr __smf_availability __optional_can_move_construct =
-  _CCCL_TRAIT(is_trivially_move_constructible, _Tp) ? __smf_availability::__trivial
-  : _CCCL_TRAIT(is_move_constructible, _Tp)
+  is_trivially_move_constructible_v<_Tp> ? __smf_availability::__trivial
+  : is_move_constructible_v<_Tp>
     ? __smf_availability::__available
     : __smf_availability::__deleted;
 
@@ -316,8 +314,7 @@ struct __optional_move_base<_Tp, __smf_availability::__available> : __optional_c
 
   _CCCL_HIDE_FROM_ABI __optional_move_base(const __optional_move_base&) = default;
 
-  _CCCL_API constexpr __optional_move_base(__optional_move_base&& __opt) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+  _CCCL_API constexpr __optional_move_base(__optional_move_base&& __opt) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     this->__construct_from(_CUDA_VSTD::move(__opt));
   }
@@ -339,10 +336,9 @@ struct __optional_move_base<_Tp, __smf_availability::__deleted> : __optional_cop
 
 template <class _Tp>
 inline constexpr __smf_availability __optional_can_copy_assign =
-  _CCCL_TRAIT(is_trivially_destructible, _Tp) && _CCCL_TRAIT(is_trivially_copy_constructible, _Tp)
-      && _CCCL_TRAIT(is_trivially_copy_assignable, _Tp)
+  is_trivially_destructible_v<_Tp> && is_trivially_copy_constructible_v<_Tp> && is_trivially_copy_assignable_v<_Tp>
     ? __smf_availability::__trivial
-  : _CCCL_TRAIT(is_destructible, _Tp) && _CCCL_TRAIT(is_copy_constructible, _Tp) && _CCCL_TRAIT(is_copy_assignable, _Tp)
+  : is_destructible_v<_Tp> && is_copy_constructible_v<_Tp> && is_copy_assignable_v<_Tp>
     ? __smf_availability::__available
     : __smf_availability::__deleted;
 
@@ -382,10 +378,9 @@ struct __optional_copy_assign_base<_Tp, __smf_availability::__deleted> : __optio
 
 template <class _Tp>
 inline constexpr __smf_availability __optional_can_move_assign =
-  _CCCL_TRAIT(is_trivially_destructible, _Tp) && _CCCL_TRAIT(is_trivially_move_constructible, _Tp)
-      && _CCCL_TRAIT(is_trivially_move_assignable, _Tp)
+  is_trivially_destructible_v<_Tp> && is_trivially_move_constructible_v<_Tp> && is_trivially_move_assignable_v<_Tp>
     ? __smf_availability::__trivial
-  : _CCCL_TRAIT(is_destructible, _Tp) && _CCCL_TRAIT(is_move_constructible, _Tp) && _CCCL_TRAIT(is_move_assignable, _Tp)
+  : is_destructible_v<_Tp> && is_move_constructible_v<_Tp> && is_move_assignable_v<_Tp>
     ? __smf_availability::__available
     : __smf_availability::__deleted;
 
@@ -405,7 +400,7 @@ struct __optional_move_assign_base<_Tp, __smf_availability::__available> : __opt
   _CCCL_HIDE_FROM_ABI __optional_move_assign_base& operator=(const __optional_move_assign_base&) = default;
 
   _CCCL_API constexpr __optional_move_assign_base& operator=(__optional_move_assign_base&& __opt) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_assignable, _Tp) && _CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+    is_nothrow_move_assignable_v<_Tp> && is_nothrow_move_constructible_v<_Tp>)
   {
     this->__assign_from(_CUDA_VSTD::move(__opt));
     return *this;

--- a/libcudacxx/include/cuda/std/__optional/optional_ref.h
+++ b/libcudacxx/include/cuda/std/__optional/optional_ref.h
@@ -59,10 +59,10 @@ private:
   __raw_type* __value_ = nullptr;
 
   _CCCL_TEMPLATE(class _Ref, class _Arg)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Ref, _Arg))
+  _CCCL_REQUIRES(is_constructible_v<_Ref, _Arg>)
   [[nodiscard]] _CCCL_API static constexpr _Ref __make_reference(_Arg&& __arg) noexcept
   {
-    static_assert(_CCCL_TRAIT(is_reference, _Ref), "optional<T&>: make-reference requires a reference as argument");
+    static_assert(is_reference_v<_Ref>, "optional<T&>: make-reference requires a reference as argument");
     return _Ref(_CUDA_VSTD::forward<_Arg>(__arg));
   }
 
@@ -96,21 +96,21 @@ public:
   _CCCL_API constexpr optional(nullopt_t) noexcept {}
 
   _CCCL_TEMPLATE(class _Arg)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Tp&, _Arg) _CCCL_AND(!__from_temporary<_Arg>))
+  _CCCL_REQUIRES(is_constructible_v<_Tp&, _Arg> _CCCL_AND(!__from_temporary<_Arg>))
   _CCCL_API explicit constexpr optional(in_place_t, _Arg&& __arg) noexcept
       : __value_(_CUDA_VSTD::addressof(__make_reference<_Tp&>(_CUDA_VSTD::forward<_Arg>(__arg))))
   {}
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES((!__is_std_optional_v<decay_t<_Up>>) _CCCL_AND _CCCL_TRAIT(is_convertible, _Up, _Tp&)
-                   _CCCL_AND(!__from_temporary<_Up>))
+  _CCCL_REQUIRES(
+    (!__is_std_optional_v<decay_t<_Up>>) _CCCL_AND is_convertible_v<_Up, _Tp&> _CCCL_AND(!__from_temporary<_Up>))
   _CCCL_API constexpr optional(_Up&& __u) noexcept(noexcept(static_cast<_Tp&>(_CUDA_VSTD::declval<_Up>())))
       : __value_(_CUDA_VSTD::addressof(static_cast<_Tp&>(_CUDA_VSTD::forward<_Up>(__u))))
   {}
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES((!__is_std_optional_v<decay_t<_Up>>) _CCCL_AND(!_CCCL_TRAIT(is_convertible, _Up, _Tp&))
-                   _CCCL_AND _CCCL_TRAIT(is_constructible, _Tp&, _Up) _CCCL_AND(!__from_temporary<_Up>))
+  _CCCL_REQUIRES((!__is_std_optional_v<decay_t<_Up>>) _CCCL_AND(!is_convertible_v<_Up, _Tp&>)
+                   _CCCL_AND is_constructible_v<_Tp&, _Up> _CCCL_AND(!__from_temporary<_Up>))
   _CCCL_API explicit constexpr optional(_Up&& __u) noexcept(noexcept(static_cast<_Tp&>(_CUDA_VSTD::declval<_Up>())))
       : __value_(_CUDA_VSTD::addressof(static_cast<_Tp&>(_CUDA_VSTD::forward<_Up>(__u))))
   {}
@@ -120,14 +120,14 @@ public:
   _CCCL_API constexpr optional(_Up&&) = delete;
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, _Up&, _Tp&) _CCCL_AND(!__from_temporary<_Up&>))
+  _CCCL_REQUIRES(is_convertible_v<_Up&, _Tp&> _CCCL_AND(!__from_temporary<_Up&>))
   _CCCL_API constexpr optional(optional<_Up>& __u) noexcept(noexcept(static_cast<_Tp&>(_CUDA_VSTD::declval<_Up&>())))
       : __value_(__u.has_value() ? _CUDA_VSTD::addressof(static_cast<_Tp&>(__u.value())) : nullptr)
   {}
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_convertible, _Up&, _Tp&)) _CCCL_AND _CCCL_TRAIT(is_constructible, _Tp&, _Up&)
-                   _CCCL_AND(!__from_temporary<_Up&>))
+  _CCCL_REQUIRES(
+    (!is_convertible_v<_Up&, _Tp&>) _CCCL_AND is_constructible_v<_Tp&, _Up&> _CCCL_AND(!__from_temporary<_Up&>))
   _CCCL_API explicit constexpr optional(optional<_Up>& __u) noexcept(
     noexcept(static_cast<_Tp&>(_CUDA_VSTD::declval<_Up&>())))
       : __value_(__u.has_value() ? _CUDA_VSTD::addressof(static_cast<_Tp&>(__u.value())) : nullptr)
@@ -138,15 +138,15 @@ public:
   _CCCL_API constexpr optional(optional<_Up>&) = delete;
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, const _Up&, _Tp&) _CCCL_AND(!__from_temporary<const _Up&>))
+  _CCCL_REQUIRES(is_convertible_v<const _Up&, _Tp&> _CCCL_AND(!__from_temporary<const _Up&>))
   _CCCL_API constexpr optional(const optional<_Up>& __u) noexcept(
     noexcept(static_cast<_Tp&>(_CUDA_VSTD::declval<const _Up&>())))
       : __value_(__u.has_value() ? _CUDA_VSTD::addressof(static_cast<_Tp&>(__u.value())) : nullptr)
   {}
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_convertible, const _Up&, _Tp&)) _CCCL_AND _CCCL_TRAIT(
-    is_constructible, _Tp&, const _Up&) _CCCL_AND(!__from_temporary<const _Up&>))
+  _CCCL_REQUIRES((!is_convertible_v<const _Up&, _Tp&>) _CCCL_AND is_constructible_v<_Tp&, const _Up&> _CCCL_AND(
+    !__from_temporary<const _Up&>))
   _CCCL_API explicit constexpr optional(const optional<_Up>& __u) noexcept(
     noexcept(static_cast<_Tp&>(_CUDA_VSTD::declval<const _Up&>())))
       : __value_(__u.has_value() ? _CUDA_VSTD::addressof(static_cast<_Tp&>(__u.value())) : nullptr)
@@ -157,15 +157,15 @@ public:
   _CCCL_API constexpr optional(const optional<_Up>&) = delete;
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, _Up, _Tp&) _CCCL_AND(!__from_temporary<_Up>))
+  _CCCL_REQUIRES(is_convertible_v<_Up, _Tp&> _CCCL_AND(!__from_temporary<_Up>))
   _CCCL_API constexpr optional(optional<_Up>&& __u) noexcept(noexcept(static_cast<_Tp&>(_CUDA_VSTD::declval<_Up>())))
       : __value_(
           __u.has_value() ? _CUDA_VSTD::addressof(static_cast<_Tp&>(_CUDA_VSTD::forward<_Up>(__u.value()))) : nullptr)
   {}
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_convertible, _Up, _Tp&)) _CCCL_AND _CCCL_TRAIT(is_constructible, _Tp&, _Up)
-                   _CCCL_AND(!__from_temporary<_Up>))
+  _CCCL_REQUIRES(
+    (!is_convertible_v<_Up, _Tp&>) _CCCL_AND is_constructible_v<_Tp&, _Up> _CCCL_AND(!__from_temporary<_Up>))
   _CCCL_API explicit constexpr optional(optional<_Up>&& __u) noexcept(
     noexcept(static_cast<_Tp&>(_CUDA_VSTD::declval<_Up>())))
       : __value_(
@@ -177,15 +177,15 @@ public:
   _CCCL_API constexpr optional(optional<_Up>&&) = delete;
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_convertible, const _Up, _Tp&) _CCCL_AND(!__from_temporary<const _Up>))
+  _CCCL_REQUIRES(is_convertible_v<const _Up, _Tp&> _CCCL_AND(!__from_temporary<const _Up>))
   _CCCL_API constexpr optional(const optional<_Up>&& __u) noexcept(
     noexcept(static_cast<_Tp&>(_CUDA_VSTD::declval<const _Up>())))
       : __value_(__u.has_value() ? _CUDA_VSTD::addressof(static_cast<_Tp&>(__u.value())) : nullptr)
   {}
 
   _CCCL_TEMPLATE(class _Up)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(is_convertible, const _Up, _Tp&)) _CCCL_AND _CCCL_TRAIT(
-    is_constructible, _Tp&, const _Up) _CCCL_AND(!__from_temporary<const _Up>))
+  _CCCL_REQUIRES((!is_convertible_v<const _Up, _Tp&>) _CCCL_AND is_constructible_v<_Tp&, const _Up> _CCCL_AND(
+    !__from_temporary<const _Up>))
   _CCCL_API explicit constexpr optional(const optional<_Up>&& __u) noexcept(
     noexcept(static_cast<_Tp&>(_CUDA_VSTD::declval<const _Up>())))
       : __value_(__u.has_value() ? _CUDA_VSTD::addressof(static_cast<_Tp&>(__u.value())) : nullptr)
@@ -205,7 +205,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, _Tp&, _Up) _CCCL_AND(!__from_temporary<_Up>))
+  _CCCL_REQUIRES(is_constructible_v<_Tp&, _Up> _CCCL_AND(!__from_temporary<_Up>))
   _CCCL_API constexpr _Tp& emplace(_Up&& __u) noexcept(noexcept(static_cast<_Tp&>(_CUDA_VSTD::forward<_Up>(__u))))
   {
     __value_ = _CUDA_VSTD::addressof(static_cast<_Tp&>(_CUDA_VSTD::forward<_Up>(__u)));
@@ -254,8 +254,8 @@ public:
   template <class _Up>
   _CCCL_API constexpr remove_cvref_t<_Tp> value_or(_Up&& __v) const
   {
-    static_assert(_CCCL_TRAIT(is_copy_constructible, _Tp), "optional<T&>::value_or: T must be copy constructible");
-    static_assert(_CCCL_TRAIT(is_convertible, _Up, _Tp), "optional<T&>::value_or: U must be convertible to T");
+    static_assert(is_copy_constructible_v<_Tp>, "optional<T&>::value_or: T must be copy constructible");
+    static_assert(is_convertible_v<_Up, _Tp>, "optional<T&>::value_or: U must be convertible to T");
     return __value_ != nullptr ? *__value_ : static_cast<_Tp>(_CUDA_VSTD::forward<_Up>(__v));
   }
 
@@ -276,14 +276,14 @@ public:
   _CCCL_API constexpr auto transform(_Func&& __f) const
   {
     using _Up = invoke_result_t<_Func, _Tp&>;
-    static_assert(!_CCCL_TRAIT(is_array, _Up), "optional<T&>::transform: Result of f(value()) should not be an Array");
-    static_assert(!_CCCL_TRAIT(is_same, _Up, in_place_t),
+    static_assert(!is_array_v<_Up>, "optional<T&>::transform: Result of f(value()) should not be an Array");
+    static_assert(!is_same_v<_Up, in_place_t>,
                   "optional<T&>::transform: Result of f(value()) should not be std::in_place_t");
-    static_assert(!_CCCL_TRAIT(is_same, _Up, nullopt_t),
+    static_assert(!is_same_v<_Up, nullopt_t>,
                   "optional<T&>::transform: Result of f(value()) should not be std::nullopt_t");
     if (__value_ != nullptr)
     {
-      if constexpr (_CCCL_TRAIT(is_lvalue_reference, _Up))
+      if constexpr (is_lvalue_reference_v<_Up>)
       {
         return optional<_Up>(_CUDA_VSTD::invoke(_CUDA_VSTD::forward<_Func>(__f), *__value_));
       }
@@ -300,7 +300,7 @@ public:
   _CCCL_API constexpr optional or_else(_Func&& __f) const
   {
     using _Up = invoke_result_t<_Func>;
-    static_assert(_CCCL_TRAIT(is_same, remove_cvref_t<_Up>, optional),
+    static_assert(is_same_v<remove_cvref_t<_Up>, optional>,
                   "optional<T&>::or_else: Result of f() should be the same type as this optional");
     if (__value_ != nullptr)
     {

--- a/libcudacxx/include/cuda/std/__random/is_valid.h
+++ b/libcudacxx/include/cuda/std/__random/is_valid.h
@@ -96,7 +96,7 @@ inline constexpr bool __libcpp_random_is_valid_urng = false;
 template <class _Gp>
 inline constexpr bool __libcpp_random_is_valid_urng<
   _Gp,
-  enable_if_t<_CCCL_TRAIT(is_unsigned, typename _Gp::result_type)
+  enable_if_t<is_unsigned_v<typename _Gp::result_type>
               && is_same_v<decltype(_CUDA_VSTD::declval<_Gp&>()()), typename _Gp::result_type>>> = true;
 
 _LIBCUDACXX_END_NAMESPACE_STD

--- a/libcudacxx/include/cuda/std/__ranges/empty_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/empty_view.h
@@ -29,7 +29,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 
 _CCCL_TEMPLATE(class _Tp)
-_CCCL_REQUIRES(_CCCL_TRAIT(is_object, _Tp))
+_CCCL_REQUIRES(is_object_v<_Tp>)
 class empty_view : public view_interface<empty_view<_Tp>>
 {
 public:

--- a/libcudacxx/include/cuda/std/__ranges/range_adaptor.h
+++ b/libcudacxx/include/cuda/std/__ranges/range_adaptor.h
@@ -44,9 +44,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_RANGES
 // make the following hold:
 // - `x | f` is equivalent to `f(x)`
 // - `f1 | f2` is an adaptor closure `g` such that `g(x)` is equivalent to `f2(f1(x))`
-template <class _Tp,
-          enable_if_t<_CCCL_TRAIT(is_class, _Tp), int>     = 0,
-          enable_if_t<same_as<_Tp, remove_cv_t<_Tp>>, int> = 0>
+template <class _Tp, enable_if_t<is_class_v<_Tp>, int> = 0, enable_if_t<same_as<_Tp, remove_cv_t<_Tp>>, int> = 0>
 struct __range_adaptor_closure
 {};
 
@@ -100,9 +98,7 @@ _CCCL_REQUIRES(__range_adaptor_can_pipe_compose<_Closure, _OtherClosure>)
     _CUDA_VSTD::forward<_OtherClosure>(__other_closure), _CUDA_VSTD::forward<_Closure>(__closure)));
 }
 
-template <class _Tp,
-          enable_if_t<_CCCL_TRAIT(is_class, _Tp), int>     = 0,
-          enable_if_t<same_as<_Tp, remove_cv_t<_Tp>>, int> = 0>
+template <class _Tp, enable_if_t<is_class_v<_Tp>, int> = 0, enable_if_t<same_as<_Tp, remove_cv_t<_Tp>>, int> = 0>
 class range_adaptor_closure : public __range_adaptor_closure<_Tp>
 {};
 

--- a/libcudacxx/include/cuda/std/__ranges/repeat_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/repeat_view.h
@@ -240,7 +240,7 @@ public:
       : __value_(in_place, __value)
       , __bound_(__bound_sentinel)
   {
-    if constexpr (!same_as<_Bound, unreachable_sentinel_t> && _CCCL_TRAIT(is_signed, _Bound))
+    if constexpr (!same_as<_Bound, unreachable_sentinel_t> && is_signed_v<_Bound>)
     {
       _CCCL_ASSERT(__bound_ >= 0, "The value of bound must be greater than or equal to 0");
     }
@@ -250,7 +250,7 @@ public:
       : __value_(in_place, _CUDA_VSTD::move(__value))
       , __bound_(__bound_sentinel)
   {
-    if constexpr (!same_as<_Bound, unreachable_sentinel_t> && _CCCL_TRAIT(is_signed, _Bound))
+    if constexpr (!same_as<_Bound, unreachable_sentinel_t> && is_signed_v<_Bound>)
     {
       _CCCL_ASSERT(__bound_ >= 0, "The value of bound must be greater than or equal to 0");
     }
@@ -263,7 +263,7 @@ public:
       : __value_(in_place, _CUDA_VSTD::make_from_tuple<_Tp>(_CUDA_VSTD::move(__value_args)))
       , __bound_(_CUDA_VSTD::make_from_tuple<_Bound>(_CUDA_VSTD::move(__bound_args)))
   {
-    if constexpr (!same_as<_Bound, unreachable_sentinel_t> && _CCCL_TRAIT(is_signed, _Bound))
+    if constexpr (!same_as<_Bound, unreachable_sentinel_t> && is_signed_v<_Bound>)
     {
       _CCCL_ASSERT(__bound_ >= 0,
                    "The behavior is undefined if Bound is not unreachable_sentinel_t and bound is negative");

--- a/libcudacxx/include/cuda/std/__string/char_traits.h
+++ b/libcudacxx/include/cuda/std/__string/char_traits.h
@@ -57,7 +57,7 @@ struct __cccl_char_traits_impl
 
   [[nodiscard]] _CCCL_API static constexpr bool lt(char_type __lhs, char_type __rhs) noexcept
   {
-    if constexpr (_CCCL_TRAIT(is_same, char_type, char))
+    if constexpr (is_same_v<char_type, char>)
     {
       return static_cast<unsigned char>(__lhs) < static_cast<unsigned char>(__rhs);
     }
@@ -130,7 +130,7 @@ struct __cccl_char_traits_impl
 
   [[nodiscard]] _CCCL_API static constexpr int_type to_int_type(char_type __c) noexcept
   {
-    if constexpr (_CCCL_TRAIT(is_same, char_type, char))
+    if constexpr (is_same_v<char_type, char>)
     {
       return int_type(static_cast<unsigned char>(__c));
     }

--- a/libcudacxx/include/cuda/std/__type_traits/common_reference.h
+++ b/libcudacxx/include/cuda/std/__type_traits/common_reference.h
@@ -97,7 +97,7 @@ using __cv_cond_res = __cond_res<__copy_cv_t<_Xp, _Yp>&, __copy_cv_t<_Yp, _Xp>&>
 //    If A and B are both lvalue reference types, COMMON-REF(A, B) is
 //    COND-RES(COPYCV(X, Y)&, COPYCV(Y, X)&) if that type exists and is a reference type.
 template <class _Ap, class _Bp>
-struct __common_ref<_Ap&, _Bp&, enable_if_t<_CCCL_TRAIT(is_reference, __cv_cond_res<_Ap, _Bp>)>>
+struct __common_ref<_Ap&, _Bp&, enable_if_t<is_reference_v<__cv_cond_res<_Ap, _Bp>>>>
 {
   using __type = __cv_cond_res<_Ap, _Bp>;
 };
@@ -113,10 +113,10 @@ struct __common_ref_rr
 {};
 
 template <class _Ap, class _Bp>
-struct __common_ref_rr<_Ap&&,
-                       _Bp&&,
-                       enable_if_t<_CCCL_TRAIT(is_convertible, _Ap&&, __common_ref_C<_Ap, _Bp>)
-                                   && _CCCL_TRAIT(is_convertible, _Bp&&, __common_ref_C<_Ap, _Bp>)>>
+struct __common_ref_rr<
+  _Ap&&,
+  _Bp&&,
+  enable_if_t<is_convertible_v<_Ap&&, __common_ref_C<_Ap, _Bp>> && is_convertible_v<_Bp&&, __common_ref_C<_Ap, _Bp>>>>
 {
   using __type = __common_ref_C<_Ap, _Bp>;
 };
@@ -136,7 +136,7 @@ struct __common_ref_lr
 {};
 
 template <class _Ap, class _Bp>
-struct __common_ref_lr<_Ap&&, _Bp&, enable_if_t<_CCCL_TRAIT(is_convertible, _Ap&&, __common_ref_D<_Ap, _Bp>)>>
+struct __common_ref_lr<_Ap&&, _Bp&, enable_if_t<is_convertible_v<_Ap&&, __common_ref_D<_Ap, _Bp>>>>
 {
   using __type = __common_ref_D<_Ap, _Bp>;
 };
@@ -202,7 +202,7 @@ template <class _Tp, class _Up>
 struct __common_reference_sub_bullet1<
   _Tp,
   _Up,
-  void_t<__common_ref_t<_Tp, _Up>, enable_if_t<_CCCL_TRAIT(is_reference, _Tp) && _CCCL_TRAIT(is_reference, _Up)>>>
+  void_t<__common_ref_t<_Tp, _Up>, enable_if_t<is_reference_v<_Tp> && is_reference_v<_Up>>>>
 {
   using type = __common_ref_t<_Tp, _Up>;
 };

--- a/libcudacxx/include/cuda/std/__type_traits/common_type.h
+++ b/libcudacxx/include/cuda/std/__type_traits/common_type.h
@@ -53,10 +53,10 @@ struct __common_type_extended_floating_point
 #if !defined(__CUDA_NO_HALF_CONVERSIONS__) && !defined(__CUDA_NO_HALF_OPERATORS__) \
   && !defined(__CUDA_NO_BFLOAT16_CONVERSIONS__) && !defined(__CUDA_NO_BFLOAT16_OPERATORS__)
 template <class _Tp, class _Up>
-struct __common_type_extended_floating_point<_Tp,
-                                             _Up,
-                                             enable_if_t<_CCCL_TRAIT(__is_extended_floating_point, remove_cvref_t<_Tp>)
-                                                         && _CCCL_TRAIT(is_arithmetic, remove_cvref_t<_Up>)>>
+struct __common_type_extended_floating_point<
+  _Tp,
+  _Up,
+  enable_if_t<__is_extended_floating_point_v<remove_cvref_t<_Tp>> && is_arithmetic_v<remove_cvref_t<_Up>>>>
 {
   using type = common_type_t<__copy_cvref_t<_Tp, float>, _Up>;
 };
@@ -65,8 +65,7 @@ template <class _Tp, class _Up>
 struct __common_type_extended_floating_point<
   _Tp,
   _Up,
-  enable_if_t<_CCCL_TRAIT(is_arithmetic, remove_cvref_t<_Tp>)
-              && _CCCL_TRAIT(__is_extended_floating_point, remove_cvref_t<_Up>)>>
+  enable_if_t<is_arithmetic_v<remove_cvref_t<_Tp>> && __is_extended_floating_point_v<remove_cvref_t<_Up>>>>
 {
   using type = common_type_t<_Tp, __copy_cvref_t<_Up, float>>;
 };
@@ -94,7 +93,7 @@ struct __common_type2_imp : __common_type3<_Tp, _Up>
 template <class _Tp, class _Up>
 using __msvc_declval_workaround =
 #if _CCCL_COMPILER(MSVC)
-  enable_if_t<_CCCL_TRAIT(is_same, __cond_type<_Tp, _Up>, __cond_type<_Up, _Tp>)>;
+  enable_if_t<is_same_v<__cond_type<_Tp, _Up>, __cond_type<_Up, _Tp>>>;
 #else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
   void;
 #endif // !_CCCL_COMPILER(MSVC)

--- a/libcudacxx/include/cuda/std/__type_traits/is_empty.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_empty.h
@@ -49,7 +49,7 @@ struct __is_empty2
   double __lx;
 };
 
-template <class _Tp, bool = _CCCL_TRAIT(is_class, _Tp)>
+template <class _Tp, bool = is_class_v<_Tp>>
 struct __cccl_empty : public integral_constant<bool, sizeof(__is_empty1<_Tp>) == sizeof(__is_empty2)>
 {};
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_pointer_interconvertible_base_of.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_pointer_interconvertible_base_of.h
@@ -37,40 +37,37 @@ inline constexpr bool is_pointer_interconvertible_base_of_v =
 #  if _CCCL_COMPILER(CLANG)
 // clang's builtin evaluates is_pointer_interconvertible_base_of_v<T, T> to be false which is not right
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, const _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, volatile _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, const volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<_Tp, const volatile _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, const _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, volatile _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, const volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<const _Tp, const volatile _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, const _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, volatile _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, volatile _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, const volatile _Tp> =
-  _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<volatile _Tp, const volatile _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, const _Tp> = _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, const _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, volatile _Tp> =
-  _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, volatile _Tp> = is_class_v<_Tp>;
 template <class _Tp>
-inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, const volatile _Tp> =
-  _CCCL_TRAIT(is_class, _Tp);
+inline constexpr bool is_pointer_interconvertible_base_of_v<const volatile _Tp, const volatile _Tp> = is_class_v<_Tp>;
 #  endif // _CCCL_COMPILER(CLANG)
 
 template <class _Tp, class _Up>

--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -74,14 +74,14 @@ using __select_traits = conditional_t<__is_primary_cccl_template<_Iter>::value, 
 // libstdc++ uses `is_base_of`
 template <class _Iter, bool>
 inline constexpr bool __is_primary_std_template_impl =
-  _CCCL_TRAIT(is_base_of, ::std::__iterator_traits<_Iter>, ::std::iterator_traits<_Iter>);
+  is_base_of_v<::std::__iterator_traits<_Iter>, ::std::iterator_traits<_Iter>>;
 template <class _Iter>
 inline constexpr bool __is_primary_std_template_impl<_Iter, true> = true;
 
 // This is needed because with a defaulted template argument subsumption fails for C++20 for concepts
 // that involve incrementable_traits
 template <class _Iter>
-struct __is_primary_std_template : bool_constant<__is_primary_std_template_impl<_Iter, _CCCL_TRAIT(is_pointer, _Iter)>>
+struct __is_primary_std_template : bool_constant<__is_primary_std_template_impl<_Iter, is_pointer_v<_Iter>>>
 {};
 #  elif defined(_LIBCPP_VERSION)
 // libc++ uses the same mechanism than we do with __primary_template
@@ -93,14 +93,14 @@ using __is_primary_std_template = _IsValidExpansion<__test_for_primary_template,
 // On MSVC we must check for the base class because `_From_primary` is only defined in C++20
 template <class _Iter, bool>
 inline constexpr bool __is_primary_std_template_impl =
-  _CCCL_TRAIT(is_base_of, ::std::_Iterator_traits_base<_Iter>, ::std::iterator_traits<_Iter>);
+  is_base_of_v<::std::_Iterator_traits_base<_Iter>, ::std::iterator_traits<_Iter>>;
 template <class _Iter>
 inline constexpr bool __is_primary_std_template_impl<_Iter, true> = true;
 
 // This is needed because with a defaulted template argument subsumption fails for C++20 for concepts
 // that involve incrementable_traits
 template <class _Iter>
-struct __is_primary_std_template : bool_constant<__is_primary_std_template_impl<_Iter, _CCCL_TRAIT(is_pointer, _Iter)>>
+struct __is_primary_std_template : bool_constant<__is_primary_std_template_impl<_Iter, is_pointer_v<_Iter>>>
 {};
 #  endif // _MSVC_STL_VERSION || _IS_WRS
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_same.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_same.h
@@ -70,10 +70,10 @@ inline constexpr bool is_same_v<_Tp, _Tp> = true;
 // (such as in a dependent return type).
 
 template <class _Tp, class _Up>
-using _IsSame = bool_constant<_CCCL_TRAIT(is_same, _Tp, _Up)>;
+using _IsSame = bool_constant<is_same_v<_Tp, _Up>>;
 
 template <class _Tp, class _Up>
-using _IsNotSame = bool_constant<!_CCCL_TRAIT(is_same, _Tp, _Up)>;
+using _IsNotSame = bool_constant<!is_same_v<_Tp, _Up>>;
 
 #endif // defined(_CCCL_BUILTIN_IS_SAME) && !defined(_LIBCUDACXX_USE_IS_SAME_FALLBACK)
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
@@ -100,15 +100,15 @@ struct __is_nothrow_swappable;
 
 template <class _Tp>
 using __swap_result_t _CCCL_NODEBUG_ALIAS =
-  enable_if_t<__detect_adl_swap::__can_define_swap<_Tp>::value && _CCCL_TRAIT(is_move_constructible, _Tp)
-              && _CCCL_TRAIT(is_move_assignable, _Tp)>;
+  enable_if_t<__detect_adl_swap::__can_define_swap<_Tp>::value
+              && is_move_constructible_v<_Tp> && is_move_assignable_v<_Tp>>;
 
 // we use type_identity_t<_Tp> as second parameter, to avoid ambiguity with std::swap, which will thus be preferred by
 // overload resolution (which is ok since std::swap is only considered when explicitly called, or found by ADL for types
 // from std::)
 template <class _Tp>
 _CCCL_API constexpr __swap_result_t<_Tp> swap(_Tp& __x, type_identity_t<_Tp>& __y) noexcept(
-  _CCCL_TRAIT(is_nothrow_move_constructible, _Tp) && _CCCL_TRAIT(is_nothrow_move_assignable, _Tp));
+  is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_assignable_v<_Tp>);
 
 template <class _Tp, size_t _Np>
 _CCCL_API constexpr enable_if_t<__detect_adl_swap::__has_no_adl_swap_array<_Tp, _Np>::value && __is_swappable<_Tp>::value>
@@ -118,7 +118,7 @@ namespace __detail
 {
 // ALL generic swap overloads MUST already have a declaration available at this point.
 
-template <class _Tp, class _Up = _Tp, bool _NotVoid = !_CCCL_TRAIT(is_void, _Tp) && !_CCCL_TRAIT(is_void, _Up)>
+template <class _Tp, class _Up = _Tp, bool _NotVoid = !is_void_v<_Tp> && !is_void_v<_Up>>
 struct __swappable_with
 {
   template <class _LHS, class _RHS>

--- a/libcudacxx/include/cuda/std/__type_traits/make_nbit_int.h
+++ b/libcudacxx/include/cuda/std/__type_traits/make_nbit_int.h
@@ -58,7 +58,7 @@ _CCCL_API constexpr auto __make_nbit_int_impl() noexcept
 #endif // _CCCL_HAS_INT128()
     else
     {
-      static_assert(_CCCL_TRAIT(__always_false, decltype(_NBits)), "Unsupported signed integer size");
+      static_assert(__always_false_v<decltype(_NBits)>, "Unsupported signed integer size");
       _CCCL_UNREACHABLE();
     }
   }
@@ -88,7 +88,7 @@ _CCCL_API constexpr auto __make_nbit_int_impl() noexcept
 #endif // _CCCL_HAS_INT128()
     else
     {
-      static_assert(_CCCL_TRAIT(__always_false, decltype(_NBits)), "Unsupported unsigned integer size");
+      static_assert(__always_false_v<decltype(_NBits)>, "Unsupported unsigned integer size");
       _CCCL_UNREACHABLE();
     }
   }

--- a/libcudacxx/include/cuda/std/__type_traits/make_unsigned.h
+++ b/libcudacxx/include/cuda/std/__type_traits/make_unsigned.h
@@ -142,7 +142,7 @@ _CCCL_API constexpr make_unsigned_t<_Tp> __to_unsigned_like(_Tp __x) noexcept
 }
 
 template <class _Tp, class _Up>
-using __copy_unsigned_t _CCCL_NODEBUG_ALIAS = conditional_t<_CCCL_TRAIT(is_unsigned, _Tp), make_unsigned_t<_Up>, _Up>;
+using __copy_unsigned_t _CCCL_NODEBUG_ALIAS = conditional_t<is_unsigned_v<_Tp>, make_unsigned_t<_Up>, _Up>;
 
 _LIBCUDACXX_END_NAMESPACE_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -835,7 +835,7 @@ template <class _Ty>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_same_as
 {
   template <class _Uy>
-  using __call _CCCL_NODEBUG_ALIAS = bool_constant<_CCCL_TRAIT(is_same, _Ty, _Uy)>;
+  using __call _CCCL_NODEBUG_ALIAS = bool_constant<is_same_v<_Ty, _Uy>>;
 };
 } // namespace __detail
 
@@ -967,7 +967,7 @@ template <class _Ty>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_remove_fn
 {
   template <class _Uy>
-  using __call _CCCL_NODEBUG_ALIAS = _If<_CCCL_TRAIT(is_same, _Ty, _Uy), __type_list<>, __type_list<_Uy>>;
+  using __call _CCCL_NODEBUG_ALIAS = _If<is_same_v<_Ty, _Uy>, __type_list<>, __type_list<_Uy>>;
 };
 } // namespace __detail
 

--- a/libcudacxx/include/cuda/std/__type_traits/type_set.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_set.h
@@ -37,7 +37,7 @@ template <class...>
 struct __type_list;
 
 template <class _Set, class... _Ty>
-struct __type_set_contains : __fold_and<_CCCL_TRAIT(is_base_of, type_identity<_Ty>, _Set)...>
+struct __type_set_contains : __fold_and<is_base_of_v<type_identity<_Ty>, _Set>...>
 {};
 
 template <class _Set, class... _Ty>
@@ -66,8 +66,7 @@ struct __tupl<_Ty, _Ts...>
     , __tupl<_Ts...>
 {
   template <class _Uy>
-  using __maybe_insert _CCCL_NODEBUG_ALIAS =
-    _If<_CCCL_TRAIT(__type_set_contains, __tupl, _Uy), __tupl, __tupl<_Uy, _Ty, _Ts...>>;
+  using __maybe_insert _CCCL_NODEBUG_ALIAS = _If<__type_set_contains_v<__tupl, _Uy>, __tupl, __tupl<_Uy, _Ty, _Ts...>>;
 
   _CCCL_API static constexpr size_t __size() noexcept
   {
@@ -119,7 +118,7 @@ template <class... _Ts>
 using __make_type_set = __type_set_insert<__type_set<>, _Ts...>;
 
 template <class _Ty, class... _Ts>
-struct __is_included_in : __fold_or<_CCCL_TRAIT(is_same, _Ty, _Ts)...>
+struct __is_included_in : __fold_or<is_same_v<_Ty, _Ts>...>
 {};
 
 template <class _Ty, class... _Ts>

--- a/libcudacxx/include/cuda/std/__utility/cmp.h
+++ b/libcudacxx/include/cuda/std/__utility/cmp.h
@@ -36,14 +36,14 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
+_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
 _CCCL_API constexpr bool cmp_equal(_Tp __t, _Up __u) noexcept
 {
-  if constexpr (_CCCL_TRAIT(is_signed, _Tp) == _CCCL_TRAIT(is_signed, _Up))
+  if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
   {
     return __t == __u;
   }
-  else if constexpr (_CCCL_TRAIT(is_signed, _Tp))
+  else if constexpr (is_signed_v<_Tp>)
   {
     return __t < 0 ? false : make_unsigned_t<_Tp>(__t) == __u;
   }
@@ -55,21 +55,21 @@ _CCCL_API constexpr bool cmp_equal(_Tp __t, _Up __u) noexcept
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
+_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
 _CCCL_API constexpr bool cmp_not_equal(_Tp __t, _Up __u) noexcept
 {
   return !_CUDA_VSTD::cmp_equal(__t, __u);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
+_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
 _CCCL_API constexpr bool cmp_less(_Tp __t, _Up __u) noexcept
 {
-  if constexpr (_CCCL_TRAIT(is_signed, _Tp) == _CCCL_TRAIT(is_signed, _Up))
+  if constexpr (is_signed_v<_Tp> == is_signed_v<_Up>)
   {
     return __t < __u;
   }
-  else if constexpr (_CCCL_TRAIT(is_signed, _Tp))
+  else if constexpr (is_signed_v<_Tp>)
   {
     return __t < 0 ? true : make_unsigned_t<_Tp>(__t) < __u;
   }
@@ -81,28 +81,28 @@ _CCCL_API constexpr bool cmp_less(_Tp __t, _Up __u) noexcept
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
+_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
 _CCCL_API constexpr bool cmp_greater(_Tp __t, _Up __u) noexcept
 {
   return _CUDA_VSTD::cmp_less(__u, __t);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
+_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
 _CCCL_API constexpr bool cmp_less_equal(_Tp __t, _Up __u) noexcept
 {
   return !_CUDA_VSTD::cmp_greater(__t, __u);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
+_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
 _CCCL_API constexpr bool cmp_greater_equal(_Tp __t, _Up __u) noexcept
 {
   return !_CUDA_VSTD::cmp_less(__t, __u);
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Up)
-_CCCL_REQUIRES(_CCCL_TRAIT(__cccl_is_integer, _Tp) _CCCL_AND _CCCL_TRAIT(__cccl_is_integer, _Up))
+_CCCL_REQUIRES(__cccl_is_integer_v<_Tp> _CCCL_AND __cccl_is_integer_v<_Up>)
 _CCCL_API constexpr bool in_range(_Up __u) noexcept
 {
   return _CUDA_VSTD::cmp_less_equal(__u, numeric_limits<_Tp>::max())

--- a/libcudacxx/include/cuda/std/__utility/exception_guard.h
+++ b/libcudacxx/include/cuda/std/__utility/exception_guard.h
@@ -76,7 +76,7 @@ struct __exception_guard_exceptions
   {}
 
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 __exception_guard_exceptions(__exception_guard_exceptions&& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_constructible, _Rollback))
+    is_nothrow_move_constructible_v<_Rollback>)
       : __rollback_(_CUDA_VSTD::move(__other.__rollback_))
       , __completed_(__other.__completed_)
   {
@@ -114,7 +114,7 @@ struct __exception_guard_noexceptions
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _CCCL_NODEBUG_ALIAS explicit __exception_guard_noexceptions(_Rollback) {}
 
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _CCCL_NODEBUG_ALIAS __exception_guard_noexceptions(
-    __exception_guard_noexceptions&& __other) noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Rollback))
+    __exception_guard_noexceptions&& __other) noexcept(is_nothrow_move_constructible_v<_Rollback>)
       : __completed_(__other.__completed_)
   {
     __other.__completed_ = true;

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -84,36 +84,32 @@ struct __pair_constraints
     __is_implicitly_default_constructible<_T1>::value && __is_implicitly_default_constructible<_T2>::value;
 
   static constexpr bool __explicit_default_constructible =
-    !__implicit_default_constructible && _CCCL_TRAIT(is_default_constructible, _T1)
-    && _CCCL_TRAIT(is_default_constructible, _T2);
+    !__implicit_default_constructible && is_default_constructible_v<_T1> && is_default_constructible_v<_T2>;
 
   static constexpr bool __explicit_constructible_from_elements =
-    _CCCL_TRAIT(is_copy_constructible, _T1) && _CCCL_TRAIT(is_copy_constructible, _T2)
-    && (!_CCCL_TRAIT(is_convertible, __make_const_lvalue_ref<_T1>, _T1)
-        || !_CCCL_TRAIT(is_convertible, __make_const_lvalue_ref<_T2>, _T2));
+    is_copy_constructible_v<_T1> && is_copy_constructible_v<_T2>
+    && (!is_convertible_v<__make_const_lvalue_ref<_T1>, _T1> || !is_convertible_v<__make_const_lvalue_ref<_T2>, _T2>);
 
   static constexpr bool __implicit_constructible_from_elements =
-    _CCCL_TRAIT(is_copy_constructible, _T1) && _CCCL_TRAIT(is_copy_constructible, _T2)
-    && _CCCL_TRAIT(is_convertible, __make_const_lvalue_ref<_T1>, _T1)
-    && _CCCL_TRAIT(is_convertible, __make_const_lvalue_ref<_T2>, _T2);
+    is_copy_constructible_v<_T1> && is_copy_constructible_v<_T2> && is_convertible_v<__make_const_lvalue_ref<_T1>, _T1>
+    && is_convertible_v<__make_const_lvalue_ref<_T2>, _T2>;
 
   template <class _U1, class _U2>
   struct __constructible
   {
     static constexpr bool __explicit_constructible =
-      _CCCL_TRAIT(is_constructible, _T1, _U1) && _CCCL_TRAIT(is_constructible, _T2, _U2)
-      && (!_CCCL_TRAIT(is_convertible, _U1, _T1) || !_CCCL_TRAIT(is_convertible, _U2, _T2));
+      is_constructible_v<_T1, _U1> && is_constructible_v<_T2, _U2>
+      && (!is_convertible_v<_U1, _T1> || !is_convertible_v<_U2, _T2>);
 
     static constexpr bool __implicit_constructible =
-      _CCCL_TRAIT(is_constructible, _T1, _U1) && _CCCL_TRAIT(is_constructible, _T2, _U2)
-      && _CCCL_TRAIT(is_convertible, _U1, _T1) && _CCCL_TRAIT(is_convertible, _U2, _T2);
+      is_constructible_v<_T1, _U1> && is_constructible_v<_T2, _U2> && is_convertible_v<_U1, _T1>
+      && is_convertible_v<_U2, _T2>;
   };
 
   template <class _U1, class _U2>
   struct __assignable
   {
-    static constexpr bool __enable_assign =
-      _CCCL_TRAIT(is_assignable, _T1&, _U1) && _CCCL_TRAIT(is_assignable, _T2&, _U2);
+    static constexpr bool __enable_assign = is_assignable_v<_T1&, _U1> && is_assignable_v<_T2&, _U2>;
   };
 };
 
@@ -128,7 +124,7 @@ struct __pair_base
   template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
             enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
   _CCCL_API explicit constexpr __pair_base() noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _T1) && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
+    is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : first()
       , second()
   {}
@@ -136,8 +132,8 @@ struct __pair_base
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
             enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
-  _CCCL_API constexpr __pair_base() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _T1)
-                                             && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
+  _CCCL_API constexpr __pair_base() noexcept(is_nothrow_default_constructible_v<_T1>
+                                             && is_nothrow_default_constructible_v<_T2>)
       : first()
       , second()
   {}
@@ -145,7 +141,7 @@ struct __pair_base
   _CCCL_EXEC_CHECK_DISABLE
   template <class _U1, class _U2>
   _CCCL_API constexpr __pair_base(_U1&& __t1, _U2&& __t2) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
+    is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : first(_CUDA_VSTD::forward<_U1>(__t1))
       , second(_CUDA_VSTD::forward<_U2>(__t2))
   {}
@@ -170,7 +166,7 @@ struct __pair_base<_T1, _T2, true>
   template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
             enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
   _CCCL_API explicit constexpr __pair_base() noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _T1) && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
+    is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : first()
       , second()
   {}
@@ -178,8 +174,8 @@ struct __pair_base<_T1, _T2, true>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
             enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
-  _CCCL_API constexpr __pair_base() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _T1)
-                                             && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
+  _CCCL_API constexpr __pair_base() noexcept(is_nothrow_default_constructible_v<_T1>
+                                             && is_nothrow_default_constructible_v<_T2>)
       : first()
       , second()
   {}
@@ -191,9 +187,9 @@ struct __pair_base<_T1, _T2, true>
 
   // We need to ensure that a reference type, which would inhibit the implicit copy assignment still works
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr __pair_base& operator=(
-    conditional_t<_CCCL_TRAIT(is_copy_assignable, _T1) && _CCCL_TRAIT(is_copy_assignable, _T2), __pair_base, __nat> const&
-      __p) noexcept(_CCCL_TRAIT(is_nothrow_copy_assignable, _T1) && _CCCL_TRAIT(is_nothrow_copy_assignable, _T2))
+  _CCCL_API constexpr __pair_base&
+  operator=(conditional_t<is_copy_assignable_v<_T1> && is_copy_assignable_v<_T2>, __pair_base, __nat> const&
+              __p) noexcept(is_nothrow_copy_assignable_v<_T1> && is_nothrow_copy_assignable_v<_T2>)
   {
     first  = __p.first;
     second = __p.second;
@@ -202,9 +198,9 @@ struct __pair_base<_T1, _T2, true>
 
   // We need to ensure that a reference type, which would inhibit the implicit move assignment still works
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr __pair_base& operator=(
-    conditional_t<_CCCL_TRAIT(is_move_assignable, _T1) && _CCCL_TRAIT(is_move_assignable, _T2), __pair_base, __nat>&&
-      __p) noexcept(_CCCL_TRAIT(is_nothrow_move_assignable, _T1) && _CCCL_TRAIT(is_nothrow_move_assignable, _T2))
+  _CCCL_API constexpr __pair_base&
+  operator=(conditional_t<is_move_assignable_v<_T1> && is_move_assignable_v<_T2>, __pair_base, __nat>&& __p) noexcept(
+    is_nothrow_move_assignable_v<_T1> && is_nothrow_move_assignable_v<_T2>)
   {
     first  = _CUDA_VSTD::forward<_T1>(__p.first);
     second = _CUDA_VSTD::forward<_T2>(__p.second);
@@ -214,7 +210,7 @@ struct __pair_base<_T1, _T2, true>
   _CCCL_EXEC_CHECK_DISABLE
   template <class _U1, class _U2>
   _CCCL_API constexpr __pair_base(_U1&& __t1, _U2&& __t2) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
+    is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : first(_CUDA_VSTD::forward<_U1>(__t1))
       , second(_CUDA_VSTD::forward<_U2>(__t2))
   {}
@@ -239,15 +235,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
             enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
-  _CCCL_API explicit constexpr pair() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _T1)
-                                               && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
+  _CCCL_API explicit constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1>
+                                               && is_nothrow_default_constructible_v<_T2>)
       : __base()
   {}
 
   template <class _Constraints                                               = __pair_constraints<_T1, _T2>,
             enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
-  _CCCL_API constexpr pair() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _T1)
-                                      && _CCCL_TRAIT(is_nothrow_default_constructible, _T2))
+  _CCCL_API constexpr pair() noexcept(is_nothrow_default_constructible_v<_T1> && is_nothrow_default_constructible_v<_T2>)
       : __base()
   {}
 
@@ -255,14 +250,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   template <class _Constraints                                                     = __pair_constraints<_T1, _T2>,
             enable_if_t<_Constraints::__explicit_constructible_from_elements, int> = 0>
   _CCCL_API explicit constexpr pair(const _T1& __t1, const _T2& __t2) noexcept(
-    _CCCL_TRAIT(is_nothrow_copy_constructible, _T1) && _CCCL_TRAIT(is_nothrow_copy_constructible, _T2))
+    is_nothrow_copy_constructible_v<_T1> && is_nothrow_copy_constructible_v<_T2>)
       : __base(__t1, __t2)
   {}
 
   template <class _Constraints                                                     = __pair_constraints<_T1, _T2>,
             enable_if_t<_Constraints::__implicit_constructible_from_elements, int> = 0>
   _CCCL_API constexpr pair(const _T1& __t1, const _T2& __t2) noexcept(
-    _CCCL_TRAIT(is_nothrow_copy_constructible, _T1) && _CCCL_TRAIT(is_nothrow_copy_constructible, _T2))
+    is_nothrow_copy_constructible_v<_T1> && is_nothrow_copy_constructible_v<_T2>)
       : __base(__t1, __t2)
   {}
 
@@ -274,7 +269,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints                                       = __pair_constructible<_U1, _U2>,
             enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _CCCL_API explicit constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
+    is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(_CUDA_VSTD::forward<_U1>(__u1), _CUDA_VSTD::forward<_U2>(__u2))
   {}
 
@@ -283,7 +278,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints                                       = __pair_constructible<_U1, _U2>,
             enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _CCCL_API constexpr pair(_U1&& __u1, _U2&& __u2) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
+    is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(_CUDA_VSTD::forward<_U1>(__u1), _CUDA_VSTD::forward<_U2>(__u2))
   {}
 
@@ -307,7 +302,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints                                       = __pair_constructible<const _U1&, const _U2&>,
             enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _CCCL_API explicit constexpr pair(const pair<_U1, _U2>& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, const _U1&) && _CCCL_TRAIT(is_nothrow_constructible, _T2, const _U2&))
+    is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
   {}
 
@@ -316,7 +311,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints                                       = __pair_constructible<const _U1&, const _U2&>,
             enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _CCCL_API constexpr pair(const pair<_U1, _U2>& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, const _U1&) && _CCCL_TRAIT(is_nothrow_constructible, _T2, const _U2&))
+    is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
   {}
 
@@ -326,7 +321,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints                                       = __pair_constructible<_U1, _U2>,
             enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _CCCL_API explicit constexpr pair(pair<_U1, _U2>&& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
+    is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(_CUDA_VSTD::forward<_U1>(__p.first), _CUDA_VSTD::forward<_U2>(__p.second))
   {}
 
@@ -335,7 +330,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints                                       = __pair_constructible<_U1, _U2>,
             enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _CCCL_API constexpr pair(pair<_U1, _U2>&& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
+    is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(_CUDA_VSTD::forward<_U1>(__p.first), _CUDA_VSTD::forward<_U2>(__p.second))
   {}
 
@@ -346,7 +341,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints                                       = __pair_constructible<const _U1&, const _U2&>,
             enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _CCCL_HOST _CCCL_API explicit constexpr pair(const ::std::pair<_U1, _U2>& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, const _U1&) && _CCCL_TRAIT(is_nothrow_constructible, _T2, const _U2&))
+    is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
   {}
 
@@ -355,7 +350,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints                                       = __pair_constructible<const _U1&, const _U2&>,
             enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _CCCL_HOST _CCCL_API constexpr pair(const ::std::pair<_U1, _U2>& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, const _U1&) && _CCCL_TRAIT(is_nothrow_constructible, _T2, const _U2&))
+    is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
   {}
 
@@ -364,7 +359,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints                                       = __pair_constructible<_U1, _U2>,
             enable_if_t<_Constraints::__explicit_constructible, int> = 0>
   _CCCL_HOST _CCCL_API explicit constexpr pair(::std::pair<_U1, _U2>&& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
+    is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(_CUDA_VSTD::forward<_U1>(__p.first), _CUDA_VSTD::forward<_U2>(__p.second))
   {}
 
@@ -373,7 +368,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints                                       = __pair_constructible<_U1, _U2>,
             enable_if_t<_Constraints::__implicit_constructible, int> = 0>
   _CCCL_HOST _CCCL_API constexpr pair(::std::pair<_U1, _U2>&& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _T1, _U1) && _CCCL_TRAIT(is_nothrow_constructible, _T2, _U2))
+    is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(_CUDA_VSTD::forward<_U1>(__p.first), _CUDA_VSTD::forward<_U2>(__p.second))
   {}
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -387,7 +382,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _Constraints = typename __pair_constraints<_T1, _T2>::template __assignable<const _U1&, const _U2&>,
             enable_if_t<_Constraints::__enable_assign, int> = 0>
   _CCCL_API constexpr pair& operator=(const pair<_U1, _U2>& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_assignable, _T1, const _U1&) && _CCCL_TRAIT(is_nothrow_assignable, _T2, const _U2&))
+    is_nothrow_assignable_v<_T1, const _U1&> && is_nothrow_assignable_v<_T2, const _U2&>)
   {
     this->first  = __p.first;
     this->second = __p.second;
@@ -398,8 +393,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _U2,
             class _Constraints = typename __pair_constraints<_T1, _T2>::template __assignable<_U1, _U2>,
             enable_if_t<_Constraints::__enable_assign, int> = 0>
-  _CCCL_API constexpr pair& operator=(pair<_U1, _U2>&& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_assignable, _T1, _U1) && _CCCL_TRAIT(is_nothrow_assignable, _T2, _U2))
+  _CCCL_API constexpr pair&
+  operator=(pair<_U1, _U2>&& __p) noexcept(is_nothrow_assignable_v<_T1, _U1> && is_nothrow_assignable_v<_T2, _U2>)
   {
     this->first  = _CUDA_VSTD::forward<_U1>(__p.first);
     this->second = _CUDA_VSTD::forward<_U2>(__p.second);
@@ -410,7 +405,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #if !_CCCL_COMPILER(NVRTC)
   template <class _UT1 = _T1, enable_if_t<is_copy_assignable<_UT1>::value && is_copy_assignable<_T2>::value, int> = 0>
   _CCCL_HOST constexpr pair& operator=(::std::pair<_T1, _T2> const& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_copy_assignable, _T1) && _CCCL_TRAIT(is_nothrow_copy_assignable, _T2))
+    is_nothrow_copy_assignable_v<_T1> && is_nothrow_copy_assignable_v<_T2>)
   {
     this->first  = __p.first;
     this->second = __p.second;
@@ -419,7 +414,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   template <class _UT1 = _T1, enable_if_t<is_move_assignable<_UT1>::value && is_move_assignable<_T2>::value, int> = 0>
   _CCCL_HOST constexpr pair& operator=(::std::pair<_T1, _T2>&& __p) noexcept(
-    _CCCL_TRAIT(is_nothrow_copy_assignable, _T1) && _CCCL_TRAIT(is_nothrow_copy_assignable, _T2))
+    is_nothrow_copy_assignable_v<_T1> && is_nothrow_copy_assignable_v<_T2>)
   {
     this->first  = _CUDA_VSTD::forward<_T1>(__p.first);
     this->second = _CUDA_VSTD::forward<_T2>(__p.second);
@@ -429,7 +424,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
 #if _CCCL_STD_VER >= 2023
   _CCCL_API constexpr const pair& operator=(pair const& __p) const
-    noexcept(_CCCL_TRAIT(is_nothrow_copy_assignable, const _T1) && _CCCL_TRAIT(is_nothrow_copy_assignable, const _T2))
+    noexcept(is_nothrow_copy_assignable_v<const _T1> && is_nothrow_copy_assignable_v<const _T2>)
     requires(is_copy_assignable_v<const _T1> && is_copy_assignable_v<const _T2>)
   {
     this->first  = __p.first;
@@ -439,7 +434,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
 #  if !_CCCL_COMPILER(NVRTC)
   _CCCL_API inline _CCCL_HOST constexpr const pair& operator=(::std::pair<_T1, _T2> const& __p) const
-    noexcept(_CCCL_TRAIT(is_nothrow_copy_assignable, const _T1) && _CCCL_TRAIT(is_nothrow_copy_assignable, const _T2))
+    noexcept(is_nothrow_copy_assignable_v<const _T1> && is_nothrow_copy_assignable_v<const _T2>)
     requires(is_copy_assignable_v<const _T1> && is_copy_assignable_v<const _T2>)
   {
     this->first  = __p.first;
@@ -449,7 +444,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #  endif // !_CCCL_COMPILER(NVRTC)
 
   _CCCL_API constexpr const pair& operator=(pair&& __p) const
-    noexcept(_CCCL_TRAIT(is_nothrow_assignable, const _T1&, _T1) && _CCCL_TRAIT(is_nothrow_assignable, const _T2&, _T2))
+    noexcept(is_nothrow_assignable_v<const _T1&, _T1> && is_nothrow_assignable_v<const _T2&, _T2>)
     requires(is_assignable_v<const _T1&, _T1> && is_assignable_v<const _T2&, _T2>)
   {
     this->first  = _CUDA_VSTD::forward<_T1>(__p.first);
@@ -459,7 +454,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
 #  if !_CCCL_COMPILER(NVRTC)
   _CCCL_API inline _CCCL_HOST constexpr const pair& operator=(::std::pair<_T1, _T2>&& __p) const
-    noexcept(_CCCL_TRAIT(is_nothrow_assignable, const _T1&, _T1) && _CCCL_TRAIT(is_nothrow_assignable, const _T2&, _T2))
+    noexcept(is_nothrow_assignable_v<const _T1&, _T1> && is_nothrow_assignable_v<const _T2&, _T2>)
     requires(is_assignable_v<const _T1&, _T1> && is_assignable_v<const _T2&, _T2>)
   {
     this->first  = _CUDA_VSTD::forward<_T1>(__p.first);

--- a/libcudacxx/include/cuda/std/__utility/swap.h
+++ b/libcudacxx/include/cuda/std/__utility/swap.h
@@ -39,7 +39,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp>
 _CCCL_API constexpr __swap_result_t<_Tp> swap(_Tp& __x, type_identity_t<_Tp>& __y) noexcept(
-  _CCCL_TRAIT(is_nothrow_move_constructible, _Tp) && _CCCL_TRAIT(is_nothrow_move_assignable, _Tp))
+  is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_assignable_v<_Tp>)
 {
   _Tp __t(_CUDA_VSTD::move(__x));
   __x = _CUDA_VSTD::move(__y);

--- a/libcudacxx/include/cuda/std/array
+++ b/libcudacxx/include/cuda/std/array
@@ -241,7 +241,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT array<_Tp, 0>
   using reverse_iterator       = _CUDA_VSTD::reverse_iterator<iterator>;
   using const_reverse_iterator = _CUDA_VSTD::reverse_iterator<const_iterator>;
 
-  using _CharType = conditional_t<_CCCL_TRAIT(is_const, _Tp), const char, char>;
+  using _CharType = conditional_t<is_const_v<_Tp>, const char, char>;
 
   struct _ArrayInStructT
   {
@@ -261,12 +261,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT array<_Tp, 0>
   // No explicit construct/copy/destroy for aggregate type
   _CCCL_API constexpr void fill(const value_type&)
   {
-    static_assert(!_CCCL_TRAIT(is_const, _Tp), "cannot fill zero-sized array of type 'const T'");
+    static_assert(!is_const_v<_Tp>, "cannot fill zero-sized array of type 'const T'");
   }
 
   _CCCL_API constexpr void swap(array&) noexcept
   {
-    static_assert(!_CCCL_TRAIT(is_const, _Tp), "cannot swap zero-sized array of type 'const T'");
+    static_assert(!is_const_v<_Tp>, "cannot swap zero-sized array of type 'const T'");
   }
 
   // iterators:
@@ -394,7 +394,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT array<_Tp, 0>
 _CCCL_DIAG_POP
 
 _CCCL_TEMPLATE(class _Tp, class... _Args)
-_CCCL_REQUIRES((_CCCL_TRAIT(is_same, _Tp, _Args) && ...))
+_CCCL_REQUIRES((is_same_v<_Tp, _Args> && ...))
 _CCCL_HOST_DEVICE array(_Tp, _Args...) -> array<_Tp, 1 + sizeof...(_Args)>;
 
 template <class _Tp, size_t _Size>
@@ -495,21 +495,19 @@ __to_array_rvalue_impl(_Tp (&&__arr)[_Size], index_sequence<_Index...>)
 
 template <typename _Tp, size_t _Size>
 [[nodiscard]] _CCCL_API constexpr array<remove_cv_t<_Tp>, _Size>
-to_array(_Tp (&__arr)[_Size]) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Tp&))
+to_array(_Tp (&__arr)[_Size]) noexcept(is_nothrow_constructible_v<_Tp, _Tp&>)
 {
-  static_assert(!_CCCL_TRAIT(is_array, _Tp), "[array.creation]/1: to_array does not accept multidimensional arrays.");
-  static_assert(_CCCL_TRAIT(is_constructible, _Tp, _Tp&),
-                "[array.creation]/1: to_array requires copy constructible elements.");
+  static_assert(!is_array_v<_Tp>, "[array.creation]/1: to_array does not accept multidimensional arrays.");
+  static_assert(is_constructible_v<_Tp, _Tp&>, "[array.creation]/1: to_array requires copy constructible elements.");
   return _CUDA_VSTD::__to_array_lvalue_impl(__arr, make_index_sequence<_Size>());
 }
 
 template <typename _Tp, size_t _Size>
 [[nodiscard]] _CCCL_API constexpr array<remove_cv_t<_Tp>, _Size>
-to_array(_Tp (&&__arr)[_Size]) noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+to_array(_Tp (&&__arr)[_Size]) noexcept(is_nothrow_move_constructible_v<_Tp>)
 {
-  static_assert(!_CCCL_TRAIT(is_array, _Tp), "[array.creation]/4: to_array does not accept multidimensional arrays.");
-  static_assert(_CCCL_TRAIT(is_move_constructible, _Tp),
-                "[array.creation]/4: to_array requires move constructible elements.");
+  static_assert(!is_array_v<_Tp>, "[array.creation]/4: to_array does not accept multidimensional arrays.");
+  static_assert(is_move_constructible_v<_Tp>, "[array.creation]/4: to_array requires move constructible elements.");
   return _CUDA_VSTD::__to_array_rvalue_impl(_CUDA_VSTD::move(__arr), make_index_sequence<_Size>());
 }
 

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -59,7 +59,7 @@ struct __avoid_promotions
 
   _CCCL_HIDE_FROM_ABI constexpr __avoid_promotions() = default;
 
-  template <class _Tp, typename = enable_if_t<_CCCL_TRAIT(is_integral, _Tp)>>
+  template <class _Tp, typename = enable_if_t<is_integral_v<_Tp>>>
   _CCCL_HOST_DEVICE constexpr __avoid_promotions(_Tp __i)
       : __data(static_cast<_Int>(__i))
   {}

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -215,13 +215,13 @@ extern "C++" {
 // NVRTC has a bug that prevented the use of delegated constructors, as it did not accept execution space annotations.
 // This creates a whole lot of boilerplate that we can avoid through a macro (see nvbug3961621)
 #  if _CCCL_COMPILER(NVRTC, <, 12, 6)
-#    define _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__class, __baseclass, ...)                                               \
-      using __base = __baseclass<__VA_ARGS__>;                                                                         \
-      _CCCL_TEMPLATE(class... _Args)                                                                                   \
-      _CCCL_REQUIRES(_CCCL_TRAIT(is_constructible, __base, _Args...))                                                  \
-      _CCCL_API constexpr __class(_Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, __base, _Args...)) \
-          : __base(_CUDA_VSTD::forward<_Args>(__args)...)                                                              \
-      {}                                                                                                               \
+#    define _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__class, __baseclass, ...)                                    \
+      using __base = __baseclass<__VA_ARGS__>;                                                              \
+      _CCCL_TEMPLATE(class... _Args)                                                                        \
+      _CCCL_REQUIRES(is_constructible_v<__base, _Args...>)                                                  \
+      _CCCL_API constexpr __class(_Args&&... __args) noexcept(is_nothrow_constructible_v<__base, _Args...>) \
+          : __base(_CUDA_VSTD::forward<_Args>(__args)...)                                                   \
+      {}                                                                                                    \
       _CCCL_HIDE_FROM_ABI constexpr __class() noexcept = default;
 #  else // ^^^ workaround ^^^ / vvv no workaround vvv
 #    define _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__class, __baseclass, ...) \

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -213,7 +213,7 @@ enum class __tuple_leaf_specialization
 template <class _Tp>
 _CCCL_API constexpr __tuple_leaf_specialization __tuple_leaf_choose()
 {
-  return _CCCL_TRAIT(is_empty, _Tp) && !_CCCL_TRAIT(is_final, _Tp) ? __tuple_leaf_specialization::__empty_non_final
+  return is_empty_v<_Tp> && !is_final_v<_Tp> ? __tuple_leaf_specialization::__empty_non_final
        : __must_synthesize_assignment_v<_Tp>
          ? __tuple_leaf_specialization::__synthesize_assignment
          : __tuple_leaf_specialization::__default;
@@ -248,13 +248,13 @@ class __tuple_leaf<_Ip, _Hp, __tuple_leaf_specialization::__default>
 
 public:
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr __tuple_leaf() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _Hp))
+  _CCCL_API constexpr __tuple_leaf() noexcept(is_nothrow_default_constructible_v<_Hp>)
       : __value_()
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr __tuple_leaf(__tuple_leaf_default_constructor_tag) noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Hp))
+    is_nothrow_default_constructible_v<_Hp>)
       : __value_()
   {}
 
@@ -281,7 +281,7 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Tp, enable_if_t<__can_forward<_Tp>::value, int> = 0>
-  _CCCL_API constexpr explicit __tuple_leaf(_Tp&& __t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Hp, _Tp))
+  _CCCL_API constexpr explicit __tuple_leaf(_Tp&& __t) noexcept(is_nothrow_constructible_v<_Hp, _Tp>)
       : __value_(_CUDA_VSTD::forward<_Tp>(__t))
   {}
 
@@ -305,7 +305,7 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Tp>
-  _CCCL_API inline __tuple_leaf& operator=(_Tp&& __t) noexcept(_CCCL_TRAIT(is_nothrow_assignable, _Hp&, _Tp))
+  _CCCL_API inline __tuple_leaf& operator=(_Tp&& __t) noexcept(is_nothrow_assignable_v<_Hp&, _Tp>)
   {
     __value_ = _CUDA_VSTD::forward<_Tp>(__t);
     return *this;
@@ -342,10 +342,10 @@ class __tuple_leaf<_Ip, _Hp, __tuple_leaf_specialization::__synthesize_assignmen
 
 public:
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr __tuple_leaf() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, _Hp))
+  _CCCL_API constexpr __tuple_leaf() noexcept(is_nothrow_default_constructible_v<_Hp>)
       : __value_()
   {
-    static_assert(!_CCCL_TRAIT(is_reference, _Hp), "Attempted to default construct a reference element in a tuple");
+    static_assert(!is_reference_v<_Hp>, "Attempted to default construct a reference element in a tuple");
   }
 
   template <class _Tp>
@@ -353,7 +353,7 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Tp, enable_if_t<__can_forward<_Tp>::value, int> = 0>
-  _CCCL_API constexpr explicit __tuple_leaf(_Tp&& __t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Hp, _Tp))
+  _CCCL_API constexpr explicit __tuple_leaf(_Tp&& __t) noexcept(is_nothrow_constructible_v<_Hp, _Tp>)
       : __value_(_CUDA_VSTD::forward<_Tp>(__t))
   {
     static_assert(__can_bind_reference<_Tp&&>,
@@ -391,7 +391,7 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Tp>
-  _CCCL_API inline __tuple_leaf& operator=(_Tp&& __t) noexcept(_CCCL_TRAIT(is_nothrow_assignable, _Hp&, _Tp))
+  _CCCL_API inline __tuple_leaf& operator=(_Tp&& __t) noexcept(is_nothrow_assignable_v<_Hp&, _Tp>)
   {
     __value_ = _CUDA_VSTD::forward<_Tp>(__t);
     return *this;
@@ -422,7 +422,7 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr __tuple_leaf(__tuple_leaf_default_constructor_tag) noexcept(
-    _CCCL_TRAIT(is_nothrow_default_constructible, _Hp))
+    is_nothrow_default_constructible_v<_Hp>)
       : _Hp()
   {}
 
@@ -471,16 +471,16 @@ public:
   {}
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <class _Tp, enable_if_t<_CCCL_TRAIT(is_assignable, _Hp&, const _Tp&), int> = 0>
-  _CCCL_API inline __tuple_leaf& operator=(const _Tp& __t) noexcept(_CCCL_TRAIT(is_nothrow_assignable, _Hp&, const _Tp&))
+  template <class _Tp, enable_if_t<is_assignable_v<_Hp&, const _Tp&>, int> = 0>
+  _CCCL_API inline __tuple_leaf& operator=(const _Tp& __t) noexcept(is_nothrow_assignable_v<_Hp&, const _Tp&>)
   {
     _Hp::operator=(__t);
     return *this;
   }
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <class _Tp, enable_if_t<_CCCL_TRAIT(is_assignable, _Hp&, _Tp), int> = 0>
-  _CCCL_API inline __tuple_leaf& operator=(_Tp&& __t) noexcept(_CCCL_TRAIT(is_nothrow_assignable, _Hp&, _Tp))
+  template <class _Tp, enable_if_t<is_assignable_v<_Hp&, _Tp>, int> = 0>
+  _CCCL_API inline __tuple_leaf& operator=(_Tp&& __t) noexcept(is_nothrow_assignable_v<_Hp&, _Tp>)
   {
     _Hp::operator=(_CUDA_VSTD::forward<_Tp>(__t));
     return *this;
@@ -513,7 +513,7 @@ template <class _Tp>
 struct __all_default_constructible;
 
 template <class... _Tp>
-struct __all_default_constructible<__tuple_types<_Tp...>> : __all<_CCCL_TRAIT(is_default_constructible, _Tp)...>
+struct __all_default_constructible<__tuple_types<_Tp...>> : __all<is_default_constructible_v<_Tp>...>
 {};
 
 struct __tuple_variadic_constructor_tag
@@ -537,7 +537,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...
                                         __tuple_all_copy_assignable_v<_Tp...>,
                                         __tuple_all_move_assignable_v<_Tp...>>
 {
-  _CCCL_API constexpr __tuple_impl() noexcept(__all<_CCCL_TRAIT(is_nothrow_default_constructible, _Tp)...>::value)
+  _CCCL_API constexpr __tuple_impl() noexcept(__all<is_nothrow_default_constructible_v<_Tp>...>::value)
       : __tuple_leaf<_Indx, _Tp>()...
   {}
 
@@ -545,7 +545,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...
   // Old MSVC cannot handle the noexept specifier outside of template arguments
   template <class... _Up,
             enable_if_t<sizeof...(_Up) == sizeof...(_Tp), int> = 0,
-            bool __all_nothrow_constructible = __all<_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Up)...>::value>
+            bool __all_nothrow_constructible                   = __all<is_nothrow_constructible_v<_Tp, _Up>...>::value>
   _CCCL_API constexpr explicit __tuple_impl(__tuple_variadic_constructor_tag,
                                             _Up&&... __u) noexcept(__all_nothrow_constructible)
       : __tuple_leaf<_Indx, _Tp>(_CUDA_VSTD::forward<_Up>(__u))...
@@ -577,7 +577,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...
 
   template <class _Tuple, enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...>>::value, int> = 0>
   _CCCL_API constexpr __tuple_impl(_Tuple&& __t) noexcept(
-    (__all<_CCCL_TRAIT(is_nothrow_constructible, _Tp, __tuple_elem_at<_Tuple, _Indx>)...>::value))
+    (__all<is_nothrow_constructible_v<_Tp, __tuple_elem_at<_Tuple, _Indx>>...>::value))
       : __tuple_leaf<_Indx, _Tp>(_CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(_CUDA_VSTD::get<_Indx>(__t)))...
   {}
 
@@ -589,8 +589,8 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...
   {}
 
   template <class _Tuple, enable_if_t<__tuple_assignable<_Tuple, tuple<_Tp...>>::value, int> = 0>
-  _CCCL_API inline __tuple_impl& operator=(_Tuple&& __t) noexcept(
-    (__all<_CCCL_TRAIT(is_nothrow_assignable, _Tp&, __tuple_elem_at<_Tuple, _Indx>)...>::value))
+  _CCCL_API inline __tuple_impl&
+  operator=(_Tuple&& __t) noexcept((__all<is_nothrow_assignable_v<_Tp&, __tuple_elem_at<_Tuple, _Indx>>...>::value))
   {
     _CUDA_VSTD::__swallow(__tuple_leaf<_Indx, _Tp>::operator=(
       _CUDA_VSTD::forward<__tuple_elem_at<_Tuple, _Indx>>(_CUDA_VSTD::get<_Indx>(__t)))...);
@@ -622,10 +622,9 @@ struct __tuple_constraints
     __all<__is_implicitly_default_constructible<_Tp>::value...>::value;
 
   static constexpr bool __explicit_default_constructible =
-    !__implicit_default_constructible && __all<_CCCL_TRAIT(is_default_constructible, _Tp)...>::value;
+    !__implicit_default_constructible && __all<is_default_constructible_v<_Tp>...>::value;
 
-  static constexpr bool __nothrow_default_constructible =
-    __all<_CCCL_TRAIT(is_nothrow_default_constructible, _Tp)...>::value;
+  static constexpr bool __nothrow_default_constructible = __all<is_nothrow_default_constructible_v<_Tp>...>::value;
 
   static constexpr bool __implicit_variadic_copy_constructible =
     __tuple_constructible<tuple<const _Tp&...>, tuple<_Tp...>>::value
@@ -635,8 +634,7 @@ struct __tuple_constraints
     __tuple_constructible<tuple<const _Tp&...>, tuple<_Tp...>>::value
     && !__tuple_convertible<tuple<const _Tp&...>, tuple<_Tp...>>::value;
 
-  static constexpr bool __nothrow_variadic_copy_constructible =
-    __all<_CCCL_TRAIT(is_nothrow_copy_constructible, _Tp)...>::value;
+  static constexpr bool __nothrow_variadic_copy_constructible = __all<is_nothrow_copy_constructible_v<_Tp>...>::value;
 
   template <class... _Args>
   struct _PackExpandsToThisTuple : false_type
@@ -657,7 +655,7 @@ struct __tuple_constraints
       __tuple_constructible<tuple<_Args...>, tuple<_Tp...>>::value
       && !__tuple_convertible<tuple<_Args...>, tuple<_Tp...>>::value;
 
-    static constexpr bool __nothrow_constructible = __all<_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args)...>::value;
+    static constexpr bool __nothrow_constructible = __all<is_nothrow_constructible_v<_Tp, _Args>...>::value;
   };
 
   template <class... _Args>
@@ -775,18 +773,18 @@ public:
 
   template <class _AllocArgT,
             class _Alloc,
-            class _Constraints                                                  = __tuple_constraints<_Tp...>,
-            enable_if_t<_CCCL_TRAIT(is_same, allocator_arg_t, _AllocArgT), int> = 0,
-            enable_if_t<_Constraints::__implicit_default_constructible, int>    = 0>
+            class _Constraints                                               = __tuple_constraints<_Tp...>,
+            enable_if_t<is_same_v<allocator_arg_t, _AllocArgT>, int>         = 0,
+            enable_if_t<_Constraints::__implicit_default_constructible, int> = 0>
   _CCCL_API inline tuple(_AllocArgT, _Alloc const& __a) noexcept(_Constraints::__nothrow_default_constructible)
       : __base_(allocator_arg_t(), __a)
   {}
 
   template <class _AllocArgT,
             class _Alloc,
-            class _Constraints                                                  = __tuple_constraints<_Tp...>,
-            enable_if_t<_CCCL_TRAIT(is_same, allocator_arg_t, _AllocArgT), int> = 0,
-            enable_if_t<_Constraints::__explicit_default_constructible, int>    = 0>
+            class _Constraints                                               = __tuple_constraints<_Tp...>,
+            enable_if_t<is_same_v<allocator_arg_t, _AllocArgT>, int>         = 0,
+            enable_if_t<_Constraints::__explicit_default_constructible, int> = 0>
   explicit _CCCL_API inline tuple(_AllocArgT, _Alloc const& __a) noexcept(_Constraints::__nothrow_default_constructible)
       : __base_(allocator_arg_t(), __a)
   {}
@@ -849,7 +847,7 @@ public:
             class _Constraints                                       = __variadic_constraints_less_rank<_Up...>,
             enable_if_t<sizeof...(_Up) < sizeof...(_Tp), int>        = 0,
             enable_if_t<_Constraints::__implicit_constructible, int> = 0>
-  _CCCL_API constexpr explicit tuple(_Up&&... __u) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _BaseT, _Up...))
+  _CCCL_API constexpr explicit tuple(_Up&&... __u) noexcept(is_nothrow_constructible_v<_BaseT, _Up...>)
       : __base_(__tuple_variadic_constructor_tag{}, _CUDA_VSTD::forward<_Up>(__u)...)
   {}
 
@@ -896,11 +894,11 @@ private:
 
 public:
   template <class _Tuple,
-            class _Constraints                                          = __tuple_like_constraints<_Tuple>,
-            enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int>   = 0,
-            enable_if_t<!_CCCL_TRAIT(is_lvalue_reference, _Tuple), int> = 0,
-            enable_if_t<_Constraints::__implicit_constructible, int>    = 0>
-  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _BaseT, _Tuple))
+            class _Constraints                                        = __tuple_like_constraints<_Tuple>,
+            enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
+            enable_if_t<!is_lvalue_reference_v<_Tuple>, int>          = 0,
+            enable_if_t<_Constraints::__implicit_constructible, int>  = 0>
+  _CCCL_API constexpr tuple(_Tuple&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
       : __base_(_CUDA_VSTD::forward<_Tuple>(__t))
   {}
 
@@ -908,16 +906,16 @@ public:
             class _Constraints                                        = __tuple_like_constraints<const _Tuple&>,
             enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
             enable_if_t<_Constraints::__implicit_constructible, int>  = 0>
-  _CCCL_API constexpr tuple(const _Tuple& __t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _BaseT, const _Tuple&))
+  _CCCL_API constexpr tuple(const _Tuple& __t) noexcept(is_nothrow_constructible_v<_BaseT, const _Tuple&>)
       : __base_(__t)
   {}
 
   template <class _Tuple,
-            class _Constraints                                          = __tuple_like_constraints<_Tuple>,
-            enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int>   = 0,
-            enable_if_t<!_CCCL_TRAIT(is_lvalue_reference, _Tuple), int> = 0,
-            enable_if_t<_Constraints::__explicit_constructible, int>    = 0>
-  _CCCL_API constexpr explicit tuple(_Tuple&& __t) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _BaseT, _Tuple))
+            class _Constraints                                        = __tuple_like_constraints<_Tuple>,
+            enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
+            enable_if_t<!is_lvalue_reference_v<_Tuple>, int>          = 0,
+            enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
+  _CCCL_API constexpr explicit tuple(_Tuple&& __t) noexcept(is_nothrow_constructible_v<_BaseT, _Tuple>)
       : __base_(_CUDA_VSTD::forward<_Tuple>(__t))
   {}
 
@@ -925,8 +923,7 @@ public:
             class _Constraints                                        = __tuple_like_constraints<const _Tuple&>,
             enable_if_t<!_PackExpandsToThisTuple<_Tuple>::value, int> = 0,
             enable_if_t<_Constraints::__explicit_constructible, int>  = 0>
-  _CCCL_API constexpr explicit tuple(const _Tuple& __t) noexcept(
-    _CCCL_TRAIT(is_nothrow_constructible, _BaseT, const _Tuple&))
+  _CCCL_API constexpr explicit tuple(const _Tuple& __t) noexcept(is_nothrow_constructible_v<_BaseT, const _Tuple&>)
       : __base_(__t)
   {}
 
@@ -946,14 +943,14 @@ public:
       : __base_(allocator_arg_t(), __a, _CUDA_VSTD::forward<_Tuple>(__t))
   {}
 
-  using _CanCopyAssign = __all<_CCCL_TRAIT(is_copy_assignable, _Tp)...>;
-  using _CanMoveAssign = __all<_CCCL_TRAIT(is_move_assignable, _Tp)...>;
+  using _CanCopyAssign = __all<is_copy_assignable_v<_Tp>...>;
+  using _CanMoveAssign = __all<is_move_assignable_v<_Tp>...>;
 
   _CCCL_HIDE_FROM_ABI tuple& operator=(const tuple& __t) = default;
   _CCCL_HIDE_FROM_ABI tuple& operator=(tuple&& __t)      = default;
 
   template <class _Tuple, enable_if_t<__tuple_assignable<_Tuple, tuple>::value, bool> = false>
-  _CCCL_API inline tuple& operator=(_Tuple&& __t) noexcept(_CCCL_TRAIT(is_nothrow_assignable, _BaseT&, _Tuple))
+  _CCCL_API inline tuple& operator=(_Tuple&& __t) noexcept(is_nothrow_assignable_v<_BaseT&, _Tuple>)
   {
     __base_.operator=(_CUDA_VSTD::forward<_Tuple>(__t));
     return *this;

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/variant
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/variant
@@ -423,7 +423,7 @@ namespace __find_detail
 template <class _Tp, class... _Types>
 _CCCL_API constexpr size_t __find_index()
 {
-  constexpr bool __matches[] = {_CCCL_TRAIT(is_same, _Tp, _Types)...};
+  constexpr bool __matches[] = {is_same_v<_Tp, _Types>...};
   size_t __result            = __not_found;
   for (size_t __i = 0; __i < sizeof...(_Types); ++__i)
   {
@@ -685,8 +685,7 @@ private:
   template <class _Visitor, class... _Values>
   _CCCL_API static constexpr void __std_visit_exhaustive_visitor_check()
   {
-    static_assert(_CCCL_TRAIT(is_invocable, _Visitor, _Values...),
-                  "`std::visit` requires the visitor to be exhaustive.");
+    static_assert(is_invocable_v<_Visitor, _Values...>, "`std::visit` requires the visitor to be exhaustive.");
   }
 
   template <class _Visitor>
@@ -1074,7 +1073,7 @@ _LIBCUDACXX_VARIANT_MOVE_CONSTRUCTOR(_Trait::_TriviallyAvailable,
 _LIBCUDACXX_VARIANT_MOVE_CONSTRUCTOR(
   _Trait::_Available,
   _CCCL_API inline __move_constructor(__move_constructor&& __that) noexcept(
-    __all<_CCCL_TRAIT(is_nothrow_move_constructible, _Types)...>::value) : __move_constructor(__valueless_t{}) {
+    __all<is_nothrow_move_constructible_v<_Types>...>::value) : __move_constructor(__valueless_t{}) {
     this->__generic_construct(*this, _CUDA_VSTD::move(__that));
   });
 
@@ -1164,12 +1163,10 @@ public:
 
 protected:
   _CCCL_EXEC_CHECK_DISABLE
-  template <
-    size_t _Ip,
-    class _Tp,
-    class _Arg,
-    enable_if_t<_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Arg) || !_CCCL_TRAIT(is_nothrow_move_constructible, _Tp),
-                int> = 0>
+  template <size_t _Ip,
+            class _Tp,
+            class _Arg,
+            enable_if_t<is_nothrow_constructible_v<_Tp, _Arg> || !is_nothrow_move_constructible_v<_Tp>, int> = 0>
   _CCCL_API inline void __assign_alt(__alt<_Ip, _Tp>& __a, _Arg&& __arg)
   {
     if (this->index() == _Ip)
@@ -1183,12 +1180,10 @@ protected:
   }
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <
-    size_t _Ip,
-    class _Tp,
-    class _Arg,
-    enable_if_t<!_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Arg) && _CCCL_TRAIT(is_nothrow_move_constructible, _Tp),
-                int> = 0>
+  template <size_t _Ip,
+            class _Tp,
+            class _Arg,
+            enable_if_t<!is_nothrow_constructible_v<_Tp, _Arg> && is_nothrow_move_constructible_v<_Tp>, int> = 0>
   _CCCL_API inline void __assign_alt(__alt<_Ip, _Tp>& __a, _Arg&& __arg)
   {
     if (this->index() == _Ip)
@@ -1248,8 +1243,7 @@ _LIBCUDACXX_VARIANT_MOVE_ASSIGNMENT(
   _Trait::_Available,
   _CCCL_API inline __move_assignment&
   operator=(__move_assignment&& __that) noexcept(
-    __all<(_CCCL_TRAIT(is_nothrow_move_constructible, _Types)
-           && _CCCL_TRAIT(is_nothrow_move_assignable, _Types))...>::value) {
+    __all<(is_nothrow_move_constructible_v<_Types> && is_nothrow_move_assignable_v<_Types>) ...>::value) {
     this->__generic_assign(_CUDA_VSTD::move(__that));
     return *this;
   });
@@ -1368,7 +1362,7 @@ public:
 private:
   _CCCL_API constexpr bool __move_nothrow() const
   {
-    constexpr bool __results[] = {_CCCL_TRAIT(is_nothrow_move_constructible, _Types)...};
+    constexpr bool __results[] = {is_nothrow_move_constructible_v<_Types>...};
     return this->valueless_by_exception() || __results[this->index()];
   }
 };
@@ -1400,7 +1394,7 @@ using __check_for_narrowing _CCCL_NODEBUG_ALIAS = typename _If<
 #ifdef _LIBCUDACXX_ENABLE_NARROWING_CONVERSIONS_IN_VARIANT
   false &&
 #endif // _LIBCUDACXX_ENABLE_NARROWING_CONVERSIONS_IN_VARIANT
-    _CCCL_TRAIT(is_arithmetic, _Dest),
+    is_arithmetic_v<_Dest>,
   __narrowing_check,
   __no_narrowing_check>::template _Apply<_Dest, _Source>;
 
@@ -1415,8 +1409,7 @@ template <class _Tp, size_t>
 struct __overload_bool
 {
   template <class _Up, class _Ap = remove_cvref_t<_Up>>
-  _CCCL_API inline auto operator()(bool, _Up&&) const
-    -> enable_if_t<_CCCL_TRAIT(is_same, _Ap, bool), type_identity<_Tp>>;
+  _CCCL_API inline auto operator()(bool, _Up&&) const -> enable_if_t<is_same_v<_Ap, bool>, type_identity<_Tp>>;
 };
 
 template <size_t _Idx>
@@ -1472,8 +1465,8 @@ struct __variant_constraints
   {
     static constexpr size_t _Ip = __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value;
 
-    static constexpr bool __constructible         = _CCCL_TRAIT(is_constructible, _Tp, _Arg);
-    static constexpr bool __nothrow_constructible = _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Arg);
+    static constexpr bool __constructible         = is_constructible_v<_Tp, _Arg>;
+    static constexpr bool __nothrow_constructible = is_nothrow_constructible_v<_Tp, _Arg>;
   };
 
   template <size_t _Ip, class... _Args>
@@ -1481,8 +1474,8 @@ struct __variant_constraints
   {
     using _Tp = variant_alternative_t<_Ip, variant<_Types...>>;
 
-    static constexpr bool __constructible         = _CCCL_TRAIT(is_constructible, _Tp, _Args...);
-    static constexpr bool __nothrow_constructible = _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...);
+    static constexpr bool __constructible         = is_constructible_v<_Tp, _Args...>;
+    static constexpr bool __nothrow_constructible = is_nothrow_constructible_v<_Tp, _Args...>;
   };
 
   template <size_t _Ip, class _Up, class... _Args>
@@ -1490,9 +1483,8 @@ struct __variant_constraints
   {
     using _Tp = variant_alternative_t<_Ip, variant<_Types...>>;
 
-    static constexpr bool __constructible = _CCCL_TRAIT(is_constructible, _Tp, initializer_list<_Up>&, _Args...);
-    static constexpr bool __nothrow_constructible =
-      _CCCL_TRAIT(is_nothrow_constructible, _Tp, initializer_list<_Up>&, _Args...);
+    static constexpr bool __constructible         = is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>;
+    static constexpr bool __nothrow_constructible = is_nothrow_constructible_v<_Tp, initializer_list<_Up>&, _Args...>;
   };
 
   template <class _Arg, class _Tp = __best_match_t<_Arg, _Types...>>
@@ -1500,41 +1492,37 @@ struct __variant_constraints
   {
     static constexpr size_t _Ip = __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value;
 
-    static constexpr bool __assignable =
-      _CCCL_TRAIT(is_assignable, _Tp&, _Arg) && _CCCL_TRAIT(is_constructible, _Tp, _Arg);
+    static constexpr bool __assignable = is_assignable_v<_Tp&, _Arg> && is_constructible_v<_Tp, _Arg>;
     static constexpr bool __nothrow_assignable =
-      _CCCL_TRAIT(is_nothrow_assignable, _Tp&, _Arg) && _CCCL_TRAIT(is_nothrow_constructible, _Tp, _Arg);
+      is_nothrow_assignable_v<_Tp&, _Arg> && is_nothrow_constructible_v<_Tp, _Arg>;
   };
 
   template <bool>
   struct __swappable
   {
     static constexpr bool __is_swappable =
-      __all<(_CCCL_TRAIT(is_move_constructible, _Types) && _CCCL_TRAIT(is_swappable, _Types))...>::value;
+      __all<(is_move_constructible_v<_Types> && is_swappable_v<_Types>) ...>::value;
 
     static constexpr bool __is_nothrow_swappable =
-      __all<(_CCCL_TRAIT(is_nothrow_move_constructible, _Types) && _CCCL_TRAIT(is_nothrow_swappable, _Types))...>::value;
+      __all<(is_nothrow_move_constructible_v<_Types> && is_nothrow_swappable_v<_Types>) ...>::value;
   };
 };
 } // namespace __variant_detail
 
 template <class... _Types>
 class _CCCL_TYPE_VISIBILITY_DEFAULT variant
-    : private __sfinae_base<
-        __all<_CCCL_TRAIT(is_copy_constructible, _Types)...>::value,
-        __all<_CCCL_TRAIT(is_move_constructible, _Types)...>::value,
-        __all<(_CCCL_TRAIT(is_copy_constructible, _Types) && _CCCL_TRAIT(is_copy_assignable, _Types))...>::value,
-        __all<(_CCCL_TRAIT(is_move_constructible, _Types) && _CCCL_TRAIT(is_move_assignable, _Types))...>::value>
+    : private __sfinae_base<__all<is_copy_constructible_v<_Types>...>::value,
+                            __all<is_move_constructible_v<_Types>...>::value,
+                            __all<(is_copy_constructible_v<_Types> && is_copy_assignable_v<_Types>) ...>::value,
+                            __all<(is_move_constructible_v<_Types> && is_move_assignable_v<_Types>) ...>::value>
 {
   static_assert(0 < sizeof...(_Types), "variant must consist of at least one alternative.");
 
-  static_assert(__all<!_CCCL_TRAIT(is_array, _Types)...>::value,
-                "variant can not have an array type as an alternative.");
+  static_assert(__all<!is_array_v<_Types>...>::value, "variant can not have an array type as an alternative.");
 
-  static_assert(__all<!_CCCL_TRAIT(is_reference, _Types)...>::value,
-                "variant can not have a reference type as an alternative.");
+  static_assert(__all<!is_reference_v<_Types>...>::value, "variant can not have a reference type as an alternative.");
 
-  static_assert(__all<!_CCCL_TRAIT(is_void, _Types)...>::value, "variant can not have a void type as an alternative.");
+  static_assert(__all<!is_void_v<_Types>...>::value, "variant can not have a void type as an alternative.");
 
   using __first_type  = variant_alternative_t<0, variant>;
   using __constraints = __variant_detail::__variant_constraints<_Types...>;
@@ -1543,7 +1531,7 @@ public:
   // Needs to be dependent to guard against incomplete types
   template <bool _Dummy = true,
             class       = enable_if_t<__dependent_type<is_default_constructible<__first_type>, _Dummy>::value>>
-  _CCCL_API constexpr variant() noexcept(_CCCL_TRAIT(is_nothrow_default_constructible, __first_type))
+  _CCCL_API constexpr variant() noexcept(is_nothrow_default_constructible_v<__first_type>)
       : __impl_(in_place_index<0>)
   {}
 
@@ -1552,7 +1540,7 @@ public:
 
   template <class _Arg>
   using __match_construct =
-    _If<!_CCCL_TRAIT(is_same, remove_cvref_t<_Arg>, variant) && !__is_inplace_type<remove_cvref_t<_Arg>>::value //
+    _If<!is_same_v<remove_cvref_t<_Arg>, variant> && !__is_inplace_type<remove_cvref_t<_Arg>>::value //
           && !__is_inplace_index<remove_cvref_t<_Arg>>::value,
         typename __constraints::template __match_construct<_Arg>,
         __variant_detail::__invalid_variant_constraints>;
@@ -1625,7 +1613,7 @@ public:
 
   template <class _Arg>
   using __match_assign =
-    _If<!_CCCL_TRAIT(is_same, remove_cvref_t<_Arg>, variant),
+    _If<!is_same_v<remove_cvref_t<_Arg>, variant>,
         typename __constraints::template __match_assign<_Arg>,
         __variant_detail::__invalid_variant_constraints>;
 
@@ -1658,7 +1646,7 @@ public:
   template <class _Tp,
             class... _Args,
             size_t _Ip = __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value,
-            enable_if_t<_CCCL_TRAIT(is_constructible, _Tp, _Args...), int> = 0>
+            enable_if_t<is_constructible_v<_Tp, _Args...>, int> = 0>
   _CCCL_API inline _Tp& emplace(_Args&&... __args)
   {
     return __impl_.template __emplace<_Ip>(_CUDA_VSTD::forward<_Args>(__args)...);
@@ -1668,7 +1656,7 @@ public:
             class _Up,
             class... _Args,
             size_t _Ip = __find_detail::__find_unambiguous_index_sfinae<_Tp, _Types...>::value,
-            enable_if_t<_CCCL_TRAIT(is_constructible, _Tp, initializer_list<_Up>&, _Args...), int> = 0>
+            enable_if_t<is_constructible_v<_Tp, initializer_list<_Up>&, _Args...>, int> = 0>
   _CCCL_API inline _Tp& emplace(initializer_list<_Up> __il, _Args&&... __args)
   {
     return __impl_.template __emplace<_Ip>(__il, _CUDA_VSTD::forward<_Args>(__args)...);
@@ -1736,7 +1724,7 @@ template <size_t _Ip, class... _Types>
 _CCCL_API constexpr variant_alternative_t<_Ip, variant<_Types...>>& get(variant<_Types...>& __v)
 {
   static_assert(_Ip < sizeof...(_Types), "");
-  static_assert(!_CCCL_TRAIT(is_void, variant_alternative_t<_Ip, variant<_Types...>>), "");
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>, "");
   return _CUDA_VSTD::__generic_get<_Ip>(__v);
 }
 
@@ -1744,7 +1732,7 @@ template <size_t _Ip, class... _Types>
 _CCCL_API constexpr variant_alternative_t<_Ip, variant<_Types...>>&& get(variant<_Types...>&& __v)
 {
   static_assert(_Ip < sizeof...(_Types), "");
-  static_assert(!_CCCL_TRAIT(is_void, variant_alternative_t<_Ip, variant<_Types...>>), "");
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>, "");
   return _CUDA_VSTD::__generic_get<_Ip>(_CUDA_VSTD::move(__v));
 }
 
@@ -1752,7 +1740,7 @@ template <size_t _Ip, class... _Types>
 _CCCL_API constexpr const variant_alternative_t<_Ip, variant<_Types...>>& get(const variant<_Types...>& __v)
 {
   static_assert(_Ip < sizeof...(_Types), "");
-  static_assert(!_CCCL_TRAIT(is_void, variant_alternative_t<_Ip, variant<_Types...>>), "");
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>, "");
   return _CUDA_VSTD::__generic_get<_Ip>(__v);
 }
 
@@ -1760,35 +1748,35 @@ template <size_t _Ip, class... _Types>
 _CCCL_API constexpr const variant_alternative_t<_Ip, variant<_Types...>>&& get(const variant<_Types...>&& __v)
 {
   static_assert(_Ip < sizeof...(_Types), "");
-  static_assert(!_CCCL_TRAIT(is_void, variant_alternative_t<_Ip, variant<_Types...>>), "");
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>, "");
   return _CUDA_VSTD::__generic_get<_Ip>(_CUDA_VSTD::move(__v));
 }
 
 template <class _Tp, class... _Types>
 _CCCL_API constexpr _Tp& get(variant<_Types...>& __v)
 {
-  static_assert(!_CCCL_TRAIT(is_void, _Tp), "");
+  static_assert(!is_void_v<_Tp>, "");
   return _CUDA_VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
 }
 
 template <class _Tp, class... _Types>
 _CCCL_API constexpr _Tp&& get(variant<_Types...>&& __v)
 {
-  static_assert(!_CCCL_TRAIT(is_void, _Tp), "");
+  static_assert(!is_void_v<_Tp>, "");
   return _CUDA_VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(_CUDA_VSTD::move(__v));
 }
 
 template <class _Tp, class... _Types>
 _CCCL_API constexpr const _Tp& get(const variant<_Types...>& __v)
 {
-  static_assert(!_CCCL_TRAIT(is_void, _Tp), "");
+  static_assert(!is_void_v<_Tp>, "");
   return _CUDA_VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
 }
 
 template <class _Tp, class... _Types>
 _CCCL_API constexpr const _Tp&& get(const variant<_Types...>&& __v)
 {
-  static_assert(!_CCCL_TRAIT(is_void, _Tp), "");
+  static_assert(!is_void_v<_Tp>, "");
   return _CUDA_VSTD::get<__find_exactly_one_t<_Tp, _Types...>::value>(_CUDA_VSTD::move(__v));
 }
 
@@ -1806,7 +1794,7 @@ _CCCL_API constexpr add_pointer_t<variant_alternative_t<_Ip, variant<_Types...>>
 get_if(variant<_Types...>* __v) noexcept
 {
   static_assert(_Ip < sizeof...(_Types), "");
-  static_assert(!_CCCL_TRAIT(is_void, variant_alternative_t<_Ip, variant<_Types...>>), "");
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>, "");
   return _CUDA_VSTD::__generic_get_if<_Ip>(__v);
 }
 
@@ -1815,21 +1803,21 @@ _CCCL_API constexpr add_pointer_t<const variant_alternative_t<_Ip, variant<_Type
 get_if(const variant<_Types...>* __v) noexcept
 {
   static_assert(_Ip < sizeof...(_Types), "");
-  static_assert(!_CCCL_TRAIT(is_void, variant_alternative_t<_Ip, variant<_Types...>>), "");
+  static_assert(!is_void_v<variant_alternative_t<_Ip, variant<_Types...>>>, "");
   return _CUDA_VSTD::__generic_get_if<_Ip>(__v);
 }
 
 template <class _Tp, class... _Types>
 _CCCL_API constexpr add_pointer_t<_Tp> get_if(variant<_Types...>* __v) noexcept
 {
-  static_assert(!_CCCL_TRAIT(is_void, _Tp), "");
+  static_assert(!is_void_v<_Tp>, "");
   return _CUDA_VSTD::get_if<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
 }
 
 template <class _Tp, class... _Types>
 _CCCL_API constexpr add_pointer_t<const _Tp> get_if(const variant<_Types...>* __v) noexcept
 {
-  static_assert(!_CCCL_TRAIT(is_void, _Tp), "");
+  static_assert(!is_void_v<_Tp>, "");
   return _CUDA_VSTD::get_if<__find_exactly_one_t<_Tp, _Types...>::value>(__v);
 }
 
@@ -1840,8 +1828,7 @@ struct __convert_to_bool
   _CCCL_API constexpr bool operator()(_T1&& __t1, _T2&& __t2) const
   {
     static_assert(
-      _CCCL_TRAIT(
-        is_convertible, decltype(_Operator{}(_CUDA_VSTD::forward<_T1>(__t1), _CUDA_VSTD::forward<_T2>(__t2))), bool),
+      is_convertible_v<decltype(_Operator{}(_CUDA_VSTD::forward<_T1>(__t1), _CUDA_VSTD::forward<_T2>(__t2))), bool>,
       "the relational operator does not return a type which is "
       "implicitly convertible to bool");
     return _Operator{}(_CUDA_VSTD::forward<_T1>(__t1), _CUDA_VSTD::forward<_T2>(__t2));

--- a/libcudacxx/include/cuda/std/inplace_vector
+++ b/libcudacxx/include/cuda/std/inplace_vector
@@ -94,7 +94,7 @@ template <class _Tp, size_t _Capacity>
   {
     return __inplace_vector_specialization::__empty;
   }
-  else if (_CCCL_TRAIT(is_trivial, _Tp))
+  else if (is_trivial_v<_Tp>)
   {
     return __inplace_vector_specialization::__trivial;
   }
@@ -124,7 +124,7 @@ struct _Rollback_change_size
   }
 };
 
-template <class _Tp, size_t _Capacity, bool = _CCCL_TRAIT(is_trivially_destructible, _Tp)>
+template <class _Tp, size_t _Capacity, bool = is_trivially_destructible_v<_Tp>>
 struct __inplace_vector_destruct_base
 {
   using size_type   = size_t;
@@ -212,7 +212,7 @@ struct __inplace_vector_storage : public __inplace_vector_destruct_base<_Tp, _Ca
   // [containers.sequences.inplace.vector.modifiers], modifiers
   template <class... _Args>
   _CCCL_API constexpr reference
-  unchecked_emplace_back(_Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+  unchecked_emplace_back(_Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
   {
     auto __final = _CUDA_VSTD::__construct_at(end(), _CUDA_VSTD::forward<_Args>(__args)...);
     ++this->__size_;
@@ -226,7 +226,7 @@ protected:
     this->__size_ -= static_cast<__size_type>(__last - __first);
   }
 
-  _CCCL_TEMPLATE(bool _IsNothrow = _CCCL_TRAIT(is_nothrow_default_constructible, _Tp))
+  _CCCL_TEMPLATE(bool _IsNothrow = is_nothrow_default_constructible_v<_Tp>)
   _CCCL_REQUIRES(_IsNothrow)
   _CCCL_API inline void __uninitialized_value_construct(iterator __first, iterator __last) noexcept
   {
@@ -238,7 +238,7 @@ protected:
     this->__size_ += static_cast<__size_type>(__last - __first);
   }
 
-  _CCCL_TEMPLATE(bool _IsNothrow = _CCCL_TRAIT(is_nothrow_default_constructible, _Tp))
+  _CCCL_TEMPLATE(bool _IsNothrow = is_nothrow_default_constructible_v<_Tp>)
   _CCCL_REQUIRES((!_IsNothrow))
   _CCCL_API inline void __uninitialized_value_construct(iterator __first, iterator __last)
   {
@@ -252,7 +252,7 @@ protected:
     this->__size_ += static_cast<__size_type>(__last - __first);
   }
 
-  _CCCL_TEMPLATE(bool _IsNothrow = _CCCL_TRAIT(is_nothrow_copy_constructible, _Tp))
+  _CCCL_TEMPLATE(bool _IsNothrow = is_nothrow_copy_constructible_v<_Tp>)
   _CCCL_REQUIRES(_IsNothrow)
   _CCCL_API inline void __uninitialized_fill(iterator __first, iterator __last, const _Tp& __value) noexcept
   {
@@ -264,7 +264,7 @@ protected:
     this->__size_ += static_cast<__size_type>(__last - __first);
   }
 
-  _CCCL_TEMPLATE(bool _IsNothrow = _CCCL_TRAIT(is_nothrow_copy_constructible, _Tp))
+  _CCCL_TEMPLATE(bool _IsNothrow = is_nothrow_copy_constructible_v<_Tp>)
   _CCCL_REQUIRES((!_IsNothrow))
   _CCCL_API inline void __uninitialized_fill(iterator __first, iterator __last, const _Tp& __value)
   {
@@ -278,7 +278,7 @@ protected:
     this->__size_ += static_cast<__size_type>(__last - __first);
   }
 
-  _CCCL_TEMPLATE(class _Iter, bool _IsNothrow = _CCCL_TRAIT(is_nothrow_copy_constructible, _Tp))
+  _CCCL_TEMPLATE(class _Iter, bool _IsNothrow = is_nothrow_copy_constructible_v<_Tp>)
   _CCCL_REQUIRES(_IsNothrow)
   _CCCL_API inline void __uninitialized_copy(_Iter __first, _Iter __last, iterator __dest) noexcept
   {
@@ -290,7 +290,7 @@ protected:
     this->__size_ += static_cast<__size_type>(__curr - __dest);
   }
 
-  _CCCL_TEMPLATE(class _Iter, bool _IsNothrow = _CCCL_TRAIT(is_nothrow_copy_constructible, _Tp))
+  _CCCL_TEMPLATE(class _Iter, bool _IsNothrow = is_nothrow_copy_constructible_v<_Tp>)
   _CCCL_REQUIRES((!_IsNothrow))
   _CCCL_API inline void __uninitialized_copy(_Iter __first, _Iter __last, iterator __dest)
   {
@@ -304,7 +304,7 @@ protected:
     this->__size_ += static_cast<__size_type>(__curr - __dest);
   }
 
-  _CCCL_TEMPLATE(class _Iter, bool _IsNothrow = _CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+  _CCCL_TEMPLATE(class _Iter, bool _IsNothrow = is_nothrow_move_constructible_v<_Tp>)
   _CCCL_REQUIRES(_IsNothrow)
   _CCCL_API inline void __uninitialized_move(_Iter __first, _Iter __last, iterator __dest) noexcept
   {
@@ -316,7 +316,7 @@ protected:
     this->__size_ += static_cast<__size_type>(__curr - __dest);
   }
 
-  _CCCL_TEMPLATE(class _Iter, bool _IsNothrow = _CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+  _CCCL_TEMPLATE(class _Iter, bool _IsNothrow = is_nothrow_move_constructible_v<_Tp>)
   _CCCL_REQUIRES((!_IsNothrow))
   _CCCL_API inline void __uninitialized_move(_Iter __first, _Iter __last, iterator __dest)
   {
@@ -332,13 +332,13 @@ protected:
 };
 
 // * If is_trivially_copy_constructible_v<T> is true, then IV has a trivial copy constructor.
-template <class _Tp, size_t _Capacity, bool = _CCCL_TRAIT(is_trivially_copy_constructible, _Tp)>
+template <class _Tp, size_t _Capacity, bool = is_trivially_copy_constructible_v<_Tp>>
 struct __inplace_vector_copy : __inplace_vector_storage<_Tp, _Capacity>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__inplace_vector_copy, __inplace_vector_storage, _Tp, _Capacity);
 
   _CCCL_API inline __inplace_vector_copy(const __inplace_vector_copy& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_copy_constructible, _Tp))
+    is_nothrow_copy_constructible_v<_Tp>)
       : __base()
   {
     this->__uninitialized_copy(__other.begin(), __other.end(), this->begin());
@@ -361,15 +361,14 @@ struct __inplace_vector_copy<_Tp, _Capacity, true> : __inplace_vector_storage<_T
 };
 
 // * If is_trivially_move_constructible_v<T> is true, then IV has a trivial move constructor.
-template <class _Tp, size_t _Capacity, bool = _CCCL_TRAIT(is_trivially_move_constructible, _Tp)>
+template <class _Tp, size_t _Capacity, bool = is_trivially_move_constructible_v<_Tp>>
 struct __inplace_vector_move : __inplace_vector_copy<_Tp, _Capacity>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__inplace_vector_move, __inplace_vector_copy, _Tp, _Capacity);
 
   _CCCL_HIDE_FROM_ABI __inplace_vector_move(const __inplace_vector_move&) = default;
 
-  _CCCL_API inline __inplace_vector_move(__inplace_vector_move&& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+  _CCCL_API inline __inplace_vector_move(__inplace_vector_move&& __other) noexcept(is_nothrow_move_constructible_v<_Tp>)
       : __base()
   {
     this->__uninitialized_move(__other.begin(), __other.end(), this->begin());
@@ -394,7 +393,7 @@ struct __inplace_vector_move<_Tp, _Capacity, true> : __inplace_vector_copy<_Tp, 
 // assignment operator
 template <class _Tp,
           size_t _Capacity,
-          bool = _CCCL_TRAIT(is_trivially_copy_constructible, _Tp) && _CCCL_TRAIT(is_trivially_copy_assignable, _Tp)>
+          bool = is_trivially_copy_constructible_v<_Tp> && is_trivially_copy_assignable_v<_Tp>>
 struct __inplace_vector_copy_assign : __inplace_vector_move<_Tp, _Capacity>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__inplace_vector_copy_assign, __inplace_vector_move, _Tp, _Capacity);
@@ -403,7 +402,7 @@ struct __inplace_vector_copy_assign : __inplace_vector_move<_Tp, _Capacity>
   _CCCL_HIDE_FROM_ABI __inplace_vector_copy_assign(__inplace_vector_copy_assign&&)      = default;
 
   _CCCL_API inline __inplace_vector_copy_assign& operator=(const __inplace_vector_copy_assign& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_copy_constructible, _Tp) && _CCCL_TRAIT(is_nothrow_copy_assignable, _Tp))
+    is_nothrow_copy_constructible_v<_Tp> && is_nothrow_copy_assignable_v<_Tp>)
   {
     if (__other.size() < this->size())
     {
@@ -435,7 +434,7 @@ struct __inplace_vector_copy_assign<_Tp, _Capacity, true> : __inplace_vector_mov
 // assignment operator
 template <class _Tp,
           size_t _Capacity,
-          bool = _CCCL_TRAIT(is_trivially_move_constructible, _Tp) && _CCCL_TRAIT(is_trivially_move_assignable, _Tp)>
+          bool = is_trivially_move_constructible_v<_Tp> && is_trivially_move_assignable_v<_Tp>>
 struct __inplace_vector_move_assign : __inplace_vector_copy_assign<_Tp, _Capacity>
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__inplace_vector_move_assign, __inplace_vector_copy_assign, _Tp, _Capacity);
@@ -445,7 +444,7 @@ struct __inplace_vector_move_assign : __inplace_vector_copy_assign<_Tp, _Capacit
   _CCCL_HIDE_FROM_ABI __inplace_vector_move_assign& operator=(const __inplace_vector_move_assign&) = default;
 
   _CCCL_API inline __inplace_vector_move_assign& operator=(__inplace_vector_move_assign&& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_move_constructible, _Tp) && _CCCL_TRAIT(is_nothrow_move_assignable, _Tp))
+    is_nothrow_move_constructible_v<_Tp> && is_nothrow_move_assignable_v<_Tp>)
   {
     if (__other.size() < this->size())
     {
@@ -546,7 +545,7 @@ struct __inplace_vector_base<_Tp, _Capacity, __inplace_vector_specialization::__
   // [containers.sequences.inplace.vector.modifiers], modifiers
   template <class... _Args>
   _CCCL_API constexpr reference
-  unchecked_emplace_back(_Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+  unchecked_emplace_back(_Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
   {
     _Tp* __final = __elems_ + __size_;
     *__final     = _Tp(_CUDA_VSTD::forward<_Args>(__args)...);
@@ -1397,8 +1396,7 @@ public:
   }
 
   template <class... _Args>
-  _CCCL_API constexpr pointer
-  try_emplace_back(_Args&&... __args) noexcept(_CCCL_TRAIT(is_nothrow_constructible, _Tp, _Args...))
+  _CCCL_API constexpr pointer try_emplace_back(_Args&&... __args) noexcept(is_nothrow_constructible_v<_Tp, _Args...>)
   {
     if (this->size() == _Capacity)
     {
@@ -1408,7 +1406,7 @@ public:
     return _CUDA_VSTD::addressof(this->unchecked_emplace_back(_CUDA_VSTD::forward<_Args>(__args)...));
   }
 
-  _CCCL_API constexpr pointer try_push_back(const _Tp& __value) noexcept(_CCCL_TRAIT(is_nothrow_copy_constructible, _Tp))
+  _CCCL_API constexpr pointer try_push_back(const _Tp& __value) noexcept(is_nothrow_copy_constructible_v<_Tp>)
   {
     if (this->size() == _Capacity)
     {
@@ -1418,7 +1416,7 @@ public:
     return _CUDA_VSTD::addressof(this->unchecked_emplace_back(__value));
   }
 
-  _CCCL_API constexpr pointer try_push_back(_Tp&& __value) noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+  _CCCL_API constexpr pointer try_push_back(_Tp&& __value) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     if (this->size() == _Capacity)
     {
@@ -1432,7 +1430,7 @@ public:
   _CCCL_REQUIRES(
     _CUDA_VRANGES::__container_compatible_range<_Range, _Tp> _CCCL_AND(!_CUDA_VRANGES::forward_range<_Range>))
   _CCCL_API constexpr _CUDA_VRANGES::iterator_t<_Range>
-  try_append_range(_Range&& __range) noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+  try_append_range(_Range&& __range) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     auto __first = _CUDA_VRANGES::begin(__range);
     auto __last  = _CUDA_VRANGES::end(__range);
@@ -1447,7 +1445,7 @@ public:
   _CCCL_REQUIRES(_CUDA_VRANGES::__container_compatible_range<_Range, _Tp> _CCCL_AND
                    _CUDA_VRANGES::forward_range<_Range> _CCCL_AND _CUDA_VRANGES::sized_range<_Range>)
   _CCCL_API constexpr _CUDA_VRANGES::iterator_t<_Range>
-  try_append_range(_Range&& __range) noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+  try_append_range(_Range&& __range) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     const auto __capacity = _Capacity - this->size();
     const auto __size     = _CUDA_VRANGES::size(__range);
@@ -1463,7 +1461,7 @@ public:
   _CCCL_REQUIRES(_CUDA_VRANGES::__container_compatible_range<_Range, _Tp> _CCCL_AND
                    _CUDA_VRANGES::forward_range<_Range> _CCCL_AND(!_CUDA_VRANGES::sized_range<_Range>))
   _CCCL_API constexpr _CUDA_VRANGES::iterator_t<_Range>
-  try_append_range(_Range&& __range) noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+  try_append_range(_Range&& __range) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     const auto __capacity = static_cast<ptrdiff_t>(_Capacity - this->size());
     auto __first          = _CUDA_VRANGES::begin(__range);
@@ -1477,14 +1475,12 @@ public:
 
   using __base::unchecked_emplace_back;
 
-  _CCCL_API constexpr reference
-  unchecked_push_back(const _Tp& __value) noexcept(_CCCL_TRAIT(is_nothrow_copy_constructible, _Tp))
+  _CCCL_API constexpr reference unchecked_push_back(const _Tp& __value) noexcept(is_nothrow_copy_constructible_v<_Tp>)
   {
     return this->unchecked_emplace_back(__value);
   }
 
-  _CCCL_API constexpr reference
-  unchecked_push_back(_Tp&& __value) noexcept(_CCCL_TRAIT(is_nothrow_move_constructible, _Tp))
+  _CCCL_API constexpr reference unchecked_push_back(_Tp&& __value) noexcept(is_nothrow_move_constructible_v<_Tp>)
   {
     return this->unchecked_emplace_back(_CUDA_VSTD::move(__value));
   }
@@ -1495,7 +1491,7 @@ public:
     this->__destroy(__end - 1, __end);
   }
 
-  _CCCL_API constexpr iterator erase(const_iterator __cpos) noexcept(_CCCL_TRAIT(is_nothrow_move_assignable, _Tp))
+  _CCCL_API constexpr iterator erase(const_iterator __cpos) noexcept(is_nothrow_move_assignable_v<_Tp>)
   {
     const auto __pos = static_cast<size_type>(__cpos - this->cbegin());
     if (__pos > this->size())
@@ -1516,7 +1512,7 @@ public:
   }
 
   _CCCL_API constexpr iterator
-  erase(const_iterator __cfirst, const_iterator __clast) noexcept(_CCCL_TRAIT(is_nothrow_move_assignable, _Tp))
+  erase(const_iterator __cfirst, const_iterator __clast) noexcept(is_nothrow_move_assignable_v<_Tp>)
   {
     const iterator __first = (iterator) __cfirst;
     const iterator __last  = (iterator) __clast;
@@ -1597,9 +1593,9 @@ public:
   _CCCL_API static constexpr void shrink_to_fit() noexcept {}
 
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_swappable, _Tp2) _CCCL_AND _CCCL_TRAIT(is_move_constructible, _Tp2))
-  _CCCL_API constexpr void swap(inplace_vector& __other) noexcept(
-    _CCCL_TRAIT(is_nothrow_swappable, _Tp2) && _CCCL_TRAIT(is_nothrow_move_constructible, _Tp2))
+  _CCCL_REQUIRES(is_swappable_v<_Tp2> _CCCL_AND is_move_constructible_v<_Tp2>)
+  _CCCL_API constexpr void
+  swap(inplace_vector& __other) noexcept(is_nothrow_swappable_v<_Tp2> && is_nothrow_move_constructible_v<_Tp2>)
   {
     if (this->size() < __other.size())
     {
@@ -1616,9 +1612,9 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_swappable, _Tp2) _CCCL_AND _CCCL_TRAIT(is_move_constructible, _Tp2))
+  _CCCL_REQUIRES(is_swappable_v<_Tp2> _CCCL_AND is_move_constructible_v<_Tp2>)
   _CCCL_API friend constexpr void swap(inplace_vector& __lhs, inplace_vector& __rhs) noexcept(
-    _Capacity == 0 || (_CCCL_TRAIT(is_nothrow_swappable, _Tp2) && _CCCL_TRAIT(is_nothrow_move_constructible, _Tp2)))
+    _Capacity == 0 || (is_nothrow_swappable_v<_Tp2> && is_nothrow_move_constructible_v<_Tp2>) )
   {
     __lhs.swap(__rhs);
   }
@@ -1674,7 +1670,7 @@ public:
 #endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
   // [containers.sequences.inplace.vector.erasure]
-  _CCCL_API constexpr size_type __erase(const _Tp& __value) noexcept(_CCCL_TRAIT(is_nothrow_move_assignable, _Tp))
+  _CCCL_API constexpr size_type __erase(const _Tp& __value) noexcept(is_nothrow_move_assignable_v<_Tp>)
   {
     const iterator __old_end = this->end();
     const iterator __new_end = _CUDA_VSTD::remove(this->begin(), __old_end, __value);
@@ -1683,7 +1679,7 @@ public:
   }
 
   template <class _Pred>
-  _CCCL_API constexpr size_type __erase_if(_Pred __pred) noexcept(_CCCL_TRAIT(is_nothrow_move_assignable, _Tp))
+  _CCCL_API constexpr size_type __erase_if(_Pred __pred) noexcept(is_nothrow_move_assignable_v<_Tp>)
   {
     const iterator __old_end = this->end();
     const iterator __new_end = _CUDA_VSTD::remove_if(this->begin(), __old_end, _CUDA_VSTD::move(__pred));
@@ -2144,14 +2140,14 @@ public:
 // [containers.sequences.inplace.vector.erasure]
 template <class _Tp, size_t _Capacity>
 _CCCL_API constexpr size_t
-erase(inplace_vector<_Tp, _Capacity>& __cont, const _Tp& __value) noexcept(_CCCL_TRAIT(is_nothrow_move_assignable, _Tp))
+erase(inplace_vector<_Tp, _Capacity>& __cont, const _Tp& __value) noexcept(is_nothrow_move_assignable_v<_Tp>)
 {
   return __cont.__erase(__value);
 }
 
 template <class _Tp, size_t _Capacity, class _Pred>
 _CCCL_API constexpr size_t
-erase_if(inplace_vector<_Tp, _Capacity>& __cont, _Pred __pred) noexcept(_CCCL_TRAIT(is_nothrow_move_assignable, _Tp))
+erase_if(inplace_vector<_Tp, _Capacity>& __cont, _Pred __pred) noexcept(is_nothrow_move_assignable_v<_Tp>)
 {
   return __cont.__erase_if(__pred);
 }

--- a/libcudacxx/include/cuda/std/numbers
+++ b/libcudacxx/include/cuda/std/numbers
@@ -45,7 +45,7 @@ _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_MSVC(4305) // truncation from 'double' to 'const _Tp'
 
 template <class _Tp>
-struct __numbers<_Tp, enable_if_t<_CCCL_TRAIT(is_floating_point, _Tp)>>
+struct __numbers<_Tp, enable_if_t<is_floating_point_v<_Tp>>>
 {
   static _CCCL_API constexpr _Tp __e() noexcept
   {

--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -62,7 +62,7 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 template <class _From, class _To>
-_CCCL_CONCEPT __span_array_convertible = _CCCL_TRAIT(is_convertible, _From (*)[], _To (*)[]);
+_CCCL_CONCEPT __span_array_convertible = is_convertible_v<_From (*)[], _To (*)[]>;
 
 template <class _Range, class _ElementType>
 _CCCL_CONCEPT_FRAGMENT(
@@ -70,11 +70,10 @@ _CCCL_CONCEPT_FRAGMENT(
   requires()(
     requires(_CUDA_VRANGES::contiguous_range<_Range>),
     requires(_CUDA_VRANGES::sized_range<_Range>),
-    requires((_CUDA_VRANGES::borrowed_range<_Range> || _CCCL_TRAIT(is_const, _ElementType))),
-    requires((!_CCCL_TRAIT(is_array, remove_cvref_t<_Range>))),
+    requires((_CUDA_VRANGES::borrowed_range<_Range> || is_const_v<_ElementType>) ),
+    requires((!is_array_v<remove_cvref_t<_Range>>) ),
     requires((!__is_std_span_v<remove_cvref_t<_Range>> && !__is_std_array_v<remove_cvref_t<_Range>>) ),
-    requires(_CCCL_TRAIT(
-      is_convertible, remove_reference_t<_CUDA_VRANGES::range_reference_t<_Range>> (*)[], _ElementType (*)[]))));
+    requires(is_convertible_v<remove_reference_t<_CUDA_VRANGES::range_reference_t<_Range>> (*)[], _ElementType (*)[]>)));
 
 template <class _Range, class _ElementType>
 _CCCL_CONCEPT __span_compatible_range = _CCCL_FRAGMENT(__span_compatible_range_, _Range, _ElementType);
@@ -86,7 +85,7 @@ _CCCL_CONCEPT __span_compatible_iterator =
 
 template <class _Sentinel, class _It>
 _CCCL_CONCEPT __span_compatible_sentinel_for =
-  sized_sentinel_for<_Sentinel, _It> && !_CCCL_TRAIT(is_convertible, _Sentinel, size_t);
+  sized_sentinel_for<_Sentinel, _It> && !is_convertible_v<_Sentinel, size_t>;
 #else // ^^^ C++20 ^^^ / vvv C++17 vvv
 template <class _It, class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__span_compatible_iterator_,
@@ -99,7 +98,7 @@ _CCCL_CONCEPT __span_compatible_iterator = _CCCL_FRAGMENT(__span_compatible_iter
 template <class _Sentinel, class _It>
 _CCCL_CONCEPT_FRAGMENT(
   __span_compatible_sentinel_for_,
-  requires()(requires(sized_sentinel_for<_Sentinel, _It>), requires(!_CCCL_TRAIT(is_convertible, _Sentinel, size_t))));
+  requires()(requires(sized_sentinel_for<_Sentinel, _It>), requires(!is_convertible_v<_Sentinel, size_t>)));
 
 template <class _Sentinel, class _It>
 _CCCL_CONCEPT __span_compatible_sentinel_for = _CCCL_FRAGMENT(__span_compatible_sentinel_for_, _Sentinel, _It);
@@ -121,8 +120,8 @@ concept __integral_constant_like =
 template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(
   __integral_constant_like_,
-  requires()(requires(_CCCL_TRAIT(is_integral, decltype(_Tp::value))),
-             requires(!_CCCL_TRAIT(is_same, bool, remove_const_t<decltype(_Tp::value)>)),
+  requires()(requires(is_integral_v<decltype(_Tp::value)>),
+             requires(!is_same_v<bool, remove_const_t<decltype(_Tp::value)>>),
              requires(convertible_to<_Tp, decltype(_Tp::value)>),
              requires(equality_comparable_with<_Tp, decltype(_Tp::value)>),
              (integral_constant<bool, _Tp() == _Tp::value>::value),
@@ -163,7 +162,7 @@ public:
   {}
 
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_const, _Tp2))
+  _CCCL_REQUIRES(is_const_v<_Tp2>)
   _CCCL_API constexpr explicit span(initializer_list<value_type> __il) noexcept
       : __data_{__il.begin()}
   {
@@ -387,7 +386,7 @@ public:
   {}
 
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
-  _CCCL_REQUIRES(_CCCL_TRAIT(is_const, _Tp2))
+  _CCCL_REQUIRES(is_const_v<_Tp2>)
   _CCCL_API constexpr span(initializer_list<value_type> __il) noexcept
       : __data_{__il.begin()}
       , __size_{__il.size()}

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/deduction.pass.cpp
@@ -28,8 +28,8 @@ __host__ __device__ constexpr bool test()
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
 
-  static_assert(_CCCL_TRAIT(cuda::std::is_convertible, const unsigned&, int)
-                && _CCCL_TRAIT(cuda::std::is_nothrow_constructible, int, const unsigned&));
+  static_assert(
+    cuda::std::is_convertible_v<const unsigned&, int> && cuda::std::is_nothrow_constructible_v<int, const unsigned&>);
 
   static_assert(cuda::std::is_same_v<
                 decltype(cuda::std::layout_stride::mapping(cuda::std::extents<int>(), cuda::std::array<unsigned, 0>())),

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/CustomTestAccessors.h
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/CustomTestAccessors.h
@@ -122,8 +122,8 @@ struct checked_accessor
   {}
 
   _CCCL_TEMPLATE(class OtherElementType)
-  _CCCL_REQUIRES((!_CCCL_TRAIT(cuda::std::is_same, OtherElementType, element_type)) _CCCL_AND _CCCL_TRAIT(
-    cuda::std::is_convertible, OtherElementType (*)[], element_type (*)[]))
+  _CCCL_REQUIRES((!cuda::std::is_same_v<OtherElementType, element_type>)
+                   _CCCL_AND cuda::std::is_convertible_v<OtherElementType (*)[], element_type (*)[]>)
   __host__ __device__ explicit constexpr checked_accessor(const checked_accessor<OtherElementType>& other) noexcept
   {
     N = other.N;

--- a/thrust/thrust/iterator/transform_iterator.h
+++ b/thrust/thrust/iterator/transform_iterator.h
@@ -266,18 +266,18 @@ public:
   _CCCL_HOST_DEVICE transform_iterator& operator=(transform_iterator const& other)
   {
     super_t::operator=(other);
-    if constexpr (_CCCL_TRAIT(::cuda::std::is_copy_assignable, AdaptableUnaryFunction))
+    if constexpr (::cuda::std::is_copy_assignable_v<AdaptableUnaryFunction>)
     {
       m_f = other.m_f;
     }
-    else if constexpr (_CCCL_TRAIT(::cuda::std::is_copy_constructible, AdaptableUnaryFunction))
+    else if constexpr (::cuda::std::is_copy_constructible_v<AdaptableUnaryFunction>)
     {
       ::cuda::std::__destroy_at(&m_f);
       ::cuda::std::__construct_at(&m_f, other.m_f);
     }
     else
     {
-      static_assert(_CCCL_TRAIT(::cuda::std::is_copy_constructible, AdaptableUnaryFunction),
+      static_assert(::cuda::std::is_copy_constructible_v<AdaptableUnaryFunction>,
                     "Cannot use thrust::transform_iterator with a functor that is neither copy constructible nor "
                     "copy assignable");
     }


### PR DESCRIPTION
This was a cludge to make C++17 code more efficient thatn C++14 was able to do. But now we dropped C++14, so we can always just use the inline variables.

I used the following two regexes to replace most of the occurences:
`_CCCL_TRAIT\(([a-zA-Z_:0-9]*), ([a-zA-Z_:0-9<>, .&]*)\)`
`_CCCL_TRAIT\(([a-zA-Z_:0-9]*), ([a-zA-Z_:0-9<>, .&]*), ([a-zA-Z_:0-9<>, .&]*)\)`

The remaining 100 cases were quickly done by hand.
