### PR TITLE
Fix fp constants

### DIFF
--- a/libcudacxx/include/cuda/std/__floating_point/constants.h
+++ b/libcudacxx/include/cuda/std/__floating_point/constants.h
@@ -25,6 +25,7 @@
 #include <cuda/std/__floating_point/arithmetic.h>
 #include <cuda/std/__floating_point/format.h>
 #include <cuda/std/__floating_point/mask.h>
+#include <cuda/std/__floating_point/native_type.h>
 #include <cuda/std/__floating_point/properties.h>
 #include <cuda/std/__floating_point/storage.h>
 
@@ -34,19 +35,37 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 // __fp_inf
 
+_CCCL_BEGIN_NV_DIAG_SUPPRESS(221) // floating-point value does not fit in required floating-point type
+
 template <__fp_format _Fmt>
 [[nodiscard]] _CCCL_API constexpr __fp_storage_t<_Fmt> __fp_inf() noexcept
 {
   static_assert(__fp_has_inf_v<_Fmt>, "The format does not support infinity");
 
-  return __fp_exp_mask_v<_Fmt>;
+  return static_cast<__fp_storage_t<_Fmt>>(__fp_exp_mask_v<_Fmt> | __fp_explicit_bit_mask_v<_Fmt>);
 }
 
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __fp_inf() noexcept
 {
-  return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_inf<__fp_format_of_v<_Tp>>());
+  static_assert(__fp_has_inf_v<__fp_format_of_v<_Tp>>, "The format does not support infinity");
+
+  if constexpr (__fp_is_native_type_v<_Tp>)
+  {
+#if defined(_CCCL_BUILTIN_HUGE_VALF)
+    return static_cast<_Tp>(_CCCL_BUILTIN_HUGE_VALF());
+#else // ^^^ _CCCL_BUILTIN_HUGE_VALF ^^^ / vvv !_CCCL_BUILTIN_HUGE_VALF vvv
+    // Workaround for nvrtc
+    return static_cast<_Tp>(static_cast<float>(0x1.ffffffp+127));
+#endif // ^^^ !_CCCL_BUILTIN_HUGE_VALF ^^^
+  }
+  else
+  {
+    return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_inf<__fp_format_of_v<_Tp>>());
+  }
 }
+
+_CCCL_END_NV_DIAG_SUPPRESS()
 
 // __fp_nan
 
@@ -55,30 +74,45 @@ template <__fp_format _Fmt>
 {
   static_assert(__fp_has_nan_v<_Fmt>, "The format does not support nan");
 
+  using _Storage = __fp_storage_t<_Fmt>;
+
   if constexpr (_Fmt == __fp_format::__fp8_nv_e4m3)
   {
-    return __fp_storage_t<_Fmt>(0x7fu);
+    return _Storage(0x7fu);
   }
   else if constexpr (_Fmt == __fp_format::__fp8_nv_e8m0)
   {
-    return __fp_storage_t<_Fmt>(0xffu);
+    return _Storage(0xffu);
   }
   else if constexpr (__fp_has_implicit_bit_v<_Fmt>)
   {
-    return static_cast<__fp_storage_t<_Fmt>>(
-      __fp_exp_mask_v<_Fmt> | (__fp_storage_t<_Fmt>(1) << (__fp_mant_nbits_v<_Fmt> - 1)));
+    return static_cast<_Storage>(__fp_exp_mask_v<_Fmt> | (_Storage(1) << (__fp_mant_nbits_v<_Fmt> - 1)));
   }
   else
   {
-    return static_cast<__fp_storage_t<_Fmt>>(
-      __fp_exp_mask_v<_Fmt> | (__fp_storage_t<_Fmt>(3) << (__fp_mant_nbits_v<_Fmt> - 2)));
+    return static_cast<_Storage>(
+      __fp_exp_mask_v<_Fmt> | __fp_explicit_bit_mask_v<_Fmt> | (_Storage(3) << (__fp_mant_nbits_v<_Fmt> - 2)));
   }
 }
 
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __fp_nan() noexcept
 {
-  return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_nan<__fp_format_of_v<_Tp>>());
+  static_assert(__fp_has_nan_v<__fp_format_of_v<_Tp>>, "The format does not support nan");
+
+  if constexpr (__fp_is_native_type_v<_Tp>)
+  {
+#if defined(_CCCL_BUILTIN_NANF)
+    return static_cast<_Tp>(_CCCL_BUILTIN_NANF(""));
+#else // ^^^ _CCCL_BUILTIN_NANF ^^^ / vvv !_CCCL_BUILTIN_NANF vvv
+    // Workaround for nvrtc
+    return _CUDA_VSTD::__fp_inf<_Tp>() / _CUDA_VSTD::__fp_inf<_Tp>();
+#endif // ^^^ !_CCCL_BUILTIN_NANF ^^^
+  }
+  else
+  {
+    return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_nan<__fp_format_of_v<_Tp>>());
+  }
 }
 
 // __fp_nans
@@ -88,22 +122,58 @@ template <__fp_format _Fmt>
 {
   static_assert(__fp_has_nans_v<_Fmt>, "The format does not support nans");
 
+  using _Storage = __fp_storage_t<_Fmt>;
+
   if constexpr (__fp_has_implicit_bit_v<_Fmt>)
   {
-    return static_cast<__fp_storage_t<_Fmt>>(
-      __fp_exp_mask_v<_Fmt> | (__fp_storage_t<_Fmt>(1) << (__fp_mant_nbits_v<_Fmt> - 2)));
+    return static_cast<_Storage>(__fp_exp_mask_v<_Fmt> | (_Storage(1) << (__fp_mant_nbits_v<_Fmt> - 2)));
   }
   else
   {
-    return static_cast<__fp_storage_t<_Fmt>>(
-      __fp_exp_mask_v<_Fmt> | (__fp_storage_t<_Fmt>(5) << (__fp_mant_nbits_v<_Fmt> - 3)));
+    return static_cast<_Storage>(
+      __fp_exp_mask_v<_Fmt> | __fp_explicit_bit_mask_v<_Fmt> | (_Storage(5) << (__fp_mant_nbits_v<_Fmt> - 3)));
   }
 }
 
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __fp_nans() noexcept
 {
-  return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_nans<__fp_format_of_v<_Tp>>());
+  constexpr auto __fmt = __fp_format_of_v<_Tp>;
+
+  static_assert(__fp_has_nans_v<__fmt>, "The format does not support nans");
+
+  if constexpr (false)
+  {
+    return _Tp{};
+  }
+#if defined(_CCCL_BUILTIN_NANSF)
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary32)
+  {
+    return static_cast<_Tp>(_CCCL_BUILTIN_NANSF(""));
+  }
+#endif // _CCCL_BUILTIN_NANSF
+#if defined(_CCCL_BUILTIN_NANS)
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary64)
+  {
+    return static_cast<_Tp>(_CCCL_BUILTIN_NANS(""));
+  }
+#endif // _CCCL_BUILTIN_NANS
+#if _CCCL_HAS_LONG_DOUBLE()
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format_of_v<long double>)
+  {
+    return static_cast<_Tp>(_CCCL_BUILTIN_NANSL(""));
+  }
+#endif // _CCCL_HAS_LONG_DOUBLE
+#if defined(_CCCL_BUILTIN_NANFS128)
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary128)
+  {
+    return static_cast<_Tp>(_CCCL_BUILTIN_NANFS128(""));
+  }
+#endif // _CCCL_BUILTIN_NANFS128
+  else
+  {
+    return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_nans<__fp_format_of_v<_Tp>>());
+  }
 }
 
 // __fp_max
@@ -111,22 +181,49 @@ template <class _Tp>
 template <__fp_format _Fmt>
 [[nodiscard]] _CCCL_API constexpr __fp_storage_t<_Fmt> __fp_max() noexcept
 {
+  using _Storage = __fp_storage_t<_Fmt>;
+
   if constexpr (_Fmt == __fp_format::__fp8_nv_e4m3)
   {
-    return __fp_storage_t<_Fmt>(0x7eu);
+    return _Storage(0x7eu);
   }
   else
   {
-    return static_cast<__fp_storage_t<_Fmt>>(
-      (__fp_storage_t<_Fmt>(__fp_exp_max_v<_Fmt> + __fp_exp_bias_v<_Fmt>) << __fp_mant_nbits_v<_Fmt>)
-      | __fp_mant_mask_v<_Fmt>);
+    return static_cast<_Storage>(
+      (_Storage(__fp_exp_max_v<_Fmt> + __fp_exp_bias_v<_Fmt>) << __fp_mant_nbits_v<_Fmt>) | __fp_mant_mask_v<_Fmt>);
   }
 }
 
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __fp_max() noexcept
 {
-  return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_max<__fp_format_of_v<_Tp>>());
+  constexpr auto __fmt = __fp_format_of_v<_Tp>;
+  if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary16)
+  {
+    return static_cast<_Tp>(0x1.ffcp+15f);
+  }
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary32)
+  {
+    return static_cast<_Tp>(0x1.fffffep+127f);
+  }
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary64)
+  {
+    return static_cast<_Tp>(0x1.fffffffffffffp+1023);
+  }
+#if _CCCL_HAS_FLOAT128()
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary128)
+  {
+    return static_cast<_Tp>(_CCCL_FLOAT128_LITERAL(0x1.ffffffffffffffffffffffffffffp+16383));
+  }
+#endif // _CCCL_HAS_FLOAT128
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__bfloat16)
+  {
+    return static_cast<_Tp>(0x1.fep+127);
+  }
+  else
+  {
+    return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_max<__fp_format_of_v<_Tp>>());
+  }
 }
 
 // __fp_min
@@ -134,14 +231,93 @@ template <class _Tp>
 template <__fp_format _Fmt>
 [[nodiscard]] _CCCL_API constexpr __fp_storage_t<_Fmt> __fp_min() noexcept
 {
-  return static_cast<__fp_storage_t<_Fmt>>(
-    __fp_storage_t<_Fmt>(__fp_exp_min_v<_Fmt> + __fp_exp_bias_v<_Fmt>) << __fp_mant_nbits_v<_Fmt>);
+  using _Storage = __fp_storage_t<_Fmt>;
+
+  if constexpr (_Fmt == __fp_format::__fp8_nv_e8m0)
+  {
+    return _Storage{0};
+  }
+  else
+  {
+    return static_cast<_Storage>((_Storage{1} << __fp_mant_nbits_v<_Fmt>) | __fp_explicit_bit_mask_v<_Fmt>);
+  }
 }
 
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __fp_min() noexcept
 {
-  return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_min<__fp_format_of_v<_Tp>>());
+  constexpr auto __fmt = __fp_format_of_v<_Tp>;
+
+  if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary16)
+  {
+    return static_cast<_Tp>(0x1p-14f);
+  }
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary32)
+  {
+    return static_cast<_Tp>(0x1p-126f);
+  }
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary64)
+  {
+    return static_cast<_Tp>(0x1p-1022);
+  }
+#if _CCCL_HAS_FLOAT128()
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary128)
+  {
+    return static_cast<_Tp>(_CCCL_FLOAT128_LITERAL(0x1p-16382));
+  }
+#endif // _CCCL_HAS_FLOAT128()
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__bfloat16)
+  {
+    return static_cast<_Tp>(0x1p-126f);
+  }
+  else
+  {
+    return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_min<__fp_format_of_v<_Tp>>());
+  }
+}
+
+// __fp_denorm_min
+
+template <__fp_format _Fmt>
+[[nodiscard]] _CCCL_API constexpr __fp_storage_t<_Fmt> __fp_denorm_min() noexcept
+{
+  static_assert(__fp_has_denorm_v<_Fmt>, "The format does not support denormals");
+  return __fp_storage_t<_Fmt>(1);
+}
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __fp_denorm_min() noexcept
+{
+  constexpr auto __fmt = __fp_format_of_v<_Tp>;
+
+  static_assert(__fp_has_denorm_v<__fmt>, "The format does not support denormals");
+
+  if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary16)
+  {
+    return static_cast<_Tp>(0x1p-24f);
+  }
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary32)
+  {
+    return static_cast<_Tp>(0x1p-149f);
+  }
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary64)
+  {
+    return static_cast<_Tp>(0x1p-1074);
+  }
+#if _CCCL_HAS_FLOAT128()
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__binary128)
+  {
+    return static_cast<_Tp>(_CCCL_FLOAT128_LITERAL(0x1p-16494));
+  }
+#endif // _CCCL_HAS_FLOAT128()
+  else if constexpr (__fp_is_native_type_v<_Tp> && __fmt == __fp_format::__bfloat16)
+  {
+    return static_cast<_Tp>(0x1p-133f);
+  }
+  else
+  {
+    return _CUDA_VSTD::__fp_from_storage<_Tp>(_CUDA_VSTD::__fp_denorm_min<__fmt>());
+  }
 }
 
 // __fp_lowest

--- a/libcudacxx/include/cuda/std/__floating_point/mask.h
+++ b/libcudacxx/include/cuda/std/__floating_point/mask.h
@@ -57,6 +57,14 @@ inline constexpr auto __fp_exp_mant_mask_v =
 template <class _Tp>
 inline constexpr auto __fp_exp_mant_mask_of_v = __fp_exp_mant_mask_v<__fp_format_of_v<_Tp>>;
 
+template <__fp_format _Fmt>
+inline constexpr auto __fp_explicit_bit_mask_v = static_cast<__fp_storage_t<_Fmt>>(
+  (static_cast<__fp_storage_t<_Fmt>>(!__fp_has_implicit_bit_v<_Fmt>)
+   << (__fp_mant_nbits_v<_Fmt> - !__fp_has_implicit_bit_v<_Fmt>) ));
+
+template <class _Tp>
+inline constexpr auto __fp_explicit_bit_mask_of_v = __fp_explicit_bit_mask_v<__fp_format_of_v<_Tp>>;
+
 _LIBCUDACXX_END_NAMESPACE_STD
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants.pass.cpp
@@ -22,56 +22,6 @@ __host__ __device__ void test_fp_storage()
 {
   constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
 
-  // __fp_has_inf_v must match numeric_limits::has_infinity
-  static_assert(cuda::std::__fp_has_inf_v<fmt> == cuda::std::numeric_limits<T>::has_infinity);
-
-  // test __fp_inf value to match numeric_limits::infinity()
-  if constexpr (cuda::std::__fp_has_inf_v<fmt>)
-  {
-    const auto val = cuda::std::__fp_inf<T>();
-    const auto ref = cuda::std::numeric_limits<T>::infinity();
-    assert(cuda::std::memcmp(&val, &ref, sizeof(T)) == 0);
-  }
-
-  // __fp_has_nan_v must match numeric_limits::has_quiet_NaN
-  static_assert(cuda::std::__fp_has_nan_v<fmt> == cuda::std::numeric_limits<T>::has_quiet_NaN);
-
-  // test __fp_nan value
-  if constexpr (cuda::std::__fp_has_nan_v<fmt>)
-  {
-    assert(cuda::std::isnan(cuda::std::__fp_nan<T>()));
-  }
-
-  // __fp_has_nans_v must match numeric_limits::has_signaling_NaN
-  static_assert(cuda::std::__fp_has_nans_v<fmt> == cuda::std::numeric_limits<T>::has_signaling_NaN);
-
-  // test __fp_nans value
-  if constexpr (cuda::std::__fp_has_nans_v<fmt>)
-  {
-    assert(cuda::std::isnan(cuda::std::__fp_nans<T>()));
-  }
-
-  // test __fp_max value to match numeric_limits::max()
-  {
-    const auto val = cuda::std::__fp_max<T>();
-    const auto ref = cuda::std::numeric_limits<T>::max();
-    assert(cuda::std::memcmp(&val, &ref, sizeof(T)) == 0);
-  }
-
-  // test __fp_min value to match numeric_limits::min()
-  {
-    const auto val = cuda::std::__fp_min<T>();
-    const auto ref = cuda::std::numeric_limits<T>::min();
-    assert(cuda::std::memcmp(&val, &ref, sizeof(T)) == 0);
-  }
-
-  // test __fp_lowest value to match numeric_limits::lowest()
-  {
-    const auto val = cuda::std::__fp_lowest<T>();
-    const auto ref = cuda::std::numeric_limits<T>::lowest();
-    assert(cuda::std::memcmp(&val, &ref, sizeof(T)) == 0);
-  }
-
   // test __fp_zero to be all zeros
 #if _CCCL_HAS_NVFP8_E8M0()
   if constexpr (!cuda::std::is_same_v<T, __nv_fp8_e8m0>)

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/denorm_min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/denorm_min.pass.cpp
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license minormation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+#include "test_macros.h"
+
+TEST_NV_DIAG_SUPPRESS(23) // integer constant is too large
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_denorm_min(cuda::std::__fp_storage_t<Fmt> expected)
+{
+  assert(cuda::std::__fp_denorm_min<Fmt>() == expected);
+  static_assert(((void) cuda::std::__fp_denorm_min<Fmt>(), true));
+}
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_denorm_min()
+{
+  static_assert(!cuda::std::__fp_has_denorm_v<Fmt>);
+}
+
+template <class T, cuda::std::enable_if_t<cuda::std::__fp_has_denorm_v<cuda::std::__fp_format_of_v<T>>, int> = 0>
+__host__ __device__ void test_fp_denorm_min()
+{
+  constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
+  assert(cuda::std::__fp_get_storage(cuda::std::__fp_denorm_min<T>()) == cuda::std::__fp_denorm_min<fmt>());
+  static_assert(((void) cuda::std::__fp_denorm_min<T>(), true));
+}
+
+template <class T, cuda::std::enable_if_t<!cuda::std::__fp_has_denorm_v<cuda::std::__fp_format_of_v<T>>, int> = 0>
+__host__ __device__ void test_fp_denorm_min()
+{}
+
+__host__ __device__ bool test()
+{
+  using namespace test_integer_literals;
+
+  // 1. Test formats
+  test_fp_denorm_min<cuda::std::__fp_format::__binary16>(0x0001u);
+  test_fp_denorm_min<cuda::std::__fp_format::__binary32>(0x00000001u);
+  test_fp_denorm_min<cuda::std::__fp_format::__binary64>(0x0000000000000001ull);
+#if _CCCL_HAS_INT128()
+  test_fp_denorm_min<cuda::std::__fp_format::__binary128>(0x00000000000000000000000000000001_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_denorm_min<cuda::std::__fp_format::__bfloat16>(0x0001u);
+#if _CCCL_HAS_INT128()
+  test_fp_denorm_min<cuda::std::__fp_format::__fp80_x86>(0x00000000000000000001_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_denorm_min<cuda::std::__fp_format::__fp8_nv_e4m3>(0x01u);
+  test_fp_denorm_min<cuda::std::__fp_format::__fp8_nv_e5m2>(0x01u);
+  test_fp_denorm_min<cuda::std::__fp_format::__fp8_nv_e8m0>();
+  test_fp_denorm_min<cuda::std::__fp_format::__fp6_nv_e2m3>(0x01u);
+  test_fp_denorm_min<cuda::std::__fp_format::__fp6_nv_e3m2>(0x01u);
+  test_fp_denorm_min<cuda::std::__fp_format::__fp4_nv_e2m1>(0x1u);
+
+  // 2. Test types
+  test_fp_denorm_min<float>();
+  test_fp_denorm_min<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_fp_denorm_min<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_NVFP16()
+  test_fp_denorm_min<__half>();
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+  test_fp_denorm_min<__nv_bfloat16>();
+#endif // _CCCL_HAS_NVBF16()
+#if _CCCL_HAS_NVFP8_E4M3()
+  test_fp_denorm_min<__nv_fp8_e4m3>();
+#endif // _CCCL_HAS_NVFP8_E4M3()
+#if _CCCL_HAS_NVFP8_E5M2()
+  test_fp_denorm_min<__nv_fp8_e5m2>();
+#endif // _CCCL_HAS_NVFP8_E5M2()
+#if _CCCL_HAS_NVFP8_E8M0()
+  test_fp_denorm_min<__nv_fp8_e8m0>();
+#endif // _CCCL_HAS_NVFP8_E8M0()
+#if _CCCL_HAS_NVFP6_E2M3()
+  test_fp_denorm_min<__nv_fp6_e2m3>();
+#endif // _CCCL_HAS_NVFP6_E2M3()
+#if _CCCL_HAS_NVFP6_E3M2()
+  test_fp_denorm_min<__nv_fp6_e3m2>();
+#endif // _CCCL_HAS_NVFP6_E3M2()
+#if _CCCL_HAS_NVFP4_E2M1()
+  test_fp_denorm_min<__nv_fp4_e2m1>();
+#endif // _CCCL_HAS_NVFP4_E2M1()
+#if _CCCL_HAS_FLOAT128()
+  test_fp_denorm_min<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  // todo: test __cccl_fp types
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/inf.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/inf.pass.cpp
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+#include "test_macros.h"
+
+TEST_NV_DIAG_SUPPRESS(23) // integer constant is too large
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_inf(cuda::std::__fp_storage_t<Fmt> expected)
+{
+  assert(cuda::std::__fp_inf<Fmt>() == expected);
+  static_assert(((void) cuda::std::__fp_inf<Fmt>(), true));
+}
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_inf()
+{
+  static_assert(!cuda::std::__fp_has_inf_v<Fmt>);
+}
+
+template <class T, cuda::std::enable_if_t<cuda::std::__fp_has_inf_v<cuda::std::__fp_format_of_v<T>>, int> = 0>
+__host__ __device__ void test_fp_inf()
+{
+  constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
+  assert(cuda::std::__fp_get_storage(cuda::std::__fp_inf<T>()) == cuda::std::__fp_inf<fmt>());
+  static_assert(((void) cuda::std::__fp_inf<T>(), true));
+}
+
+template <class T, cuda::std::enable_if_t<!cuda::std::__fp_has_inf_v<cuda::std::__fp_format_of_v<T>>, int> = 0>
+__host__ __device__ void test_fp_inf()
+{}
+
+__host__ __device__ bool test()
+{
+  using namespace test_integer_literals;
+
+  // 1. Test formats
+  test_fp_inf<cuda::std::__fp_format::__binary16>(0x7c00u);
+  test_fp_inf<cuda::std::__fp_format::__binary32>(0x7f800000u);
+  test_fp_inf<cuda::std::__fp_format::__binary64>(0x7ff0000000000000ull);
+#if _CCCL_HAS_INT128()
+  test_fp_inf<cuda::std::__fp_format::__binary128>(0x7fff0000000000000000000000000000_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_inf<cuda::std::__fp_format::__bfloat16>(0x7f80u);
+#if _CCCL_HAS_INT128()
+  test_fp_inf<cuda::std::__fp_format::__fp80_x86>(0x7fff8000000000000000_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_inf<cuda::std::__fp_format::__fp8_nv_e4m3>();
+  test_fp_inf<cuda::std::__fp_format::__fp8_nv_e5m2>(0x7cu);
+  test_fp_inf<cuda::std::__fp_format::__fp8_nv_e8m0>();
+  test_fp_inf<cuda::std::__fp_format::__fp6_nv_e2m3>();
+  test_fp_inf<cuda::std::__fp_format::__fp6_nv_e3m2>();
+  test_fp_inf<cuda::std::__fp_format::__fp4_nv_e2m1>();
+
+  // 2. Test types
+  test_fp_inf<float>();
+  test_fp_inf<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_fp_inf<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_NVFP16()
+  test_fp_inf<__half>();
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+  test_fp_inf<__nv_bfloat16>();
+#endif // _CCCL_HAS_NVBF16()
+#if _CCCL_HAS_NVFP8_E4M3()
+  test_fp_inf<__nv_fp8_e4m3>();
+#endif // _CCCL_HAS_NVFP8_E4M3()
+#if _CCCL_HAS_NVFP8_E5M2()
+  test_fp_inf<__nv_fp8_e5m2>();
+#endif // _CCCL_HAS_NVFP8_E5M2()
+#if _CCCL_HAS_NVFP8_E8M0()
+  test_fp_inf<__nv_fp8_e8m0>();
+#endif // _CCCL_HAS_NVFP8_E8M0()
+#if _CCCL_HAS_NVFP6_E2M3()
+  test_fp_inf<__nv_fp6_e2m3>();
+#endif // _CCCL_HAS_NVFP6_E2M3()
+#if _CCCL_HAS_NVFP6_E3M2()
+  test_fp_inf<__nv_fp6_e3m2>();
+#endif // _CCCL_HAS_NVFP6_E3M2()
+#if _CCCL_HAS_NVFP4_E2M1()
+  test_fp_inf<__nv_fp4_e2m1>();
+#endif // _CCCL_HAS_NVFP4_E2M1()
+#if _CCCL_HAS_FLOAT128()
+  test_fp_inf<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  // todo: test __cccl_fp types
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/lowest.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/lowest.pass.cpp
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license minormation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+
+#include "literal.h"
+#include "test_macros.h"
+
+TEST_NV_DIAG_SUPPRESS(23) // integer constant is too large
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_lowest(cuda::std::__fp_storage_t<Fmt> expected)
+{
+  assert(cuda::std::__fp_lowest<Fmt>() == expected);
+  static_assert(((void) cuda::std::__fp_lowest<Fmt>(), true));
+}
+
+template <class T>
+__host__ __device__ void test_fp_lowest()
+{
+  constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
+  assert(cuda::std::__fp_get_storage(cuda::std::__fp_lowest<T>()) == cuda::std::__fp_lowest<fmt>());
+  static_assert(((void) cuda::std::__fp_lowest<T>(), true));
+}
+
+__host__ __device__ bool test()
+{
+  using namespace test_integer_literals;
+
+  // 1. Test formats
+  test_fp_lowest<cuda::std::__fp_format::__binary16>(0xfbffu);
+  test_fp_lowest<cuda::std::__fp_format::__binary32>(0xff7fffffu);
+  test_fp_lowest<cuda::std::__fp_format::__binary64>(0xffefffffffffffffull);
+#if _CCCL_HAS_INT128()
+  test_fp_lowest<cuda::std::__fp_format::__binary128>(0xfffeffffffffffffffffffffffffffff_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_lowest<cuda::std::__fp_format::__bfloat16>(0xff7fu);
+#if _CCCL_HAS_INT128()
+  test_fp_lowest<cuda::std::__fp_format::__fp80_x86>(0xfffeffffffffffffffff_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_lowest<cuda::std::__fp_format::__fp8_nv_e4m3>(0xfeu);
+  test_fp_lowest<cuda::std::__fp_format::__fp8_nv_e5m2>(0xfbu);
+  test_fp_lowest<cuda::std::__fp_format::__fp8_nv_e8m0>(0x00u);
+  test_fp_lowest<cuda::std::__fp_format::__fp6_nv_e2m3>(0x3fu);
+  test_fp_lowest<cuda::std::__fp_format::__fp6_nv_e3m2>(0x3fu);
+  test_fp_lowest<cuda::std::__fp_format::__fp4_nv_e2m1>(0xfu);
+
+  // 2. Test types
+  test_fp_lowest<float>();
+  test_fp_lowest<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_fp_lowest<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_NVFP16()
+  test_fp_lowest<__half>();
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+  test_fp_lowest<__nv_bfloat16>();
+#endif // _CCCL_HAS_NVBF16()
+#if _CCCL_HAS_NVFP8_E4M3()
+  test_fp_lowest<__nv_fp8_e4m3>();
+#endif // _CCCL_HAS_NVFP8_E4M3()
+#if _CCCL_HAS_NVFP8_E5M2()
+  test_fp_lowest<__nv_fp8_e5m2>();
+#endif // _CCCL_HAS_NVFP8_E5M2()
+#if _CCCL_HAS_NVFP8_E8M0()
+  test_fp_lowest<__nv_fp8_e8m0>();
+#endif // _CCCL_HAS_NVFP8_E8M0()
+#if _CCCL_HAS_NVFP6_E2M3()
+  test_fp_lowest<__nv_fp6_e2m3>();
+#endif // _CCCL_HAS_NVFP6_E2M3()
+#if _CCCL_HAS_NVFP6_E3M2()
+  test_fp_lowest<__nv_fp6_e3m2>();
+#endif // _CCCL_HAS_NVFP6_E3M2()
+#if _CCCL_HAS_NVFP4_E2M1()
+  test_fp_lowest<__nv_fp4_e2m1>();
+#endif // _CCCL_HAS_NVFP4_E2M1()
+#if _CCCL_HAS_FLOAT128()
+  test_fp_lowest<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  // todo: test __cccl_fp types
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/max.pass.cpp
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license maxormation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+#include "test_macros.h"
+
+TEST_NV_DIAG_SUPPRESS(23) // integer constant is too large
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_max(cuda::std::__fp_storage_t<Fmt> expected)
+{
+  assert(cuda::std::__fp_max<Fmt>() == expected);
+  static_assert(((void) cuda::std::__fp_max<Fmt>(), true));
+}
+
+template <class T>
+__host__ __device__ void test_fp_max()
+{
+  constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
+  assert(cuda::std::__fp_get_storage(cuda::std::__fp_max<T>()) == cuda::std::__fp_max<fmt>());
+  static_assert(((void) cuda::std::__fp_max<T>(), true));
+}
+
+__host__ __device__ bool test()
+{
+  using namespace test_integer_literals;
+
+  // 1. Test formats
+  test_fp_max<cuda::std::__fp_format::__binary16>(0x7bffu);
+  test_fp_max<cuda::std::__fp_format::__binary32>(0x7f7fffffu);
+  test_fp_max<cuda::std::__fp_format::__binary64>(0x7fefffffffffffffull);
+#if _CCCL_HAS_INT128()
+  test_fp_max<cuda::std::__fp_format::__binary128>(0x7ffeffffffffffffffffffffffffffff_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_max<cuda::std::__fp_format::__bfloat16>(0x7f7fu);
+#if _CCCL_HAS_INT128()
+  test_fp_max<cuda::std::__fp_format::__fp80_x86>(0x7ffeffffffffffffffff_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_max<cuda::std::__fp_format::__fp8_nv_e4m3>(0x7eu);
+  test_fp_max<cuda::std::__fp_format::__fp8_nv_e5m2>(0x7bu);
+  test_fp_max<cuda::std::__fp_format::__fp8_nv_e8m0>(0xfeu);
+  test_fp_max<cuda::std::__fp_format::__fp6_nv_e2m3>(0x1fu);
+  test_fp_max<cuda::std::__fp_format::__fp6_nv_e3m2>(0x1fu);
+  test_fp_max<cuda::std::__fp_format::__fp4_nv_e2m1>(0x7u);
+
+  // 2. Test types
+  test_fp_max<float>();
+  test_fp_max<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_fp_max<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_NVFP16()
+  test_fp_max<__half>();
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+  test_fp_max<__nv_bfloat16>();
+#endif // _CCCL_HAS_NVBF16()
+#if _CCCL_HAS_NVFP8_E4M3()
+  test_fp_max<__nv_fp8_e4m3>();
+#endif // _CCCL_HAS_NVFP8_E4M3()
+#if _CCCL_HAS_NVFP8_E5M2()
+  test_fp_max<__nv_fp8_e5m2>();
+#endif // _CCCL_HAS_NVFP8_E5M2()
+#if _CCCL_HAS_NVFP8_E8M0()
+  test_fp_max<__nv_fp8_e8m0>();
+#endif // _CCCL_HAS_NVFP8_E8M0()
+#if _CCCL_HAS_NVFP6_E2M3()
+  test_fp_max<__nv_fp6_e2m3>();
+#endif // _CCCL_HAS_NVFP6_E2M3()
+#if _CCCL_HAS_NVFP6_E3M2()
+  test_fp_max<__nv_fp6_e3m2>();
+#endif // _CCCL_HAS_NVFP6_E3M2()
+#if _CCCL_HAS_NVFP4_E2M1()
+  test_fp_max<__nv_fp4_e2m1>();
+#endif // _CCCL_HAS_NVFP4_E2M1()
+#if _CCCL_HAS_FLOAT128()
+  test_fp_max<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  // todo: test __cccl_fp types
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/min.pass.cpp
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license minormation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+
+#include "literal.h"
+#include "test_macros.h"
+
+TEST_NV_DIAG_SUPPRESS(23) // integer constant is too large
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_min(cuda::std::__fp_storage_t<Fmt> expected)
+{
+  assert(cuda::std::__fp_min<Fmt>() == expected);
+  static_assert(((void) cuda::std::__fp_min<Fmt>(), true));
+}
+
+template <class T>
+__host__ __device__ void test_fp_min()
+{
+  constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
+  assert(cuda::std::__fp_get_storage(cuda::std::__fp_min<T>()) == cuda::std::__fp_min<fmt>());
+  static_assert(((void) cuda::std::__fp_min<T>(), true));
+}
+
+__host__ __device__ bool test()
+{
+  using namespace test_integer_literals;
+
+  // 1. Test formats
+  test_fp_min<cuda::std::__fp_format::__binary16>(0x0400u);
+  test_fp_min<cuda::std::__fp_format::__binary32>(0x00800000u);
+  test_fp_min<cuda::std::__fp_format::__binary64>(0x0010000000000000ull);
+#if _CCCL_HAS_INT128()
+  test_fp_min<cuda::std::__fp_format::__binary128>(0x00010000000000000000000000000000_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_min<cuda::std::__fp_format::__bfloat16>(0x0080u);
+#if _CCCL_HAS_INT128()
+  test_fp_min<cuda::std::__fp_format::__fp80_x86>(0x00018000000000000000_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_min<cuda::std::__fp_format::__fp8_nv_e4m3>(0x08u);
+  test_fp_min<cuda::std::__fp_format::__fp8_nv_e5m2>(0x04u);
+  test_fp_min<cuda::std::__fp_format::__fp8_nv_e8m0>(0x00u);
+  test_fp_min<cuda::std::__fp_format::__fp6_nv_e2m3>(0x08u);
+  test_fp_min<cuda::std::__fp_format::__fp6_nv_e3m2>(0x04u);
+  test_fp_min<cuda::std::__fp_format::__fp4_nv_e2m1>(0x2u);
+
+  // 2. Test types
+  test_fp_min<float>();
+  test_fp_min<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_fp_min<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_NVFP16()
+  test_fp_min<__half>();
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+  test_fp_min<__nv_bfloat16>();
+#endif // _CCCL_HAS_NVBF16()
+#if _CCCL_HAS_NVFP8_E4M3()
+  test_fp_min<__nv_fp8_e4m3>();
+#endif // _CCCL_HAS_NVFP8_E4M3()
+#if _CCCL_HAS_NVFP8_E5M2()
+  test_fp_min<__nv_fp8_e5m2>();
+#endif // _CCCL_HAS_NVFP8_E5M2()
+#if _CCCL_HAS_NVFP8_E8M0()
+  test_fp_min<__nv_fp8_e8m0>();
+#endif // _CCCL_HAS_NVFP8_E8M0()
+#if _CCCL_HAS_NVFP6_E2M3()
+  test_fp_min<__nv_fp6_e2m3>();
+#endif // _CCCL_HAS_NVFP6_E2M3()
+#if _CCCL_HAS_NVFP6_E3M2()
+  test_fp_min<__nv_fp6_e3m2>();
+#endif // _CCCL_HAS_NVFP6_E3M2()
+#if _CCCL_HAS_NVFP4_E2M1()
+  test_fp_min<__nv_fp4_e2m1>();
+#endif // _CCCL_HAS_NVFP4_E2M1()
+#if _CCCL_HAS_FLOAT128()
+  test_fp_min<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  // todo: test __cccl_fp types
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/nan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/nan.pass.cpp
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license nanormation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+#include "test_macros.h"
+
+TEST_NV_DIAG_SUPPRESS(23) // integer constant is too large
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_nan(cuda::std::__fp_storage_t<Fmt> expected)
+{
+  assert(cuda::std::__fp_nan<Fmt>() == expected);
+  static_assert(((void) cuda::std::__fp_nan<Fmt>(), true));
+}
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_nan()
+{
+  static_assert(!cuda::std::__fp_has_nan_v<Fmt>);
+}
+
+template <class T, cuda::std::enable_if_t<cuda::std::__fp_has_nan_v<cuda::std::__fp_format_of_v<T>>, int> = 0>
+__host__ __device__ void test_fp_nan()
+{
+  constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
+  const auto result  = cuda::std::__fp_nan<T>();
+  assert(cuda::std::isnan(result));
+  if constexpr (fmt == cuda::std::__fp_format::__fp8_nv_e4m3 || fmt == cuda::std::__fp_format::__fp8_nv_e5m2
+                || fmt == cuda::std::__fp_format::__fp8_nv_e8m0 || fmt == cuda::std::__fp_format::__fp6_nv_e2m3
+                || fmt == cuda::std::__fp_format::__fp6_nv_e3m2 || fmt == cuda::std::__fp_format::__fp4_nv_e2m1)
+  {
+    assert(cuda::std::__fp_get_storage(result) == cuda::std::__fp_nan<fmt>());
+  }
+  else
+  {
+    const auto nan_distinct_mask = cuda::std::__fp_storage_t<fmt>{1}
+                                << (cuda::std::__fp_mant_nbits_v<fmt> - 1 - !cuda::std::__fp_has_implicit_bit_v<fmt>);
+    assert(cuda::std::__fp_get_storage(result) & nan_distinct_mask);
+  }
+  static_assert(((void) cuda::std::__fp_nan<T>(), true));
+}
+
+template <class T, cuda::std::enable_if_t<!cuda::std::__fp_has_nan_v<cuda::std::__fp_format_of_v<T>>, int> = 0>
+__host__ __device__ void test_fp_nan()
+{}
+
+__host__ __device__ bool test()
+{
+  using namespace test_integer_literals;
+
+  // 1. Test formats
+  test_fp_nan<cuda::std::__fp_format::__binary16>(0x7e00u);
+  test_fp_nan<cuda::std::__fp_format::__binary32>(0x7fc00000u);
+  test_fp_nan<cuda::std::__fp_format::__binary64>(0x7ff8000000000000ull);
+#if _CCCL_HAS_INT128()
+  test_fp_nan<cuda::std::__fp_format::__binary128>(0x7fff8000000000000000000000000000_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_nan<cuda::std::__fp_format::__bfloat16>(0x7fc0u);
+#if _CCCL_HAS_INT128()
+  test_fp_nan<cuda::std::__fp_format::__fp80_x86>(0x7fffc000000000000000_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_nan<cuda::std::__fp_format::__fp8_nv_e4m3>(0x7fu);
+  test_fp_nan<cuda::std::__fp_format::__fp8_nv_e5m2>(0x7eu);
+  test_fp_nan<cuda::std::__fp_format::__fp8_nv_e8m0>(0xffu);
+  test_fp_nan<cuda::std::__fp_format::__fp6_nv_e2m3>();
+  test_fp_nan<cuda::std::__fp_format::__fp6_nv_e3m2>();
+  test_fp_nan<cuda::std::__fp_format::__fp4_nv_e2m1>();
+
+  // 2. Test types
+  test_fp_nan<float>();
+  test_fp_nan<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_fp_nan<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_NVFP16()
+  test_fp_nan<__half>();
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+  test_fp_nan<__nv_bfloat16>();
+#endif // _CCCL_HAS_NVBF16()
+#if _CCCL_HAS_NVFP8_E4M3()
+  test_fp_nan<__nv_fp8_e4m3>();
+#endif // _CCCL_HAS_NVFP8_E4M3()
+#if _CCCL_HAS_NVFP8_E5M2()
+  test_fp_nan<__nv_fp8_e5m2>();
+#endif // _CCCL_HAS_NVFP8_E5M2()
+#if _CCCL_HAS_NVFP8_E8M0()
+  test_fp_nan<__nv_fp8_e8m0>();
+#endif // _CCCL_HAS_NVFP8_E8M0()
+#if _CCCL_HAS_NVFP6_E2M3()
+  test_fp_nan<__nv_fp6_e2m3>();
+#endif // _CCCL_HAS_NVFP6_E2M3()
+#if _CCCL_HAS_NVFP6_E3M2()
+  test_fp_nan<__nv_fp6_e3m2>();
+#endif // _CCCL_HAS_NVFP6_E3M2()
+#if _CCCL_HAS_NVFP4_E2M1()
+  test_fp_nan<__nv_fp4_e2m1>();
+#endif // _CCCL_HAS_NVFP4_E2M1()
+#if _CCCL_HAS_FLOAT128()
+  test_fp_nan<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  // todo: test __cccl_fp types
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/nans.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/constants/nans.pass.cpp
@@ -1,0 +1,124 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license nansormation.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+#include <cuda/std/cmath>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+#include "test_macros.h"
+
+TEST_NV_DIAG_SUPPRESS(23) // integer constant is too large
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_nans(cuda::std::__fp_storage_t<Fmt> expected)
+{
+  assert(cuda::std::__fp_nans<Fmt>() == expected);
+  static_assert(((void) cuda::std::__fp_nans<Fmt>(), true));
+}
+
+template <cuda::std::__fp_format Fmt>
+__host__ __device__ void test_fp_nans()
+{
+  static_assert(!cuda::std::__fp_has_nans_v<Fmt>);
+}
+
+template <class T, cuda::std::enable_if_t<cuda::std::__fp_has_nans_v<cuda::std::__fp_format_of_v<T>>, int> = 0>
+__host__ __device__ void test_fp_nans()
+{
+  constexpr auto fmt = cuda::std::__fp_format_of_v<T>;
+  const auto result  = cuda::std::__fp_nans<T>();
+  assert(cuda::std::isnan(result));
+  if constexpr (fmt == cuda::std::__fp_format::__fp8_nv_e4m3 || fmt == cuda::std::__fp_format::__fp8_nv_e5m2
+                || fmt == cuda::std::__fp_format::__fp8_nv_e8m0 || fmt == cuda::std::__fp_format::__fp6_nv_e2m3
+                || fmt == cuda::std::__fp_format::__fp6_nv_e3m2 || fmt == cuda::std::__fp_format::__fp4_nv_e2m1)
+  {
+    assert(cuda::std::__fp_get_storage(result) == cuda::std::__fp_nans<fmt>());
+  }
+  else
+  {
+    const auto nan_distinct_mask = cuda::std::__fp_storage_t<fmt>{1}
+                                << (cuda::std::__fp_mant_nbits_v<fmt> - 1 - !cuda::std::__fp_has_implicit_bit_v<fmt>);
+    assert(!(cuda::std::__fp_get_storage(result) & nan_distinct_mask));
+  }
+  static_assert(((void) cuda::std::__fp_nans<T>(), true));
+}
+
+template <class T, cuda::std::enable_if_t<!cuda::std::__fp_has_nans_v<cuda::std::__fp_format_of_v<T>>, int> = 0>
+__host__ __device__ void test_fp_nans()
+{}
+
+__host__ __device__ bool test()
+{
+  using namespace test_integer_literals;
+
+  // 1. Test formats
+  test_fp_nans<cuda::std::__fp_format::__binary16>(0x7d00u);
+  test_fp_nans<cuda::std::__fp_format::__binary32>(0x7fa00000u);
+  test_fp_nans<cuda::std::__fp_format::__binary64>(0x7ff4000000000000ull);
+#if _CCCL_HAS_INT128()
+  test_fp_nans<cuda::std::__fp_format::__binary128>(0x7fff4000000000000000000000000000_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_nans<cuda::std::__fp_format::__bfloat16>(0x7fa0u);
+#if _CCCL_HAS_INT128()
+  test_fp_nans<cuda::std::__fp_format::__fp80_x86>(0x7fffa000000000000000_u128);
+#endif // _CCCL_HAS_INT128()
+  test_fp_nans<cuda::std::__fp_format::__fp8_nv_e4m3>();
+  test_fp_nans<cuda::std::__fp_format::__fp8_nv_e5m2>(0x7du);
+  test_fp_nans<cuda::std::__fp_format::__fp8_nv_e8m0>();
+  test_fp_nans<cuda::std::__fp_format::__fp6_nv_e2m3>();
+  test_fp_nans<cuda::std::__fp_format::__fp6_nv_e3m2>();
+  test_fp_nans<cuda::std::__fp_format::__fp4_nv_e2m1>();
+
+  // 2. Test types
+  test_fp_nans<float>();
+  test_fp_nans<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_fp_nans<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_NVFP16()
+  test_fp_nans<__half>();
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+  test_fp_nans<__nv_bfloat16>();
+#endif // _CCCL_HAS_NVBF16()
+#if _CCCL_HAS_NVFP8_E4M3()
+  test_fp_nans<__nv_fp8_e4m3>();
+#endif // _CCCL_HAS_NVFP8_E4M3()
+#if _CCCL_HAS_NVFP8_E5M2()
+  test_fp_nans<__nv_fp8_e5m2>();
+#endif // _CCCL_HAS_NVFP8_E5M2()
+#if _CCCL_HAS_NVFP8_E8M0()
+  test_fp_nans<__nv_fp8_e8m0>();
+#endif // _CCCL_HAS_NVFP8_E8M0()
+#if _CCCL_HAS_NVFP6_E2M3()
+  test_fp_nans<__nv_fp6_e2m3>();
+#endif // _CCCL_HAS_NVFP6_E2M3()
+#if _CCCL_HAS_NVFP6_E3M2()
+  test_fp_nans<__nv_fp6_e3m2>();
+#endif // _CCCL_HAS_NVFP6_E3M2()
+#if _CCCL_HAS_NVFP4_E2M1()
+  test_fp_nans<__nv_fp4_e2m1>();
+#endif // _CCCL_HAS_NVFP4_E2M1()
+#if _CCCL_HAS_FLOAT128()
+  test_fp_nans<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  // todo: test __cccl_fp types
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}


### PR DESCRIPTION
There are issues with fp types that have explicit leading bit, because it must be set to `1` unless a denormal is represented.

This PR fixes that, introduces `__fp_explicit_bit_mask_v` and `__fp_denorm_min` , and improves the quality of the tests.