### PR TITLE
[backport -> 3.1.x][libcu++] Rename memory resource concepts to indicate asynchronous allocations are the default ones (#5313)

### DIFF
--- a/cub/cub/detail/temporary_storage.cuh
+++ b/cub/cub/detail/temporary_storage.cuh
@@ -351,29 +351,29 @@ private:
 
 template <typename MRT>
 CUB_RUNTIME_FUNCTION cudaError_t
-allocate_async(void*& d_temp_storage, size_t temp_storage_bytes, MRT& mr, ::cuda::stream_ref stream)
+allocate(::cuda::stream_ref stream, void*& d_temp_storage, size_t temp_storage_bytes, MRT& mr)
 {
   NV_IF_ELSE_TARGET(
     NV_IS_HOST,
     (
-      try { d_temp_storage = mr.allocate_async(temp_storage_bytes, stream); } catch (...) {
+      try { d_temp_storage = mr.allocate(stream, temp_storage_bytes); } catch (...) {
         return cudaErrorMemoryAllocation;
       }),
-    (d_temp_storage = mr.allocate_async(temp_storage_bytes, stream);));
+    (d_temp_storage = mr.allocate(stream, temp_storage_bytes);));
   return cudaSuccess;
 }
 
 template <typename MRT>
 CUB_RUNTIME_FUNCTION cudaError_t
-deallocate_async(void* d_temp_storage, size_t temp_storage_bytes, MRT& mr, ::cuda::stream_ref stream)
+deallocate(::cuda::stream_ref stream, void* d_temp_storage, size_t temp_storage_bytes, MRT& mr)
 {
   NV_IF_ELSE_TARGET(
     NV_IS_HOST,
     (
-      try { mr.deallocate_async(d_temp_storage, temp_storage_bytes, stream); } catch (...) {
+      try { mr.deallocate(stream, d_temp_storage, temp_storage_bytes); } catch (...) {
         return cudaErrorMemoryAllocation;
       }),
-    (mr.deallocate_async(d_temp_storage, temp_storage_bytes, stream);));
+    (mr.deallocate(stream, d_temp_storage, temp_storage_bytes);));
   return cudaSuccess;
 }
 

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -122,22 +122,21 @@ struct device_memory_resource
     _CCCL_ASSERT_CUDA_API(::cudaFree, "deallocate failed", ptr);
   }
 
-  void* allocate_async(size_t bytes, size_t /* alignment */, ::cuda::stream_ref stream)
+  void* allocate(::cuda::stream_ref stream, size_t bytes, size_t /* alignment */)
   {
-    return allocate_async(bytes, stream);
+    return allocate(stream, bytes);
   }
 
-  void* allocate_async(size_t bytes, ::cuda::stream_ref stream)
+  void* allocate(::cuda::stream_ref stream, size_t bytes)
   {
     void* ptr{nullptr};
-    _CCCL_TRY_CUDA_API(
-      ::cudaMallocAsync, "allocate_async failed to allocate with cudaMallocAsync", &ptr, bytes, stream.get());
+    _CCCL_TRY_CUDA_API(::cudaMallocAsync, "allocate failed to allocate with cudaMallocAsync", &ptr, bytes, stream.get());
     return ptr;
   }
 
-  void deallocate_async(void* ptr, size_t /* bytes */, const ::cuda::stream_ref stream)
+  void deallocate(const ::cuda::stream_ref stream, void* ptr, size_t /* bytes */)
   {
-    _CCCL_ASSERT_CUDA_API(::cudaFreeAsync, "deallocate_async failed", ptr, stream.get());
+    _CCCL_ASSERT_CUDA_API(::cudaFreeAsync, "deallocate failed", ptr, stream.get());
   }
 };
 
@@ -497,7 +496,7 @@ public:
       }
 
       // TODO(gevtushenko): use uninitialized buffer whenit's available
-      error = CubDebug(detail::temporary_storage::allocate_async(d_temp_storage, temp_storage_bytes, mr, stream));
+      error = CubDebug(detail::temporary_storage::allocate(stream, d_temp_storage, temp_storage_bytes, mr));
       if (error != cudaSuccess)
       {
         return error;
@@ -509,7 +508,7 @@ public:
 
       // Try to deallocate regardless of the error to avoid memory leaks
       cudaError_t deallocate_error =
-        CubDebug(detail::temporary_storage::deallocate_async(d_temp_storage, temp_storage_bytes, mr, stream));
+        CubDebug(detail::temporary_storage::deallocate(stream, d_temp_storage, temp_storage_bytes, mr));
 
       if (error != cudaSuccess)
       {
@@ -622,7 +621,7 @@ public:
     }
 
     // TODO(gevtushenko): use uninitialized buffer when it's available
-    error = CubDebug(detail::temporary_storage::allocate_async(d_temp_storage, temp_storage_bytes, mr, stream));
+    error = CubDebug(detail::temporary_storage::allocate(stream, d_temp_storage, temp_storage_bytes, mr));
     if (error != cudaSuccess)
     {
       return error;
@@ -642,7 +641,7 @@ public:
 
     // Try to deallocate regardless of the error to avoid memory leaks
     cudaError_t deallocate_error =
-      CubDebug(detail::temporary_storage::deallocate_async(d_temp_storage, temp_storage_bytes, mr, stream));
+      CubDebug(detail::temporary_storage::deallocate(stream, d_temp_storage, temp_storage_bytes, mr));
 
     if (error != cudaSuccess)
     {

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -174,23 +174,23 @@ struct device_memory_resource : cub::detail::device_memory_resource
   size_t* bytes_allocated    = nullptr;
   size_t* bytes_deallocated  = nullptr;
 
-  void* allocate(size_t /* bytes */, size_t /* alignment */)
+  void* allocate_sync(size_t /* bytes */, size_t /* alignment */)
   {
     FAIL("CUB shouldn't use synchronous allocation");
     return nullptr;
   }
 
-  void deallocate(void* /* ptr */, size_t /* bytes */)
+  void deallocate_sync(void* /* ptr */, size_t /* bytes */)
   {
     FAIL("CUB shouldn't use synchronous deallocation");
   }
 
-  void* allocate_async(size_t bytes, size_t /* alignment */, ::cuda::stream_ref stream)
+  void* allocate(::cuda::stream_ref stream, size_t bytes, size_t /* alignment */)
   {
-    return allocate_async(bytes, stream);
+    return allocate(stream, bytes);
   }
 
-  void* allocate_async(size_t bytes, ::cuda::stream_ref stream)
+  void* allocate(::cuda::stream_ref stream, size_t bytes)
   {
     REQUIRE(target_stream == stream.get());
 
@@ -198,10 +198,10 @@ struct device_memory_resource : cub::detail::device_memory_resource
     {
       *bytes_allocated += bytes;
     }
-    return cub::detail::device_memory_resource::allocate_async(bytes, stream);
+    return cub::detail::device_memory_resource::allocate(stream, bytes);
   }
 
-  void deallocate_async(void* ptr, size_t bytes, const ::cuda::stream_ref stream)
+  void deallocate(const ::cuda::stream_ref stream, void* ptr, size_t bytes)
   {
     REQUIRE(target_stream == stream.get());
 
@@ -209,7 +209,7 @@ struct device_memory_resource : cub::detail::device_memory_resource
     {
       *bytes_deallocated += bytes;
     }
-    cub::detail::device_memory_resource::deallocate_async(ptr, bytes, stream);
+    cub::detail::device_memory_resource::deallocate(stream, ptr, bytes);
   }
 };
 
@@ -226,17 +226,17 @@ struct throwing_memory_resource
     FAIL("CUB shouldn't use synchronous deallocation");
   }
 
-  void* allocate_async(size_t /* bytes */, size_t /* alignment */, ::cuda::stream_ref /* stream */)
+  void* allocate(::cuda::stream_ref /* stream */, size_t /* bytes */, size_t /* alignment */)
   {
     throw "test";
   }
 
-  void* allocate_async(size_t /* bytes */, ::cuda::stream_ref /* stream */)
+  void* allocate(::cuda::stream_ref /* stream */, size_t /* bytes */)
   {
     throw "test";
   }
 
-  void deallocate_async(void* /* ptr */, size_t /* bytes */, const ::cuda::stream_ref /* stream */)
+  void deallocate(const ::cuda::stream_ref /* stream */, void* /* ptr */, size_t /* bytes */)
   {
     throw "test";
   }
@@ -258,12 +258,12 @@ struct device_side_memory_resource
     cuda::std::terminate();
   }
 
-  __host__ __device__ void* allocate_async(size_t bytes, size_t /* alignment */, ::cuda::stream_ref stream)
+  __host__ __device__ void* allocate(::cuda::stream_ref stream, size_t bytes, size_t /* alignment */)
   {
-    return allocate_async(bytes, stream);
+    return allocate(stream, bytes);
   }
 
-  __host__ __device__ void* allocate_async(size_t bytes, ::cuda::stream_ref /* stream */)
+  __host__ __device__ void* allocate(::cuda::stream_ref /* stream */, size_t bytes)
   {
     if (bytes_allocated)
     {
@@ -272,7 +272,7 @@ struct device_side_memory_resource
     return static_cast<void*>(static_cast<char*>(ptr) + *bytes_allocated);
   }
 
-  __host__ __device__ void deallocate_async(void* /* ptr */, size_t bytes, const ::cuda::stream_ref /* stream */)
+  __host__ __device__ void deallocate(const ::cuda::stream_ref /* stream */, void* /* ptr */, size_t bytes)
   {
     if (bytes_deallocated)
     {

--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -659,7 +659,7 @@ async_buffer<_Tp, _TargetProperties...> make_async_buffer(
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Resource, class... _SourceProperties)
-_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+_CCCL_REQUIRES(_CUDA_VMR::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
 auto make_async_buffer(stream_ref __stream, _Resource&& __mr, const async_buffer<_Tp, _SourceProperties...>& __source)
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
@@ -680,7 +680,7 @@ async_buffer<_Tp, _Properties...> make_async_buffer(stream_ref __stream, any_asy
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Resource)
-_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+_CCCL_REQUIRES(_CUDA_VMR::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
 auto make_async_buffer(stream_ref __stream, _Resource&& __mr)
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
@@ -698,7 +698,7 @@ make_async_buffer(stream_ref __stream, any_async_resource<_Properties...> __mr, 
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Resource)
-_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+_CCCL_REQUIRES(_CUDA_VMR::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
 auto make_async_buffer(stream_ref __stream, _Resource&& __mr, size_t __size)
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
@@ -716,7 +716,7 @@ make_async_buffer(stream_ref __stream, any_async_resource<_Properties...> __mr, 
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Resource)
-_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+_CCCL_REQUIRES(_CUDA_VMR::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
 auto make_async_buffer(stream_ref __stream, _Resource&& __mr, size_t __size, const _Tp& __value)
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
@@ -734,7 +734,7 @@ async_buffer<_Tp, _Properties...> make_async_buffer(
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Resource)
-_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+_CCCL_REQUIRES(_CUDA_VMR::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
 auto make_async_buffer(stream_ref __stream, _Resource&& __mr, size_t __size, ::cuda::experimental::no_init_t)
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
@@ -753,7 +753,7 @@ make_async_buffer(stream_ref __stream, any_async_resource<_Properties...> __mr, 
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Resource, class _Iter)
-_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource> _CCCL_AND
+_CCCL_REQUIRES(_CUDA_VMR::resource<_Resource> _CCCL_AND __has_default_queries<_Resource> _CCCL_AND
                  _CUDA_VSTD::__is_cpp17_forward_iterator<_Iter>::value)
 auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _Iter __first, _Iter __last)
 {
@@ -772,7 +772,7 @@ async_buffer<_Tp, _Properties...> make_async_buffer(
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Resource)
-_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+_CCCL_REQUIRES(_CUDA_VMR::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
 auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _CUDA_VSTD::initializer_list<_Tp> __ilist)
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;
@@ -791,7 +791,7 @@ make_async_buffer(stream_ref __stream, any_async_resource<_Properties...> __mr, 
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Resource, class _Range)
-_CCCL_REQUIRES(_CUDA_VMR::async_resource<_Resource> _CCCL_AND __has_default_queries<_Resource> _CCCL_AND
+_CCCL_REQUIRES(_CUDA_VMR::resource<_Resource> _CCCL_AND __has_default_queries<_Resource> _CCCL_AND
                  _CUDA_VRANGES::forward_range<_Range>)
 auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _Range&& __range)
 {

--- a/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_async_buffer.cuh
@@ -144,24 +144,24 @@ private:
   {
     __async_resource* __resource_;
 
-    void* allocate(std::size_t __size, std::size_t __alignment)
+    void* allocate_sync(std::size_t __size, std::size_t __alignment)
     {
-      return __resource_->allocate(__size, __alignment);
+      return __resource_->allocate_sync(__size, __alignment);
     }
 
-    void deallocate(void* __ptr, std::size_t __size, std::size_t __alignment) noexcept
+    void deallocate_sync(void* __ptr, std::size_t __size, std::size_t __alignment) noexcept
     {
-      __resource_->deallocate(__ptr, __size, __alignment);
+      __resource_->deallocate_sync(__ptr, __size, __alignment);
     }
 
-    void* allocate_async(std::size_t __size, std::size_t __alignment, ::cuda::stream_ref __stream)
+    void* allocate(::cuda::stream_ref __stream, std::size_t __size, std::size_t __alignment)
     {
-      return __resource_->allocate_async(__size, __alignment, __stream);
+      return __resource_->allocate(__stream, __size, __alignment);
     }
 
-    void deallocate_async(void* __ptr, std::size_t __size, std::size_t __alignment, ::cuda::stream_ref __stream) noexcept
+    void deallocate(::cuda::stream_ref __stream, void* __ptr, std::size_t __size, std::size_t __alignment) noexcept
     {
-      __resource_->deallocate_async(__ptr, __size, __alignment, __stream);
+      __resource_->deallocate(__stream, __ptr, __size, __alignment);
     }
 
     friend bool operator==(const __fake_resource_ref& __lhs, const __fake_resource_ref& __rhs) noexcept
@@ -200,7 +200,7 @@ public:
       : __mr_(_CUDA_VSTD::move(__mr))
       , __stream_(__stream)
       , __count_(__count)
-      , __buf_(__count_ == 0 ? nullptr : __mr_.allocate_async(__get_allocation_size(__count_), __stream_))
+      , __buf_(__count_ == 0 ? nullptr : __mr_.allocate(__stream_, __get_allocation_size(__count_)))
   {}
 
   _CCCL_HIDE_FROM_ABI uninitialized_async_buffer(const uninitialized_async_buffer&)            = delete;
@@ -240,7 +240,7 @@ public:
 
     if (__buf_)
     {
-      __mr_.deallocate_async(__buf_, __get_allocation_size(__count_), __stream_);
+      __mr_.deallocate(__stream_, __buf_, __get_allocation_size(__count_));
     }
     __mr_     = _CUDA_VSTD::move(__other.__mr_);
     __stream_ = _CUDA_VSTD::exchange(__other.__stream_, ::cuda::stream_ref{::cudaStream_t{}});
@@ -249,23 +249,23 @@ public:
     return *this;
   }
 
-  //! @brief Destroys an \c uninitialized_async_buffer, deallocates the buffer in stream order on the stream that was
-  //! used to create the buffer and destroys the memory resource.
+  //! @brief Destroys an \c uninitialized_async_buffer, deallocates the buffer in stream order on the stream that
+  //! was used to create the buffer and destroys the memory resource.
   //! @warning destroy does not destroy any objects that may or may not reside within the buffer. It is the
   //! user's responsibility to ensure that all objects within the buffer have been properly destroyed.
   _CCCL_HIDE_FROM_ABI void destroy()
   {
     if (__buf_)
     {
-      __mr_.deallocate_async(__buf_, __get_allocation_size(__count_), __stream_);
+      __mr_.deallocate(__stream_, __buf_, __get_allocation_size(__count_));
       __buf_   = nullptr;
       __count_ = 0;
     }
     auto __tmp_mr = _CUDA_VSTD::move(__mr_);
   }
 
-  //! @brief Destroys an \c uninitialized_async_buffer and deallocates the buffer in stream order on the stream that was
-  //! used to create the buffer.
+  //! @brief Destroys an \c uninitialized_async_buffer and deallocates the buffer in stream order on the stream
+  //! that was used to create the buffer.
   //! @warning The destructor does not destroy any objects that may or may not reside within the buffer. It is the
   //! user's responsibility to ensure that all objects within the buffer have been properly destroyed.
   _CCCL_HIDE_FROM_ABI ~uninitialized_async_buffer()

--- a/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
@@ -143,7 +143,7 @@ public:
   _CCCL_HIDE_FROM_ABI uninitialized_buffer(__resource __mr, const size_t __count)
       : __mr_(_CUDA_VSTD::move(__mr))
       , __count_(__count)
-      , __buf_(__count_ == 0 ? nullptr : __mr_.allocate(__get_allocation_size(__count_)))
+      , __buf_(__count_ == 0 ? nullptr : __mr_.allocate_sync(__get_allocation_size(__count_)))
   {}
 
   _CCCL_HIDE_FROM_ABI uninitialized_buffer(const uninitialized_buffer&)            = delete;
@@ -181,7 +181,7 @@ public:
 
     if (__buf_)
     {
-      __mr_.deallocate(__buf_, __get_allocation_size(__count_));
+      __mr_.deallocate_sync(__buf_, __get_allocation_size(__count_));
     }
 
     __mr_    = _CUDA_VSTD::move(__other.__mr_);
@@ -197,7 +197,7 @@ public:
   {
     if (__buf_)
     {
-      __mr_.deallocate(__buf_, __get_allocation_size(__count_));
+      __mr_.deallocate_sync(__buf_, __get_allocation_size(__count_));
       __buf_   = nullptr;
       __count_ = 0;
     }

--- a/cudax/include/cuda/experimental/__memory_resource/device_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/device_memory_resource.cuh
@@ -104,7 +104,7 @@ public:
   using default_queries = properties_list<device_accessible>;
 #endif // _CCCL_DOXYGEN_INVOKED
 };
-static_assert(_CUDA_VMR::resource_with<device_memory_resource, device_accessible>, "");
+static_assert(_CUDA_VMR::synchronous_resource_with<device_memory_resource, device_accessible>, "");
 } // namespace cuda::experimental
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/cudax/include/cuda/experimental/__memory_resource/legacy_pinned_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/legacy_pinned_memory_resource.cuh
@@ -54,13 +54,13 @@ public:
   //! @param __alignment The requested alignment of the allocation.
   //! @throw std::invalid_argument in case of invalid alignment or \c cuda::cuda_error of the returned error code.
   //! @return Pointer to the newly allocated memory
-  [[nodiscard]] void* allocate(const size_t __bytes,
-                               const size_t __alignment = _CUDA_VMR::default_cuda_malloc_host_alignment) const
+  [[nodiscard]] void* allocate_sync(const size_t __bytes,
+                                    const size_t __alignment = _CUDA_VMR::default_cuda_malloc_host_alignment) const
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     if (!__is_valid_alignment(__alignment))
     {
-      _CUDA_VSTD::__throw_invalid_argument("Invalid alignment passed to legacy_pinned_memory_resource::allocate.");
+      _CUDA_VSTD::__throw_invalid_argument("Invalid alignment passed to legacy_pinned_memory_resource::allocate_sync.");
     }
 
     void* __ptr{nullptr};
@@ -69,16 +69,16 @@ public:
   }
 
   //! @brief Deallocate memory pointed to by \p __ptr.
-  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`.
-  //! @param __bytes The number of bytes that was passed to the `allocate` call that returned \p __ptr.
-  //! @param __alignment The alignment that was passed to the `allocate` call that returned \p __ptr.
-  void deallocate(
+  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate_sync`.
+  //! @param __bytes The number of bytes that was passed to the allocation call that returned \p __ptr.
+  //! @param __alignment The alignment that was passed to the allocation call that returned \p __ptr.
+  void deallocate_sync(
     void* __ptr, const size_t, const size_t __alignment = _CUDA_VMR::default_cuda_malloc_host_alignment) const noexcept
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _CCCL_ASSERT(__is_valid_alignment(__alignment),
-                 "Invalid alignment passed to legacy_pinned_memory_resource::deallocate.");
-    _CCCL_ASSERT_CUDA_API(::cudaFreeHost, "legacy_pinned_memory_resource::deallocate failed", __ptr);
+                 "Invalid alignment passed to legacy_pinned_memory_resource::deallocate_sync.");
+    _CCCL_ASSERT_CUDA_API(::cudaFreeHost, "legacy_pinned_memory_resource::deallocate_sync failed", __ptr);
     (void) __alignment;
   }
 
@@ -116,8 +116,8 @@ public:
   using default_queries = properties_list<device_accessible, host_accessible>;
 };
 
-static_assert(_CUDA_VMR::resource_with<legacy_pinned_memory_resource, device_accessible>, "");
-static_assert(_CUDA_VMR::resource_with<legacy_pinned_memory_resource, host_accessible>, "");
+static_assert(_CUDA_VMR::synchronous_resource_with<legacy_pinned_memory_resource, device_accessible>, "");
+static_assert(_CUDA_VMR::synchronous_resource_with<legacy_pinned_memory_resource, host_accessible>, "");
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__memory_resource/managed_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/managed_memory_resource.cuh
@@ -62,13 +62,13 @@ public:
   //! @param __alignment The requested alignment of the allocation.
   //! @throw std::invalid_argument in case of invalid alignment or \c cuda::cuda_error of the returned error code.
   //! @return Pointer to the newly allocated memory
-  [[nodiscard]] void* allocate(const size_t __bytes,
-                               const size_t __alignment = _CUDA_VMR::default_cuda_malloc_alignment) const
+  [[nodiscard]] void* allocate_sync(const size_t __bytes,
+                                    const size_t __alignment = _CUDA_VMR::default_cuda_malloc_alignment) const
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     if (!__is_valid_alignment(__alignment))
     {
-      _CUDA_VSTD::__throw_invalid_argument("Invalid alignment passed to managed_memory_resource::allocate.");
+      _CUDA_VSTD::__throw_invalid_argument("Invalid alignment passed to managed_memory_resource::allocate_sync.");
     }
 
     void* __ptr{nullptr};
@@ -85,9 +85,9 @@ public:
   //! @throws cuda::cuda_error If an error code was return by the cuda api call.
   //! @returns Pointer to the newly allocated memory.
   [[nodiscard]] void*
-  allocate_async(const size_t __bytes, const size_t __alignment, [[maybe_unused]] const ::cuda::stream_ref __stream)
+  allocate([[maybe_unused]] const ::cuda::stream_ref __stream, const size_t __bytes, const size_t __alignment)
   {
-    return allocate(__bytes, __alignment);
+    return allocate_sync(__bytes, __alignment);
   }
 
   //! @brief Allocate CUDA unified memory of size at least \p __bytes.
@@ -95,52 +95,54 @@ public:
   //! @param __stream Stream on which to perform allocation.
   //! @throws cuda::cuda_error If an error code was return by the cuda api call.
   //! @returns Pointer to the newly allocated memory.
-  [[nodiscard]] void* allocate_async(const size_t __bytes, [[maybe_unused]] const ::cuda::stream_ref __stream)
+  [[nodiscard]] void* allocate([[maybe_unused]] const ::cuda::stream_ref __stream, const size_t __bytes)
   {
-    return allocate(__bytes);
+    return allocate_sync(__bytes);
+  }
+
+  //! @brief Deallocate memory pointed to by \p __ptr.
+  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate` or `allocate_sync`
+  //! @param __bytes The number of bytes that was passed to the allocation call that returned \p __ptr.
+  //! @param __alignment The alignment that was passed to the allocation call that returned \p __ptr.
+  void deallocate_sync(
+    void* __ptr,
+    const size_t,
+    [[maybe_unused]] const size_t __alignment = _CUDA_VMR::default_cuda_malloc_alignment) const noexcept
+  {
+    // We need to ensure that the provided alignment matches the minimal provided alignment
+    _CCCL_ASSERT(__is_valid_alignment(__alignment),
+                 "Invalid alignment passed to managed_memory_resource::deallocate_sync.");
+    _CCCL_ASSERT_CUDA_API(::cudaFree, "managed_memory_resource::deallocate_sync failed", __ptr);
   }
 
   //! @brief Deallocate memory pointed to by \p __ptr.
   //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`.
-  //! @param __bytes The number of bytes that was passed to the `allocate` call that returned \p __ptr.
-  //! @param __alignment The alignment that was passed to the `allocate` call that returned \p __ptr.
-  void deallocate(void* __ptr,
-                  const size_t,
-                  [[maybe_unused]] const size_t __alignment = _CUDA_VMR::default_cuda_malloc_alignment) const noexcept
+  //! @param __bytes The number of bytes that was passed to the allocation call that returned \p __ptr.
+  //! @param __alignment The alignment that was passed to the allocation call that returned \p __ptr.
+  //! @param __stream A stream that has a stream ordering relationship with the stream used in the
+  //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate</a> call
+  //! that returned \p __ptr.
+  //! @note The pointer passed to `deallocate` must not be in use in a stream other than \p __stream.
+  //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate`.
+  void deallocate([[maybe_unused]] const ::cuda::stream_ref __stream,
+                  void* __ptr,
+                  const size_t __bytes,
+                  [[maybe_unused]] const size_t __alignment)
   {
-    // We need to ensure that the provided alignment matches the minimal provided alignment
-    _CCCL_ASSERT(__is_valid_alignment(__alignment), "Invalid alignment passed to managed_memory_resource::deallocate.");
-    _CCCL_ASSERT_CUDA_API(::cudaFree, "managed_memory_resource::deallocate failed", __ptr);
+    deallocate_sync(__ptr, __bytes);
   }
 
   //! @brief Deallocate memory pointed to by \p __ptr.
-  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate_async`.
-  //! @param __bytes The number of bytes that was passed to the `allocate_async` call that returned \p __ptr.
-  //! @param __alignment The alignment that was passed to the `allocate_async` call that returned \p __ptr.
+  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`.
+  //! @param __bytes The number of bytes that was passed to the allocation call that returned \p __ptr.
   //! @param __stream A stream that has a stream ordering relationship with the stream used in the
-  //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate_async</a> call
+  //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate</a> call
   //! that returned \p __ptr.
-  //! @note The pointer passed to `deallocate_async` must not be in use in a stream other than \p __stream.
-  //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate_async`.
-  void deallocate_async(void* __ptr,
-                        const size_t __bytes,
-                        [[maybe_unused]] const size_t __alignment,
-                        [[maybe_unused]] const ::cuda::stream_ref __stream)
+  //! @note The pointer passed to `deallocate` must not be in use in a stream other than \p __stream.
+  //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate`.
+  void deallocate([[maybe_unused]] const ::cuda::stream_ref __stream, void* __ptr, size_t __bytes)
   {
-    deallocate(__ptr, __bytes);
-  }
-
-  //! @brief Deallocate memory pointed to by \p __ptr.
-  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate_async`.
-  //! @param __bytes The number of bytes that was passed to the `allocate_async` call that returned \p __ptr.
-  //! @param __stream A stream that has a stream ordering relationship with the stream used in the
-  //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate_async</a> call
-  //! that returned \p __ptr.
-  //! @note The pointer passed to `deallocate_async` must not be in use in a stream other than \p __stream.
-  //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate_async`.
-  void deallocate_async(void* __ptr, size_t __bytes, [[maybe_unused]] const ::cuda::stream_ref __stream)
-  {
-    deallocate(__ptr, __bytes);
+    deallocate_sync(__ptr, __bytes);
   }
 
   //! @brief Equality comparison with another \c managed_memory_resource.
@@ -176,8 +178,8 @@ public:
 
   using default_queries = properties_list<device_accessible, host_accessible>;
 };
-static_assert(_CUDA_VMR::async_resource_with<managed_memory_resource, device_accessible>, "");
-static_assert(_CUDA_VMR::async_resource_with<managed_memory_resource, host_accessible>, "");
+static_assert(_CUDA_VMR::resource_with<managed_memory_resource, device_accessible>, "");
+static_assert(_CUDA_VMR::resource_with<managed_memory_resource, host_accessible>, "");
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__memory_resource/memory_resource_base.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/memory_resource_base.cuh
@@ -72,19 +72,20 @@ public:
   //! @throws std::invalid_argument In case of invalid alignment.
   //! @throws cuda::cuda_error If an error code was return by the CUDA API call.
   //! @returns Pointer to the newly allocated memory.
-  [[nodiscard]] void* allocate(const size_t __bytes, const size_t __alignment = _CUDA_VMR::default_cuda_malloc_alignment)
+  [[nodiscard]] void* allocate_sync(const size_t __bytes,
+                                    const size_t __alignment = _CUDA_VMR::default_cuda_malloc_alignment)
   {
     if (!__is_valid_alignment(__alignment))
     {
       _CUDA_VSTD_NOVERSION::__throw_invalid_argument(
         "Invalid alignment passed to "
-        "__memory_resource_base::allocate_async.");
+        "__memory_resource_base::allocate_sync.");
     }
 
     void* __ptr{nullptr};
     _CCCL_TRY_CUDA_API(
       ::cudaMallocFromPoolAsync,
-      "__memory_resource_base::allocate failed to allocate with cudaMallocFromPoolAsync",
+      "__memory_resource_base::allocate_sync failed to allocate with cudaMallocFromPoolAsync",
       &__ptr,
       __bytes,
       __pool_,
@@ -93,18 +94,19 @@ public:
     return __ptr;
   }
 
-  //! @brief Deallocate memory pointed to by \p __ptr.
-  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`.
-  //! @param __bytes  The number of bytes that was passed to the `allocate` call that returned \p __ptr.
-  //! @param __alignment The alignment that was passed to the `allocate` call that returned \p __ptr.
-  //! @note The pointer passed to `deallocate` must not be in use in a stream. It is the caller's responsibility to
-  //! properly synchronize all relevant streams before calling `deallocate`.
-  void deallocate(
+  //! @brief deallocate_sync memory pointed to by \p __ptr.
+  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate_sync`.
+  //! @param __bytes  The number of bytes that was passed to the allocation call that returned \p __ptr.
+  //! @param __alignment The alignment that was passed to the allocation call that returned \p __ptr.
+  //! @note The pointer passed to `deallocate_sync` must not be in use in a stream. It is the caller's responsibility to
+  //! properly synchronize all relevant streams before calling `deallocate_sync`.
+  void deallocate_sync(
     void* __ptr, const size_t, [[maybe_unused]] const size_t __alignment = _CUDA_VMR::default_cuda_malloc_alignment)
   {
-    _CCCL_ASSERT(__is_valid_alignment(__alignment), "Invalid alignment passed to __memory_resource_base::deallocate.");
+    _CCCL_ASSERT(__is_valid_alignment(__alignment),
+                 "Invalid alignment passed to __memory_resource_base::deallocate_sync.");
     _CCCL_ASSERT_CUDA_API(
-      ::cudaFreeAsync, "__memory_resource_base::deallocate failed", __ptr, __cccl_allocation_stream().get());
+      ::cudaFreeAsync, "__memory_resource_base::deallocate_sync failed", __ptr, __cccl_allocation_stream().get());
     __cccl_allocation_stream().sync();
   }
 
@@ -115,16 +117,16 @@ public:
   //! @throws std::invalid_argument In case of invalid alignment.
   //! @throws cuda::cuda_error If an error code was return by the cuda api call.
   //! @returns Pointer to the newly allocated memory.
-  [[nodiscard]] void* allocate_async(const size_t __bytes, const size_t __alignment, const ::cuda::stream_ref __stream)
+  [[nodiscard]] void* allocate(const ::cuda::stream_ref __stream, const size_t __bytes, const size_t __alignment)
   {
     if (!__is_valid_alignment(__alignment))
     {
       _CUDA_VSTD_NOVERSION::__throw_invalid_argument(
         "Invalid alignment passed to "
-        "__memory_resource_base::allocate_async.");
+        "__memory_resource_base::allocate.");
     }
 
-    return allocate_async(__bytes, __stream);
+    return allocate(__stream, __bytes);
   }
 
   //! @brief Allocate device memory of size at least \p __bytes via cudaMallocFromPoolAsync.
@@ -132,12 +134,12 @@ public:
   //! @param __stream Stream on which to perform allocation.
   //! @throws cuda::cuda_error If an error code was return by the cuda api call.
   //! @returns Pointer to the newly allocated memory.
-  [[nodiscard]] void* allocate_async(const size_t __bytes, const ::cuda::stream_ref __stream)
+  [[nodiscard]] void* allocate(const ::cuda::stream_ref __stream, const size_t __bytes)
   {
     void* __ptr{nullptr};
     _CCCL_TRY_CUDA_API(
       ::cudaMallocFromPoolAsync,
-      "__memory_resource_base::allocate_async failed to allocate with cudaMallocFromPoolAsync",
+      "__memory_resource_base::allocate failed to allocate with cudaMallocFromPoolAsync",
       &__ptr,
       __bytes,
       __pool_,
@@ -146,33 +148,33 @@ public:
   }
 
   //! @brief Deallocate memory pointed to by \p __ptr.
-  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate_async`
-  //! @param __bytes The number of bytes that was passed to the `allocate_async` call that returned \p __ptr.
-  //! @param __alignment The alignment that was passed to the `allocate_async` call that returned \p __ptr.
+  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`
+  //! @param __bytes The number of bytes that was passed to the allocation call that returned \p __ptr.
+  //! @param __alignment The alignment that was passed to the allocation call that returned \p __ptr.
   //! @param __stream A stream that has a stream ordering relationship with the stream used in the
-  //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate_async</a> call
+  //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate</a> call
   //! that returned \p __ptr.
-  //! @note The pointer passed to `deallocate_async` must not be in use in a stream other than \p __stream.
-  //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate_async`.
-  void deallocate_async(
-    void* __ptr, const size_t __bytes, const size_t __alignment, [[maybe_unused]] const ::cuda::stream_ref __stream)
+  //! @note The pointer passed to `deallocate` must not be in use in a stream other than \p __stream.
+  //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate`.
+  void deallocate(
+    [[maybe_unused]] const ::cuda::stream_ref __stream, void* __ptr, const size_t __bytes, const size_t __alignment)
   {
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _CCCL_ASSERT(__is_valid_alignment(__alignment), "Invalid alignment passed to __memory_resource_base::deallocate.");
-    deallocate_async(__ptr, __bytes, __stream);
+    deallocate(__stream, __ptr, __bytes);
   }
 
   //! @brief Deallocate memory pointed to by \p __ptr.
-  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate_async`.
-  //! @param __bytes The number of bytes that was passed to the `allocate_async` call that returned \p __ptr.
+  //! @param __ptr Pointer to be deallocated. Must have been allocated through a call to `allocate`.
+  //! @param __bytes The number of bytes that was passed to the allocation call that returned \p __ptr.
   //! @param __stream A stream that has a stream ordering relationship with the stream used in the
-  //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate_async</a> call
+  //! <a href="https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__MEMORY__POOLS.html">allocate</a> call
   //! that returned \p __ptr.
-  //! @note The pointer passed to `deallocate_async` must not be in use in a stream other than \p __stream.
-  //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate_async`.
-  void deallocate_async(void* __ptr, size_t, const ::cuda::stream_ref __stream)
+  //! @note The pointer passed to `deallocate` must not be in use in a stream other than \p __stream.
+  //! It is the caller's responsibility to properly synchronize all relevant streams before calling `deallocate`.
+  void deallocate(const ::cuda::stream_ref __stream, void* __ptr, size_t)
   {
-    _CCCL_ASSERT_CUDA_API(::cudaFreeAsync, "__memory_resource_base::deallocate_async failed", __ptr, __stream.get());
+    _CCCL_ASSERT_CUDA_API(::cudaFreeAsync, "__memory_resource_base::deallocate failed", __ptr, __stream.get());
   }
 
   //! @brief Enable access to memory allocated through this memory resource by the supplied devices

--- a/cudax/include/cuda/experimental/__memory_resource/pinned_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/pinned_memory_resource.cuh
@@ -102,8 +102,8 @@ public:
 #  endif // _CCCL_DOXYGEN_INVOKED
 };
 
-static_assert(_CUDA_VMR::async_resource_with<pinned_memory_resource, device_accessible>, "");
-static_assert(_CUDA_VMR::async_resource_with<pinned_memory_resource, host_accessible>, "");
+static_assert(_CUDA_VMR::resource_with<pinned_memory_resource, device_accessible>, "");
+static_assert(_CUDA_VMR::resource_with<pinned_memory_resource, host_accessible>, "");
 
 #endif // _CCCL_CUDACC_AT_LEAST(12, 6)
 

--- a/cudax/include/cuda/experimental/__memory_resource/resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/resource.cuh
@@ -32,8 +32,8 @@ namespace cuda::experimental
 
 template <class _Resource, class _OtherResource>
 _CCCL_CONCEPT __non_polymorphic_resources = _CCCL_REQUIRES_EXPR((_Resource, _OtherResource))(
-  requires(_CUDA_VMR::resource<_Resource>),
-  requires(_CUDA_VMR::resource<_OtherResource>),
+  requires(_CUDA_VMR::synchronous_resource<_Resource>),
+  requires(_CUDA_VMR::synchronous_resource<_OtherResource>),
   requires(__non_polymorphic<_Resource>),
   requires(__non_polymorphic<_OtherResource>));
 

--- a/cudax/test/algorithm/common.cuh
+++ b/cudax/test/algorithm/common.cuh
@@ -82,7 +82,7 @@ struct weird_buffer
 
   weird_buffer(legacy_pinned_memory_resource& res, std::size_t s)
       : resource(res)
-      , data((int*) res.allocate(s * sizeof(int)))
+      , data((int*) res.allocate_sync(s * sizeof(int)))
       , size(s)
   {
     memset(data, 0, size);
@@ -90,7 +90,7 @@ struct weird_buffer
 
   ~weird_buffer()
   {
-    resource.deallocate(data, size);
+    resource.deallocate_sync(data, size);
   }
 
   weird_buffer(const weird_buffer&) = delete;

--- a/cudax/test/containers/async_buffer/copy.cu
+++ b/cudax/test/containers/async_buffer/copy.cu
@@ -162,56 +162,71 @@ C2H_CCCLRT_TEST("make_async_buffer variants", "[container][async_buffer]")
   auto buf =
     cuda::experimental::make_async_buffer(input.stream(), cudax::device_memory_resource{cuda::device_ref{0}}, input);
   CUDAX_CHECK(equal_range(buf));
-  static_assert(_CUDA_VMR::resource_with<typename decltype(buf)::__resource_t, cuda::mr::device_accessible>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf)::__resource_t, cuda::mr::host_accessible>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf)::__resource_t, other_property>);
+  static_assert(
+    _CUDA_VMR::synchronous_resource_with<typename decltype(buf)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(!_CUDA_VMR::synchronous_resource_with<typename decltype(buf)::__resource_t, cuda::mr::host_accessible>);
+  static_assert(!_CUDA_VMR::synchronous_resource_with<typename decltype(buf)::__resource_t, other_property>);
 
   auto buf2 = cuda::experimental::make_async_buffer<int, cuda::mr::device_accessible>(
     input.stream(), {cudax::device_memory_resource{cuda::device_ref{0}}}, input);
   CUDAX_CHECK(equal_range(buf2));
-  static_assert(_CUDA_VMR::resource_with<typename decltype(buf2)::__resource_t, cuda::mr::device_accessible>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf2)::__resource_t, other_property>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf2)::__resource_t, cuda::mr::host_accessible>);
+  static_assert(
+    _CUDA_VMR::synchronous_resource_with<typename decltype(buf2)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(!_CUDA_VMR::synchronous_resource_with<typename decltype(buf2)::__resource_t, other_property>);
+  static_assert(
+    !_CUDA_VMR::synchronous_resource_with<typename decltype(buf2)::__resource_t, cuda::mr::host_accessible>);
 
   // from any resource
   auto any_res = cudax::any_async_resource<cuda::mr::device_accessible, other_property>(
     cudax::device_memory_resource{cuda::device_ref{0}});
   auto buf3 = cudax::make_async_buffer(input.stream(), any_res, input);
   CUDAX_CHECK(equal_range(buf3));
-  static_assert(_CUDA_VMR::resource_with<typename decltype(buf3)::__resource_t, cuda::mr::device_accessible>);
-  static_assert(_CUDA_VMR::resource_with<typename decltype(buf3)::__resource_t, other_property>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf3)::__resource_t, cuda::mr::host_accessible>);
+  static_assert(
+    _CUDA_VMR::synchronous_resource_with<typename decltype(buf3)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(_CUDA_VMR::synchronous_resource_with<typename decltype(buf3)::__resource_t, other_property>);
+  static_assert(
+    !_CUDA_VMR::synchronous_resource_with<typename decltype(buf3)::__resource_t, cuda::mr::host_accessible>);
 
   auto buf4 = cudax::make_async_buffer<int, cuda::mr::device_accessible>(input.stream(), {any_res}, input);
   CUDAX_CHECK(equal_range(buf4));
-  static_assert(_CUDA_VMR::resource_with<typename decltype(buf4)::__resource_t, cuda::mr::device_accessible>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf4)::__resource_t, other_property>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf4)::__resource_t, cuda::mr::host_accessible>);
+  static_assert(
+    _CUDA_VMR::synchronous_resource_with<typename decltype(buf4)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(!_CUDA_VMR::synchronous_resource_with<typename decltype(buf4)::__resource_t, other_property>);
+  static_assert(
+    !_CUDA_VMR::synchronous_resource_with<typename decltype(buf4)::__resource_t, cuda::mr::host_accessible>);
 
   // from a resource reference
   auto res_ref = cudax::async_resource_ref<cuda::mr::device_accessible, other_property>{any_res};
   auto buf5    = cudax::make_async_buffer(input.stream(), res_ref, input);
   CUDAX_CHECK(equal_range(buf5));
-  static_assert(_CUDA_VMR::resource_with<typename decltype(buf5)::__resource_t, cuda::mr::device_accessible>);
-  static_assert(_CUDA_VMR::resource_with<typename decltype(buf5)::__resource_t, other_property>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf5)::__resource_t, cuda::mr::host_accessible>);
+  static_assert(
+    _CUDA_VMR::synchronous_resource_with<typename decltype(buf5)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(_CUDA_VMR::synchronous_resource_with<typename decltype(buf5)::__resource_t, other_property>);
+  static_assert(
+    !_CUDA_VMR::synchronous_resource_with<typename decltype(buf5)::__resource_t, cuda::mr::host_accessible>);
 
   auto buf6 = cudax::make_async_buffer<int, cuda::mr::device_accessible>(input.stream(), {res_ref}, input);
   CUDAX_CHECK(equal_range(buf6));
-  static_assert(_CUDA_VMR::resource_with<typename decltype(buf6)::__resource_t, cuda::mr::device_accessible>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf6)::__resource_t, other_property>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf6)::__resource_t, cuda::mr::host_accessible>);
+  static_assert(
+    _CUDA_VMR::synchronous_resource_with<typename decltype(buf6)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(!_CUDA_VMR::synchronous_resource_with<typename decltype(buf6)::__resource_t, other_property>);
+  static_assert(
+    !_CUDA_VMR::synchronous_resource_with<typename decltype(buf6)::__resource_t, cuda::mr::host_accessible>);
 
   auto shared_res = cudax::make_shared_resource<cudax::device_memory_resource>(cuda::device_ref{0});
   auto buf7       = cudax::make_async_buffer(input.stream(), shared_res, input);
   CUDAX_CHECK(equal_range(buf7));
-  static_assert(_CUDA_VMR::resource_with<typename decltype(buf7)::__resource_t, cuda::mr::device_accessible>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf7)::__resource_t, other_property>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf7)::__resource_t, cuda::mr::host_accessible>);
+  static_assert(
+    _CUDA_VMR::synchronous_resource_with<typename decltype(buf7)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(!_CUDA_VMR::synchronous_resource_with<typename decltype(buf7)::__resource_t, other_property>);
+  static_assert(
+    !_CUDA_VMR::synchronous_resource_with<typename decltype(buf7)::__resource_t, cuda::mr::host_accessible>);
 
   auto buf8 = cudax::make_async_buffer<int, cuda::mr::device_accessible>(input.stream(), {shared_res}, input);
   CUDAX_CHECK(equal_range(buf8));
-  static_assert(_CUDA_VMR::resource_with<typename decltype(buf8)::__resource_t, cuda::mr::device_accessible>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf8)::__resource_t, other_property>);
-  static_assert(!_CUDA_VMR::resource_with<typename decltype(buf8)::__resource_t, cuda::mr::host_accessible>);
+  static_assert(
+    _CUDA_VMR::synchronous_resource_with<typename decltype(buf8)::__resource_t, cuda::mr::device_accessible>);
+  static_assert(!_CUDA_VMR::synchronous_resource_with<typename decltype(buf8)::__resource_t, other_property>);
+  static_assert(
+    !_CUDA_VMR::synchronous_resource_with<typename decltype(buf8)::__resource_t, cuda::mr::host_accessible>);
 }

--- a/cudax/test/containers/async_buffer/test_resources.h
+++ b/cudax/test/containers/async_buffer/test_resources.h
@@ -44,21 +44,21 @@ struct memory_resource_wrapper
   // https://github.com/NVIDIA/cccl/issues/4166
   cudax::any_async_resource<Properties...> resource_;
 
-  void* allocate(std::size_t size, std::size_t alignment)
+  void* allocate_sync(std::size_t size, std::size_t alignment)
   {
-    return resource_.allocate(size, alignment);
+    return resource_.allocate_sync(size, alignment);
   }
-  void deallocate(void* ptr, std::size_t size, std::size_t alignment)
+  void deallocate_sync(void* ptr, std::size_t size, std::size_t alignment)
   {
-    resource_.deallocate(ptr, size, alignment);
+    resource_.deallocate_sync(ptr, size, alignment);
   }
-  void* allocate_async(std::size_t size, std::size_t alignment, cuda::stream_ref stream)
+  void* allocate(cuda::stream_ref stream, std::size_t size, std::size_t alignment)
   {
-    return resource_.allocate_async(size, alignment, stream);
+    return resource_.allocate(stream, size, alignment);
   }
-  void deallocate_async(void* ptr, std::size_t size, std::size_t alignment, cuda::stream_ref stream)
+  void deallocate(cuda::stream_ref stream, void* ptr, std::size_t size, std::size_t alignment)
   {
-    resource_.deallocate_async(ptr, size, alignment, stream);
+    resource_.deallocate(stream, ptr, size, alignment);
   }
 
   bool operator==(const memory_resource_wrapper&) const

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -21,16 +21,16 @@ using env_t     = cudax::env_t<cuda::mr::device_accessible>;
 
 struct test_resource
 {
-  void* allocate(size_t, size_t)
+  void* allocate_sync(size_t, size_t)
   {
     return nullptr;
   }
-  void* allocate_async(size_t, size_t, cuda::stream_ref)
+  void* allocate(cuda::stream_ref, size_t, size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, size_t, size_t) {}
-  void deallocate_async(void*, size_t, size_t, cuda::stream_ref) {}
+  void deallocate_sync(void*, size_t, size_t) {}
+  void deallocate(cuda::stream_ref, void*, size_t, size_t) {}
 
   constexpr bool operator==(const test_resource&) const noexcept
   {

--- a/cudax/test/graph/graph_smoke.cu
+++ b/cudax/test/graph/graph_smoke.cu
@@ -160,7 +160,7 @@ C2H_TEST("Path builder with kernel nodes", "[graph]")
 {
   cudax::stream s{cuda::device_ref{0}};
   cudax::managed_memory_resource mr;
-  int* ptr = static_cast<int*>(mr.allocate(sizeof(int)));
+  int* ptr = static_cast<int*>(mr.allocate_sync(sizeof(int)));
   *ptr     = 0;
 
   SECTION("simple graph with kernel node")
@@ -276,9 +276,9 @@ C2H_TEST("Path builder with kernel nodes", "[graph]")
     SECTION("Multi-device graph")
     {
       cudax::device_memory_resource dev0_mr(cuda::devices[0]);
-      int* dev0_ptr = static_cast<int*>(dev0_mr.allocate(sizeof(int)));
+      int* dev0_ptr = static_cast<int*>(dev0_mr.allocate_sync(sizeof(int)));
       cudax::device_memory_resource dev1_mr(cuda::devices[1]);
-      int* dev1_ptr = static_cast<int*>(dev1_mr.allocate(sizeof(int)));
+      int* dev1_ptr = static_cast<int*>(dev1_mr.allocate_sync(sizeof(int)));
 
       cudax::graph_builder g(cuda::devices[0]);
       cudax::path_builder dev0_pb = cudax::start_path(g);
@@ -302,10 +302,10 @@ C2H_TEST("Path builder with kernel nodes", "[graph]")
       s.sync();
       CUDAX_REQUIRE(*ptr == 43);
 
-      dev0_mr.deallocate(dev0_ptr, sizeof(int));
-      dev1_mr.deallocate(dev1_ptr, sizeof(int));
+      dev0_mr.deallocate_sync(dev0_ptr, sizeof(int));
+      dev1_mr.deallocate_sync(dev1_ptr, sizeof(int));
     }
   }
 
-  mr.deallocate(ptr, sizeof(int));
+  mr.deallocate_sync(ptr, sizeof(int));
 }

--- a/cudax/test/memory_resource/any_async_resource.cu
+++ b/cudax/test/memory_resource/any_async_resource.cu
@@ -19,7 +19,7 @@
 TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_async_resource", "[container][resource]", big_resource, small_resource)
 {
   using TestResource = TestType;
-  static_assert(cuda::mr::resource_with<TestResource, cudax::host_accessible>);
+  static_assert(cuda::mr::synchronous_resource_with<TestResource, cudax::host_accessible>);
   constexpr bool is_big = sizeof(TestResource) > cuda::__default_small_object_size;
 
   SECTION("construct and destruct")
@@ -76,7 +76,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_async_resource", "[container][resou
   // Reset the counters:
   this->counts = Counts();
 
-  SECTION("allocate and deallocate")
+  SECTION("allocate and deallocate_sync")
   {
     Counts expected{};
     CHECK(this->counts == expected);
@@ -87,12 +87,12 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_async_resource", "[container][resou
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      void* ptr = mr.allocate(bytes(50), align(8));
+      void* ptr = mr.allocate_sync(bytes(50), align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
 
-      mr.deallocate(ptr, bytes(50), align(8));
+      mr.deallocate_sync(ptr, bytes(50), align(8));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -104,7 +104,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_async_resource", "[container][resou
   // Reset the counters:
   this->counts = Counts();
 
-  SECTION("allocate_async and deallocate_async")
+  SECTION("allocate and deallocate")
   {
     Counts expected{};
     CHECK(this->counts == expected);
@@ -116,12 +116,12 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_async_resource", "[container][resou
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      void* ptr = mr.allocate_async(bytes(50), align(8), ::cuda::stream_ref{stream});
+      void* ptr = mr.allocate(::cuda::stream_ref{stream}, bytes(50), align(8));
       CHECK(ptr == this);
       ++expected.allocate_async_count;
       CHECK(this->counts == expected);
 
-      mr.deallocate_async(ptr, bytes(50), align(8), ::cuda::stream_ref{stream});
+      mr.deallocate(::cuda::stream_ref{stream}, ptr, bytes(50), align(8));
       ++expected.deallocate_async_count;
       CHECK(this->counts == expected);
     }
@@ -146,11 +146,11 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_async_resource", "[container][resou
       cudax::resource_ref<cudax::host_accessible> ref = mr;
 
       CHECK(this->counts == expected);
-      auto* ptr = ref.allocate(bytes(100), align(8));
+      auto* ptr = ref.allocate_sync(bytes(100), align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
-      ref.deallocate(ptr, bytes(0), align(0));
+      ref.deallocate_sync(ptr, bytes(0), align(0));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }

--- a/cudax/test/memory_resource/any_resource.cu
+++ b/cudax/test/memory_resource/any_resource.cu
@@ -84,7 +84,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
   // Reset the counters:
   this->counts = Counts();
 
-  SECTION("allocate and deallocate")
+  SECTION("allocate and deallocate_sync")
   {
     Counts expected{};
     CHECK(this->counts == expected);
@@ -95,12 +95,12 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      void* ptr = mr.allocate(bytes(50), align(8));
+      void* ptr = mr.allocate_sync(bytes(50), align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
 
-      mr.deallocate(ptr, bytes(50), align(8));
+      mr.deallocate_sync(ptr, bytes(50), align(8));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -146,11 +146,11 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
       CHECK(get_property(ref2, get_data{}) == 42);
 
       CHECK(this->counts == expected);
-      auto* ptr = ref.allocate(bytes(100), align(8));
+      auto* ptr = ref.allocate_sync(bytes(100), align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
-      ref.deallocate(ptr, bytes(0), align(0));
+      ref.deallocate_sync(ptr, bytes(0), align(0));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -177,11 +177,11 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
       CHECK(get_property(ref2, get_data{}) == 42);
 
       CHECK(this->counts == expected);
-      auto* ptr = ref.allocate(bytes(100), align(8));
+      auto* ptr = ref.allocate_sync(bytes(100), align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
-      ref.deallocate(ptr, bytes(0), align(0));
+      ref.deallocate_sync(ptr, bytes(0), align(0));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -208,11 +208,11 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
       ++expected.copy_count;
       CHECK(this->counts == expected);
 
-      auto* ptr = ref.allocate(bytes(100), align(8));
+      auto* ptr = ref.allocate_sync(bytes(100), align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
-      ref.deallocate(ptr, bytes(0), align(0));
+      ref.deallocate_sync(ptr, bytes(0), align(0));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }

--- a/cudax/test/memory_resource/common_tests.cuh
+++ b/cudax/test/memory_resource/common_tests.cuh
@@ -21,13 +21,13 @@ void test_deallocate_async(ResourceType& resource)
   test::pinned<int> i(0);
   cuda::atomic_ref atomic_i(*i);
 
-  int* allocation = static_cast<int*>(resource.allocate(sizeof(int)));
+  int* allocation = static_cast<int*>(resource.allocate_sync(sizeof(int)));
 
   cudax::launch(stream, test::one_thread_dims, test::spin_until_80{}, i.get());
   cudax::launch(stream, test::one_thread_dims, test::assign_42{}, allocation);
   cudax::launch(stream, test::one_thread_dims, test::verify_42{}, allocation);
 
-  resource.deallocate_async(allocation, sizeof(int), stream);
+  resource.deallocate(stream, allocation, sizeof(int));
 
   atomic_i.store(80);
   stream.sync();

--- a/cudax/test/memory_resource/device_memory_resource.cu
+++ b/cudax/test/memory_resource/device_memory_resource.cu
@@ -84,11 +84,11 @@ C2H_CCCLRT_TEST("device_memory_resource construction", "[memory_resource]")
                        current_device);
   }
 
-  using async_resource = cudax::device_memory_resource;
+  using test_resource = cudax::device_memory_resource;
   SECTION("Default construction")
   {
     {
-      async_resource default_constructed{cuda::device_ref{0}};
+      test_resource default_constructed{cuda::device_ref{0}};
       CHECK(default_constructed.get() == current_default_pool);
     }
 
@@ -118,7 +118,7 @@ C2H_CCCLRT_TEST("device_memory_resource construction", "[memory_resource]")
     _CCCL_TRY_CUDA_API(::cudaMemPoolCreate, "Failed to call cudaMemPoolCreate", &cuda_pool_handle, &pool_properties);
 
     {
-      async_resource from_cudaMemPool{cuda_pool_handle};
+      test_resource from_cudaMemPool{cuda_pool_handle};
       CHECK(from_cudaMemPool.get() == cuda_pool_handle);
       CHECK(from_cudaMemPool.get() != current_default_pool);
     }
@@ -144,7 +144,7 @@ C2H_CCCLRT_TEST("device_memory_resource construction", "[memory_resource]")
       42,
     };
     cudax::device_memory_pool pool{current_device, props};
-    async_resource from_initial_pool_size{pool};
+    test_resource from_initial_pool_size{pool};
 
     ::cudaMemPool_t get = from_initial_pool_size.get();
     CHECK(get != current_default_pool);
@@ -166,7 +166,7 @@ C2H_CCCLRT_TEST("device_memory_resource construction", "[memory_resource]")
       20,
     };
     cudax::device_memory_pool pool{current_device, props};
-    async_resource with_threshold{pool};
+    test_resource with_threshold{pool};
 
     ::cudaMemPool_t get = with_threshold.get();
     CHECK(get != current_default_pool);
@@ -190,7 +190,7 @@ C2H_CCCLRT_TEST("device_memory_resource construction", "[memory_resource]")
       cudax::cudaMemAllocationHandleType::cudaMemHandleTypePosixFileDescriptor,
     };
     cudax::device_memory_pool pool{current_device, props};
-    async_resource with_allocation_handle{pool};
+    test_resource with_allocation_handle{pool};
 
     ::cudaMemPool_t get = with_allocation_handle.get();
     CHECK(get != current_default_pool);
@@ -224,44 +224,44 @@ C2H_CCCLRT_TEST("device_memory_resource allocation", "[memory_resource]")
   }
   cudax::device_memory_resource res{cuda::device_ref{0}};
 
-  { // allocate / deallocate
-    auto* ptr = res.allocate(42);
+  { // allocate_sync / deallocate_sync
+    auto* ptr = res.allocate_sync(42);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
     ensure_device_ptr(ptr);
 
-    res.deallocate(ptr, 42);
+    res.deallocate_sync(ptr, 42);
+  }
+
+  { // allocate_sync / deallocate_sync with alignment
+    auto* ptr = res.allocate_sync(42, 4);
+    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
+    ensure_device_ptr(ptr);
+
+    res.deallocate_sync(ptr, 42, 4);
+  }
+
+  { // allocate / deallocate
+    cuda::experimental::stream_ref stream{raw_stream};
+
+    auto* ptr = res.allocate(stream, 42);
+    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
+
+    stream.sync();
+    ensure_device_ptr(ptr);
+
+    res.deallocate(stream, ptr, 42);
   }
 
   { // allocate / deallocate with alignment
-    auto* ptr = res.allocate(42, 4);
-    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
-    ensure_device_ptr(ptr);
-
-    res.deallocate(ptr, 42, 4);
-  }
-
-  { // allocate_async / deallocate_async
     cuda::experimental::stream_ref stream{raw_stream};
 
-    auto* ptr = res.allocate_async(42, stream);
+    auto* ptr = res.allocate(stream, 42, 4);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
 
     stream.sync();
     ensure_device_ptr(ptr);
 
-    res.deallocate_async(ptr, 42, stream);
-  }
-
-  { // allocate_async / deallocate_async with alignment
-    cuda::experimental::stream_ref stream{raw_stream};
-
-    auto* ptr = res.allocate_async(42, 4, stream);
-    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
-
-    stream.sync();
-    ensure_device_ptr(ptr);
-
-    res.deallocate_async(ptr, 42, 4, stream);
+    res.deallocate(stream, ptr, 42, 4);
   }
 
 #if _CCCL_HAS_EXCEPTIONS()
@@ -270,7 +270,7 @@ C2H_CCCLRT_TEST("device_memory_resource allocation", "[memory_resource]")
     {
       try
       {
-        [[maybe_unused]] auto* ptr = res.allocate(5, 42);
+        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 42);
       }
       catch (std::invalid_argument&)
       {
@@ -285,7 +285,7 @@ C2H_CCCLRT_TEST("device_memory_resource allocation", "[memory_resource]")
     {
       try
       {
-        [[maybe_unused]] auto* ptr = res.allocate(5, 1337);
+        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 1337);
       }
       catch (std::invalid_argument&)
       {
@@ -294,12 +294,12 @@ C2H_CCCLRT_TEST("device_memory_resource allocation", "[memory_resource]")
       CHECK(false);
     }
   }
-  { // allocate_async with too small alignment
+  { // allocate with too small alignment
     while (true)
     {
       try
       {
-        [[maybe_unused]] auto* ptr = res.allocate_async(5, 42, raw_stream);
+        [[maybe_unused]] auto* ptr = res.allocate(raw_stream, 5, 42);
       }
       catch (std::invalid_argument&)
       {
@@ -309,12 +309,12 @@ C2H_CCCLRT_TEST("device_memory_resource allocation", "[memory_resource]")
     }
   }
 
-  { // allocate_async with non matching alignment
+  { // allocate with non matching alignment
     while (true)
     {
       try
       {
-        [[maybe_unused]] auto* ptr = res.allocate_async(5, 1337, raw_stream);
+        [[maybe_unused]] auto* ptr = res.allocate(raw_stream, 5, 1337);
       }
       catch (std::invalid_argument&)
       {
@@ -339,11 +339,11 @@ enum class AccessibilityType
 template <AccessibilityType Accessibility>
 struct resource
 {
-  void* allocate(size_t, size_t)
+  void* allocate_sync(size_t, size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, size_t, size_t) {}
+  void deallocate_sync(void*, size_t, size_t) {}
 
   bool operator==(const resource&) const
   {
@@ -359,24 +359,24 @@ struct resource
   friend void get_property(const resource&, cudax::device_accessible) noexcept
   {}
 };
-static_assert(cuda::mr::resource<resource<AccessibilityType::Host>>, "");
-static_assert(!cuda::mr::resource_with<resource<AccessibilityType::Host>, cudax::device_accessible>, "");
-static_assert(cuda::mr::resource<resource<AccessibilityType::Device>>, "");
-static_assert(cuda::mr::resource_with<resource<AccessibilityType::Device>, cudax::device_accessible>, "");
+static_assert(cuda::mr::synchronous_resource<resource<AccessibilityType::Host>>, "");
+static_assert(!cuda::mr::synchronous_resource_with<resource<AccessibilityType::Host>, cudax::device_accessible>, "");
+static_assert(cuda::mr::synchronous_resource<resource<AccessibilityType::Device>>, "");
+static_assert(cuda::mr::synchronous_resource_with<resource<AccessibilityType::Device>, cudax::device_accessible>, "");
 
 template <AccessibilityType Accessibility>
-struct async_resource : public resource<Accessibility>
+struct test_resource : public resource<Accessibility>
 {
-  void* allocate_async(size_t, size_t, cuda::stream_ref)
+  void* allocate(cuda::stream_ref, size_t, size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, size_t, size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, size_t, size_t) {}
 };
-static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>, "");
-static_assert(!cuda::mr::async_resource_with<async_resource<AccessibilityType::Host>, cudax::device_accessible>, "");
-static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
-static_assert(cuda::mr::async_resource_with<async_resource<AccessibilityType::Device>, cudax::device_accessible>, "");
+static_assert(cuda::mr::resource<test_resource<AccessibilityType::Host>>, "");
+static_assert(!cuda::mr::resource_with<test_resource<AccessibilityType::Host>, cudax::device_accessible>, "");
+static_assert(cuda::mr::resource<test_resource<AccessibilityType::Device>>, "");
+static_assert(cuda::mr::resource_with<test_resource<AccessibilityType::Device>, cudax::device_accessible>, "");
 
 C2H_CCCLRT_TEST("device_memory_resource comparison", "[memory_resource]")
 {
@@ -439,8 +439,8 @@ C2H_CCCLRT_TEST("device_memory_resource comparison", "[memory_resource]")
   }
 
   { // comparison against a different resource through resource_ref
-    async_resource<AccessibilityType::Host> host_async_resource{};
-    async_resource<AccessibilityType::Device> device_async_resource{};
+    test_resource<AccessibilityType::Host> host_async_resource{};
+    test_resource<AccessibilityType::Device> device_async_resource{};
     CHECK(!(first == host_async_resource));
     CHECK((first != host_async_resource));
     CHECK(!(first == device_async_resource));
@@ -466,14 +466,14 @@ C2H_CCCLRT_TEST("Async memory resource access", "")
       CUDAX_CHECK(resource.is_accessible_from(cuda::devices[0]));
 
       auto allocate_and_check_access = [&](auto& resource) {
-        auto* ptr1  = resource.allocate_async(sizeof(int), stream);
-        auto* ptr2  = resource.allocate(sizeof(int));
+        auto* ptr1  = resource.allocate(stream, sizeof(int));
+        auto* ptr2  = resource.allocate_sync(sizeof(int));
         auto config = cudax::distribute<1>(1);
         cudax::launch(stream, config, test::assign_42{}, (int*) ptr1);
         cudax::launch(stream, config, test::assign_42{}, (int*) ptr2);
         stream.sync();
-        resource.deallocate_async(ptr1, sizeof(int), stream);
-        resource.deallocate(ptr2, sizeof(int));
+        resource.deallocate(stream, ptr1, sizeof(int));
+        resource.deallocate_sync(ptr2, sizeof(int));
       };
 
       resource.enable_access_from(peers);

--- a/cudax/test/memory_resource/managed_memory_resource.cu
+++ b/cudax/test/memory_resource/managed_memory_resource.cu
@@ -61,49 +61,78 @@ C2H_TEST("managed_memory_resource allocation", "[memory_resource]")
   managed_resource res{};
   cudax::stream stream{cuda::device_ref{0}};
 
-  { // allocate / deallocate
-    auto* ptr = res.allocate(42);
+  { // allocate_sync / deallocate_sync
+    auto* ptr = res.allocate_sync(42);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
     ensure_managed_ptr(ptr);
 
-    res.deallocate(ptr, 42);
+    res.deallocate_sync(ptr, 42);
+  }
+
+  { // allocate_sync / deallocate_sync with alignment
+    auto* ptr = res.allocate_sync(42, 4);
+    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
+    ensure_managed_ptr(ptr);
+
+    res.deallocate_sync(ptr, 42, 4);
+  }
+
+  { // allocate / deallocate
+    auto* ptr = res.allocate(stream, 42);
+    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
+
+    stream.sync();
+    ensure_managed_ptr(ptr);
+
+    res.deallocate(stream, ptr, 42);
   }
 
   { // allocate / deallocate with alignment
-    auto* ptr = res.allocate(42, 4);
-    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
-    ensure_managed_ptr(ptr);
-
-    res.deallocate(ptr, 42, 4);
-  }
-
-  { // allocate_async / deallocate_async
-    auto* ptr = res.allocate_async(42, stream);
+    auto* ptr = res.allocate(stream, 42, 4);
     static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
 
     stream.sync();
     ensure_managed_ptr(ptr);
 
-    res.deallocate_async(ptr, 42, stream);
-  }
-
-  { // allocate_async / deallocate_async with alignment
-    auto* ptr = res.allocate_async(42, 4, stream);
-    static_assert(cuda::std::is_same<decltype(ptr), void*>::value, "");
-
-    stream.sync();
-    ensure_managed_ptr(ptr);
-
-    res.deallocate_async(ptr, 42, 4, stream);
+    res.deallocate(stream, ptr, 42, 4);
   }
 
 #if _CCCL_HAS_EXCEPTIONS()
+  { // allocate_sync with too small alignment
+    while (true)
+    {
+      try
+      {
+        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 42);
+      }
+      catch (std::invalid_argument&)
+      {
+        break;
+      }
+      CHECK(false);
+    }
+  }
+
+  { // allocate_sync with non matching alignment
+    while (true)
+    {
+      try
+      {
+        [[maybe_unused]] auto* ptr = res.allocate_sync(5, 1337);
+      }
+      catch (std::invalid_argument&)
+      {
+        break;
+      }
+      CHECK(false);
+    }
+  }
   { // allocate with too small alignment
     while (true)
     {
       try
       {
-        [[maybe_unused]] auto* ptr = res.allocate(5, 42);
+        [[maybe_unused]] auto* ptr = res.allocate(stream, 5, 42);
       }
       catch (std::invalid_argument&)
       {
@@ -118,36 +147,7 @@ C2H_TEST("managed_memory_resource allocation", "[memory_resource]")
     {
       try
       {
-        [[maybe_unused]] auto* ptr = res.allocate(5, 1337);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
-  }
-  { // allocate_async with too small alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_async(5, 42, stream);
-      }
-      catch (std::invalid_argument&)
-      {
-        break;
-      }
-      CHECK(false);
-    }
-  }
-
-  { // allocate_async with non matching alignment
-    while (true)
-    {
-      try
-      {
-        [[maybe_unused]] auto* ptr = res.allocate_async(5, 1337, stream);
+        [[maybe_unused]] auto* ptr = res.allocate(stream, 5, 1337);
       }
       catch (std::invalid_argument&)
       {
@@ -168,11 +168,11 @@ enum class AccessibilityType
 template <AccessibilityType Accessibility>
 struct resource
 {
-  void* allocate(size_t, size_t)
+  void* allocate_sync(size_t, size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, size_t, size_t) noexcept {}
+  void deallocate_sync(void*, size_t, size_t) noexcept {}
 
   bool operator==(const resource&) const
   {
@@ -183,27 +183,27 @@ struct resource
     return false;
   }
 };
-static_assert(cuda::mr::resource<resource<AccessibilityType::Host>>, "");
-static_assert(cuda::mr::resource<resource<AccessibilityType::Device>>, "");
+static_assert(cuda::mr::synchronous_resource<resource<AccessibilityType::Host>>, "");
+static_assert(cuda::mr::synchronous_resource<resource<AccessibilityType::Device>>, "");
 
 template <AccessibilityType Accessibility>
-struct async_resource : public resource<Accessibility>
+struct test_resource : public resource<Accessibility>
 {
-  void* allocate_async(size_t, size_t, cuda::stream_ref)
+  void* allocate(cuda::stream_ref, size_t, size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, size_t, size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, size_t, size_t) {}
 };
-static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Host>>, "");
-static_assert(cuda::mr::async_resource<async_resource<AccessibilityType::Device>>, "");
+static_assert(cuda::mr::resource<test_resource<AccessibilityType::Host>>, "");
+static_assert(cuda::mr::resource<test_resource<AccessibilityType::Device>>, "");
 
 // test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
 struct derived_managed_resource : cudax::managed_memory_resource
 {
   using cudax::managed_memory_resource::managed_memory_resource;
 };
-static_assert(cuda::mr::resource<derived_managed_resource>, "");
+static_assert(cuda::mr::synchronous_resource<derived_managed_resource>, "");
 
 C2H_TEST("managed_memory_resource comparison", "[memory_resource]")
 {

--- a/cudax/test/memory_resource/memory_pools.cu
+++ b/cudax/test/memory_resource/memory_pools.cu
@@ -346,7 +346,7 @@ C2H_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_TYPES)
     cudax::stream stream{cuda::device_ref{0}};
 
     // Allocate a buffer to prime
-    auto* ptr = resource.allocate_async(256 * sizeof(int), stream);
+    auto* ptr = resource.allocate(stream, 256 * sizeof(int));
     stream.sync();
 
     { // cudaMemPoolAttrReservedMemHigh
@@ -408,8 +408,8 @@ C2H_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_TYPES)
     }
 
     // Reallocate as the checks above have screwed with the allocation count
-    resource.deallocate_async(ptr, 256 * sizeof(int), stream);
-    ptr = resource.allocate_async(2048 * sizeof(int), stream);
+    resource.deallocate(stream, ptr, 256 * sizeof(int));
+    ptr = resource.allocate(stream, 2048 * sizeof(int));
     stream.sync();
 
     { // cudaMemPoolAttrReservedMemCurrent
@@ -457,7 +457,7 @@ C2H_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_TYPES)
     }
 
     // Free the last allocation
-    resource.deallocate_async(ptr, 2048 * sizeof(int), stream);
+    resource.deallocate(stream, ptr, 2048 * sizeof(int));
     stream.sync();
   }
 
@@ -470,9 +470,9 @@ C2H_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_TYPES)
     cudax::stream stream{cuda::device_ref{0}};
 
     // Allocate 2 buffers
-    auto* ptr1 = resource.allocate_async(2048 * sizeof(int), stream);
-    auto* ptr2 = resource.allocate_async(2048 * sizeof(int), stream);
-    resource.deallocate_async(ptr1, 2048 * sizeof(int), stream);
+    auto* ptr1 = resource.allocate(stream, 2048 * sizeof(int));
+    auto* ptr2 = resource.allocate(stream, 2048 * sizeof(int));
+    resource.deallocate(stream, ptr1, 2048 * sizeof(int));
     stream.sync();
 
     // Ensure that we still hold some memory, otherwise everything is freed
@@ -502,7 +502,7 @@ C2H_TEST_LIST("device_memory_pool accessors", "[memory_resource]", TEST_TYPES)
     CHECK(new_backing_size >= 4096 * sizeof(int));
 
     // Free the last allocation
-    resource.deallocate_async(ptr2, 2048 * sizeof(int), stream);
+    resource.deallocate(stream, ptr2, 2048 * sizeof(int));
     stream.sync();
 
     // There is nothing allocated anymore, so all memory is released

--- a/cudax/test/memory_resource/shared_resource.cu
+++ b/cudax/test/memory_resource/shared_resource.cu
@@ -18,7 +18,7 @@
 TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource]", big_resource, small_resource)
 {
   using TestResource = TestType;
-  static_assert(cuda::mr::async_resource<cudax::shared_resource<TestResource>>);
+  static_assert(cuda::mr::resource<cudax::shared_resource<TestResource>>);
 
   SECTION("construct and destruct")
   {
@@ -76,7 +76,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
   // Reset the counters:
   this->counts = Counts();
 
-  SECTION("allocate and deallocate")
+  SECTION("allocate_sync and deallocate_sync")
   {
     Counts expected{};
     CHECK(this->counts == expected);
@@ -85,12 +85,12 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       ++expected.object_count;
       CHECK(this->counts == expected);
 
-      void* ptr = mr.allocate(bytes(50), align(8));
+      void* ptr = mr.allocate_sync(bytes(50), align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
 
-      mr.deallocate(ptr, bytes(50), align(8));
+      mr.deallocate_sync(ptr, bytes(50), align(8));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -113,11 +113,11 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       cudax::resource_ref<cudax::host_accessible> ref = mr;
 
       CHECK(this->counts == expected);
-      auto* ptr = ref.allocate(bytes(100), align(8));
+      auto* ptr = ref.allocate_sync(bytes(100), align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
-      ref.deallocate(ptr, bytes(0), align(0));
+      ref.deallocate_sync(ptr, bytes(0), align(0));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }

--- a/cudax/test/memory_resource/test_resource.cuh
+++ b/cudax/test/memory_resource/test_resource.cuh
@@ -31,10 +31,10 @@ struct Counts
         << "object: " << counts.object_count << ", " //
         << "move: " << counts.move_count << ", " //
         << "copy: " << counts.copy_count << ", " //
-        << "allocate: " << counts.allocate_count << ", " //
-        << "deallocate: " << counts.deallocate_count << ", " //
-        << "allocate_async: " << counts.allocate_async_count << ", " //
-        << "deallocate_async: " << counts.deallocate_async_count << ", " //
+        << "allocate_sync: " << counts.allocate_count << ", " //
+        << "deallocate_sync: " << counts.deallocate_count << ", " //
+        << "allocate: " << counts.allocate_async_count << ", " //
+        << "deallocate: " << counts.deallocate_async_count << ", " //
         << "equal_to: " << counts.equal_to_count << ", " //
         << "new: " << counts.new_count << ", " //
         << "delete: " << counts.delete_count;
@@ -142,7 +142,7 @@ struct test_resource
     return *this;
   }
 
-  void* allocate(std::size_t bytes, std::size_t align)
+  void* allocate_sync(std::size_t bytes, std::size_t align)
   {
     _assert_valid();
     CHECK(bytes == fixture->bytes_);
@@ -151,7 +151,7 @@ struct test_resource
     return fixture;
   }
 
-  void deallocate(void* ptr, std::size_t bytes, std::size_t align) noexcept
+  void deallocate_sync(void* ptr, std::size_t bytes, std::size_t align) noexcept
   {
     _assert_valid();
     CHECK(ptr == fixture);
@@ -161,7 +161,7 @@ struct test_resource
     return;
   }
 
-  void* allocate_async(std::size_t bytes, std::size_t align, ::cuda::stream_ref)
+  void* allocate(::cuda::stream_ref, std::size_t bytes, std::size_t align)
   {
     _assert_valid();
     CHECK(bytes == fixture->bytes_);
@@ -170,7 +170,7 @@ struct test_resource
     return fixture;
   }
 
-  void deallocate_async(void* ptr, std::size_t bytes, std::size_t align, ::cuda::stream_ref) noexcept
+  void deallocate(::cuda::stream_ref, void* ptr, std::size_t bytes, std::size_t align) noexcept
   {
     _assert_valid();
     CHECK(ptr == fixture);

--- a/docs/libcudacxx/extended_api/memory_resource/properties.rst
+++ b/docs/libcudacxx/extended_api/memory_resource/properties.rst
@@ -67,10 +67,10 @@ require a stateful property with ``cuda::has_property_with`` as shown in the exa
    template<class MemoryResource>
    void* allocate_check_alignment(MemoryResource& resource, std::size_t size) {
        if constexpr(cuda::has_property_with<MemoryResource, required_alignment, std::size_t>) {
-           return resource.allocate(size, get_property(resource, required_alignment{}));
+           return resource.allocate_sync(size, get_property(resource, required_alignment{}));
        } else {
            // Use default alignment
-           return resource.allocate(size, 42);
+           return resource.allocate_sync(size, 42);
        }
    }
 
@@ -83,11 +83,11 @@ base type at all. This common use case is covered by ``cuda::forward_property``,
    class logging_resource : cuda::forward_property<logging_resource<MemoryResource>, MemoryResource> {
        MemoryResource base;
    public:
-       void* allocate(std::size_t size, std::size_t alignment) {
+       void* allocate_sync(std::size_t size, std::size_t alignment) {
            std::cout << "allocating\n";
-           return base.allocate(size, alignment);
+           return base.allocate_sync(size, alignment);
        }
-       void deallocate(void* ptr, std::size_t size, std::size_t alignment) noexcept {
+       void deallocate_sync(void* ptr, std::size_t size, std::size_t alignment) noexcept {
            std::cout << "deallocating\n";
            return base.deallocate(ptr, size, alignment);
        }

--- a/docs/libcudacxx/extended_api/memory_resource/resource.rst
+++ b/docs/libcudacxx/extended_api/memory_resource/resource.rst
@@ -1,7 +1,7 @@
 .. _libcudacxx-extended-api-memory-resources-resource:
 
-The ``cuda::resource`` concept
--------------------------------
+The ``cuda::synchronous_resource`` concept
+-------------------------------------------
 
 The `std::pmr::memory_resource <https://en.cppreference.com/w/cpp/header/memory_resource>`__ feature provides only a
 single ``allocate`` interface, which is sufficient for homogeneous memory systems. However, CUDA provides both
@@ -12,19 +12,22 @@ whether a memory resource can utilize stream-ordered allocations. Even if the ap
 to properly tell the memory resource to use stream-ordered allocation. Ideally, this should not be something discovered
 through an assert at run time, but should be checked by the compiler.
 
-The ``cuda::mr::resource`` concept provides basic type checks to ensure that a given memory resource provides the
-expected ``allocate`` / ``deallocate`` interface and is also equality comparable, which covers the whole API surface of
+Because asynchronous memory management is critical for performance, ``cuda::mr::resource`` defaults to stream-ordered interface provided by ``allocate`` / ``deallocate``.
+For cases where stream-ordered allocation is not possible, ``cuda::mr::synchronous_resource`` is provided.
+
+The ``cuda::mr::synchronous_resource`` concept provides basic type checks to ensure that a given memory resource provides the
+expected ``allocate_sync`` / ``deallocate_sync`` interface and is also equality comparable, which covers the whole API surface of
 `std::pmr::memory_resource <https://en.cppreference.com/w/cpp/header/memory_resource>`__.
 See below for different memory resources and potential pitfals.
 
 To demonstrate, the following example defines several resources, only some of which are valid implementations of the
-``cuda::mr::resource`` concept. The ``static_assertion``'s will result in compile-time errors for the invalid resources.
+``cuda::mr::synchronous_resource`` concept. The ``static_assertion``'s will result in compile-time errors for the invalid resources.
 
 .. code:: cpp
 
    struct valid_resource {
-     void* allocate(std::size_t, std::size_t) { return nullptr; }
-     void deallocate(void*, std::size_t, std::size_t) noexcept {}
+     void* allocate_sync(std::size_t, std::size_t) { return nullptr; }
+     void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
      bool operator==(const valid_resource&) const { return true; }
      // NOTE: C++20 thankfully added operator rewrite rules so defining operator!= is not required.
      // However, if compiled with C++14 / C++17, operator != must also be defined.
@@ -34,73 +37,73 @@ To demonstrate, the following example defines several resources, only some of wh
 
    struct invalid_argument {};
    struct invalid_allocate_argument {
-     void* allocate(invalid_argument, std::size_t) { return nullptr; }
-     void deallocate(void*, std::size_t, std::size_t) noexcept {}
+     void* allocate_sync(invalid_argument, std::size_t) { return nullptr; }
+     void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
      bool operator==(const invalid_allocate_argument&) { return true; }
    };
    static_assert(!cuda::mr::resource<invalid_allocate_argument>, "");
 
    struct invalid_allocate_return {
-     int allocate(std::size_t, std::size_t) { return 42; }
-     void deallocate(void*, std::size_t, std::size_t) noexcept {}
+     int allocate_sync(std::size_t, std::size_t) { return 42; }
+     void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
      bool operator==(const invalid_allocate_return&) { return true; }
    };
    static_assert(!cuda::mr::resource<invalid_allocate_return>, "");
 
    struct invalid_deallocate_argument {
-     void* allocate(std::size_t, std::size_t) { return nullptr; }
-     void deallocate(void*, invalid_argument, std::size_t) noexcept {}
+     void* allocate_sync(std::size_t, std::size_t) { return nullptr; }
+     void deallocate_sync(void*, invalid_argument, std::size_t) noexcept {}
      bool operator==(const invalid_deallocate_argument&) { return true; }
    };
    static_assert(!cuda::mr::resource<invalid_deallocate_argument>, "");
 
    struct non_comparable {
-     void* allocate(std::size_t, std::size_t) { return nullptr; }
-     void deallocate(void*, std::size_t, std::size_t) noexcept {}
+     void* allocate_sync(std::size_t, std::size_t) { return nullptr; }
+     void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
    };
    static_assert(!cuda::mr::resource<non_comparable>, "");
 
    struct non_eq_comparable {
-     void* allocate(std::size_t, std::size_t) { return nullptr; }
-     void deallocate(void*, std::size_t, std::size_t) noexcept {}
+     void* allocate_sync(std::size_t, std::size_t) { return nullptr; }
+     void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
      bool operator!=(const non_eq_comparable&) { return false; }
    };
-   static_assert(!cuda::mr::resource<non_eq_comparable>, "");
+   static_assert(!cuda::mr::synchronous_resource<non_eq_comparable>, "");
 
 In addition to the `std::pmr::memory_resource <https://en.cppreference.com/w/cpp/header/memory_resource>`_ interface the
-``cuda::mr::async_resource`` concept verifies that a memory resource also satisfies the ``allocate_async`` /
-``deallocate_async`` interface. Requiring both the PMR interface and the async interface is a deliberate design decision.
+``cuda::mr::resource`` concept verifies that a memory resource also satisfies the ``allocate`` /
+``deallocate`` interface. Requiring both the PMR interface and the async interface is a deliberate design decision.
 
 .. code:: cpp
 
    struct valid_resource {
-     void* allocate(std::size_t, std::size_t) { return nullptr; }
-     void deallocate(void*, std::size_t, std::size_t) noexcept {}
-     void* allocate_async(std::size_t, std::size_t, cuda::stream_ref) { return nullptr; }
-     void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+     void* allocate_sync(std::size_t, std::size_t) { return nullptr; }
+     void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+     void* allocate(cuda::stream_ref, std::size_t, std::size_t) { return nullptr; }
+     void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
      bool operator==(const valid_resource&) const { return true; }
      bool operator!=(const valid_resource&) const { return false; }
    };
-   static_assert(cuda::mr::async_resource<valid_resource>, "");
+   static_assert(cuda::mr::resource<valid_resource>, "");
 
 A library can easily decide whether to use the async interface:
 
 .. code:: cpp
 
    template<class MemoryResource>
-       requires cuda::mr::resource<MemoryResource>
-   void* maybe_allocate_async(MemoryResource& resource, std::size_t size, std::size_t align, cuda::stream_ref stream) {
-       if constexpr(cuda::mr::async_resource<MemoryResource>) {
-           return resource.allocate_async(size, align, stream);
+       requires cuda::mr::synchronous_resource<MemoryResource>
+   void* allocate_maybe_sync(cuda::stream_ref stream, MemoryResource& resource, std::size_t size, std::size_t align) {
+       if constexpr(cuda::mr::resource<MemoryResource>) {
+           return resource.allocate(stream, size, align);
        } else {
-           return resource.allocate(size, align);
+           return resource.allocate_sync(size, align);
        }
    }
 
 .. rubric:: Putting them together
 
-Applications and libraries may want to combine type checks for arbitrary properties with the ``{async_}resource``
-concept. The ``{async_}resource_with`` concept allows checking resources for arbitrary properties.
+Applications and libraries may want to combine type checks for arbitrary properties with the ``{synchronous_}resource``
+concept. The ``{synchronous_}resource_with`` concept allows checking resources for arbitrary properties.
 
 .. code:: cpp
 
@@ -108,8 +111,8 @@ concept. The ``{async_}resource_with`` concept allows checking resources for arb
        using value_type = std::size_t;
    };
    struct my_memory_resource {
-       void* allocate(std::size_t, std::size_t) { return nullptr; }
-       void deallocate(void*, std::size_t, std::size_t) noexcept {}
+       void* allocate_sync(std::size_t, std::size_t) { return nullptr; }
+       void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
        bool operator==(const my_memory_resource&) const { return true; }
        bool operator!=(const my_memory_resource&) const { return false; }
 
@@ -120,28 +123,28 @@ concept. The ``{async_}resource_with`` concept allows checking resources for arb
 
    template<class MemoryResource>
        requires cuda::mr::resource<MemoryResource>
-   void* maybe_allocate_async_check_alignment(MemoryResource& resource, std::size_t size, cuda::stream_ref stream) {
-       if constexpr(cuda::mr::async_resource_with<MemoryResource, required_alignment>) {
-           return resource.allocate_async(size, get_property(resource, required_alignment), stream);
-       } else if constexpr (cuda::mr::async_resource<MemoryResource>) {
-           return resource.allocate_async(size, my_default_alignment, stream);
-       } else if constexpr (cuda::mr::resource_with<MemoryResource, required_alignment>) {
-           return resource.allocate(size, get_property(resource, required_alignment));
+   void* allocate_maybe_sync_check_alignment(MemoryResource& resource, std::size_t size, cuda::stream_ref stream) {
+       if constexpr(cuda::mr::resource_with<MemoryResource, required_alignment>) {
+           return resource.allocate(stream, size, get_property(resource, required_alignment));
+       } else if constexpr (cuda::mr::resource<MemoryResource>) {
+           return resource.allocate(stream, size, my_default_alignment);
+       } else if constexpr (cuda::mr::synchronous_resource_with<MemoryResource, required_alignment>) {
+           return resource.allocate_sync(size, get_property(resource, required_alignment));
        } else {
-           return resource.allocate(size, my_default_alignment);
+           return resource.allocate_sync(size, my_default_alignment);
        }
    }
 
    // Potentially more concise
    template<class MemoryResource>
        requires cuda::mr::resource<MemoryResource>
-   void* maybe_allocate_async_check_alignment2(MemoryResource& resource, std::size_t size, cuda::stream_ref stream) {
+   void* allocate_maybe_sync_check_alignment2(MemoryResource& resource, std::size_t size, cuda::stream_ref stream) {
        constexpr std::size_t align = cuda::mr::resource_with<MemoryResource, required_alignment>
                                    ? get_property(resource, required_alignment)
                                    : my_default_alignment;
-       if constexpr(cuda::mr::async_resource<MemoryResource>) {
-           return resource.allocate_async(size, align, stream);
+       if constexpr(cuda::mr::resource<MemoryResource>) {
+           return resource.allocate(stream, size, align);
        } else {
-           return resource.allocate(size, align);
+           return resource.allocate_sync(size, align);
        }
    }

--- a/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
@@ -36,10 +36,10 @@ _LIBCUDACXX_BEGIN_NAMESPACE_CUDA_MR
 template <class _Resource>
 _CCCL_CONCEPT __internal_async_resource = _CCCL_REQUIRES_EXPR(
   (_Resource), _Resource& __res, void* __ptr, size_t __bytes, size_t __alignment, ::cuda::stream_ref __stream)(
-  _Same_as(void*) __res.allocate(__bytes, __alignment),
-  _Same_as(void*) __res.allocate_async(__bytes, __alignment, __stream),
-  _Same_as(void) __res.deallocate_async(__ptr, __bytes, __alignment, __stream),
-  _Same_as(void) __res.deallocate(__ptr, __bytes, __alignment),
+  _Same_as(void*) __res.allocate_sync(__bytes, __alignment),
+  _Same_as(void*) __res.allocate(__stream, __bytes, __alignment),
+  _Same_as(void) __res.deallocate(__stream, __ptr, __bytes, __alignment),
+  _Same_as(void) __res.deallocate_sync(__ptr, __bytes, __alignment),
   requires(_CUDA_VSTD::equality_comparable<_Resource>));
 
 struct __get_memory_resource_t;

--- a/libcudacxx/include/cuda/__memory_resource/resource_ref.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource_ref.h
@@ -155,30 +155,30 @@ struct _Resource_vtable_builder
   template <class _Resource>
   static void* _Alloc(void* __object, size_t __bytes, size_t __alignment)
   {
-    return static_cast<_Resource*>(__object)->allocate(__bytes, __alignment);
+    return static_cast<_Resource*>(__object)->allocate_sync(__bytes, __alignment);
   }
 
   template <class _Resource>
   static void _Dealloc(void* __object, void* __ptr, size_t __bytes, size_t __alignment) noexcept
   {
     // TODO: this breaks RMM because their memory resources do not declare their
-    // deallocate functions to be noexcept. Comment out the check for now until
+    // deallocate_sync functions to be noexcept. Comment out the check for now until
     // we can fix RMM.
     // static_assert(noexcept(static_cast<_Resource*>(__object)->deallocate(__ptr, __bytes, __alignment)));
-    return static_cast<_Resource*>(__object)->deallocate(__ptr, __bytes, __alignment);
+    return static_cast<_Resource*>(__object)->deallocate_sync(__ptr, __bytes, __alignment);
   }
 
   template <class _Resource>
   static void* _Alloc_async(void* __object, size_t __bytes, size_t __alignment, ::cuda::stream_ref __stream)
   {
-    return static_cast<_Resource*>(__object)->allocate_async(__bytes, __alignment, __stream);
+    return static_cast<_Resource*>(__object)->allocate(__stream, __bytes, __alignment);
   }
 
   template <class _Resource>
   static void
   _Dealloc_async(void* __object, void* __ptr, size_t __bytes, size_t __alignment, ::cuda::stream_ref __stream)
   {
-    return static_cast<_Resource*>(__object)->deallocate_async(__ptr, __bytes, __alignment, __stream);
+    return static_cast<_Resource*>(__object)->deallocate(__stream, __ptr, __bytes, __alignment);
   }
 
   template <class _Resource>
@@ -387,12 +387,12 @@ struct _CCCL_DECLSPEC_EMPTY_BASES _Alloc_base : _Resource_ref_base
       , __static_vtable(__static_vtabl_)
   {}
 
-  [[nodiscard]] void* allocate(size_t __bytes, size_t __alignment = alignof(_CUDA_VSTD::max_align_t))
+  [[nodiscard]] void* allocate_sync(size_t __bytes, size_t __alignment = alignof(_CUDA_VSTD::max_align_t))
   {
     return __static_vtable->__alloc_fn(_Get_object(), __bytes, __alignment);
   }
 
-  void deallocate(void* _Ptr, size_t __bytes, size_t __alignment = alignof(_CUDA_VSTD::max_align_t)) noexcept
+  void deallocate_sync(void* _Ptr, size_t __bytes, size_t __alignment = alignof(_CUDA_VSTD::max_align_t)) noexcept
   {
     __static_vtable->__dealloc_fn(_Get_object(), _Ptr, __bytes, __alignment);
   }
@@ -427,22 +427,22 @@ struct _Async_alloc_base : public _Alloc_base<_Vtable, _Wrapper_type>
       : _Alloc_base<_Vtable, _Wrapper_type>(__object_, __static_vtabl_)
   {}
 
-  [[nodiscard]] void* allocate_async(size_t __bytes, size_t __alignment, ::cuda::stream_ref __stream)
+  [[nodiscard]] void* allocate(::cuda::stream_ref __stream, size_t __bytes, size_t __alignment)
   {
     return this->__static_vtable->__async_alloc_fn(this->_Get_object(), __bytes, __alignment, __stream);
   }
 
-  [[nodiscard]] void* allocate_async(size_t __bytes, ::cuda::stream_ref __stream)
+  [[nodiscard]] void* allocate(::cuda::stream_ref __stream, size_t __bytes)
   {
     return this->__static_vtable->__async_alloc_fn(this->_Get_object(), __bytes, alignof(max_align_t), __stream);
   }
 
-  void deallocate_async(void* _Ptr, size_t __bytes, ::cuda::stream_ref __stream)
+  void deallocate(::cuda::stream_ref __stream, void* _Ptr, size_t __bytes)
   {
     this->__static_vtable->__async_dealloc_fn(this->_Get_object(), _Ptr, __bytes, alignof(max_align_t), __stream);
   }
 
-  void deallocate_async(void* _Ptr, size_t __bytes, size_t __alignment, ::cuda::stream_ref __stream)
+  void deallocate(::cuda::stream_ref __stream, void* _Ptr, size_t __bytes, size_t __alignment)
   {
     this->__static_vtable->__async_dealloc_fn(this->_Get_object(), _Ptr, __bytes, __alignment, __stream);
   }
@@ -510,48 +510,48 @@ private:
   {}
 
 public:
-  //! @brief Constructs a \c basic_resource_ref from a type that satisfies the \c resource or \c async_resource concept
+  //! @brief Constructs a \c basic_resource_ref from a type that satisfies the \c resource or \c resource concept
   //! as well as all properties
   //! @param __res The resource to be wrapped within the \c basic_resource_ref
   _CCCL_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
   _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Default)
-                   _CCCL_AND resource_with<_Resource, _Properties...>)
+                   _CCCL_AND synchronous_resource_with<_Resource, _Properties...>)
   basic_resource_ref(_Resource& __res) noexcept
       : _Resource_base<_Alloc_type, _WrapperType::_Reference>(
           _CUDA_VSTD::addressof(__res), &__alloc_vtable<_Alloc_type, _WrapperType::_Reference, _Resource>)
       , __vtable(__vtable::template _Create<_Resource>())
   {}
 
-  //! @brief Constructs a \c resource_ref from a type that satisfies the \c async_resource concept  as well as all
+  //! @brief Constructs a \c resource_ref from a type that satisfies the \c resource concept  as well as all
   //! properties. This ignores the async interface of the passed in resource
   //! @param __res The resource to be wrapped within the \c resource_ref
   _CCCL_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
   _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Async)
-                   _CCCL_AND async_resource_with<_Resource, _Properties...>)
+                   _CCCL_AND resource_with<_Resource, _Properties...>)
   basic_resource_ref(_Resource& __res) noexcept
       : _Resource_base<_Alloc_type, _WrapperType::_Reference>(
           _CUDA_VSTD::addressof(__res), &__alloc_vtable<_Alloc_type, _WrapperType::_Reference, _Resource>)
       , __vtable(__vtable::template _Create<_Resource>())
   {}
 
-  //! @brief Constructs a \c basic_resource_ref from a type that satisfies the \c resource or \c async_resource concept
+  //! @brief Constructs a \c basic_resource_ref from a type that satisfies the \c resource or \c resource concept
   //! as well as all properties
   //! @param __res Pointer to a resource to be wrapped within the \c basic_resource_ref
   _CCCL_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
   _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Default)
-                   _CCCL_AND resource_with<_Resource, _Properties...>)
+                   _CCCL_AND synchronous_resource_with<_Resource, _Properties...>)
   basic_resource_ref(_Resource* __res) noexcept
       : _Resource_base<_Alloc_type, _WrapperType::_Reference>(
           __res, &__alloc_vtable<_Alloc_type, _WrapperType::_Reference, _Resource>)
       , __vtable(__vtable::template _Create<_Resource>())
   {}
 
-  //! @brief Constructs a \c resource_ref from a type that satisfies the \c async_resource concept  as well as all
+  //! @brief Constructs a \c resource_ref from a type that satisfies the \c resource concept  as well as all
   //! properties. This ignores the async interface of the passed in resource
   //! @param __res Pointer to a resource to be wrapped within the \c resource_ref
   _CCCL_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
   _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Async)
-                   _CCCL_AND async_resource_with<_Resource, _Properties...>)
+                   _CCCL_AND resource_with<_Resource, _Properties...>)
   basic_resource_ref(_Resource* __res) noexcept
       : _Resource_base<_Alloc_type, _WrapperType::_Reference>(
           __res, &__alloc_vtable<_Alloc_type, _WrapperType::_Reference, _Resource>)
@@ -639,7 +639,7 @@ public:
 template <class... _Properties>
 using resource_ref = basic_resource_ref<_AllocType::_Default, _Properties...>;
 
-//! @brief Type erased wrapper around a `async_resource` that satisfies \tparam _Properties
+//! @brief Type erased wrapper around a `resource` that satisfies \tparam _Properties
 //! @tparam _Properties The properties that any async resource wrapped within the `async_resource_ref` needs to satisfy
 template <class... _Properties>
 using async_resource_ref = basic_resource_ref<_AllocType::_Async, _Properties...>;

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
@@ -20,54 +20,54 @@
 
 void test_allocate()
 {
-  { // allocate(size)
-    async_resource<cuda::mr::host_accessible> input{42};
+  { // allocate_sync(size)
+    test_resource<cuda::mr::host_accessible> input{42};
     cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate(0, 0) == ref.allocate(0));
+    assert(input.allocate_sync(0, 0) == ref.allocate_sync(0));
 
     int expected_after_deallocate = 1337;
-    ref.deallocate(static_cast<void*>(&expected_after_deallocate), 0);
+    ref.deallocate_sync(static_cast<void*>(&expected_after_deallocate), 0);
     assert(input._val == expected_after_deallocate);
   }
 
-  { // allocate(size, alignment)
-    async_resource<cuda::mr::host_accessible> input{42};
+  { // allocate_sync(size, alignment)
+    test_resource<cuda::mr::host_accessible> input{42};
     cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate(0, 0) == ref.allocate(0, 0));
+    assert(input.allocate_sync(0, 0) == ref.allocate_sync(0, 0));
 
     int expected_after_deallocate = 1337;
-    ref.deallocate(static_cast<void*>(&expected_after_deallocate), 0, 0);
+    ref.deallocate_sync(static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
   }
 }
 
 void test_allocate_async()
 {
-  { // allocate(size)
-    async_resource<cuda::mr::host_accessible> input{42};
+  { // allocate_sync(size)
+    test_resource<cuda::mr::host_accessible> input{42};
     cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, ::cudaStream_t{}) == ref.allocate_async(0, ::cudaStream_t{}));
+    assert(input.allocate(::cudaStream_t{}, 0, 0) == ref.allocate(::cudaStream_t{}, 0, 0));
 
     int expected_after_deallocate = 1337;
-    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, ::cudaStream_t{});
+    ref.deallocate(::cudaStream_t{}, static_cast<void*>(&expected_after_deallocate), 0);
     assert(input._val == expected_after_deallocate);
   }
 
-  { // allocate(size, alignment)
-    async_resource<cuda::mr::host_accessible> input{42};
+  { // allocate_sync(size, alignment)
+    test_resource<cuda::mr::host_accessible> input{42};
     cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, ::cudaStream_t{}) == ref.allocate_async(0, 0, ::cudaStream_t{}));
+    assert(input.allocate(::cudaStream_t{}, 0, 0) == ref.allocate(::cudaStream_t{}, 0, 0));
 
     int expected_after_deallocate = 1337;
-    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, ::cudaStream_t{});
+    ref.deallocate(::cudaStream_t{}, static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
   }
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/construction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/construction.pass.cpp
@@ -26,15 +26,15 @@ using ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible,
                                          property_without_value<std::size_t>>;
 
 using matching_properties =
-  async_resource<cuda::mr::host_accessible,
-                 property_with_value<double>,
-                 property_without_value<std::size_t>,
-                 property_with_value<int>>;
+  test_resource<cuda::mr::host_accessible,
+                property_with_value<double>,
+                property_without_value<std::size_t>,
+                property_with_value<int>>;
 
 using missing_stateful_property =
-  async_resource<cuda::mr::host_accessible, property_with_value<int>, property_without_value<std::size_t>>;
+  test_resource<cuda::mr::host_accessible, property_with_value<int>, property_without_value<std::size_t>>;
 using missing_stateless_property =
-  async_resource<cuda::mr::host_accessible, property_with_value<int>, property_with_value<double>>;
+  test_resource<cuda::mr::host_accessible, property_with_value<int>, property_with_value<double>>;
 
 using cuda::std::is_constructible;
 static_assert(is_constructible<ref, matching_properties&>::value, "");
@@ -63,17 +63,17 @@ using ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible,
                                          property_with_value<double>,
                                          property_without_value<std::size_t>>;
 
-using res = async_resource<cuda::mr::host_accessible,
-                           property_with_value<int>,
-                           property_with_value<double>,
-                           property_without_value<std::size_t>>;
+using res = test_resource<cuda::mr::host_accessible,
+                          property_with_value<int>,
+                          property_with_value<double>,
+                          property_without_value<std::size_t>>;
 
 using other_res =
-  async_resource<cuda::mr::host_accessible,
-                 property_without_value<int>,
-                 property_with_value<int>,
-                 property_with_value<double>,
-                 property_without_value<std::size_t>>;
+  test_resource<cuda::mr::host_accessible,
+                property_without_value<int>,
+                property_with_value<int>,
+                property_with_value<double>,
+                property_without_value<std::size_t>>;
 
 using cuda::std::is_assignable;
 static_assert(cuda::std::is_assignable<ref, res&>::value, "");

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/conversion.pass.cpp
@@ -27,7 +27,7 @@ struct Fake_alloc_base
 template <class PropA, class PropB>
 void test_conversion_from_async_resource_ref()
 {
-  async_resource<cuda::mr::host_accessible, PropA, PropB> input{42};
+  test_resource<cuda::mr::host_accessible, PropA, PropB> input{42};
   cuda::mr::async_resource_ref<cuda::mr::host_accessible, PropA, PropB> ref_input{input};
 
   { // lvalue
@@ -40,11 +40,11 @@ void test_conversion_from_async_resource_ref()
     assert(fake_orig->static_vtable == fake_conv->static_vtable);
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, ::cudaStream_t{}) == ref.allocate_async(0, 0, ::cudaStream_t{}));
+    assert(input.allocate(::cudaStream_t{}, 0, 0) == ref.allocate(::cudaStream_t{}, 0, 0));
 
     // Ensure we are deallocating properly
     int expected_after_deallocate = 1337;
-    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, ::cudaStream_t{});
+    ref.deallocate(::cudaStream_t{}, static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
   }
 
@@ -59,11 +59,11 @@ void test_conversion_from_async_resource_ref()
     assert(fake_orig->static_vtable == fake_conv->static_vtable);
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate_async(0, 0, ::cudaStream_t{}) == ref.allocate_async(0, 0, ::cudaStream_t{}));
+    assert(input.allocate(::cudaStream_t{}, 0, 0) == ref.allocate(::cudaStream_t{}, 0, 0));
 
     // Ensure we are deallocating properly
     int expected_after_deallocate = 1337;
-    ref.deallocate_async(static_cast<void*>(&expected_after_deallocate), 0, 0, ::cudaStream_t{});
+    ref.deallocate(::cudaStream_t{}, static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
   }
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.fail.cpp
@@ -29,10 +29,10 @@ using different_properties =
                                property_with_value<int>,
                                property_without_value<std::size_t>>;
 
-using res = async_resource<cuda::mr::host_accessible,
-                           property_with_value<int>,
-                           property_with_value<double>,
-                           property_without_value<std::size_t>>;
+using res = test_resource<cuda::mr::host_accessible,
+                          property_with_value<int>,
+                          property_with_value<double>,
+                          property_without_value<std::size_t>>;
 
 void test_equality()
 {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.pass.cpp
@@ -30,15 +30,15 @@ using pertubed_properties =
                                property_with_value<int>,
                                property_without_value<std::size_t>>;
 
-using res = async_resource<cuda::mr::host_accessible,
-                           property_with_value<int>,
-                           property_with_value<double>,
-                           property_without_value<std::size_t>>;
+using res = test_resource<cuda::mr::host_accessible,
+                          property_with_value<int>,
+                          property_with_value<double>,
+                          property_without_value<std::size_t>>;
 using other_res =
-  async_resource<cuda::mr::host_accessible,
-                 property_with_value<double>,
-                 property_with_value<int>,
-                 property_without_value<std::size_t>>;
+  test_resource<cuda::mr::host_accessible,
+                property_with_value<double>,
+                property_with_value<int>,
+                property_without_value<std::size_t>>;
 
 void test_equality()
 {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/properties.pass.cpp
@@ -89,7 +89,7 @@ template <class... Properties>
 void test_async_resource_ref()
 {
   constexpr int expected_initially = 42;
-  async_resource<cuda::mr::host_accessible, Properties...> input{expected_initially};
+  test_resource<cuda::mr::host_accessible, Properties...> input{expected_initially};
   cuda::mr::async_resource_ref<cuda::mr::host_accessible, Properties...> ref{input};
 
   // Check all the potentially stateful properties
@@ -121,13 +121,13 @@ void test_async_resource_ref()
 
 void test_property_forwarding()
 {
-  using res = async_resource<cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>;
+  using res = test_resource<cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>;
   using ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible, property_with_value<short>>;
 
-  static_assert(cuda::mr::async_resource_with<res, property_with_value<short>, property_with_value<int>>, "");
-  static_assert(!cuda::mr::async_resource_with<ref, property_with_value<short>, property_with_value<int>>, "");
+  static_assert(cuda::mr::resource_with<res, property_with_value<short>, property_with_value<int>>, "");
+  static_assert(!cuda::mr::resource_with<ref, property_with_value<short>, property_with_value<int>>, "");
 
-  static_assert(cuda::mr::async_resource_with<res, property_with_value<short>>, "");
+  static_assert(cuda::mr::resource_with<res, property_with_value<short>>, "");
 }
 
 void test_async_resource_ref()

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/types.h
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/types.h
@@ -23,35 +23,35 @@ struct property_without_value
 {};
 
 template <class... Properties>
-struct async_resource
+struct test_resource
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
 
-  void deallocate(void* ptr, std::size_t, std::size_t) noexcept
+  void deallocate_sync(void* ptr, std::size_t, std::size_t) noexcept
   {
     // ensure that we did get the right inputs forwarded
     _val = *static_cast<int*>(ptr);
   }
 
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return &_val;
   }
 
-  void deallocate_async(void* ptr, std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate(cuda::stream_ref, void* ptr, std::size_t, std::size_t)
   {
     // ensure that we did get the right inputs forwarded
     _val = *static_cast<int*>(ptr);
   }
 
-  bool operator==(const async_resource& other) const
+  bool operator==(const test_resource& other) const
   {
     return _val == other._val;
   }
-  bool operator!=(const async_resource& other) const
+  bool operator!=(const test_resource& other) const
   {
     return _val != other._val;
   }
@@ -60,11 +60,11 @@ struct async_resource
 
   _CCCL_TEMPLATE(class Property)
   _CCCL_REQUIRES((!cuda::property_with_value<Property>) && _CUDA_VSTD::__is_included_in_v<Property, Properties...>)
-  friend void get_property(const async_resource&, Property) noexcept {}
+  friend void get_property(const test_resource&, Property) noexcept {}
 
   _CCCL_TEMPLATE(class Property)
   _CCCL_REQUIRES(cuda::property_with_value<Property>&& _CUDA_VSTD::__is_included_in_v<Property, Properties...>)
-  friend typename Property::value_type get_property(const async_resource& res, Property) noexcept
+  friend typename Property::value_type get_property(const test_resource& res, Property) noexcept
   {
     return static_cast<typename Property::value_type>(res._val);
   }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/async_resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/async_resource.pass.cpp
@@ -22,16 +22,16 @@ struct invalid_argument
 
 struct valid_resource
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
   bool operator==(const valid_resource&) const
   {
     return true;
@@ -41,16 +41,16 @@ struct valid_resource
     return false;
   }
 };
-static_assert(cuda::mr::async_resource<valid_resource>, "");
+static_assert(cuda::mr::resource<valid_resource>, "");
 
 struct invalid_allocate_missing
 {
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
   bool operator==(const invalid_allocate_missing&) const
   {
     return true;
@@ -60,19 +60,19 @@ struct invalid_allocate_missing
     return false;
   }
 };
-static_assert(!cuda::mr::async_resource<invalid_allocate_missing>, "");
+static_assert(!cuda::mr::resource<invalid_allocate_missing>, "");
 
 struct invalid_deallocate_missing
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
   bool operator==(const invalid_allocate_missing&) const
   {
     return true;
@@ -82,20 +82,20 @@ struct invalid_deallocate_missing
     return false;
   }
 };
-static_assert(!cuda::mr::async_resource<invalid_deallocate_missing>, "");
+static_assert(!cuda::mr::resource<invalid_deallocate_missing>, "");
 
 struct invalid_allocate_async_argument
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  void* allocate_async(invalid_argument, std::size_t)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  void* allocate(std::size_t, invalid_argument)
   {
     return nullptr;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
   bool operator==(const invalid_allocate_async_argument&) const
   {
     return true;
@@ -105,20 +105,20 @@ struct invalid_allocate_async_argument
     return false;
   }
 };
-static_assert(!cuda::mr::async_resource<invalid_allocate_async_argument>, "");
+static_assert(!cuda::mr::resource<invalid_allocate_async_argument>, "");
 
 struct invalid_allocate_async_return
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  int allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  int allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return 42;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
   bool operator==(const invalid_allocate_async_return&) const
   {
     return true;
@@ -128,20 +128,20 @@ struct invalid_allocate_async_return
     return false;
   }
 };
-static_assert(!cuda::mr::async_resource<invalid_allocate_async_return>, "");
+static_assert(!cuda::mr::resource<invalid_allocate_async_return>, "");
 
 struct invalid_deallocate_async_argument
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, invalid_argument, std::size_t) {}
+  void deallocate(std::size_t, void*, invalid_argument) {}
   bool operator==(const invalid_deallocate_async_argument&) const
   {
     return true;
@@ -151,61 +151,61 @@ struct invalid_deallocate_async_argument
     return false;
   }
 };
-static_assert(!cuda::mr::async_resource<invalid_deallocate_async_argument>, "");
+static_assert(!cuda::mr::resource<invalid_deallocate_async_argument>, "");
 
 struct non_comparable
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
 };
-static_assert(!cuda::mr::async_resource<non_comparable>, "");
+static_assert(!cuda::mr::resource<non_comparable>, "");
 
 struct non_eq_comparable
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
   bool operator!=(const non_eq_comparable&) const
   {
     return false;
   }
 };
-static_assert(!cuda::mr::async_resource<non_eq_comparable>, "");
+static_assert(!cuda::mr::resource<non_eq_comparable>, "");
 
 #if TEST_STD_VER < 2020
 struct non_neq_comparable
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
   bool operator==(const non_neq_comparable&) const
   {
     return true;
   }
 };
-static_assert(!cuda::mr::async_resource<non_neq_comparable>, "");
+static_assert(!cuda::mr::resource<non_neq_comparable>, "");
 #endif // TEST_STD_VER < 2020
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/async_resource_with.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/async_resource_with.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::async_resource_with
+// cuda::mr::resource_with
 
 #include <cuda/memory_resource>
 #include <cuda/std/cstdint>
@@ -22,16 +22,16 @@ struct prop
 
 struct valid_resource_with_property
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
   bool operator==(const valid_resource_with_property&) const
   {
     return true;
@@ -42,20 +42,20 @@ struct valid_resource_with_property
   }
   friend void get_property(const valid_resource_with_property&, prop_with_value) {}
 };
-static_assert(cuda::mr::async_resource_with<valid_resource_with_property, prop_with_value>, "");
+static_assert(cuda::mr::resource_with<valid_resource_with_property, prop_with_value>, "");
 
 struct valid_resource_without_property
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
   bool operator==(const valid_resource_without_property&) const
   {
     return true;
@@ -65,26 +65,26 @@ struct valid_resource_without_property
     return false;
   }
 };
-static_assert(!cuda::mr::async_resource_with<valid_resource_without_property, prop_with_value>, "");
+static_assert(!cuda::mr::resource_with<valid_resource_without_property, prop_with_value>, "");
 
 struct invalid_resource_with_property
 {
   friend void get_property(const invalid_resource_with_property&, prop_with_value) {}
 };
-static_assert(!cuda::mr::async_resource_with<invalid_resource_with_property, prop_with_value>, "");
+static_assert(!cuda::mr::resource_with<invalid_resource_with_property, prop_with_value>, "");
 
 struct resource_with_many_properties
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate_async(void*, std::size_t, std::size_t, cuda::stream_ref) {}
+  void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) {}
   bool operator==(const resource_with_many_properties&) const
   {
     return true;
@@ -96,14 +96,14 @@ struct resource_with_many_properties
   friend void get_property(const resource_with_many_properties&, prop_with_value) {}
   friend void get_property(const resource_with_many_properties&, prop) {}
 };
-static_assert(cuda::mr::async_resource_with<resource_with_many_properties, prop_with_value, prop>, "");
-static_assert(!cuda::mr::async_resource_with<resource_with_many_properties, prop_with_value, int, prop>, "");
+static_assert(cuda::mr::resource_with<resource_with_many_properties, prop_with_value, prop>, "");
+static_assert(!cuda::mr::resource_with<resource_with_many_properties, prop_with_value, int, prop>, "");
 
 struct derived_with_property : public valid_resource_without_property
 {
   friend void get_property(const derived_with_property&, prop_with_value) {}
 };
-static_assert(cuda::mr::async_resource_with<derived_with_property, prop_with_value>, "");
+static_assert(cuda::mr::resource_with<derived_with_property, prop_with_value>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/resource.pass.cpp
@@ -22,11 +22,11 @@ struct invalid_argument
 
 struct valid_resource
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
   bool operator==(const valid_resource&) const
   {
     return true;
@@ -36,15 +36,15 @@ struct valid_resource
     return false;
   }
 };
-static_assert(cuda::mr::resource<valid_resource>, "");
+static_assert(cuda::mr::synchronous_resource<valid_resource>, "");
 
 struct invalid_allocate_argument
 {
-  void* allocate(invalid_argument, std::size_t)
+  void* allocate_sync(invalid_argument, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
   bool operator==(const invalid_allocate_argument&)
   {
     return true;
@@ -54,15 +54,15 @@ struct invalid_allocate_argument
     return false;
   }
 };
-static_assert(!cuda::mr::resource<invalid_allocate_argument>, "");
+static_assert(!cuda::mr::synchronous_resource<invalid_allocate_argument>, "");
 
 struct invalid_allocate_return
 {
-  int allocate(std::size_t, std::size_t)
+  int allocate_sync(std::size_t, std::size_t)
   {
     return 42;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
   bool operator==(const invalid_allocate_return&)
   {
     return true;
@@ -72,15 +72,15 @@ struct invalid_allocate_return
     return false;
   }
 };
-static_assert(!cuda::mr::resource<invalid_allocate_return>, "");
+static_assert(!cuda::mr::synchronous_resource<invalid_allocate_return>, "");
 
 struct invalid_deallocate_argument
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, invalid_argument, std::size_t) noexcept {}
+  void deallocate_sync(void*, invalid_argument, std::size_t) noexcept {}
   bool operator==(const invalid_deallocate_argument&)
   {
     return true;
@@ -90,46 +90,46 @@ struct invalid_deallocate_argument
     return false;
   }
 };
-static_assert(!cuda::mr::resource<invalid_deallocate_argument>, "");
+static_assert(!cuda::mr::synchronous_resource<invalid_deallocate_argument>, "");
 
 struct non_comparable
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
 };
-static_assert(!cuda::mr::resource<non_comparable>, "");
+static_assert(!cuda::mr::synchronous_resource<non_comparable>, "");
 
 struct non_eq_comparable
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
   bool operator!=(const non_eq_comparable&)
   {
     return false;
   }
 };
-static_assert(!cuda::mr::resource<non_eq_comparable>, "");
+static_assert(!cuda::mr::synchronous_resource<non_eq_comparable>, "");
 
 #if TEST_STD_VER < 2020
 struct non_neq_comparable
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
   bool operator==(const non_neq_comparable&)
   {
     return true;
   }
 };
-static_assert(!cuda::mr::resource<non_neq_comparable>, "");
+static_assert(!cuda::mr::synchronous_resource<non_neq_comparable>, "");
 #endif // TEST_STD_VER < 2020
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/resource_with.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/concepts/resource_with.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::resource_with
+// cuda::mr::synchronous_resource_with
 
 #include <cuda/memory_resource>
 #include <cuda/std/cstdint>
@@ -22,11 +22,11 @@ struct prop
 
 struct valid_resource_with_property
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
   bool operator==(const valid_resource_with_property&) const
   {
     return true;
@@ -37,15 +37,15 @@ struct valid_resource_with_property
   }
   friend void get_property(const valid_resource_with_property&, prop_with_value) {}
 };
-static_assert(cuda::mr::resource_with<valid_resource_with_property, prop_with_value>, "");
+static_assert(cuda::mr::synchronous_resource_with<valid_resource_with_property, prop_with_value>, "");
 
 struct valid_resource_without_property
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
   bool operator==(const valid_resource_without_property&) const
   {
     return true;
@@ -55,21 +55,21 @@ struct valid_resource_without_property
     return false;
   }
 };
-static_assert(!cuda::mr::resource_with<valid_resource_without_property, prop_with_value>, "");
+static_assert(!cuda::mr::synchronous_resource_with<valid_resource_without_property, prop_with_value>, "");
 
 struct invalid_resource_with_property
 {
   friend void get_property(const invalid_resource_with_property&, prop_with_value) {}
 };
-static_assert(!cuda::mr::resource_with<invalid_resource_with_property, prop_with_value>, "");
+static_assert(!cuda::mr::synchronous_resource_with<invalid_resource_with_property, prop_with_value>, "");
 
 struct resource_with_many_properties
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
-  void deallocate(void*, std::size_t, std::size_t) noexcept {}
+  void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
   bool operator==(const resource_with_many_properties&) const
   {
     return true;
@@ -81,14 +81,14 @@ struct resource_with_many_properties
   friend void get_property(const resource_with_many_properties&, prop_with_value) {}
   friend void get_property(const resource_with_many_properties&, prop) {}
 };
-static_assert(cuda::mr::resource_with<resource_with_many_properties, prop_with_value, prop>, "");
-static_assert(!cuda::mr::resource_with<resource_with_many_properties, prop_with_value, int, prop>, "");
+static_assert(cuda::mr::synchronous_resource_with<resource_with_many_properties, prop_with_value, prop>, "");
+static_assert(!cuda::mr::synchronous_resource_with<resource_with_many_properties, prop_with_value, int, prop>, "");
 
 struct derived_with_property : public valid_resource_without_property
 {
   friend void get_property(const derived_with_property&, prop_with_value) {}
 };
-static_assert(cuda::mr::resource_with<derived_with_property, prop_with_value>, "");
+static_assert(cuda::mr::synchronous_resource_with<derived_with_property, prop_with_value>, "");
 
 int main(int, char**)
 {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/get_memory_resource/get_memory_resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/get_memory_resource/get_memory_resource.pass.cpp
@@ -15,23 +15,23 @@
 
 struct test_resource
 {
-  __host__ __device__ void* allocate(std::size_t, std::size_t)
+  __host__ __device__ void* allocate_sync(std::size_t, std::size_t)
   {
     return nullptr;
   }
 
-  __host__ __device__ void deallocate(void* ptr, std::size_t, std::size_t) noexcept
+  __host__ __device__ void deallocate_sync(void* ptr, std::size_t, std::size_t) noexcept
   {
     // ensure that we did get the right inputs forwarded
     _val = *static_cast<int*>(ptr);
   }
 
-  __host__ __device__ void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  __host__ __device__ void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return &_val;
   }
 
-  __host__ __device__ void deallocate_async(void* ptr, std::size_t, std::size_t, cuda::stream_ref)
+  __host__ __device__ void deallocate(cuda::stream_ref, void* ptr, std::size_t, std::size_t)
   {
     // ensure that we did get the right inputs forwarded
     _val = *static_cast<int*>(ptr);
@@ -169,12 +169,12 @@ __host__ __device__ void test()
     {
       struct resource
       {
-        __host__ __device__ void* allocate(std::size_t, std::size_t)
+        __host__ __device__ void* allocate_sync(std::size_t, std::size_t)
         {
           return nullptr;
         }
 
-        __host__ __device__ void deallocate(void*, std::size_t, std::size_t) noexcept {}
+        __host__ __device__ void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
 
         __host__ __device__ bool operator==(const resource&) const noexcept
         {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/allocate.pass.cpp
@@ -20,27 +20,27 @@
 
 void test_allocate()
 {
-  { // allocate(size)
+  { // allocate_sync(size)
     resource<cuda::mr::host_accessible> input{42};
     cuda::mr::resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate(0, 0) == ref.allocate(0));
+    assert(input.allocate_sync(0, 0) == ref.allocate_sync(0));
 
     int expected_after_deallocate = 1337;
-    ref.deallocate(static_cast<void*>(&expected_after_deallocate), 0);
+    ref.deallocate_sync(static_cast<void*>(&expected_after_deallocate), 0);
     assert(input._val == expected_after_deallocate);
   }
 
-  { // allocate(size, alignment)
+  { // allocate_sync(size, alignment)
     resource<cuda::mr::host_accessible> input{42};
     cuda::mr::resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate(0, 0) == ref.allocate(0, 0));
+    assert(input.allocate_sync(0, 0) == ref.allocate_sync(0, 0));
 
     int expected_after_deallocate = 1337;
-    ref.deallocate(static_cast<void*>(&expected_after_deallocate), 0, 0);
+    ref.deallocate_sync(static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
   }
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/conversion.pass.cpp
@@ -40,11 +40,11 @@ void test_conversion_from_resource_ref()
     assert(fake_orig.static_vtable == fake_conv.static_vtable);
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate(0, 0) == ref.allocate(0, 0));
+    assert(input.allocate_sync(0, 0) == ref.allocate_sync(0, 0));
 
     // Ensure we are deallocating properly
     int expected_after_deallocate = 1337;
-    ref.deallocate(static_cast<void*>(&expected_after_deallocate), 0, 0);
+    ref.deallocate_sync(static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
   }
 
@@ -59,11 +59,11 @@ void test_conversion_from_resource_ref()
     assert(fake_orig.static_vtable == fake_conv.static_vtable);
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate(0, 0) == ref.allocate(0, 0));
+    assert(input.allocate_sync(0, 0) == ref.allocate_sync(0, 0));
 
     // Ensure we are deallocating properly
     int expected_after_deallocate = 1337;
-    ref.deallocate(static_cast<void*>(&expected_after_deallocate), 0, 0);
+    ref.deallocate_sync(static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
   }
 }
@@ -84,11 +84,11 @@ void test_conversion_from_async_resource_ref()
     assert(fake_orig->static_vtable == fake_conv->static_vtable);
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate(0, 0) == ref.allocate(0, 0));
+    assert(input.allocate_sync(0, 0) == ref.allocate_sync(0, 0));
 
     // Ensure we are deallocating properly
     int expected_after_deallocate = 1337;
-    ref.deallocate(static_cast<void*>(&expected_after_deallocate), 0, 0);
+    ref.deallocate_sync(static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
   }
 
@@ -103,11 +103,11 @@ void test_conversion_from_async_resource_ref()
     assert(fake_orig->static_vtable == fake_conv->static_vtable);
 
     // Ensure that we properly pass on the allocate function
-    assert(input.allocate(0, 0) == ref.allocate(0, 0));
+    assert(input.allocate_sync(0, 0) == ref.allocate_sync(0, 0));
 
     // Ensure we are deallocating properly
     int expected_after_deallocate = 1337;
-    ref.deallocate(static_cast<void*>(&expected_after_deallocate), 0, 0);
+    ref.deallocate_sync(static_cast<void*>(&expected_after_deallocate), 0, 0);
     assert(input._val == expected_after_deallocate);
   }
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/inheritance.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/inheritance.pass.cpp
@@ -23,9 +23,9 @@ struct resource_base
 {
   virtual ~resource_base() = default;
 
-  virtual void* allocate(std::size_t, std::size_t) = 0;
+  virtual void* allocate_sync(std::size_t, std::size_t) = 0;
 
-  virtual void deallocate(void* ptr, std::size_t, std::size_t) noexcept = 0;
+  virtual void deallocate_sync(void* ptr, std::size_t, std::size_t) noexcept = 0;
 
   bool operator==(const resource_base& other) const
   {
@@ -57,12 +57,12 @@ struct resource_derived_first : public resource_base<Properties...>
       : _val(val)
   {}
 
-  void* allocate(std::size_t, std::size_t) override
+  void* allocate_sync(std::size_t, std::size_t) override
   {
     return &_val;
   }
 
-  void deallocate(void* ptr, std::size_t, std::size_t) noexcept override {}
+  void deallocate_sync(void* ptr, std::size_t, std::size_t) noexcept override {}
 
   bool operator==(const resource_derived_first& other) const
   {
@@ -75,7 +75,7 @@ struct resource_derived_first : public resource_base<Properties...>
 
   int _val = 0;
 };
-static_assert(cuda::mr::resource<resource_derived_first<>>, "");
+static_assert(cuda::mr::synchronous_resource<resource_derived_first<>>, "");
 
 struct some_data
 {
@@ -91,12 +91,12 @@ struct resource_derived_second : public resource_base<Properties...>
       : _val(val)
   {}
 
-  void* allocate(std::size_t, std::size_t) override
+  void* allocate_sync(std::size_t, std::size_t) override
   {
     return &_val->_val;
   }
 
-  void deallocate(void* ptr, std::size_t, std::size_t) noexcept override {}
+  void deallocate_sync(void* ptr, std::size_t, std::size_t) noexcept override {}
 
   bool operator==(const resource_derived_second& other) const
   {
@@ -121,12 +121,12 @@ void test_resource_ref()
   cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref_second{second};
 
   // Ensure that we properly pass on the allocate function
-  assert(ref_first.allocate(0, 0) == first.allocate(0, 0));
-  assert(ref_second.allocate(0, 0) == second.allocate(0, 0));
+  assert(ref_first.allocate_sync(0, 0) == first.allocate_sync(0, 0));
+  assert(ref_second.allocate_sync(0, 0) == second.allocate_sync(0, 0));
 
   // Ensure that assignment still works
   ref_second = ref_first;
-  assert(ref_second.allocate(0, 0) == first.allocate(0, 0));
+  assert(ref_second.allocate_sync(0, 0) == first.allocate_sync(0, 0));
 }
 
 template <class... Properties>
@@ -147,12 +147,12 @@ void test_resource_ref_from_pointer()
   cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref_second = indirection(&second);
 
   // Ensure that we properly pass on the allocate function
-  assert(ref_first.allocate(0, 0) == first.allocate(0, 0));
-  assert(ref_second.allocate(0, 0) == second.allocate(0, 0));
+  assert(ref_first.allocate_sync(0, 0) == first.allocate_sync(0, 0));
+  assert(ref_second.allocate_sync(0, 0) == second.allocate_sync(0, 0));
 
   // Ensure that assignment still works
   ref_second = ref_first;
-  assert(ref_second.allocate(0, 0) == first.allocate(0, 0));
+  assert(ref_second.allocate_sync(0, 0) == first.allocate_sync(0, 0));
 }
 
 // clang complains about pure virtual functions being called, so ensure that we properly crash if so

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/properties.pass.cpp
@@ -121,11 +121,15 @@ void test_property_forwarding()
   using ref = cuda::mr::resource_ref<cuda::mr::host_accessible, property_with_value<short>>;
 
   static_assert(
-    cuda::mr::resource_with<res, cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>, "");
+    cuda::mr::
+      synchronous_resource_with<res, cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>,
+    "");
   static_assert(
-    !cuda::mr::resource_with<ref, cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>, "");
+    !cuda::mr::
+      synchronous_resource_with<ref, cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>,
+    "");
 
-  static_assert(cuda::mr::resource_with<res, cuda::mr::host_accessible, property_with_value<short>>, "");
+  static_assert(cuda::mr::synchronous_resource_with<res, cuda::mr::host_accessible, property_with_value<short>>, "");
 }
 
 void test_resource_ref()

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/types.h
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/types.h
@@ -25,23 +25,23 @@ struct property_without_value
 template <class... Properties>
 struct resource
 {
-  void* allocate(std::size_t, std::size_t)
+  void* allocate_sync(std::size_t, std::size_t)
   {
     return &_val;
   }
 
-  void deallocate(void* ptr, std::size_t, std::size_t) noexcept
+  void deallocate_sync(void* ptr, std::size_t, std::size_t) noexcept
   {
     // ensure that we did get the right inputs forwarded
     _val = *static_cast<int*>(ptr);
   }
 
-  void* allocate_async(std::size_t, std::size_t, cuda::stream_ref)
+  void* allocate(cuda::stream_ref, std::size_t, std::size_t)
   {
     return &_val;
   }
 
-  void deallocate_async(void* ptr, std::size_t, std::size_t, cuda::stream_ref)
+  void deallocate(cuda::stream_ref, void* ptr, std::size_t, std::size_t)
   {
     // ensure that we did get the right inputs forwarded
     _val = *static_cast<int*>(ptr);

--- a/libcudacxx/test/support/test_memory_resource.h
+++ b/libcudacxx/test/support/test_memory_resource.h
@@ -111,7 +111,7 @@ protected:
   virtual void do_deallocate(void* p, std::size_t s, std::size_t a)
   {
     C.countDealloc(p, s, a);
-    P.deallocate(p, s, a);
+    P.deallocate_sync(p, s, a);
   }
 
   virtual bool do_is_equal(memory_resource const& other) const noexcept
@@ -143,7 +143,7 @@ struct NullProvider
   {
     return nullptr;
   }
-  void deallocate(void*, size_t, size_t) noexcept {}
+  void deallocate_sync(void*, size_t, size_t) noexcept {}
   void reset() {}
 
 private:
@@ -157,7 +157,7 @@ struct NewDeleteProvider
   {
     return ::operator new(s);
   }
-  void deallocate(void* p, size_t, size_t) noexcept
+  void deallocate_sync(void* p, size_t, size_t) noexcept
   {
     ::operator delete(p);
   }
@@ -191,7 +191,7 @@ struct BufferProvider
     return ret;
   }
 
-  void deallocate(void*, size_t, size_t) noexcept {}
+  void deallocate_sync(void*, size_t, size_t) noexcept {}
 
   void reset()
   {


### PR DESCRIPTION
This is a back port of [https://github.com/NVIDIA/cccl/pull/5313](url) to 3.1 branch

Original change description:
We want to position stream ordered allocations as the default ones. This means that resource concept names and member functions should not have async in the name, instead we will add sync or synchronous to things that are not async capable. We considered requiring stream ordered operation, but ultimately it seemed too limiting for potential future resources.

This PR makes the following renames:
mr::resource -> mr::synchronous_resource
mr::resource_with -> mr::synchronous_resource_with
mr::async_resource -> mr::resource
mr::async_resource_with -> mr::resource_with
.allocate() -> .allocate_sync()
.deallocate() -> .deallocate_sync()
.allocate_async() -> .allocate()
.deallocate_async() -> .deallocate()

Most CCCL Runtime APIs that take a stream as an argument do so in the first position. This way it's easier to tell something is asynchronous without the async in the name. This change aligns memory resources with this rule, now allocate and deallocate takes stream_ref as first argument instead of the last one.