### PR TITLE
Safe `cuda::std::memset/memcpy` API

### DIFF
--- a/docs/libcudacxx/standard_api/c_library.rst
+++ b/docs/libcudacxx/standard_api/c_library.rst
@@ -3,6 +3,13 @@
 C Library
 =========
 
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   c_library/cstring
+
+
 Any Standard C++ header not listed below is omitted.
 
 .. list-table::
@@ -75,7 +82,7 @@ Any Standard C++ header not listed below is omitted.
      - CUDA 12.3
      - `\<cstdlib\> <https://en.cppreference.com/w/cpp/header/cstdlib>`_
 
-   * - ``<cuda/std/cstring>``
+   * - :ref:`\<cuda/std/cstring\> <libcudacxx-standard-api-cstring>`
      - Provides array manipulation functions such as ``memcpy``, ``memset`` and ``memcmp``
      - CCCL 3.0.0
      - CUDA 13.0

--- a/docs/libcudacxx/standard_api/c_library/cstring.rst
+++ b/docs/libcudacxx/standard_api/c_library/cstring.rst
@@ -1,0 +1,43 @@
+.. _libcudacxx-standard-api-cstring:
+
+``<cuda/std/cstring>``
+======================
+
+``cuda::std::memset``
+---------------------
+
+.. code:: cpp
+
+   __host__ __device__
+   inline void* memset(void* dest, int ch, size_t count) noexcept;
+
+See `std::memset <https://en.cppreference.com/w/cpp/string/byte/memset.html>`_ for the full documentation.
+
+**Preconditions**
+
+Since CCCL 3.2.x / CUDA Toolkit 13.2:
+
+    - ``dest`` is a valid pointer
+    - ``dest + count`` is a valid pointer
+
+----
+
+``cuda::std::memcpy``
+---------------------
+
+.. code:: cpp
+
+   __host__ __device__
+   inline void* memcpy(void* dest, const void* src, size_t count) noexcept;
+
+See `std::memcpy <https://en.cppreference.com/w/cpp/string/byte/memcpy.html>`_  for the full documentation.
+
+**Preconditions**
+
+Since CCCL 3.2.x / CUDA Toolkit 13.2:
+
+    - ``src`` is a valid pointer
+    - ``src + count`` is a valid pointer
+    - ``dest`` is a valid pointer
+    - ``dest + count`` is a valid pointer
+    - ``src`` and ``dest`` don't overlap

--- a/libcudacxx/include/cuda/__memory/check_address.h
+++ b/libcudacxx/include/cuda/__memory/check_address.h
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___MEMORY_IS_VALID_ADDRESS
+#define _CUDA___MEMORY_IS_VALID_ADDRESS
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__memory/address_space.h>
+#include <cuda/std/__utility/cmp.h>
+#include <cuda/std/cstddef>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+[[nodiscard]] _CCCL_API inline bool __is_valid_address_range(const void* __ptr, _CUDA_VSTD::size_t __n) noexcept
+{
+  if (__ptr == nullptr)
+  {
+    return false;
+  }
+  if (::cuda::device::is_address_from(__ptr, ::cuda::device::address_space::shared))
+  {
+    if (_CUDA_VSTD::cmp_greater(__n, _CUDA_VSTD::numeric_limits<uint32_t>::max()))
+    {
+      return false;
+    }
+    auto __limit = size_t{_CUDA_VSTD::numeric_limits<_CUDA_VSTD::uint32_t>::max()} - __n;
+    return reinterpret_cast<_CUDA_VSTD::uintptr_t>(__ptr) <= __limit;
+  }
+  auto __limit = size_t{_CUDA_VSTD::numeric_limits<_CUDA_VSTD::uintptr_t>::max()} - __n;
+  return reinterpret_cast<_CUDA_VSTD::uintptr_t>(__ptr) <= __limit;
+}
+
+[[nodiscard]] _CCCL_API inline bool __is_valid_address(const void* __ptr) noexcept
+{
+  return __is_valid_address_range(__ptr, 0);
+}
+
+[[nodiscard]] _CCCL_API inline bool
+__are_ptrs_overlapping(const void* __ptr_lhs, const void* __ptr_rhs, _CUDA_VSTD::size_t __n) noexcept
+{
+  auto __ptr1 = static_cast<const char*>(__ptr_lhs);
+  auto __ptr2 = static_cast<const char*>(__ptr_rhs);
+  return ((__ptr1 + __n) < __ptr2) || ((__ptr2 + __n) < __ptr1);
+}
+
+_LIBCUDACXX_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___MEMORY_IS_VALID_ADDRESS

--- a/libcudacxx/include/cuda/std/cstring
+++ b/libcudacxx/include/cuda/std/cstring
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__memory/check_address.h>
 #include <cuda/std/__string/constexpr_c_functions.h>
 
 #if !_CCCL_COMPILER(NVRTC)
@@ -31,9 +32,21 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
-using ::memcpy;
-using ::memset;
 using ::size_t;
+
+_CCCL_API inline void* memcpy(void* _CCCL_RESTRICT __dest, const void* _CCCL_RESTRICT __src, size_t __count) noexcept
+{
+  _CCCL_ASSERT(::cuda::__is_valid_address_range(__src, __count), "memcpy: source range is invalid");
+  _CCCL_ASSERT(::cuda::__is_valid_address_range(__dest, __count), "memcpy: destination range is invalid");
+  _CCCL_ASSERT(::cuda::__are_ptrs_overlapping(__src, __dest, __count), "memcpy: source and destination overlap");
+  return ::memcpy(__dest, __src, __count);
+}
+
+_CCCL_API inline void* memset(void* __dest, int __ch, size_t __count) noexcept
+{
+  _CCCL_ASSERT(::cuda::__is_valid_address_range(__dest, __count), "memcpy: source range is invalid");
+  return ::memset(__dest, __ch, __count);
+}
 
 _CCCL_API constexpr char* strcpy(char* _CCCL_RESTRICT __dst, const char* _CCCL_RESTRICT __src)
 {


### PR DESCRIPTION
## Description

The PR implements `cuda::std::memset` and ``cuda::std::memcpy``  instead of forwarding to `::memset/::memcpy`.
The main enhancement is from a safety standpoint, providing the following checks:

- pointers are not `NULL`.
- pointers are valid for a given memory space, e.g. shared mem is 32-bit.
- pointers + count is valid, i.e. no overflow.
- pointers are not overlapping.