### PR TITLE
implement a variant of P3206 for getting a sender's completion behavior

### DIFF
--- a/cudax/include/cuda/experimental/__execution/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/bulk.cuh
@@ -73,12 +73,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
     return experimental::make_config(block_dims<__block_threads>(), grid_dims(__grid_blocks));
   }
 
-  _CCCL_TEMPLATE(class _Query)
-  _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query>)
-  [[nodiscard]] _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>)
-    -> decltype(auto)
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Query, class... _Args)
+  _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query, _Args...>)
+  [[nodiscard]] _CCCL_API constexpr auto query(_Query, _Args&&... __args) const
+    noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query, _Args...>)
+      -> __query_result_t<env_of_t<_Sndr>, _Query, _Args...>
   {
-    return execution::get_env(__sndr_).query(_Query{});
+    return execution::get_env(__sndr_).query(_Query{}, static_cast<_Args&&>(__args)...);
   }
 
   _Shape __shape_;

--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -588,9 +588,9 @@ struct __gather_sigs_fn<set_stopped_t>
   using __call _CCCL_NODEBUG_ALIAS = __stopped_types<_Sigs, _Variant, _Tuple<>>;
 };
 
-template <class _Sigs, class _WantedTag, template <class...> class _TaggedTuple, template <class...> class _Variant>
+template <class _Sigs, class _WantedTag, template <class...> class _Tuple, template <class...> class _Variant>
 using __gather_completion_signatures _CCCL_NODEBUG_ALIAS =
-  typename __gather_sigs_fn<_WantedTag>::template __call<_Sigs, _TaggedTuple, _Variant>;
+  typename __gather_sigs_fn<_WantedTag>::template __call<_Sigs, _Tuple, _Variant>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // __eptr_completion and __eptr_completion_if

--- a/cudax/include/cuda/experimental/__execution/concepts.cuh
+++ b/cudax/include/cuda/experimental/__execution/concepts.cuh
@@ -106,7 +106,7 @@ inline constexpr bool enable_sender = __enable_sender<_Sndr>();
 template <class... _Env>
 struct __completions_tester
 {
-  template <class _Sndr, bool EnableIfConstexpr = ((void) get_completion_signatures<_Sndr, _Env...>(), true)>
+  template <class _Sndr, bool _EnableIfConstexpr = ((void) execution::get_completion_signatures<_Sndr, _Env...>(), true)>
   _CCCL_API static constexpr auto __is_valid(int) -> bool
   {
     return __valid_completion_signatures<completion_signatures_of_t<_Sndr, _Env...>>;

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -112,8 +112,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional_t
 
     template <class... _As>
     using __opstate_list_t = _CUDA_VSTD::__type_list<
-      connect_result_t<_CUDA_VSTD::__call_result_t<_Then, __just_from_t<_As...>>, __rcvr_ref_t<_Rcvr>>,
-      connect_result_t<_CUDA_VSTD::__call_result_t<_Else, __just_from_t<_As...>>, __rcvr_ref_t<_Rcvr>>>;
+      connect_result_t<_CUDA_VSTD::__call_result_t<_Then, __just_from_t<_As...>>, __rcvr_ref<_Rcvr>>,
+      connect_result_t<_CUDA_VSTD::__call_result_t<_Else, __just_from_t<_As...>>, __rcvr_ref<_Rcvr>>>;
 
     using __next_ops_variant_t _CCCL_NODEBUG_ALIAS =
       __value_types<_Completions, __opstate_list_t, __type_concat_into_quote<__variant>::__call>;
@@ -138,13 +138,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional_t
         if (static_cast<_Pred&&>(__state_->__params_.pred)(__as...))
         {
           auto& __op = __state_->__ops_.__emplace_from(
-            connect, static_cast<_Then&&>(__state_->__params_.on_true)(__just), __ref_rcvr(__state_->__rcvr_));
+            connect, static_cast<_Then&&>(__state_->__params_.on_true)(__just), __rcvr_ref(__state_->__rcvr_));
           execution::start(__op);
         }
         else
         {
           auto& __op = __state_->__ops_.__emplace_from(
-            connect, static_cast<_Else&&>(__state_->__params_.on_false)(__just), __ref_rcvr(__state_->__rcvr_));
+            connect, static_cast<_Else&&>(__state_->__params_.on_false)(__just), __rcvr_ref(__state_->__rcvr_));
           execution::start(__op);
         }
       }

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -112,8 +112,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional_t
 
     template <class... _As>
     using __opstate_list_t = _CUDA_VSTD::__type_list<
-      connect_result_t<_CUDA_VSTD::__call_result_t<_Then, __just_from_t<_As...>>, __rcvr_ref<_Rcvr>>,
-      connect_result_t<_CUDA_VSTD::__call_result_t<_Else, __just_from_t<_As...>>, __rcvr_ref<_Rcvr>>>;
+      connect_result_t<_CUDA_VSTD::__call_result_t<_Then, __just_from_t<_As...>>, __rcvr_ref_t<_Rcvr>>,
+      connect_result_t<_CUDA_VSTD::__call_result_t<_Else, __just_from_t<_As...>>, __rcvr_ref_t<_Rcvr>>>;
 
     using __next_ops_variant_t _CCCL_NODEBUG_ALIAS =
       __value_types<_Completions, __opstate_list_t, __type_concat_into_quote<__variant>::__call>;
@@ -138,13 +138,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional_t
         if (static_cast<_Pred&&>(__state_->__params_.pred)(__as...))
         {
           auto& __op = __state_->__ops_.__emplace_from(
-            connect, static_cast<_Then&&>(__state_->__params_.on_true)(__just), __rcvr_ref(__state_->__rcvr_));
+            connect, static_cast<_Then&&>(__state_->__params_.on_true)(__just), __ref_rcvr(__state_->__rcvr_));
           execution::start(__op);
         }
         else
         {
           auto& __op = __state_->__ops_.__emplace_from(
-            connect, static_cast<_Else&&>(__state_->__params_.on_false)(__just), __rcvr_ref(__state_->__rcvr_));
+            connect, static_cast<_Else&&>(__state_->__params_.on_false)(__just), __ref_rcvr(__state_->__rcvr_));
           execution::start(__op);
         }
       }

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -120,12 +120,13 @@ _CCCL_GLOBAL_CONSTANT __detail::__env_ref_fn __env_ref{};
 template <class _Env>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __fwd_env_
 {
-  _CCCL_TEMPLATE(class _Query)
-  _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND __queryable_with<_Env, _Query>)
-  [[nodiscard]] _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<_Env, _Query>)
-    -> __query_result_t<_Env, _Query>
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Query, class... _Args)
+  _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND __queryable_with<_Env, _Query, _Args...>)
+  [[nodiscard]] _CCCL_API constexpr auto query(_Query, _Args&&... __args) const
+    noexcept(__nothrow_queryable_with<_Env, _Query, _Args...>) -> __query_result_t<_Env, _Query, _Args...>
   {
-    return __env_.query(_Query{});
+    return __env_.query(_Query{}, static_cast<_Args&&>(__args)...);
   }
 
   _Env __env_;

--- a/cudax/include/cuda/experimental/__execution/just.cuh
+++ b/cudax/include/cuda/experimental/__execution/just.cuh
@@ -75,6 +75,14 @@ private:
     __tuple_t __values_;
   };
 
+  struct __attrs_t
+  {
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_completion_behavior_t) noexcept
+    {
+      return completion_behavior::inline_completion;
+    }
+  };
+
   template <class... _Ts>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_base_t;
 
@@ -126,6 +134,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_t<_JustTag, _SetTag>::__sndr_base_t
   connect(_Rcvr __rcvr) const& noexcept(__nothrow_decay_copyable<_Rcvr, _Ts const&...>) -> __opstate_t<_Rcvr, _Ts...>
   {
     return __opstate_t<_Rcvr, _Ts...>{static_cast<_Rcvr&&>(__rcvr), __values_};
+  }
+
+  [[nodiscard]] _CCCL_API static constexpr auto get_env() noexcept
+  {
+    return __attrs_t{};
   }
 
   _CCCL_NO_UNIQUE_ADDRESS __just_tag_t __tag_;

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -35,6 +35,7 @@
 #include <cuda/experimental/__execution/env.cuh>
 #include <cuda/experimental/__execution/exception.cuh>
 #include <cuda/experimental/__execution/rcvr_ref.cuh>
+#include <cuda/experimental/__execution/rcvr_with_env.cuh>
 #include <cuda/experimental/__execution/transform_completion_signatures.cuh>
 #include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
@@ -46,166 +47,183 @@
 
 namespace cuda::experimental::execution
 {
-// Declare types to use for diagnostics:
-struct _FUNCTION_MUST_RETURN_A_SENDER;
-
-namespace __let
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_base_t
 {
-template <class _Sndr, class _Domain>
-struct __attrs_t : __attrs_t<_Sndr, __nil>
-{
-  using __attrs_t<_Sndr, __nil>::query;
-
-  [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> _Domain
+  template <class _Fn>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr2_fn
   {
-    return {};
-  }
-};
+    template <class... _As>
+    using __call _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_As>&...>;
+  };
 
-template <class _Sndr>
-struct __attrs_t<_Sndr, __nil>
-{
-  template <class _Tag>
-  _CCCL_API constexpr auto query(get_completion_scheduler_t<_Tag>) const = delete;
-
-  _CCCL_TEMPLATE(class _Query)
-  _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND(!_CUDA_VSTD::same_as<_Query, get_domain_t>)
-                   _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query>)
-  [[nodiscard]] _CCCL_API constexpr auto query(_Query) const noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query>)
-    -> __query_result_t<env_of_t<_Sndr>, _Query>
+  template <class _Fn, class... _Env>
+  struct __completion_behavior_transform_fn
   {
-    return execution::get_env(__sndr_).query(_Query{});
-  }
+    template <class _Tag, class... _Ts>
+    [[nodiscard]] _CCCL_API constexpr auto operator()(_Tag (*)(_Ts...)) const noexcept
+    {
+      if constexpr (_CUDA_VSTD::__type_callable<__sndr2_fn<_Fn>, _Ts...>::value)
+      {
+        using __sndr2_t = _CUDA_VSTD::__type_call<__sndr2_fn<_Fn>, _Ts...>;
+        return execution::get_completion_behavior<__sndr2_t, _Env...>();
+      }
+      else
+      {
+        return completion_behavior::unknown;
+      }
+    }
+  };
 
-  const _Sndr& __sndr_;
+  template <class _Rcvr, class _Env2>
+  struct __sndr2_rcvr_t : __rcvr_ref<__rcvr_with_env_t<_Rcvr, _Env2>>
+  {
+    _CCCL_TRIVIAL_API explicit constexpr __sndr2_rcvr_t(__rcvr_with_env_t<_Rcvr, _Env2>& __rcvr) noexcept
+        : __rcvr_ref<__rcvr_with_env_t<_Rcvr, _Env2>>{__rcvr}
+    {}
+  };
 };
-} // namespace __let
 
 template <class _LetTag, class _SetTag>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t : __let_base_t
 {
   _CUDAX_SEMI_PRIVATE :
   friend struct let_value_t;
   friend struct let_error_t;
   friend struct let_stopped_t;
 
-  using __let_tag_t = _LetTag;
-  using __set_tag_t = _SetTag;
-
-  /// @brief Computes the type of a variant of tuples to hold the results of
-  /// the predecessor sender.
+  //! @brief Computes the type of a variant of tuples to hold the results of the
+  //! predecessor sender.
   template <class _Completions, class _Env>
-  using __results_t _CCCL_NODEBUG_ALIAS =
-    __gather_completion_signatures<_Completions, __set_tag_t, _CUDA_VSTD::__decayed_tuple, __variant>;
+  using __sndr1_results_t _CCCL_NODEBUG_ALIAS =
+    __gather_completion_signatures<_Completions, _SetTag, _CUDA_VSTD::__decayed_tuple, __variant>;
 
-  template <class _Fn>
-  struct __sender2_fn
+  // This environment is part of the receiver used to connect the secondary sender.
+  template <class _Attrs>
+  _CCCL_API static constexpr auto __mk_env2(const _Attrs& __attrs) noexcept
   {
+    if constexpr (_CUDA_VSTD::__is_callable_v<get_completion_scheduler_t<_SetTag>, _Attrs>)
+    {
+      return __sch_env_t{get_completion_scheduler<_SetTag>(__attrs)};
+    }
+    else if constexpr (_CUDA_VSTD::__is_callable_v<get_domain_t, _Attrs>)
+    {
+      return prop{get_domain, get_domain(__attrs)};
+    }
+    else
+    {
+      return env{};
+    }
+  }
+
+  template <class _Attrs>
+  using __env2_t _CCCL_NODEBUG_ALIAS = decltype(__let_t::__mk_env2(_CUDA_VSTD::declval<_Attrs>()));
+
+  template <class _Fn, class _Rcvr, class _Env2>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_base_t
+  {
+    //! @brief For a given set of result datums, compute the type of the secondary
+    //! sender's operation state.
     template <class... _As>
-    using __call _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_As>&...>;
-  };
+    using __sndr2_opstate_fn _CCCL_NODEBUG_ALIAS =
+      connect_result_t<_CUDA_VSTD::__type_call<__sndr2_fn<_Fn>, _As...>, __sndr2_rcvr_t<_Rcvr, _Env2>>;
 
-  template <class _Fn, class _Rcvr>
-  struct __opstate_fn
-  {
-    template <class... _As>
-    using __call _CCCL_NODEBUG_ALIAS =
-      connect_result_t<_CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_As>&...>, __rcvr_ref_t<_Rcvr>>;
-  };
-
-  /// @brief Computes the type of a variant of operation states to hold
-  /// the second operation state.
-  template <class _Completions, class _Fn, class _Rcvr>
-  using __opstate2_t _CCCL_NODEBUG_ALIAS =
-    __gather_completion_signatures<_Completions, __set_tag_t, __opstate_fn<_Fn, _Rcvr>::template __call, __variant>;
-
-  template <class _Rcvr, class _Fn, class _Completions>
-  struct __state_t
-  {
-    _Rcvr __rcvr_;
+    __rcvr_with_env_t<_Rcvr, _Env2> __rcvr_;
     _Fn __fn_;
-    __results_t<_Completions, __fwd_env_t<env_of_t<_Rcvr>>> __result_{};
-    __opstate2_t<_Completions, _Fn, _Rcvr> __opstate2_{};
   };
 
-  template <class _Rcvr, class _Fn, class _Completions>
-  struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
+  template <class _Fn, class _Rcvr, class _Env2, class _Completions>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_t : __state_base_t<_Fn, _Rcvr, _Env2>
+  {
+    using __sndr2_opstate_t _CCCL_NODEBUG_ALIAS =
+      __gather_completion_signatures<_Completions, _SetTag, __state_t::template __sndr2_opstate_fn, __variant>;
+
+    __sndr1_results_t<_Completions, __fwd_env_t<env_of_t<_Rcvr>>> __result_{};
+    __sndr2_opstate_t __opstate2_{};
+  };
+
+  //! @brief This is the receiver that gets connected to the predecessor sender. It caches
+  //! the results of the predecessor and then calls the user-provided function with them
+  //! to produce the secondary sender, which it then connects and starts.
+  template <class _Fn, class _Rcvr, class _Env2, class _Completions>
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr1_rcvr_t
   {
     using receiver_concept = receiver_t;
+
+    template <class... _As>
+    _CCCL_API void __complete(_SetTag, _As&&... __as) noexcept
+    {
+      _CCCL_TRY
+      {
+        // Store the results so the lvalue refs we pass to the function will be valid for
+        // the duration of the async op.
+        auto& __tupl =
+          __state_->__result_.template __emplace<_CUDA_VSTD::__decayed_tuple<_As...>>(static_cast<_As&&>(__as)...);
+
+        // Call the function with the results and connect the resulting sender, storing
+        // the operation state in __state_->__opstate2_.
+        auto& __next_op = __state_->__opstate2_.__emplace_from(
+          execution::connect,
+          _CUDA_VSTD::__apply(static_cast<_Fn&&>(__state_->__fn_), __tupl),
+          __sndr2_rcvr_t(__state_->__rcvr_));
+        execution::start(__next_op);
+      }
+      _CCCL_CATCH_ALL
+      {
+        execution::set_error(static_cast<_Rcvr&&>(__state_->__rcvr_.__base()), ::std::current_exception());
+      }
+    }
 
     template <class _Tag, class... _As>
     _CCCL_API void __complete(_Tag, _As&&... __as) noexcept
     {
-      if constexpr (_Tag{} == __set_tag_t{})
-      {
-        _CCCL_TRY
-        {
-          // Store the results so the lvalue refs we pass to the function
-          // will be valid for the duration of the async op.
-          auto& __tupl =
-            __state_->__result_.template __emplace<_CUDA_VSTD::__decayed_tuple<_As...>>(static_cast<_As&&>(__as)...);
-          // Call the function with the results and connect the resulting
-          // sender, storing the operation state in __state_->__opstate2_.
-          auto& __next_op = __state_->__opstate2_.__emplace_from(
-            execution::connect,
-            _CUDA_VSTD::__apply(static_cast<_Fn&&>(__state_->__fn_), __tupl),
-            __ref_rcvr(__state_->__rcvr_));
-          execution::start(__next_op);
-        }
-        _CCCL_CATCH_ALL
-        {
-          execution::set_error(static_cast<_Rcvr&&>(__state_->__rcvr_), ::std::current_exception());
-        }
-      }
-      else
-      {
-        // Forward the completion to the receiver unchanged.
-        _Tag{}(static_cast<_Rcvr&&>(__state_->__rcvr_), static_cast<_As&&>(__as)...);
-      }
+      // Forward the completion to the receiver unchanged.
+      _Tag{}(static_cast<_Rcvr&&>(__state_->__rcvr_.__base()), static_cast<_As&&>(__as)...);
     }
 
     template <class... _As>
-    _CCCL_TRIVIAL_API void set_value(_As&&... __as) noexcept
+    _CCCL_API void set_value(_As&&... __as) noexcept
     {
       __complete(execution::set_value, static_cast<_As&&>(__as)...);
     }
 
     template <class _Error>
-    _CCCL_TRIVIAL_API void set_error(_Error&& __error) noexcept
+    _CCCL_API void set_error(_Error&& __error) noexcept
     {
       __complete(execution::set_error, static_cast<_Error&&>(__error));
     }
 
-    _CCCL_TRIVIAL_API void set_stopped() noexcept
+    _CCCL_API void set_stopped() noexcept
     {
       __complete(execution::set_stopped);
     }
 
     [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> __fwd_env_t<env_of_t<_Rcvr>>
     {
-      return __fwd_env(execution::get_env(__state_->__rcvr_));
+      return __fwd_env(execution::get_env(__state_->__rcvr_.__base()));
     }
 
-    __state_t<_Rcvr, _Fn, _Completions>* __state_;
+    __state_t<_Fn, _Rcvr, _Env2, _Completions>* __state_;
   };
 
-  /// @brief The `let_(value|error|stopped)` operation state.
-  /// @tparam _CvSndr The cvref-qualified predecessor sender type.
-  /// @tparam _Fn The function to be called when the predecessor sender
-  /// completes.
-  /// @tparam _Rcvr The receiver connected to the `let_(value|error|stopped)`
-  /// sender.
+  //! @brief The `let_(value|error|stopped)` operation state.
+  //! @tparam _CvSndr The cvref-qualified predecessor sender type.
+  //! @tparam _Fn The user-provided function to be called with the result datums of the
+  //! predecessor sender.
+  //! @tparam _Rcvr The receiver connected to the `let_(value|error|stopped)`
+  //! sender.
   template <class _CvSndr, class _Fn, class _Rcvr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
     using operation_state_concept = operation_state_t;
     using __completions_t         = completion_signatures_of_t<_CvSndr, __fwd_env_t<env_of_t<_Rcvr>>>;
-    using __rcvr_t                = __let_t::__rcvr_t<_Rcvr, _Fn, __completions_t>;
+    using __env2_t                = __let_t::__env2_t<env_of_t<_CvSndr>>;
+    using __sndr1_rcvr_t          = __let_t::__sndr1_rcvr_t<_Fn, _Rcvr, __env2_t, __completions_t>;
 
     _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Fn __fn, _Rcvr __rcvr) noexcept(
-      __nothrow_decay_copyable<_Fn, _Rcvr> && __nothrow_connectable<_CvSndr, __rcvr_t>)
-        : __state_{static_cast<_Rcvr&&>(__rcvr), static_cast<_Fn&&>(__fn)}
-        , __opstate1_(execution::connect(static_cast<_CvSndr&&>(__sndr), __rcvr_t{&__state_}))
+      __nothrow_decay_copyable<_Fn, _Rcvr> && __nothrow_connectable<_CvSndr, __sndr1_rcvr_t>)
+        : __state_{{{static_cast<_Rcvr&&>(__rcvr), __let_t::__mk_env2(execution::get_env(__sndr))},
+                    static_cast<_Fn&&>(__fn)}}
+        , __opstate1_(execution::connect(static_cast<_CvSndr&&>(__sndr), __sndr1_rcvr_t{&__state_}))
     {}
 
     _CCCL_IMMOVABLE(__opstate_t);
@@ -215,11 +233,52 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t
       execution::start(__opstate1_);
     }
 
-    __state_t<_Rcvr, _Fn, __completions_t> __state_;
-    connect_result_t<_CvSndr, __rcvr_t> __opstate1_;
+    __state_t<_Fn, _Rcvr, __env2_t, __completions_t> __state_;
+    connect_result_t<_CvSndr, __sndr1_rcvr_t> __opstate1_;
   };
 
-  template <class _Fn, class... _Env>
+  template <class _Fn>
+  struct __domain_transform_fn
+  {
+    template <class... _Ts>
+    using __call _CCCL_NODEBUG_ALIAS =
+      __detail::__domain_of_t<env_of_t<_CUDA_VSTD::__type_call<__sndr2_fn<_Fn>, _Ts...>>,
+                              get_completion_scheduler_t<set_value_t>,
+                              default_domain>;
+  };
+
+  struct __domain_reduce_fn
+  {
+    using __reduce_fn_t =
+      _CUDA_VSTD::__type_try_catch<_CUDA_VSTD::__type_quote<_CUDA_VSTD::common_type_t>, _CUDA_VSTD::__type_always<__nil>>;
+
+    template <class... _Domains>
+    using __call _CCCL_NODEBUG_ALIAS =
+      _CUDA_VSTD::_If<sizeof...(_Domains) == 0, default_domain, _CUDA_VSTD::__type_call<__reduce_fn_t, _Domains...>>;
+  };
+
+  template <class _Sndr, class _Fn>
+  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto __get_completion_domain() noexcept
+  {
+    // we can know the completion domain for non-dependent senders
+    using __completions = completion_signatures_of_t<_Sndr>;
+    if constexpr (__valid_completion_signatures<__completions>)
+    {
+      return __gather_completion_signatures<__completions,
+                                            _SetTag,
+                                            __domain_transform_fn<_Fn>::template __call,
+                                            __domain_reduce_fn::template __call>{};
+    }
+    else
+    {
+      return __nil{};
+    }
+  }
+
+  template <class _Sndr, class _Fn>
+  using __completion_domain_of_t _CCCL_NODEBUG_ALIAS = decltype(__let_t::__get_completion_domain<_Sndr, _Fn>());
+
+  template <class _Fn, class _Env2, class... _Env>
   struct __transform_args_fn
   {
     template <class... _Ts>
@@ -231,71 +290,33 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t
                                             _WHAT(_ARGUMENTS_ARE_NOT_DECAY_COPYABLE),
                                             _WITH_ARGUMENTS(_Ts...)>();
       }
-      else if constexpr (!_CUDA_VSTD::__is_callable_v<_Fn, _CUDA_VSTD::decay_t<_Ts>&...>)
+      else if constexpr (!_CUDA_VSTD::__type_callable<__sndr2_fn<_Fn>, _Ts...>::value)
       {
         return invalid_completion_signature<_WHERE(_IN_ALGORITHM, _LetTag),
                                             _WHAT(_FUNCTION_IS_NOT_CALLABLE),
                                             _WITH_FUNCTION(_Fn),
                                             _WITH_ARGUMENTS(_CUDA_VSTD::decay_t<_Ts> & ...)>();
       }
-      else if constexpr (!__is_sender<_CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_Ts>&...>>)
-      {
-        return invalid_completion_signature<_WHERE(_IN_ALGORITHM, _LetTag),
-                                            _WHAT(_FUNCTION_MUST_RETURN_A_SENDER),
-                                            _WITH_FUNCTION(_Fn),
-                                            _WITH_ARGUMENTS(_CUDA_VSTD::decay_t<_Ts> & ...)>();
-      }
       else
       {
-        // TODO: test that _Sndr satisfies sender_in<_Sndr, _Env...>
-        using _Sndr _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_Ts>&...>;
-        // The function is callable with the arguments and returns a sender, but we
-        // do not know whether connect will throw.
-        return concat_completion_signatures(get_completion_signatures<_Sndr, _Env...>(), __eptr_completion());
+        using __sndr2_t = _CUDA_VSTD::__type_call<__sndr2_fn<_Fn>, _Ts...>;
+        if constexpr (!sender<__sndr2_t>)
+        {
+          return invalid_completion_signature<_WHERE(_IN_ALGORITHM, _LetTag),
+                                              _WHAT(_FUNCTION_MUST_RETURN_A_SENDER),
+                                              _WITH_FUNCTION(_Fn),
+                                              _WITH_ARGUMENTS(_CUDA_VSTD::decay_t<_Ts> & ...),
+                                              _WITH_RETURN_TYPE(__sndr2_t)>();
+        }
+        else
+        {
+          //  The function is callable with the arguments and returns a sender, but we
+          //  do not know whether connect will throw.
+          return execution::get_completion_signatures<__sndr2_t, env<_Env2, _Env>...>() + __eptr_completion();
+        }
       }
     }
   };
-
-  template <class _Fn>
-  struct __domain_transform_fn
-  {
-    template <class... _Ts>
-    [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()(__set_tag_t (*)(_Ts...)) const
-    {
-      using __result_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::__call_result_t<_Fn, _CUDA_VSTD::decay_t<_Ts>&...>;
-      // ask the result sender if it knows where it will complete:
-      return __detail::__domain_of_t<env_of_t<__result_t>, get_completion_scheduler_t<set_value_t>, __nil>{};
-    }
-  };
-
-  struct __domain_reduce_fn
-  {
-    template <class... _Domains>
-    [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()(_Domains...) const
-    {
-      using __fn_t = _CUDA_VSTD::__type_try_catch<_CUDA_VSTD::__type_quote<_CUDA_VSTD::common_type_t>,
-                                                  _CUDA_VSTD::__type_always<__nil>>;
-      return _CUDA_VSTD::__type_call<__fn_t, _Domains...>{};
-    }
-  };
-
-  template <class _Sndr, class _Fn>
-  [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto __get_completion_domain() noexcept
-  {
-    // we can know the completion domain for non-dependent senders
-    using __completions = completion_signatures_of_t<_Sndr>;
-    if constexpr (__valid_completion_signatures<__completions>)
-    {
-      return __completions{}.select(__set_tag_t{}).transform_reduce(__domain_transform_fn<_Fn>{}, __domain_reduce_fn{});
-    }
-    else
-    {
-      return __nil{};
-    }
-  }
-
-  template <class _Sndr, class _Fn>
-  using __completion_domain_of_t _CCCL_NODEBUG_ALIAS = decltype(__get_completion_domain<_Sndr, _Fn>());
 
   template <class _Sndr, class _Fn>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_base_t;
@@ -306,26 +327,26 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t
   {
     template <class _Sndr>
     [[nodiscard]] _CCCL_TRIVIAL_API auto operator()(_Sndr __sndr) const
-      -> _CUDA_VSTD::__call_result_t<__let_tag_t, _Sndr, _Fn>
+      -> _CUDA_VSTD::__call_result_t<_LetTag, _Sndr, _Fn>
     {
-      return __let_tag_t{}(static_cast<_Sndr&&>(__sndr), __fn_);
+      return _LetTag{}(static_cast<_Sndr&&>(__sndr), __fn_);
     }
 
     template <class _Sndr>
     [[nodiscard]] _CCCL_TRIVIAL_API friend auto operator|(_Sndr __sndr, const __closure_base_t& __self)
-      -> _CUDA_VSTD::__call_result_t<__let_tag_t, _Sndr, _Fn>
+      -> _CUDA_VSTD::__call_result_t<_LetTag, _Sndr, _Fn>
     {
-      return __let_tag_t{}(static_cast<_Sndr&&>(__sndr), __self.__fn_);
+      return _LetTag{}(static_cast<_Sndr&&>(__sndr), __self.__fn_);
     }
 
     _Fn __fn_;
   };
 
 public:
-  /// @brief The `let_(value|error|stopped)` sender.
-  /// @tparam _Sndr The predecessor sender.
-  /// @tparam _Fn The function to be called when the predecessor sender
-  /// completes.
+  //! @brief The `let_(value|error|stopped)` sender.
+  //! @tparam _Sndr The predecessor sender.
+  //! @tparam _Fn The function to be called when the predecessor sender
+  //! completes.
   template <class _Sndr, class _Fn>
   [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(_Sndr __sndr, _Fn __fn) const;
 
@@ -364,25 +385,37 @@ template <class _LetTag, class _SetTag>
 template <class _Sndr, class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_LetTag, _SetTag>::__sndr_base_t
 {
-  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
-  using __domain_t                         = __completion_domain_of_t<_Sndr, _Fn>;
+  using sender_concept = sender_t;
 
+  // the env of the receiver used to connect the secondary sender
   template <class _Self, class... _Env>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
     _CUDAX_LET_COMPLETIONS(auto(__child_completions) = get_child_completion_signatures<_Self, _Sndr, _Env...>())
     {
-      if constexpr (__set_tag_t{} == execution::set_value)
+      using __sch_t               = __query_result_or_t<env_of_t<_Sndr>, get_completion_scheduler_t<_SetTag>, __nil>;
+      using __domain_t            = __detail::__domain_of_t<env_of_t<_Sndr>, get_completion_scheduler_t<_SetTag>>;
+      using __env2_t              = __let_t::__env2_t<env_of_t<_Sndr>>;
+      using __completion_domain_t = __completion_domain_of_t<_Sndr, _Fn>;
+
+      if constexpr (_CUDA_VSTD::is_same_v<__completion_domain_t, __nil> && sizeof...(_Env) != 0)
       {
-        return transform_completion_signatures(__child_completions, __transform_args_fn<_Fn, _Env...>{});
+        return invalid_completion_signature<_WHERE(_IN_ALGORITHM, _LetTag),
+                                            _WHAT(_FUNCTION_MUST_RETURN_SENDERS_THAT_ALL_COMPLETE_IN_A_COMMON_DOMAIN),
+                                            _WITH_FUNCTION(_Fn)>();
       }
-      else if constexpr (__set_tag_t{} == execution::set_error)
+      else if constexpr (_SetTag{} == execution::set_value)
       {
-        return transform_completion_signatures(__child_completions, {}, __transform_args_fn<_Fn, _Env...>{});
+        return transform_completion_signatures(__child_completions, __transform_args_fn<_Fn, __env2_t, _Env...>{});
+      }
+      else if constexpr (_SetTag{} == execution::set_error)
+      {
+        return transform_completion_signatures(__child_completions, {}, __transform_args_fn<_Fn, __env2_t, _Env...>{});
       }
       else
       {
-        return transform_completion_signatures(__child_completions, {}, {}, __transform_args_fn<_Fn, _Env...>{});
+        return transform_completion_signatures(
+          __child_completions, {}, {}, __transform_args_fn<_Fn, __env2_t, _Env...>{});
       }
     }
 
@@ -406,12 +439,58 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_LetTag, _SetTag>::__sndr_base_t
     return __opstate_t<const _Sndr&, _Fn, _Rcvr>(__sndr_, __fn_, static_cast<_Rcvr&&>(__rcvr));
   }
 
-  [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> __let::__attrs_t<_Sndr, __domain_t>
+  struct __attrs_t
+  {
+    template <class _Tag>
+    _CCCL_API constexpr auto query(get_completion_scheduler_t<_Tag>) const = delete;
+
+    _CCCL_TEMPLATE(class _Fn2 = _Fn, class _Domain = __completion_domain_of_t<_Sndr, _Fn2>)
+    _CCCL_REQUIRES((!_CUDA_VSTD::same_as<_Domain, __nil>) )
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_t) noexcept -> _Domain
+    {
+      return {};
+    }
+
+    template <class... _Env>
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_completion_behavior_t, const _Env&...) noexcept
+    {
+      if constexpr (sender_in<_Sndr, _Env...>)
+      {
+        // The completion behavior of let_value(sndr, fn) is the weakest completion behavior of
+        // sndr and all the senders that fn can potentially produce.
+        return (
+          execution::min) (execution::get_completion_behavior<_Sndr, __fwd_env_t<_Env>...>(),
+                           execution::get_completion_signatures<_Sndr, __fwd_env_t<_Env>...>() //
+                             .select(_SetTag{}) //
+                             .transform_reduce(__completion_behavior_transform_fn<_Fn, _Env...>{}, execution::min));
+      }
+      else
+      {
+        return completion_behavior::unknown;
+      }
+    }
+
+    _CCCL_EXEC_CHECK_DISABLE
+    _CCCL_TEMPLATE(class _Query, class... _Args)
+    _CCCL_REQUIRES(__forwarding_query<_Query> _CCCL_AND(
+      !_CUDA_VSTD::__is_included_in_v<_Query, get_domain_t, get_completion_behavior_t>)
+                     _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query, _Args...>)
+    [[nodiscard]] _CCCL_API constexpr auto query(_Query, _Args&&... __args) const
+      noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query, _Args...>)
+        -> __query_result_t<env_of_t<_Sndr>, _Query, _Args...>
+    {
+      return execution::get_env(__sndr_).query(_Query{}, static_cast<_Args&&>(__args)...);
+    }
+
+    const _Sndr& __sndr_;
+  };
+
+  [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> __attrs_t
   {
     return {__sndr_};
   }
 
-  _CCCL_NO_UNIQUE_ADDRESS __let_tag_t __tag_;
+  _CCCL_NO_UNIQUE_ADDRESS _LetTag __tag_;
   _Fn __fn_;
   _Sndr __sndr_;
 };
@@ -463,12 +542,12 @@ template <class _Sndr, class _Fn>
     // type-checking to the point where the sender is connected.
     using __completions_t = completion_signatures_of_t<_Sndr>;
     constexpr bool __all_non_dependent =
-      __gather_completion_signatures<__completions_t, _SetTag, __sender2_fn<_Fn>::template __call, __all_non_dependent_t>::
+      __gather_completion_signatures<__completions_t, _SetTag, __sndr2_fn<_Fn>::template __call, __all_non_dependent_t>::
         value;
 
     if constexpr (__all_non_dependent)
     {
-      __assert_valid_completion_signatures(get_completion_signatures<__sndr_t>());
+      execution::__assert_valid_completion_signatures(get_completion_signatures<__sndr_t>());
     }
   }
   return transform_sender(__domain_t{}, __sndr_t{{{}, static_cast<_Fn&&>(__fn), static_cast<_Sndr&&>(__sndr)}});

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -77,8 +77,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_base_t
   template <class _Rcvr, class _Env2>
   struct __sndr2_rcvr_t : __rcvr_ref_t<__rcvr_with_env_t<_Rcvr, _Env2>>
   {
+    using __base_t = __rcvr_ref_t<__rcvr_with_env_t<_Rcvr, _Env2>>;
+
     _CCCL_TRIVIAL_API explicit constexpr __sndr2_rcvr_t(__rcvr_with_env_t<_Rcvr, _Env2>& __rcvr) noexcept
-        : __rcvr_ref_t<__rcvr_with_env_t<_Rcvr, _Env2>>{__rcvr}
+        : __base_t(__ref_rcvr(__rcvr))
     {}
   };
 };

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -135,7 +135,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t : __let_base_t
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_t : __state_base_t<_Fn, _Rcvr, _Env2>
   {
     using __sndr2_opstate_t _CCCL_NODEBUG_ALIAS =
-      __gather_completion_signatures<_Completions, _SetTag, __state_t::template __sndr2_opstate_fn, __variant>;
+      __gather_completion_signatures<_Completions,
+                                     _SetTag,
+                                     __state_t::__state_base_t::template __sndr2_opstate_fn,
+                                     __variant>;
 
     __sndr1_results_t<_Completions, __fwd_env_t<env_of_t<_Rcvr>>> __result_{};
     __sndr2_opstate_t __opstate2_{};

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -83,6 +83,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_base_t
         : __base_t(__ref_rcvr(__rcvr))
     {}
   };
+
+  template <size_t _Ny>
+  using __type_at_fn = _CUDA_VSTD::__detail::__type_at_fn<_Ny>;
 };
 
 template <class _LetTag, class _SetTag>
@@ -400,8 +403,11 @@ template <class _Sndr, class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_LetTag, _SetTag>::__sndr_base_t
 {
   using sender_concept = sender_t;
-  using __let_tag_t    = typename __let_t::__let_tag_t; // needed to avoid an MSVC bug
-  using __set_tag_t    = typename __let_t::__set_tag_t; // needed to avoid an MSVC bug
+
+#if _CCCL_COMPILER(MSVC)
+  using __let_tag_t = _CUDA_VSTD::__type_apply<__type_at_fn<0>, __let_t>;
+  using __set_tag_t = _CUDA_VSTD::__type_apply<__type_at_fn<1>, __let_t>;
+#endif // _CCCL_COMPILER(MSVC)
 
   // the env of the receiver used to connect the secondary sender
   template <class _Self, class... _Env>

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -100,15 +100,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t : __let_base_t
   //! predecessor sender.
   template <class _Completions, class _Env>
   using __sndr1_results_t _CCCL_NODEBUG_ALIAS =
-    __gather_completion_signatures<_Completions, _SetTag, _CUDA_VSTD::__decayed_tuple, __variant>;
+    __gather_completion_signatures<_Completions, __set_tag_t, _CUDA_VSTD::__decayed_tuple, __variant>;
 
   // This environment is part of the receiver used to connect the secondary sender.
   template <class _Attrs>
   _CCCL_API static constexpr auto __mk_env2(const _Attrs& __attrs) noexcept
   {
-    if constexpr (_CUDA_VSTD::__is_callable_v<get_completion_scheduler_t<_SetTag>, _Attrs>)
+    if constexpr (_CUDA_VSTD::__is_callable_v<get_completion_scheduler_t<__set_tag_t>, _Attrs>)
     {
-      return __sch_env_t{get_completion_scheduler<_SetTag>(__attrs)};
+      return __sch_env_t{get_completion_scheduler<__set_tag_t>(__attrs)};
     }
     else if constexpr (_CUDA_VSTD::__is_callable_v<get_domain_t, _Attrs>)
     {
@@ -141,7 +141,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t : __let_base_t
   {
     using __sndr2_opstate_t _CCCL_NODEBUG_ALIAS =
       __gather_completion_signatures<_Completions,
-                                     _SetTag,
+                                     __set_tag_t,
                                      __state_t::__state_base_t::template __sndr2_opstate_fn,
                                      __variant>;
 
@@ -158,7 +158,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t : __let_base_t
     using receiver_concept = receiver_t;
 
     template <class... _As>
-    _CCCL_API void __complete(_SetTag, _As&&... __as) noexcept
+    _CCCL_API void __complete(__set_tag_t, _As&&... __as) noexcept
     {
       _CCCL_TRY
       {
@@ -273,7 +273,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t : __let_base_t
     if constexpr (__valid_completion_signatures<__completions>)
     {
       return __gather_completion_signatures<__completions,
-                                            _SetTag,
+                                            __set_tag_t,
                                             __domain_transform_fn<_Fn>::template __call,
                                             __domain_reduce_fn::template __call>{};
     }
@@ -294,13 +294,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t : __let_base_t
     {
       if constexpr (!__decay_copyable<_Ts...>)
       {
-        return invalid_completion_signature<_WHERE(_IN_ALGORITHM, _LetTag),
+        return invalid_completion_signature<_WHERE(_IN_ALGORITHM, __let_tag_t),
                                             _WHAT(_ARGUMENTS_ARE_NOT_DECAY_COPYABLE),
                                             _WITH_ARGUMENTS(_Ts...)>();
       }
       else if constexpr (!_CUDA_VSTD::__type_callable<__sndr2_fn<_Fn>, _Ts...>::value)
       {
-        return invalid_completion_signature<_WHERE(_IN_ALGORITHM, _LetTag),
+        return invalid_completion_signature<_WHERE(_IN_ALGORITHM, __let_tag_t),
                                             _WHAT(_FUNCTION_IS_NOT_CALLABLE),
                                             _WITH_FUNCTION(_Fn),
                                             _WITH_ARGUMENTS(_CUDA_VSTD::decay_t<_Ts> & ...)>();
@@ -310,7 +310,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t : __let_base_t
         using __sndr2_t = _CUDA_VSTD::__type_call<__sndr2_fn<_Fn>, _Ts...>;
         if constexpr (!sender<__sndr2_t>)
         {
-          return invalid_completion_signature<_WHERE(_IN_ALGORITHM, _LetTag),
+          return invalid_completion_signature<_WHERE(_IN_ALGORITHM, __let_tag_t),
                                               _WHAT(_FUNCTION_MUST_RETURN_A_SENDER),
                                               _WITH_FUNCTION(_Fn),
                                               _WITH_ARGUMENTS(_CUDA_VSTD::decay_t<_Ts> & ...),
@@ -341,16 +341,16 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t : __let_base_t
   {
     template <class _Sndr>
     [[nodiscard]] _CCCL_TRIVIAL_API auto operator()(_Sndr __sndr) const
-      -> _CUDA_VSTD::__call_result_t<_LetTag, _Sndr, _Fn>
+      -> _CUDA_VSTD::__call_result_t<__let_tag_t, _Sndr, _Fn>
     {
-      return _LetTag{}(static_cast<_Sndr&&>(__sndr), __fn_);
+      return __let_tag_t{}(static_cast<_Sndr&&>(__sndr), __fn_);
     }
 
     template <class _Sndr>
     [[nodiscard]] _CCCL_TRIVIAL_API friend auto operator|(_Sndr __sndr, const __closure_base_t& __self)
-      -> _CUDA_VSTD::__call_result_t<_LetTag, _Sndr, _Fn>
+      -> _CUDA_VSTD::__call_result_t<__let_tag_t, _Sndr, _Fn>
     {
-      return _LetTag{}(static_cast<_Sndr&&>(__sndr), __self.__fn_);
+      return __let_tag_t{}(static_cast<_Sndr&&>(__sndr), __self.__fn_);
     }
 
     _Fn __fn_;
@@ -415,7 +415,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_LetTag, _SetTag>::__sndr_base_t
 
       if constexpr (_CUDA_VSTD::is_same_v<__completion_domain_t, __nil> && sizeof...(_Env) != 0)
       {
-        return invalid_completion_signature<_WHERE(_IN_ALGORITHM, _LetTag),
+        return invalid_completion_signature<_WHERE(_IN_ALGORITHM, __let_tag_t),
                                             _WHAT(_FUNCTION_MUST_RETURN_SENDERS_THAT_ALL_COMPLETE_IN_A_COMMON_DOMAIN),
                                             _WITH_FUNCTION(_Fn)>();
       }
@@ -474,7 +474,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_LetTag, _SetTag>::__sndr_base_t
         // behavior of sndr and all the senders that fn can potentially produce. (MSVC
         // needs the constexpr computation broken up, hence the local variables.)
         constexpr auto __completions =
-          execution::get_completion_signatures<_Sndr, __fwd_env_t<_Env>...>().select(_SetTag{});
+          execution::get_completion_signatures<_Sndr, __fwd_env_t<_Env>...>().select(__set_tag_t{});
         constexpr auto __behavior =
           __completions.transform_reduce(__completion_behavior_transform_fn<_Fn, _Env...>{}, execution::min);
         return (execution::min) (execution::get_completion_behavior<_Sndr, __fwd_env_t<_Env>...>(), __behavior);
@@ -545,7 +545,7 @@ template <class _LetTag, class _SetTag>
 template <class _Sndr, class _Fn>
 [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto __let_t<_LetTag, _SetTag>::operator()(_Sndr __sndr, _Fn __fn) const
 {
-  using __sndr_t   = typename _LetTag::template __sndr_t<_Sndr, _Fn>;
+  using __sndr_t   = typename __let_tag_t::template __sndr_t<_Sndr, _Fn>;
   using __domain_t = __early_domain_of_t<_Sndr>;
   // If the incoming sender is non-dependent, we can check the completion signatures of
   // the composed sender immediately.
@@ -557,8 +557,10 @@ template <class _Sndr, class _Fn>
     // type-checking to the point where the sender is connected.
     using __completions_t = completion_signatures_of_t<_Sndr>;
     constexpr bool __all_non_dependent =
-      __gather_completion_signatures<__completions_t, _SetTag, __sndr2_fn<_Fn>::template __call, __all_non_dependent_t>::
-        value;
+      __gather_completion_signatures<__completions_t,
+                                     __set_tag_t,
+                                     __sndr2_fn<_Fn>::template __call,
+                                     __all_non_dependent_t>::value;
 
     if constexpr (__all_non_dependent)
     {
@@ -572,7 +574,7 @@ template <class _LetTag, class _SetTag>
 template <class _Fn>
 [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto __let_t<_LetTag, _SetTag>::operator()(_Fn __fn) const noexcept
 {
-  using __closure_t = typename _LetTag::template __closure_t<_Fn>;
+  using __closure_t = typename __let_tag_t::template __closure_t<_Fn>;
   return __closure_t{{static_cast<_Fn&&>(__fn)}};
 }
 

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -400,6 +400,8 @@ template <class _Sndr, class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_LetTag, _SetTag>::__sndr_base_t
 {
   using sender_concept = sender_t;
+  using __let_tag_t    = typename __let_t::__let_tag_t; // needed to avoid an MSVC bug
+  using __set_tag_t    = typename __let_t::__set_tag_t; // needed to avoid an MSVC bug
 
   // the env of the receiver used to connect the secondary sender
   template <class _Self, class... _Env>

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -94,6 +94,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t : __let_base_t
   friend struct let_stopped_t;
 
   using __let_tag_t = _LetTag; // needed to avoid an MSVC bug
+  using __set_tag_t = _SetTag; // needed to avoid an MSVC bug
 
   //! @brief Computes the type of a variant of tuples to hold the results of the
   //! predecessor sender.
@@ -410,6 +411,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_LetTag, _SetTag>::__sndr_base_t
       using __domain_t            = __detail::__domain_of_t<env_of_t<_Sndr>, get_completion_scheduler_t<_SetTag>>;
       using __env2_t              = __let_t::__env2_t<env_of_t<_Sndr>>;
       using __completion_domain_t = __completion_domain_of_t<_Sndr, _Fn>;
+      using __transform_fn_t      = __transform_args_fn<_Fn, __env2_t, _Env...>;
 
       if constexpr (_CUDA_VSTD::is_same_v<__completion_domain_t, __nil> && sizeof...(_Env) != 0)
       {
@@ -417,18 +419,17 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_LetTag, _SetTag>::__sndr_base_t
                                             _WHAT(_FUNCTION_MUST_RETURN_SENDERS_THAT_ALL_COMPLETE_IN_A_COMMON_DOMAIN),
                                             _WITH_FUNCTION(_Fn)>();
       }
-      else if constexpr (_SetTag{} == execution::set_value)
+      else if constexpr (__set_tag_t{} == execution::set_value)
       {
-        return transform_completion_signatures(__child_completions, __transform_args_fn<_Fn, __env2_t, _Env...>{});
+        return transform_completion_signatures(__child_completions, __transform_fn_t{});
       }
-      else if constexpr (_SetTag{} == execution::set_error)
+      else if constexpr (__set_tag_t{} == execution::set_error)
       {
-        return transform_completion_signatures(__child_completions, {}, __transform_args_fn<_Fn, __env2_t, _Env...>{});
+        return transform_completion_signatures(__child_completions, {}, __transform_fn_t{});
       }
       else
       {
-        return transform_completion_signatures(
-          __child_completions, {}, {}, __transform_args_fn<_Fn, __env2_t, _Env...>{});
+        return transform_completion_signatures(__child_completions, {}, {}, __transform_fn_t{});
       }
     }
 

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -407,9 +407,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t<_LetTag, _SetTag>::__sndr_base_t
   {
     _CUDAX_LET_COMPLETIONS(auto(__child_completions) = get_child_completion_signatures<_Self, _Sndr, _Env...>())
     {
-      using __sch_t               = __query_result_or_t<env_of_t<_Sndr>, get_completion_scheduler_t<_SetTag>, __nil>;
-      using __domain_t            = __detail::__domain_of_t<env_of_t<_Sndr>, get_completion_scheduler_t<_SetTag>>;
-      using __env2_t              = __let_t::__env2_t<env_of_t<_Sndr>>;
+      using __sch_t    = __query_result_or_t<env_of_t<_Sndr>, get_completion_scheduler_t<__set_tag_t>, __nil>;
+      using __domain_t = __detail::__domain_of_t<env_of_t<_Sndr>, get_completion_scheduler_t<__set_tag_t>>;
+      using __env2_t   = __let_t::__env2_t<env_of_t<_Sndr>>;
       using __completion_domain_t = __completion_domain_of_t<_Sndr, _Fn>;
       using __transform_fn_t      = __transform_args_fn<_Fn, __env2_t, _Env...>;
 

--- a/cudax/include/cuda/experimental/__execution/meta.cuh
+++ b/cudax/include/cuda/experimental/__execution/meta.cuh
@@ -44,13 +44,13 @@ namespace cuda::experimental::execution
 template <class...>
 struct _DIAGNOSTIC;
 
-struct _WHERE;
+struct _UNKNOWN;
 
-struct _IN_ALGORITHM;
+struct _WHERE;
 
 struct _WHAT;
 
-struct _WHY;
+struct _IN_ALGORITHM;
 
 struct _WITH_FUNCTION;
 
@@ -69,20 +69,17 @@ struct _WITH_COMPLETION_SIGNATURE;
 
 struct _FUNCTION_IS_NOT_CALLABLE;
 
-struct _UNKNOWN;
+struct _FUNCTION_MUST_RETURN_A_SENDER;
+
+struct _FUNCTION_MUST_RETURN_SENDERS_THAT_ALL_COMPLETE_IN_A_COMMON_DOMAIN;
+
+struct _WITH_RETURN_TYPE;
 
 struct _SENDER_HAS_TOO_MANY_SUCCESS_COMPLETIONS;
 
 struct _ARGUMENTS_ARE_NOT_DECAY_COPYABLE;
 
 struct _THE_ENVIRONMENT_OF_THE_RECEIVER_DOES_NOT_HAVE_A_SCHEDULER_FOR_ON_TO_RETURN_TO;
-
-template <class... _Sigs>
-struct _WITH_COMPLETIONS
-{};
-
-struct _NOT_ABLE_TO_DETERMINE_WHAT_STREAM_TO_USE_FOR_THIS_OPERATION
-{};
 
 struct __merror_base
 {

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -28,6 +28,11 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 #include <cuda/std/__concepts/derived_from.h>
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/is_callable.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__utility/rel_ops.h>
+#include <cuda/std/__utility/unreachable.h>
 
 #include <cuda/experimental/__execution/domain.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
@@ -229,6 +234,143 @@ _CCCL_GLOBAL_CONSTANT struct get_launch_config_t
     return true;
   }
 } get_launch_config{};
+
+namespace __completion_behavior
+{
+enum class _CCCL_TYPE_VISIBILITY_DEFAULT completion_behavior : int
+{
+  unknown, ///< The completion behavior is unknown.
+  asynchronous, ///< The operation's completion will not happen on the calling thread before `start()`
+                ///< returns.
+  synchronous, ///< The operation's completion happens-before the return of `start()`.
+  inline_completion ///< The operation completes synchronously within `start()` on the same thread that called
+                    ///< `start()`.
+};
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+[[nodiscard]] _CCCL_API constexpr auto operator<=>(completion_behavior a, completion_behavior b) noexcept
+  -> _CUDA_VSTD::strong_ordering
+{
+  return static_cast<int>(a) <=> static_cast<int>(b);
+}
+#else
+[[nodiscard]] _CCCL_API constexpr auto operator<(completion_behavior a, completion_behavior b) noexcept -> bool
+{
+  return static_cast<int>(a) < static_cast<int>(b);
+}
+[[nodiscard]] _CCCL_API constexpr auto operator==(completion_behavior a, completion_behavior b) noexcept -> bool
+{
+  return static_cast<int>(a) == static_cast<int>(b);
+}
+using namespace _CUDA_VSTD::rel_ops;
+#endif
+} // namespace __completion_behavior
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT min_t;
+
+struct completion_behavior
+{
+private:
+  template <__completion_behavior::completion_behavior _CB>
+  using __constant_t = _CUDA_VSTD::integral_constant<__completion_behavior::completion_behavior, _CB>;
+
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT unknown_t //
+      : __constant_t<__completion_behavior::completion_behavior::unknown>
+  {};
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT asynchronous_t //
+      : __constant_t<__completion_behavior::completion_behavior::asynchronous>
+  {};
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT synchronous_t //
+      : __constant_t<__completion_behavior::completion_behavior::synchronous>
+  {};
+  struct _CCCL_TYPE_VISIBILITY_DEFAULT inline_completion_t //
+      : __constant_t<__completion_behavior::completion_behavior::inline_completion>
+  {};
+
+  friend struct min_t;
+
+public:
+  static constexpr unknown_t unknown{};
+  static constexpr asynchronous_t asynchronous{};
+  static constexpr synchronous_t synchronous{};
+  static constexpr inline_completion_t inline_completion{};
+};
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// get_completion_behavior: A sender can define this attribute to describe the sender's
+// completion behavior
+struct get_completion_behavior_t
+{
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_CUDA_VSTD::__ignore_t, _CUDA_VSTD::__ignore_t = {}) const noexcept
+  {
+    return completion_behavior::unknown;
+  }
+
+  _CCCL_TEMPLATE(class _Attrs)
+  _CCCL_REQUIRES(__queryable_with<_Attrs, get_completion_behavior_t>)
+  [[nodiscard]] _CCCL_API constexpr auto operator()(const _Attrs& __attrs, _CUDA_VSTD::__ignore_t = {}) const noexcept
+  {
+    static_assert(__nothrow_queryable_with<_Attrs, get_completion_behavior_t>,
+                  "The get_completion_behavior query must be noexcept.");
+    static_assert(_CUDA_VSTD::is_convertible_v<__query_result_t<_Attrs, get_completion_behavior_t>,
+                                               __completion_behavior::completion_behavior>,
+                  "The get_completion_behavior query must return one of the static member variables in "
+                  "execution::completion_behavior.");
+    return __attrs.query(*this);
+  }
+
+  _CCCL_TEMPLATE(class _Attrs, class _Env)
+  _CCCL_REQUIRES(__queryable_with<_Attrs, get_completion_behavior_t, const _Env&>)
+  [[nodiscard]] _CCCL_API constexpr auto operator()(const _Attrs& __attrs, const _Env& __env) const noexcept
+  {
+    static_assert(__nothrow_queryable_with<_Attrs, get_completion_behavior_t, const _Env&>,
+                  "The get_completion_behavior query must be noexcept.");
+    static_assert(_CUDA_VSTD::is_convertible_v<__query_result_t<_Attrs, get_completion_behavior_t, const _Env&>,
+                                               __completion_behavior::completion_behavior>,
+                  "The get_completion_behavior query must return one of the static member variables in "
+                  "execution::completion_behavior.");
+    return __attrs.query(*this, __env);
+  }
+
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(forwarding_query_t) noexcept -> bool
+  {
+    return true;
+  }
+};
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT min_t
+{
+  template <__completion_behavior::completion_behavior... _CBs>
+  [[nodiscard]] _CCCL_API constexpr auto operator()(completion_behavior::__constant_t<_CBs>...) const noexcept
+  {
+    constexpr auto __behavior = _CUDA_VSTD::min({_CBs...});
+    if constexpr (__behavior == completion_behavior::unknown)
+    {
+      return completion_behavior::unknown;
+    }
+    else if constexpr (__behavior == completion_behavior::asynchronous)
+    {
+      return completion_behavior::asynchronous;
+    }
+    else if constexpr (__behavior == completion_behavior::synchronous)
+    {
+      return completion_behavior::synchronous;
+    }
+    else if constexpr (__behavior == completion_behavior::inline_completion)
+    {
+      return completion_behavior::inline_completion;
+    }
+    _CCCL_UNREACHABLE();
+  }
+};
+
+_CCCL_GLOBAL_CONSTANT min_t min{};
+
+template <class _Sndr, class... _Env>
+[[nodiscard]] _CCCL_API constexpr auto get_completion_behavior() noexcept
+{
+  return _CUDA_VSTD::__call_result_t<get_completion_behavior_t, env_of_t<_Sndr>, _Env...>{};
+}
 
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
@@ -21,14 +21,10 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__type_traits/is_specialization_of.h>
 #include <cuda/std/__memory/addressof.h>
-#include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
-#include <cuda/std/__type_traits/is_same.h>
 
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/env.cuh>
-#include <cuda/experimental/__execution/type_traits.cuh>
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
@@ -36,37 +32,34 @@ _CCCL_BEGIN_NV_DIAG_SUPPRESS(114) // function "foo" was referenced but not defin
 
 namespace cuda::experimental::execution
 {
-template <class _Rcvr, class _Env = env_of_t<_Rcvr>>
+template <class _Rcvr>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_ref
 {
   using receiver_concept = receiver_t;
 
-  _CCCL_API explicit constexpr __rcvr_ref(_Rcvr& __rcvr) noexcept
-      : __rcvr_{_CUDA_VSTD::addressof(__rcvr)}
+  _CCCL_TRIVIAL_API constexpr explicit __rcvr_ref(_Rcvr& __rcvr) noexcept
+      : __rcvr_(_CUDA_VSTD::addressof(__rcvr))
   {}
 
   template <class... _As>
-  _CCCL_TRIVIAL_API constexpr void set_value(_As&&... __as) noexcept
+  _CCCL_API constexpr void set_value(_As&&... __as) noexcept
   {
     execution::set_value(static_cast<_Rcvr&&>(*__rcvr_), static_cast<_As&&>(__as)...);
   }
 
   template <class _Error>
-  _CCCL_TRIVIAL_API constexpr void set_error(_Error&& __err) noexcept
+  _CCCL_API constexpr void set_error(_Error&& __err) noexcept
   {
     execution::set_error(static_cast<_Rcvr&&>(*__rcvr_), static_cast<_Error&&>(__err));
   }
 
-  _CCCL_TRIVIAL_API constexpr void set_stopped() noexcept
+  _CCCL_API constexpr void set_stopped() noexcept
   {
     execution::set_stopped(static_cast<_Rcvr&&>(*__rcvr_));
   }
 
-  [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto get_env() const noexcept -> _Env
+  [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> env_of_t<_Rcvr>
   {
-    static_assert(sizeof(_Rcvr) > 0, "Receiver type is incomplete.");
-    static_assert(_CUDA_VSTD::is_same_v<_Env, env_of_t<_Rcvr>>,
-                  "get_env() must return the same type as env_of_t<_Rcvr>");
     return execution::get_env(*__rcvr_);
   }
 
@@ -74,60 +67,8 @@ private:
   _Rcvr* __rcvr_;
 };
 
-namespace __detail
-{
-template <class _Rcvr, size_t = sizeof(_Rcvr)>
-_CCCL_API constexpr auto __is_type_complete(int) noexcept
-{
-  return true;
-}
 template <class _Rcvr>
-_CCCL_API constexpr auto __is_type_complete(long) noexcept
-{
-  return false;
-}
-} // namespace __detail
-
-// The __ref_rcvr function and its helpers are used to avoid wrapping a receiver in a
-// __rcvr_ref when that is possible. The logic goes as follows:
-//
-// 1. If the receiver is an instance of __rcvr_ref, return it.
-// 2. If the type is incomplete or an operation state, return a __rcvr_ref wrapping the
-//    receiver.
-// 3. If the receiver is nothrow copy constructible, return it.
-// 4. Otherwise, return a __rcvr_ref wrapping the receiver.
-template <class _Env = void, class _Rcvr>
-[[nodiscard]] _CCCL_TRIVIAL_API constexpr auto __ref_rcvr(_Rcvr& __rcvr) noexcept
-{
-  if constexpr (_CUDA_VSTD::is_same_v<_Env, void>)
-  {
-    return execution::__ref_rcvr<env_of_t<_Rcvr>>(__rcvr);
-  }
-  else if constexpr (::cuda::__is_specialization_of_v<_Rcvr, __rcvr_ref>)
-  {
-    return __rcvr;
-  }
-  else if constexpr (!__detail::__is_type_complete<_Rcvr>(0))
-  {
-    return __rcvr_ref<_Rcvr, _Env>{__rcvr};
-  }
-  else if constexpr (__is_operation_state<_Rcvr>)
-  {
-    return __rcvr_ref<_Rcvr, _Env>{__rcvr};
-  }
-  else if constexpr (__nothrow_constructible<_Rcvr, const _Rcvr&> && _CUDA_VSTD::is_copy_constructible_v<_Rcvr>)
-  {
-    return const_cast<const _Rcvr&>(__rcvr);
-  }
-  else
-  {
-    return __rcvr_ref{__rcvr};
-  }
-  _CCCL_UNREACHABLE();
-}
-
-template <class _Rcvr, class _Env = env_of_t<_Rcvr>>
-using __rcvr_ref_t _CCCL_NODEBUG_ALIAS = decltype(::cuda::experimental::execution::__ref_rcvr<_Env>(declval<_Rcvr&>()));
+_CCCL_HOST_DEVICE __rcvr_ref(_Rcvr&) -> __rcvr_ref<_Rcvr>;
 
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/read_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/read_env.cuh
@@ -85,6 +85,14 @@ private:
     }
   };
 
+  struct __attrs_t
+  {
+    [[nodiscard]] _CCCL_API static constexpr auto query(get_completion_behavior_t) noexcept
+    {
+      return completion_behavior::inline_completion;
+    }
+  };
+
 public:
   template <class _Query>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
@@ -100,8 +108,6 @@ template <class _Query>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t::__sndr_t
 {
   using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
-  _CCCL_NO_UNIQUE_ADDRESS read_env_t __tag;
-  _CCCL_NO_UNIQUE_ADDRESS _Query __query;
 
   template <class _Self, class _Env>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
@@ -134,6 +140,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t::__sndr_t
   {
     return __opstate_t<_Rcvr, _Query>{static_cast<_Rcvr&&>(__rcvr)};
   }
+
+  [[nodiscard]] _CCCL_API static constexpr auto get_env() noexcept
+  {
+    return __attrs_t{};
+  }
+
+  _CCCL_NO_UNIQUE_ADDRESS read_env_t __tag;
+  _CCCL_NO_UNIQUE_ADDRESS _Query __query;
 };
 
 template <class _Query>

--- a/cudax/include/cuda/experimental/__execution/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__execution/run_loop.cuh
@@ -149,40 +149,41 @@ public:
         return __opstate_t<_Rcvr>{&__loop_->__queue_, static_cast<_Rcvr&&>(__rcvr)};
       }
 
-      template <class _Self, class _Env>
+      template <class _Self>
       [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
       {
-#if _CCCL_HAS_EXCEPTIONS()
-        if constexpr (!noexcept(get_stop_token(declval<_Env>()).stop_requested()))
-        {
-          return completion_signatures<set_value_t(), set_error_t(::std::exception_ptr), set_stopped_t()>{};
-        }
-        else
-#endif // !_CCCL_HAS_EXCEPTIONS()
-          return completion_signatures<set_value_t(), set_stopped_t()>{};
+        return completion_signatures<set_value_t(), set_stopped_t()>{};
       }
 
     private:
       friend scheduler;
 
-      struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_t
+      struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
       {
         run_loop* __loop_;
 
-        _CCCL_API constexpr auto query(get_completion_scheduler_t<set_value_t>) const noexcept -> scheduler
+        [[nodiscard]] _CCCL_API constexpr auto query(get_completion_scheduler_t<set_value_t>) const noexcept
+          -> scheduler
         {
           return __loop_->get_scheduler();
         }
 
-        _CCCL_API constexpr auto query(get_completion_scheduler_t<set_stopped_t>) const noexcept -> scheduler
+        [[nodiscard]] _CCCL_API constexpr auto query(get_completion_scheduler_t<set_stopped_t>) const noexcept
+          -> scheduler
         {
           return __loop_->get_scheduler();
+        }
+
+        [[nodiscard]] _CCCL_API static constexpr auto query(get_completion_behavior_t) noexcept
+        {
+          return completion_behavior::asynchronous;
         }
       };
 
-      _CCCL_API constexpr auto get_env() const noexcept -> __env_t
+    public:
+      _CCCL_API constexpr auto get_env() const noexcept -> __attrs_t
       {
-        return __env_t{__loop_};
+        return __attrs_t{__loop_};
       }
 
     private:

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -51,11 +51,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t
   {
     _CCCL_API constexpr explicit __state_t(_Rcvr&& __rcvr, _Sndr2&& __sndr2)
         : __rcvr_(static_cast<_Rcvr&&>(__rcvr))
-        , __opstate2_(execution::connect(static_cast<_Sndr2&&>(__sndr2), __rcvr_ref(__rcvr_)))
+        , __opstate2_(execution::connect(static_cast<_Sndr2&&>(__sndr2), __ref_rcvr(__rcvr_)))
     {}
 
     _Rcvr __rcvr_;
-    connect_result_t<_Sndr2, __rcvr_ref<_Rcvr>> __opstate2_;
+    connect_result_t<_Sndr2, __rcvr_ref_t<_Rcvr>> __opstate2_;
   };
 
   template <class _Rcvr, class _Sndr2>

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -356,6 +356,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
     return __sndr_.__get_stream_(__sndr_.__sndr_, env{});
   }
 
+  // This sender executes asynchronously with respect to 'start()':
+  [[nodiscard]] _CCCL_API static constexpr auto query(get_completion_behavior_t) noexcept
+  {
+    return completion_behavior::asynchronous;
+  }
+
   // This forwards even non-forwarding queries. A stream sender adaptor is not an ordinary
   // sender adaptor, like `then` or `let_value`. A stream sender adaptor is an
   // implementation detail that is not visible to the user. It should be as transparent as

--- a/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/scheduler.cuh
@@ -84,6 +84,11 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT stream_scheduler
       return {};
     }
 
+    [[nodiscard]] _CCCL_TRIVIAL_API static constexpr auto query(get_completion_behavior_t) noexcept
+    {
+      return completion_behavior::asynchronous;
+    }
+
     stream_ref __stream_;
   };
 

--- a/cudax/test/execution/common/impulse_scheduler.cuh
+++ b/cudax/test/execution/common/impulse_scheduler.cuh
@@ -88,7 +88,7 @@ private:
     }
   };
 
-  struct env_t
+  struct _attrs_t
   {
     data_t* data_;
 
@@ -100,6 +100,11 @@ private:
     impulse_scheduler query(cudax_async::get_completion_scheduler_t<cudax_async::set_stopped_t>) const noexcept
     {
       return impulse_scheduler{data_};
+    }
+
+    static constexpr auto query(cudax_async::get_completion_behavior_t) noexcept
+    {
+      return cudax_async::completion_behavior::asynchronous;
     }
   };
 
@@ -123,7 +128,7 @@ private:
 
     auto get_env() const noexcept
     {
-      return env_t{data_};
+      return _attrs_t{data_};
     }
   };
 

--- a/cudax/test/execution/common/inline_scheduler.cuh
+++ b/cudax/test/execution/common/inline_scheduler.cuh
@@ -26,7 +26,8 @@ struct inline_scheduler
 private:
   struct _attrs_t
   {
-    _CCCL_HOST_DEVICE auto query(cudax_async::get_completion_scheduler_t<cudax_async::set_value_t>) const noexcept
+    _CCCL_HOST_DEVICE static constexpr auto
+    query(cudax_async::get_completion_scheduler_t<cudax_async::set_value_t>) noexcept
     {
       return inline_scheduler{};
     }
@@ -35,6 +36,11 @@ private:
     {
       return {};
     }
+
+    _CCCL_HOST_DEVICE static constexpr auto query(cudax_async::get_completion_behavior_t) noexcept
+    {
+      return cudax_async::completion_behavior::inline_completion;
+    }
   };
 
   template <class Rcvr>
@@ -42,12 +48,12 @@ private:
   {
     using operation_state_concept = cudax_async::operation_state_t;
 
-    Rcvr _rcvr;
-
-    _CCCL_HOST_DEVICE void start() noexcept
+    _CCCL_HOST_DEVICE constexpr void start() noexcept
     {
       cudax_async::set_value(static_cast<Rcvr&&>(_rcvr));
     }
+
+    Rcvr _rcvr;
   };
 
 public:
@@ -64,12 +70,12 @@ public:
     }
 
     template <class Rcvr>
-    _CCCL_HOST_DEVICE _opstate_t<Rcvr> connect(Rcvr rcvr) const
+    _CCCL_HOST_DEVICE constexpr _opstate_t<Rcvr> connect(Rcvr rcvr) const
     {
       return {{}, static_cast<Rcvr&&>(rcvr)};
     }
 
-    _CCCL_HOST_DEVICE _attrs_t get_env() const noexcept
+    _CCCL_HOST_DEVICE static constexpr _attrs_t get_env() noexcept
     {
       return {};
     }
@@ -77,7 +83,7 @@ public:
 
   inline_scheduler() = default;
 
-  _CCCL_HOST_DEVICE _sndr_t schedule() const noexcept
+  _CCCL_HOST_DEVICE static constexpr _sndr_t schedule() noexcept
   {
     return {};
   }

--- a/cudax/test/execution/test_just.cu
+++ b/cudax/test/execution/test_just.cu
@@ -10,9 +10,39 @@
 
 #include <cuda/experimental/execution.cuh>
 
-#include "testing.cuh"
+#include <system_error>
 
-C2H_TEST("this is a dummy test", "[just]")
+#include "common/checked_receiver.cuh"
+
+namespace ex = cuda::experimental::execution;
+
+C2H_TEST("simple test of just sender factory", "[just]")
 {
-  REQUIRE(1 == 1);
+  auto sndr  = ex::just(42);
+  using Sndr = decltype(sndr);
+  static_assert(ex::__is_sender<Sndr>, "just(42) must be a sender");
+  static_assert(ex::get_completion_behavior<Sndr>() == ex::completion_behavior::inline_completion);
+  auto op = ex::connect(sndr, checked_value_receiver{42});
+  ex::start(op);
+}
+
+C2H_TEST("simple test of just_error sender factory", "[just]")
+{
+  auto ec    = ::std::errc::invalid_argument;
+  auto sndr  = ex::just_error(ec);
+  using Sndr = decltype(sndr);
+  static_assert(ex::__is_sender<Sndr>, "just_error(...) must be a sender");
+  static_assert(ex::get_completion_behavior<Sndr>() == ex::completion_behavior::inline_completion);
+  auto op = ex::connect(sndr, checked_error_receiver{ec});
+  ex::start(op);
+}
+
+C2H_TEST("simple test of just_stopped sender factory", "[just]")
+{
+  auto sndr  = ex::just_stopped();
+  using Sndr = decltype(sndr);
+  static_assert(ex::__is_sender<Sndr>, "just_stopped() must be a sender");
+  static_assert(ex::get_completion_behavior<Sndr>() == ex::completion_behavior::inline_completion);
+  auto op = ex::connect(sndr, checked_stopped_receiver{});
+  ex::start(op);
 }

--- a/cudax/test/execution/test_let_value.cu
+++ b/cudax/test/execution/test_let_value.cu
@@ -304,7 +304,7 @@ C2H_TEST("let_value exposes a parameter that is destructed when the main operati
 C2H_TEST("let_value works when changing threads", "[adaptors][let_value]")
 {
   ex::thread_context worker;
-  std::atomic<bool> called{false};
+  cuda::std::atomic<bool> called{false};
   {
     // lunch some work on the worker thread
     auto sndr =

--- a/cudax/test/execution/test_let_value.cu
+++ b/cudax/test/execution/test_let_value.cu
@@ -10,6 +10,7 @@
 
 #include <cuda/experimental/execution.cuh>
 
+// IWYU pragma: keep
 #include "common/checked_receiver.cuh"
 #include "common/error_scheduler.cuh" // IWYU pragma: keep
 #include "common/impulse_scheduler.cuh" // IWYU pragma: keep
@@ -33,23 +34,27 @@ struct let_value_test_domain
   }
 };
 
-// C2H_TEST("let_value returns a sender", "[adaptors][let_value]")
-// {
-//   auto sndr = ex::let_value(ex::just(), [] {
-//     return ex::just();
-//   });
-//   static_assert(ex::sender<decltype(sndr)>);
-//   (void) sndr;
-// }
+C2H_TEST("let_value returns a sender", "[adaptors][let_value]")
+{
+  auto sndr  = ex::let_value(ex::just(), [] {
+    return ex::just();
+  });
+  using Sndr = decltype(sndr);
+  static_assert(ex::sender<Sndr>);
+  static_assert(ex::get_completion_behavior<Sndr>() == ex::completion_behavior::inline_completion);
+  (void) sndr;
+}
 
-// C2H_TEST("let_value with environment returns a sender", "[adaptors][let_value]")
-// {
-//   auto sndr = ex::let_value(ex::just(), [] {
-//     return ex::just();
-//   });
-//   static_assert(ex::sender_in<decltype(sndr), ex::env<>>);
-//   (void) sndr;
-// }
+C2H_TEST("let_value with environment returns a sender", "[adaptors][let_value]")
+{
+  auto sndr  = ex::let_value(ex::just(), [] {
+    return ex::just();
+  });
+  using Sndr = decltype(sndr);
+  static_assert(ex::sender_in<Sndr, ex::env<>>);
+  static_assert(ex::get_completion_behavior<Sndr>() == ex::completion_behavior::inline_completion);
+  (void) sndr;
+}
 
 C2H_TEST("let_value simple example", "[adaptors][let_value]")
 {
@@ -296,33 +301,32 @@ C2H_TEST("let_value exposes a parameter that is destructed when the main operati
   CHECK(param_destructed);
 }
 
-// NOT YET SUPPORTED
-// C2H_TEST("let_value works when changing threads", "[adaptors][let_value]")
-// {
-//   exec::static_thread_pool pool{2};
-//   std::atomic<bool> called{false};
-//   {
-//     // lunch some work on the thread pool
-//     auto sndr = ex::transfer_just(pool.get_scheduler(), 7) //
-//              | ex::let_value([]_CCCL_HOST_DEVICE(int& x) {
-//                  return ex::just(x * 2 - 1);
-//                }) //
-//              | ex::then([&]_CCCL_HOST_DEVICE(int x) {
-//                  CHECK(x == 13);
-//                  called.store(true);
-//                });
-//     ex::start_detached(std::move(sndr));
-//   }
-//   // wait for the work to be executed, with timeout
-//   // perform a poor-man's sync
-//   // NOTE: it's a shame that the `join` method in static_thread_pool is not public
-//   for (int i = 0; i < 1000 && !called.load(); i++)
-//   {
-//     std::this_thread::sleep_for(1ms);
-//   }
-//   // the work should be executed
-//   REQUIRE(called);
-// }
+C2H_TEST("let_value works when changing threads", "[adaptors][let_value]")
+{
+  ex::thread_context worker;
+  std::atomic<bool> called{false};
+  {
+    // lunch some work on the worker thread
+    auto sndr =
+      ex::just(7) //
+      | ex::continues_on(worker.get_scheduler()) //
+      | ex::let_value([](int& x) {
+          return ex::just(x * 2 - 1);
+        }) //
+      | ex::then([&](int x) {
+          CHECK(x == 13);
+          called.store(true);
+        });
+
+    using Sndr = decltype(sndr);
+
+    static_assert(ex::get_completion_behavior<Sndr>() == ex::completion_behavior::asynchronous);
+    ex::start_detached(std::move(sndr));
+  }
+  worker.join();
+  // the work should be executed
+  REQUIRE(called);
+}
 
 C2H_TEST("let_value has the values_type corresponding to the given values", "[adaptors][let_value]")
 {
@@ -413,7 +417,7 @@ C2H_TEST("let_value can nest", "[adaptors][let_value]")
   wait_for_value(std::move(work), 2);
 }
 
-constexpr struct test_query_t
+constexpr struct test_query_t : ex::forwarding_query_t
 {
   template <class Env>
   _CCCL_API constexpr auto operator()(const Env& env) const noexcept -> decltype(env.query(*this))
@@ -466,6 +470,28 @@ C2H_TEST("let_value works when the function returns a dependent sender", "[adapt
 // }
 
 #endif // _CCCL_HOST_COMPILATION()
+
+#if !_CCCL_CUDA_COMPILER(NVCC)
+// This example causes nvcc to segfault
+struct let_value_test_domain2
+{};
+
+C2H_TEST("let_value predecessor's domain is accessible via the receiver connected to the secondary sender",
+         "[adaptors][let_value]")
+{
+  auto attrs  = ex::prop{ex::get_domain, let_value_test_domain2{}};
+  using Sndr2 = decltype(ex::read_env(ex::get_domain));
+
+  auto sndr = ex::just() //
+            | ex::write_attrs(attrs) //
+            | ex::let_value([]() noexcept -> Sndr2 {
+                return ex::read_env(ex::get_domain);
+              });
+  auto [result] = ex::sync_wait(std::move(sndr)).value();
+  static_assert(_CUDA_VSTD::is_same_v<decltype(result), let_value_test_domain2>);
+  (void) result;
+}
+#endif // !_CCCL_CUDA_COMPILER(NVCC)
 
 C2H_TEST("let_value has the correct completion domain", "[adaptors][let_value]")
 {

--- a/cudax/test/execution/test_write_env.cu
+++ b/cudax/test/execution/test_write_env.cu
@@ -23,7 +23,7 @@ struct my_domain
 {};
 
 // Simple test query
-struct query1_t
+struct query1_t : ex::forwarding_query_t
 {
   template <class Env>
   _CCCL_API auto operator()(const Env& env) const noexcept -> decltype(env.query(*this))


### PR DESCRIPTION
## Description

aka, fixing the cudax stream scheduler, part N of M.

finding the correct customization of the `continues_on` algorithm requires accurate information about which execution context you are transferring _from_. for example, transferring execution from the gpu to the cpu requires special sauce. the `continues_on` algorithm can only insert that special sauce when it knows that the `continues_on` sender will be started on the gpu.

given a sender expression tree, accurate algorithm dispatch requires each node to be "colored" with the domain of the execution context that will execute that node. in fact, each node can have two different "colors": the domain on which the sender will start, and the domain on which it will complete.

a sender such as `just()` doesn't know the domain on which it will complete, but it _does_ know that if it is _started_ on a given domain, it will also complete there. that is because it completes "inline". this metadata can be used to help color the nodes of a sender expression tree.

this pr adds a sender query for asking a sender for its completion behavior. the possible behaviors are:

* `unknown`: a sender may or may not complete synchronously on the calling thread
* `asynchronous`: the sender will _not_ complete synchronously on the calling thread
* `synchronous`: the completion of the sender happens-before the return from `start`
* `inline_completion`: `start` will directly execute the sender's completion

### other uses:

this metadata has other uses besides. a repeating algorithm typically uses a so-called trampoline to guard against stack overflow if the sender being repeated completes inline too many times. if the sender is known to complete asynchronously, the trampoline can be avoided.

also, `sync_wait` uses synchronization primitives because the sender might complete on a different thread. but if the sender is known to complete inline, no synchronization is necessary.

operations like `start_detached` don't make sense for senders that complete synchronously. this query can be used to make `start_detached(just())` ill-formed, or to avoid the dynamic allocation.

this pr will be followed by others that use this query to more accurately color sender expression trees and optimize certain algorithms.

it is based on the proposal [P3206](https://wg21.link/P3206) .


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
