### PR TITLE
Backport to 3.1: NVTX ranges for C2H, NVTX as system headers, and handle NVTX being disabled in C2H

### DIFF
--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -5,6 +5,7 @@
 
 #include <cuda/std/detail/__config>
 
+#include <cuda/__nvtx/nvtx3.h>
 #include <cuda/std/bit>
 #include <cuda/std/cmath>
 #include <cuda/std/limits>
@@ -329,6 +330,25 @@ struct Catch::StringMaker<cudaError>
 #include <c2h/custom_type.h>
 #include <c2h/generators.h>
 
+namespace detail
+{
+struct nvtx_c2h_domain
+{
+  static constexpr const char* name = "C2H";
+};
+
+template <typename T>
+struct nvtx_fixture
+{
+  nvtx_fixture()
+      : nvtx_range(Catch::getResultCapture().getCurrentTestName())
+  {}
+
+private:
+  ::nvtx3::v1::scoped_range_in<nvtx_c2h_domain> nvtx_range;
+};
+} // namespace detail
+
 #define C2H_TEST_NAME_IMPL(NAME, PARAM) C2H_TEST_STR(NAME) "(" C2H_TEST_STR(PARAM) ")"
 
 #define C2H_TEST_NAME(NAME) C2H_TEST_NAME_IMPL(NAME, VAR_IDX)
@@ -338,7 +358,7 @@ struct Catch::StringMaker<cudaError>
 
 #define C2H_TEST_IMPL(ID, NAME, TAG, ...)                                  \
   using C2H_TEST_CONCAT(types_, ID) = c2h::cartesian_product<__VA_ARGS__>; \
-  TEMPLATE_LIST_TEST_CASE(C2H_TEST_NAME(NAME), TAG, C2H_TEST_CONCAT(types_, ID))
+  TEMPLATE_LIST_TEST_CASE_METHOD(::detail::nvtx_fixture, C2H_TEST_NAME(NAME), TAG, C2H_TEST_CONCAT(types_, ID))
 
 #define C2H_TEST(NAME, TAG, ...) C2H_TEST_IMPL(__LINE__, NAME, TAG, __VA_ARGS__)
 
@@ -351,7 +371,7 @@ struct Catch::StringMaker<cudaError>
 
 #define C2H_TEST_LIST_IMPL(ID, NAME, TAG, ...)                     \
   using C2H_TEST_CONCAT(types_, ID) = c2h::type_list<__VA_ARGS__>; \
-  TEMPLATE_LIST_TEST_CASE(C2H_TEST_NAME(NAME), TAG, C2H_TEST_CONCAT(types_, ID))
+  TEMPLATE_LIST_TEST_CASE_METHOD(::detail::nvtx_fixture, C2H_TEST_NAME(NAME), TAG, C2H_TEST_CONCAT(types_, ID))
 
 #define C2H_TEST_LIST(NAME, TAG, ...) C2H_TEST_LIST_IMPL(__LINE__, NAME, TAG, __VA_ARGS__)
 

--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -5,7 +5,7 @@
 
 #include <cuda/std/detail/__config>
 
-#include <cuda/__nvtx/nvtx3.h>
+#include <cuda/__nvtx/nvtx.h>
 #include <cuda/std/bit>
 #include <cuda/std/cmath>
 #include <cuda/std/limits>
@@ -338,14 +338,11 @@ struct nvtx_c2h_domain
 };
 
 template <typename T>
-struct nvtx_fixture
+class nvtx_fixture
 {
-  nvtx_fixture()
-      : nvtx_range(Catch::getResultCapture().getCurrentTestName())
-  {}
-
-private:
-  ::nvtx3::v1::scoped_range_in<nvtx_c2h_domain> nvtx_range;
+#if _CCCL_HAS_NVTX3()
+  ::nvtx3::v1::scoped_range_in<nvtx_c2h_domain> nvtx_range{Catch::getResultCapture().getCurrentTestName()};
+#endif // _CCCL_HAS_NVTX3()
 };
 } // namespace detail
 

--- a/cub/test/catch2_test_device_for_utils.cu
+++ b/cub/test/catch2_test_device_for_utils.cu
@@ -99,8 +99,8 @@ void test()
 
 C2H_TEST("Device for utils correctly detect value overloads", "[for][device]")
 {
-  test<int>();
-  test<double>();
+  ::test<int>();
+  ::test<double>();
 
   // conversions do not work ;(
   STATIC_REQUIRE(cub::detail::for_each::has_unique_value_overload<char, value_t<int>>::value);

--- a/libcudacxx/include/cuda/__nvtx/nvtx.h
+++ b/libcudacxx/include/cuda/__nvtx/nvtx.h
@@ -25,10 +25,13 @@
 #  define CCCL_DISABLE_NVTX
 #endif // _CCCL_DOXYGEN_INVOKED
 
+#define _CCCL_HAS_NVTX3() 0
+
 // Enable the functionality of this header if:
 // * The NVTX3 C API is available in CTK
 // * NVTX is not explicitly disabled (via CCCL_DISABLE_NVTX or NVTX_DISABLE)
-// * NVTX3 uses module as an identifier, which trips up NVHPC
+// * the compiler is not nvc++ (NVTX3 uses module as an identifier, which trips up NVHPC)
+// * the compiler is not NVRTC
 #if _CCCL_HAS_INCLUDE(<nvtx3/nvToolsExt.h>) && !defined(CCCL_DISABLE_NVTX) && !defined(NVTX_DISABLE) \
                       && (!_CCCL_COMPILER(NVHPC))                                                    \
                       && !_CCCL_COMPILER(NVRTC)
@@ -57,12 +60,26 @@
 // of NVTX3 will continue to declare previous API versions. See also:
 // https://github.com/NVIDIA/NVTX/blob/release-v3/c/include/nvtx3/nvtx3.hpp#L2835-L2841.
 #  ifdef NVTX3_CPP_DEFINITIONS_V1_0
-#    include <cuda/std/optional>
+#    undef _CCCL_HAS_NVTX3
+#    define _CCCL_HAS_NVTX3() 1
+#  else // NVTX3_CPP_DEFINITIONS_V1_0
+// If this happens NVTX3 changed in a way we did not anticipate, and we need to get in touch with them
+#    if _CCCL_COMPILER(MSVC)
+#      pragma message( \
+        "warning: nvtx3.h is available but does not define the V1 API. This is odd. Please open a GitHub issue at: https://github.com/NVIDIA/cccl/issues.")
+#    else
+#      warning nvtx3.h is available but does not define the V1 API. This is odd. Please open a GitHub issue at: https://github.com/NVIDIA/cccl/issues.
+#    endif
+#  endif // NVTX3_CPP_DEFINITIONS_V1_0
+#endif // _CCCL_HAS_INCLUDE(<nvtx3/nvToolsExt.h>) && !defined(CCCL_DISABLE_NVTX) && !defined(NVTX_DISABLE) &&
+       // (!_CCCL_COMPILER(NVHPC)) && !_CCCL_COMPILER(NVRTC)
 
-#    include <cuda/std/__cccl/prologue.h>
+#if _CCCL_HAS_NVTX3()
+#  include <cuda/std/optional>
+
+#  include <cuda/std/__cccl/prologue.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
-
 namespace detail
 {
 struct NVTXCCCLDomain
@@ -70,45 +87,34 @@ struct NVTXCCCLDomain
   static constexpr const char* name{"CCCL"};
 };
 } // namespace detail
+_LIBCUDACXX_END_NAMESPACE_CUDA
 
 // Hook for the NestedNVTXRangeGuard from the unit tests
-#    ifndef _CCCL_BEFORE_NVTX_RANGE_SCOPE
-#      define _CCCL_BEFORE_NVTX_RANGE_SCOPE(name)
-#    endif // !CCCL_DETAIL_BEFORE_NVTX_RANGE_SCOPE
+#  ifndef _CCCL_BEFORE_NVTX_RANGE_SCOPE
+#    define _CCCL_BEFORE_NVTX_RANGE_SCOPE(name)
+#  endif // !CCCL_DETAIL_BEFORE_NVTX_RANGE_SCOPE
 
 // Conditionally inserts a NVTX range starting here until the end of the current function scope in host code. Does
 // nothing in device code.
 // The optional is needed to defer the construction of an NVTX range (host-only code) and message string registration
 // into a dispatch region running only on the host, while preserving the semantic scope where the range is declared.
-#    define _CCCL_NVTX_RANGE_SCOPE_IF(condition, name)                                                               \
-      _CCCL_BEFORE_NVTX_RANGE_SCOPE(name)                                                                            \
-      _CUDA_VSTD::optional<::nvtx3::v1::scoped_range_in<::cuda::detail::NVTXCCCLDomain>> __cuda_nvtx3_range;         \
-      NV_IF_TARGET(                                                                                                  \
-        NV_IS_HOST,                                                                                                  \
-        static const ::nvtx3::v1::registered_string_in<::cuda::detail::NVTXCCCLDomain> __cuda_nvtx3_func_name{name}; \
-        static const ::nvtx3::v1::event_attributes __cuda_nvtx3_func_attr{__cuda_nvtx3_func_name};                   \
-        if (condition) __cuda_nvtx3_range.emplace(__cuda_nvtx3_func_attr);                                           \
-        (void) __cuda_nvtx3_range;)
+#  define _CCCL_NVTX_RANGE_SCOPE_IF(condition, name)                                                               \
+    _CCCL_BEFORE_NVTX_RANGE_SCOPE(name)                                                                            \
+    _CUDA_VSTD::optional<::nvtx3::v1::scoped_range_in<::cuda::detail::NVTXCCCLDomain>> __cuda_nvtx3_range;         \
+    NV_IF_TARGET(                                                                                                  \
+      NV_IS_HOST,                                                                                                  \
+      static const ::nvtx3::v1::registered_string_in<::cuda::detail::NVTXCCCLDomain> __cuda_nvtx3_func_name{name}; \
+      static const ::nvtx3::v1::event_attributes __cuda_nvtx3_func_attr{__cuda_nvtx3_func_name};                   \
+      if (condition) __cuda_nvtx3_range.emplace(__cuda_nvtx3_func_attr);                                           \
+      (void) __cuda_nvtx3_range;)
 
-#    define _CCCL_NVTX_RANGE_SCOPE(name) _CCCL_NVTX_RANGE_SCOPE_IF(true, name)
-#  else // NVTX3_CPP_DEFINITIONS_V1_0
-#    if _CCCL_COMPILER(MSVC)
-#      pragma message( \
-        "warning: nvtx3.h is available but does not define the V1 API. This is odd. Please open a GitHub issue at: https://github.com/NVIDIA/cccl/issues.")
-#    else
-#      warning nvtx3.h is available but does not define the V1 API. This is odd. Please open a GitHub issue at: https://github.com/NVIDIA/cccl/issues.
-#    endif
-#    define _CCCL_NVTX_RANGE_SCOPE_IF(condition, name)
-#    define _CCCL_NVTX_RANGE_SCOPE(name)
-#  endif // NVTX3_CPP_DEFINITIONS_V1_0
-
-_LIBCUDACXX_END_NAMESPACE_CUDA
+#  define _CCCL_NVTX_RANGE_SCOPE(name) _CCCL_NVTX_RANGE_SCOPE_IF(true, name)
 
 #  include <cuda/std/__cccl/epilogue.h>
 
-#else // _CCCL_HAS_INCLUDE(<nvtx3/nvToolsExt.h> ) && !defined(CCCL_DISABLE_NVTX) && !defined(NVTX_DISABLE)
+#else // _CCCL_HAS_NVTX3()
 #  define _CCCL_NVTX_RANGE_SCOPE_IF(condition, name)
 #  define _CCCL_NVTX_RANGE_SCOPE(name)
-#endif // _CCCL_HAS_INCLUDE(<nvtx3/nvToolsExt.h> ) && !defined(CCCL_DISABLE_NVTX) && !defined(NVTX_DISABLE)
+#endif // _CCCL_HAS_NVTX3()
 
 #endif // _CUDA___NVTX_NVTX_H

--- a/libcudacxx/include/cuda/__nvtx/nvtx.h
+++ b/libcudacxx/include/cuda/__nvtx/nvtx.h
@@ -32,6 +32,14 @@
 #if _CCCL_HAS_INCLUDE(<nvtx3/nvToolsExt.h>) && !defined(CCCL_DISABLE_NVTX) && !defined(NVTX_DISABLE) \
                       && (!_CCCL_COMPILER(NVHPC))                                                    \
                       && !_CCCL_COMPILER(NVRTC)
+
+// Since NVTX 3.2, the NVTX headers can declare themselves as system headers by declaring the following macro:
+#  ifdef NVTX_AS_SYSTEM_HEADER
+#    define NVTX_AS_SYSTEM_HEADER_DEFINED_BY_USER
+#  else // NVTX_AS_SYSTEM_HEADER
+#    define NVTX_AS_SYSTEM_HEADER
+#  endif // NVTX_AS_SYSTEM_HEADER
+
 // Include our NVTX3 C++ wrapper if not available from the CTK or not provided by the user
 // Note: NVTX3 is available in the CTK since 12.9, so we can drop our copy once this is the minimum supported version
 #  if _CCCL_HAS_INCLUDE(<nvtx3/nvtx3.hpp>)
@@ -39,6 +47,11 @@
 #  else // _CCCL_HAS_INCLUDE(<nvtx3/nvtx3.hpp>)
 #    include <cuda/__nvtx/nvtx3.h>
 #  endif // _CCCL_HAS_INCLUDE(<nvtx3/nvtx3.hpp>)
+
+#  ifndef NVTX_AS_SYSTEM_HEADER_DEFINED_BY_USER
+#    undef NVTX_AS_SYSTEM_HEADER
+#  endif // NVTX_AS_SYSTEM_HEADER_DEFINED_BY_USER
+#  undef NVTX_AS_SYSTEM_HEADER_DEFINED_BY_USER
 
 // We expect the NVTX3 V1 C++ API to be available when nvtx3.hpp is available. This should work, because newer versions
 // of NVTX3 will continue to declare previous API versions. See also:


### PR DESCRIPTION
This backports the following 3 PRs:

- Add NVTX ranges to C2H tests (#5332)
- Make NVTX headers declare themselves as system headers (#5508) 
- Handle NVTX3 being disable in C2H (#5511) 

Fixes NVBug 5442875