### PR TITLE
Fixes out-of-bounds reads for custom equality operator

### DIFF
--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -817,20 +817,12 @@ struct AgentSelectIf
     {
       const auto src = (d_in + streaming_context.input_offset()) + tile_offset;
 
-      // Pre-initialize such that invalid items for out-of-bounds indexes won't be passed to the equality operator
-      InputT oob_value = *src;
-      // For performance reasons, we only attempt vectorization for DeviceSelect::Unique
+      // For unique, we need to pre-initialize such that invalid items for out-of-bounds indexes won't be passed to the
+      // equality operator
       if constexpr (SELECT_METHOD == USE_DISCONTINUITY)
       {
+        InputT oob_value = *src;
         vectorized_fill(items, oob_value);
-      }
-      else
-      {
-        _CCCL_PRAGMA_UNROLL_FULL()
-        for (int i = 0; i < ITEMS_PER_THREAD; ++i)
-        {
-          items[i] = oob_value;
-        }
       }
       BlockLoadT(temp_storage.load_items).Load(src, items, num_tile_items);
     }
@@ -915,20 +907,12 @@ struct AgentSelectIf
     {
       const auto src = (d_in + streaming_context.input_offset()) + tile_offset;
 
-      // Pre-initialize such that invalid items for out-of-bounds indexes won't be passed to the equality operator
-      InputT oob_value = *src;
-      // For performance reasons, we only attempt vectorization for DeviceSelect::Unique
+      // For unique, we need to pre-initialize such that invalid items for out-of-bounds indexes won't be passed to the
+      // equality operator
       if constexpr (SELECT_METHOD == USE_DISCONTINUITY)
       {
+        InputT oob_value = *src;
         vectorized_fill(items, oob_value);
-      }
-      else
-      {
-        _CCCL_PRAGMA_UNROLL_FULL()
-        for (int i = 0; i < ITEMS_PER_THREAD; ++i)
-        {
-          items[i] = oob_value;
-        }
       }
       BlockLoadT(temp_storage.load_items).Load(src, items, num_tile_items);
     }

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -812,7 +812,10 @@ struct AgentSelectIf
     if (IS_LAST_TILE)
     {
       BlockLoadT(temp_storage.load_items)
-        .Load((d_in + streaming_context.input_offset()) + tile_offset, items, num_tile_items);
+        .Load((d_in + streaming_context.input_offset()) + tile_offset,
+              items,
+              num_tile_items,
+              *(d_in + streaming_context.input_offset() + tile_offset));
     }
     else
     {
@@ -892,7 +895,10 @@ struct AgentSelectIf
     if (IS_LAST_TILE)
     {
       BlockLoadT(temp_storage.load_items)
-        .Load((d_in + streaming_context.input_offset()) + tile_offset, items, num_tile_items);
+        .Load((d_in + streaming_context.input_offset()) + tile_offset,
+              items,
+              num_tile_items,
+              *(d_in + streaming_context.input_offset() + tile_offset));
     }
     else
     {

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -811,11 +811,9 @@ struct AgentSelectIf
     // Load items
     if (IS_LAST_TILE)
     {
+      const auto src = (d_in + streaming_context.input_offset()) + tile_offset;
       BlockLoadT(temp_storage.load_items)
-        .Load((d_in + streaming_context.input_offset()) + tile_offset,
-              items,
-              num_tile_items,
-              *(d_in + streaming_context.input_offset() + tile_offset));
+        .Load(src, items, num_tile_items, *src);
     }
     else
     {
@@ -894,11 +892,9 @@ struct AgentSelectIf
     // Load items
     if (IS_LAST_TILE)
     {
+      const auto src = (d_in + streaming_context.input_offset()) + tile_offset;
       BlockLoadT(temp_storage.load_items)
-        .Load((d_in + streaming_context.input_offset()) + tile_offset,
-              items,
-              num_tile_items,
-              *(d_in + streaming_context.input_offset() + tile_offset));
+        .Load(src, items, num_tile_items, *src);
     }
     else
     {

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -805,7 +805,9 @@ struct AgentSelectIf
   _CCCL_DEVICE _CCCL_FORCEINLINE OffsetT
   ConsumeFirstTile(int num_tile_items, OffsetT tile_offset, MemoryOrderedTileStateT& tile_state_wrapper)
   {
-    InputT items[ITEMS_PER_THREAD];
+    // To avoid misaligned writes in vectorized_fill, we need to ensure that the items are aligned to at least four
+    // bytes
+    alignas(::cuda::std::max(4, static_cast<int>(alignof(T)))) InputT items[ITEMS_PER_THREAD];
     OffsetT selection_flags[ITEMS_PER_THREAD];
     OffsetT selection_indices[ITEMS_PER_THREAD];
 
@@ -889,7 +891,9 @@ struct AgentSelectIf
   _CCCL_DEVICE _CCCL_FORCEINLINE OffsetT ConsumeSubsequentTile(
     int num_tile_items, int tile_idx, OffsetT tile_offset, MemoryOrderedTileStateT& tile_state_wrapper)
   {
-    InputT items[ITEMS_PER_THREAD];
+    // To avoid misaligned writes in vectorized_fill, we need to ensure that the items are aligned to at least four
+    // bytes
+    alignas(::cuda::std::max(4, static_cast<int>(alignof(T)))) InputT items[ITEMS_PER_THREAD];
     OffsetT selection_flags[ITEMS_PER_THREAD];
     OffsetT selection_indices[ITEMS_PER_THREAD];
 

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -49,6 +49,7 @@
 #include <cub/block/block_load.cuh>
 #include <cub/block/block_scan.cuh>
 #include <cub/block/block_store.cuh>
+#include <cub/detail/vectorized_fill.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/grid/grid_queue.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
@@ -812,8 +813,11 @@ struct AgentSelectIf
     if (IS_LAST_TILE)
     {
       const auto src = (d_in + streaming_context.input_offset()) + tile_offset;
-      BlockLoadT(temp_storage.load_items)
-        .Load(src, items, num_tile_items, *src);
+
+      // Pre-initialize such that invalid items for out-of-bounds indexes won't be passed to the equality operator
+      InputT oob_value = *src;
+      vectorized_fill(items, oob_value);
+      BlockLoadT(temp_storage.load_items).Load(src, items, num_tile_items);
     }
     else
     {
@@ -893,8 +897,10 @@ struct AgentSelectIf
     if (IS_LAST_TILE)
     {
       const auto src = (d_in + streaming_context.input_offset()) + tile_offset;
-      BlockLoadT(temp_storage.load_items)
-        .Load(src, items, num_tile_items, *src);
+      // Pre-initialize such that invalid items for out-of-bounds indexes won't be passed to the equality operator
+      InputT oob_value = *src;
+      vectorized_fill(items, oob_value);
+      BlockLoadT(temp_storage.load_items).Load(src, items, num_tile_items);
     }
     else
     {

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -55,6 +55,7 @@
 #include <cub/iterator/cache_modified_input_iterator.cuh>
 #include <cub/util_type.cuh>
 
+#include <cuda/std/functional>
 #include <cuda/std/type_traits>
 
 CUB_NAMESPACE_BEGIN
@@ -805,9 +806,9 @@ struct AgentSelectIf
   _CCCL_DEVICE _CCCL_FORCEINLINE OffsetT
   ConsumeFirstTile(int num_tile_items, OffsetT tile_offset, MemoryOrderedTileStateT& tile_state_wrapper)
   {
-    // To avoid misaligned writes in vectorized_fill, we need to ensure that the items are aligned to at least four
+    // To avoid misaligned writes in vectorized_fill, we need to ensure that the array is aligned to at least four
     // bytes
-    alignas(::cuda::std::max(4, static_cast<int>(alignof(T)))) InputT items[ITEMS_PER_THREAD];
+    alignas(::cuda::std::max(4, static_cast<int>(alignof(InputT)))) InputT items[ITEMS_PER_THREAD];
     OffsetT selection_flags[ITEMS_PER_THREAD];
     OffsetT selection_indices[ITEMS_PER_THREAD];
 
@@ -893,7 +894,7 @@ struct AgentSelectIf
   {
     // To avoid misaligned writes in vectorized_fill, we need to ensure that the items are aligned to at least four
     // bytes
-    alignas(::cuda::std::max(4, static_cast<int>(alignof(T)))) InputT items[ITEMS_PER_THREAD];
+    alignas(::cuda::std::max(4, static_cast<int>(alignof(InputT)))) InputT items[ITEMS_PER_THREAD];
     OffsetT selection_flags[ITEMS_PER_THREAD];
     OffsetT selection_indices[ITEMS_PER_THREAD];
 

--- a/cub/cub/detail/vectorized_fill.cuh
+++ b/cub/cub/detail/vectorized_fill.cuh
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/config.cuh>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+CUB_NAMESPACE_BEGIN
+
+namespace detail
+{
+
+template <typename T, int ItemsPerThread, typename ValueT>
+_CCCL_HOST_DEVICE _CCCL_FORCEINLINE void vectorized_fill(T (&data)[ItemsPerThread], ValueT value)
+{
+  if constexpr (sizeof(T) < sizeof(::cuda::std::uint32_t) && std::is_trivially_copyable_v<T>)
+  {
+    constexpr int items_per_dword = sizeof(::cuda::std::uint32_t) / sizeof(T);
+    constexpr int dword_count     = ItemsPerThread / items_per_dword;
+
+    ::cuda::std::uint32_t vectorized_default = 0;
+    for (int i = 0; i < items_per_dword; ++i)
+    {
+      ::cuda::std::memcpy(reinterpret_cast<T*>(&vectorized_default) + i, &value, sizeof(T));
+    }
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < dword_count; ++i)
+    {
+      reinterpret_cast<::cuda::std::uint32_t*>(data)[i] = vectorized_default;
+    }
+
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = dword_count * items_per_dword; i < ItemsPerThread; ++i)
+    {
+      data[i] = value;
+    }
+  }
+  else
+  {
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (int i = 0; i < ItemsPerThread; ++i)
+    {
+      data[i] = value;
+    }
+  }
+}
+
+} // namespace detail
+
+CUB_NAMESPACE_END

--- a/cub/test/catch2_test_util_vectorized_fill.cu
+++ b/cub/test/catch2_test_util_vectorized_fill.cu
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/detail/vectorized_fill.cuh>
+
+#include <thrust/detail/raw_pointer_cast.h>
+#include <thrust/device_vector.h>
+
+#include <cuda/std/functional>
+
+#include "catch2_test_launch_helper.h"
+#include <c2h/catch2_test_helper.h>
+
+template <typename T, int NumItems>
+__global__ void vectorized_fill_kernel(T* in, T val, T* out, ::cuda::std::integral_constant<int, NumItems>)
+{
+  // Dummy data to test proper alignment of data array
+  [[maybe_unused]] char x{42};
+
+  // To avoid misaligned writes in vectorized_fill, we need to ensure that the array is aligned to at least four
+  // bytes (e.g., see AgentSelectIf)
+  alignas(::cuda::std::max(4, static_cast<int>(alignof(T)))) T data[NumItems];
+  for (int i = 0; i < NumItems; ++i)
+  {
+    data[i] = in[i];
+  }
+
+  cub::detail::vectorized_fill(data, val);
+
+  for (int i = 0; i < NumItems; ++i)
+  {
+    out[i] = data[i];
+  }
+}
+
+template <typename T, int NumItems>
+CUB_RUNTIME_FUNCTION static cudaError_t test_vectorized_fill_wrapper(
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  T* in,
+  T val,
+  T* out,
+  ::cuda::std::integral_constant<int, NumItems> num_items_val,
+  cudaStream_t stream = 0)
+{
+  if (d_temp_storage == nullptr)
+  {
+    temp_storage_bytes = 1;
+    return cudaSuccess;
+  }
+  vectorized_fill_kernel<<<1, 1, 0, stream>>>(in, val, out, num_items_val);
+  return cudaSuccess;
+}
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+DECLARE_LAUNCH_WRAPPER(test_vectorized_fill_wrapper, test_vectorized_fill_from_device);
+
+using types = c2h::type_list<char, std::int16_t, float, uchar3, double2, c2h::custom_type_t<c2h::equal_comparable_t>>;
+
+using num_items_list = c2h::enum_type_list<int, 1, 2, 3, 4, 5, 7, 8, 11, 16, 17>;
+
+C2H_TEST("CUB's vectorized_fill", "[util][vectorized_fill]", types, num_items_list)
+{
+  using type              = typename c2h::get<0, TestType>;
+  constexpr int num_items = c2h::get<1, TestType>::value;
+
+  c2h::device_vector<type> in(num_items);
+  c2h::device_vector<type> out(num_items);
+  c2h::gen(C2H_SEED(1), in);
+  c2h::gen(C2H_SEED(1), out);
+
+  // Pick a random value to fill the array with
+  c2h::device_vector<type> val(1);
+  c2h::gen(C2H_SEED(2), val);
+  type value = val[0];
+
+  c2h::device_vector<type> original_in(in);
+  c2h::device_vector<type> expected_vals(num_items, value);
+
+  test_vectorized_fill_from_device(
+    thrust::raw_pointer_cast(in.data()),
+    value,
+    thrust::raw_pointer_cast(out.data()),
+    ::cuda::std::integral_constant<int, num_items>{});
+
+  REQUIRE(in == original_in);
+  REQUIRE(out == expected_vals);
+}

--- a/thrust/testing/cuda/unique.cu
+++ b/thrust/testing/cuda/unique.cu
@@ -1,4 +1,6 @@
+#include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/execution_policy.h>
+#include <thrust/iterator/counting_iterator.h>
 #include <thrust/unique.h>
 
 #include <unittest/unittest.h>
@@ -20,6 +22,25 @@ struct multiply_n
   __host__ __device__ T operator()(T x)
   {
     return x * multiplier;
+  }
+};
+
+struct check_valid_item_op
+{
+  ::cuda::std::uint32_t* error_counter{};
+  int expected_upper_bound{};
+
+  __device__ bool operator()(const int lhs, const int rhs) const
+  {
+    if (lhs > expected_upper_bound || rhs > expected_upper_bound)
+    {
+      if (error_counter)
+      {
+        atomicAdd(error_counter, 1);
+      }
+      return false;
+    }
+    return lhs == rhs;
   }
 };
 
@@ -400,3 +421,27 @@ void TestUniqueWithLargeNumberOfItems()
   }
 }
 DECLARE_UNITTEST(TestUniqueWithLargeNumberOfItems);
+
+void TestUniqueWithCustomEqualityOp()
+{
+  using Vector = thrust::device_vector<int>;
+  using T      = Vector::value_type;
+
+  auto constexpr num_items = 1000;
+  auto data                = thrust::make_counting_iterator(T{0});
+
+  thrust::device_vector<::cuda::std::uint32_t> error_counter(1, 0);
+  auto const error_counter_ptr = thrust::raw_pointer_cast(error_counter.data());
+
+  Vector unique_out(num_items);
+  auto unique_out_end = thrust::unique_copy(
+    data, data + num_items, unique_out.begin(), check_valid_item_op{error_counter_ptr, num_items - 1});
+
+  auto num_selected_out = cuda::std::distance(unique_out.begin(), unique_out_end);
+  ASSERT_EQUAL(num_selected_out, num_items);
+  ASSERT_EQUAL(error_counter[0], ::cuda::std::uint32_t{0});
+  bool all_results_correct = thrust::equal(unique_out.cbegin(), unique_out.cend(), data);
+  ASSERT_EQUAL(all_results_correct, true);
+}
+
+DECLARE_UNITTEST(TestUniqueWithCustomEqualityOp);


### PR DESCRIPTION
This is an alternative solution to https://github.com/NVIDIA/cccl/pull/5566.

## Description

The PR establishes the same behaviour for out-of-bounds items as present in thrust before the migration in https://github.com/NVIDIA/cccl/pull/5396.

It's worth noting, that before this PR, CUB invocations where the item type would be not a scalar/builtin type, out-of-bounds items would be default initialized and, hence, for oob items, those would be passed to a custom `operator==` of that item type. However, scalar/builtin types would remain uninitialized. The behavior for out-of-bounds items _after this_ PR will be the same as it used to be for `thrust.unique` before https://github.com/NVIDIA/cccl/pull/5396, i.e., to copy the first item of the last tile to the out-of-bounds items (independent of the item type).

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Closes https://github.com/NVIDIA/cccl/issues/5504 <!-- Link issue here -->

- [x] Benchmark changes
- [x] Investigate previous behavior for non-scalar/non-builtin types for out-of-bounds padding
- [x] [in case we pursue vectorized initialization of oob items]: Add tests for vectorized initialization
- [x] [in case we pursue vectorized initialization of oob items]: Re-benchmark all other select-based algorithms
- [x] Add test for custom equality operator