### PR TITLE
Port `thrust::shuffle_iterator` to cuda

### DIFF
--- a/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
@@ -29,6 +29,7 @@
 #include <cuda/std/__random/is_valid.h>
 #include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_nothrow_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
@@ -98,9 +99,24 @@ public:
 
   _CCCL_HIDE_FROM_ABI constexpr shuffle_iterator() noexcept = default;
 
+  //! @brief Constructs a shuffle iterator from a given bijection and an optional start position
+  //! @param __bijection The bijection representing the shuffled integer sequence
+  //! @param __start The position of the iterator in the shuffled integer sequence
   _CCCL_API constexpr shuffle_iterator(_Bijection __bijection, value_type __start = 0) noexcept(
     ::cuda::std::is_nothrow_move_constructible_v<_Bijection>)
       : __bijection_(::cuda::std::move(__bijection))
+      , __current_(__start)
+  {}
+
+  //! @brief Constructs a shuffle iterator representing a sequence of size @param __num_elements from a random number
+  //! generator @param __gen and an optional start position @param __start
+  //! It constructs the bijection function @tparam _Bijection from the desired size of the sequence and a random number
+  //! generator
+  template <class _RNG>
+  // constraining here breaks CTAD
+  _CCCL_API explicit constexpr shuffle_iterator(value_type __num_elements, _RNG&& __gen, value_type __start = 0) //
+    noexcept(_CUDA_VSTD::is_nothrow_constructible_v<_Bijection, value_type, _RNG>)
+      : __bijection_(__num_elements, _CUDA_VSTD::forward<_RNG>(__gen))
       , __current_(__start)
   {}
 

--- a/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
@@ -1,0 +1,275 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___ITERATOR_SHUFFLE_ITERATOR_H
+#define _CUDA___ITERATOR_SHUFFLE_ITERATOR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#  include <cuda/std/__compare/three_way_comparable.h>
+#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#include <cuda/__random/random_bijection.h>
+#include <cuda/std/__concepts/constructible.h>
+#include <cuda/std/__random/is_valid.h>
+#include <cuda/std/__type_traits/is_constructible.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/make_signed.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+//! @brief Verifies that a given type @tparam _Bijection is a valid bijection function.
+//! It verifies
+//! * The bijection has a type alias ``index_type`` that satisfies ``integral``
+//! * The bijection has a non-mutable member function size() that returns the number of elements as ``index_type``
+//! * The bijection has a non-mutable call operator that takes a value of type ``index_type`` in the range
+//! ``[0, size())`` and projects it into the range ``[0, size())``
+template <class _Bijection>
+_CCCL_CONCEPT __is_bijection = _CCCL_REQUIRES_EXPR((_Bijection), const _Bijection& __fun)(
+  typename(typename _Bijection::index_type),
+  requires(::cuda::std::is_integral_v<typename _Bijection::index_type>),
+  requires(::cuda::std::is_same_v<decltype(__fun.size()), typename _Bijection::index_type>),
+  requires(
+    ::cuda::std::is_same_v<decltype(__fun(typename _Bijection::index_type(0))), typename _Bijection::index_type>));
+
+//! @brief shuffle_iterator is an iterator which generates a sequence of values representing a random permutation.
+//! @tparam _IndexType The type of the index to shuffle. Defaults to uint64_t
+//! @tparam _BijectionFunc The bijection to use. This should be a bijective function that maps [0..n) -> [0..n). It must
+//! be deterministic and stateless. Defaults to cuda::random_biijection<_IndexType>
+//!
+//! @class shuffle_iterator is an iterator which generates a sequence of values representing a random permutation. This
+//! iterator is useful for working with random permutations of a range without explicitly storing them in memory. The
+//! shuffle iterator is also useful for sampling from a range by selecting only a subset of the elements in the
+//! permutation.
+//!
+//! The following code snippet demonstrates how to create a @param shuffle_iterator which generates a random permutation
+//! of the range[0, 4)
+//!
+//! @code
+//! #include <cuda/iterator>
+//! ...
+//! // create a shuffle iterator
+//! cuda::shuffle_iterator iterator{4, cuda::std::minstd_rand(0xDEADBEEF)};
+//! // iterator[0] returns 1
+//! // iterator[1] returns 3
+//! // iterator[2] returns 2
+//! // iterator[3] returns 0
+//! @endcode
+template <class _IndexType = ::cuda::std::size_t, class _Bijection = random_bijection<_IndexType>>
+class shuffle_iterator
+{
+private:
+  _Bijection __bijection_{};
+  _IndexType __current_{0};
+
+  static_assert(::cuda::std::is_integral_v<_IndexType>, "_IndexType must be an integral type");
+  static_assert(__is_bijection<_Bijection>, "_Bijection must be a valid bijection function");
+
+public:
+  using iterator_category = ::cuda::std::random_access_iterator_tag;
+  using iterator_concept  = ::cuda::std::random_access_iterator_tag;
+  using value_type        = _IndexType;
+  using difference_type   = ::cuda::std::make_signed_t<value_type>;
+
+  _CCCL_HIDE_FROM_ABI constexpr shuffle_iterator() noexcept = default;
+
+  _CCCL_API constexpr shuffle_iterator(_Bijection __bijection, value_type __start = 0) noexcept(
+    ::cuda::std::is_nothrow_move_constructible_v<_Bijection>)
+      : __bijection_(::cuda::std::move(__bijection))
+      , __current_(__start)
+  {}
+
+  [[nodiscard]] _CCCL_API constexpr value_type operator*() const noexcept(noexcept(__bijection_(0)))
+  {
+    _CCCL_ASSERT(__current_ < static_cast<value_type>(__bijection_.size()),
+                 "shuffle_iterator::operator*: Trying to dereference a shuffle_iterator past the end!");
+    return static_cast<value_type>(__bijection_(static_cast<typename _Bijection::index_type>(__current_)));
+  }
+
+  [[nodiscard]] _CCCL_API constexpr value_type operator[](difference_type __n) const noexcept(noexcept(__bijection_(0)))
+  {
+    _CCCL_ASSERT(static_cast<value_type>(static_cast<difference_type>(__current_) + __n)
+                   < static_cast<value_type>(__bijection_.size()),
+                 "shuffle_iterator::operator*: Trying to subscript a shuffle_iterator past the end!");
+    return static_cast<value_type>(__bijection_(static_cast<typename _Bijection::index_type>(__current_ + __n)));
+  }
+
+  _CCCL_API constexpr shuffle_iterator& operator++() noexcept
+  {
+    ++__current_;
+    return *this;
+  }
+
+  _CCCL_API constexpr shuffle_iterator operator++(int) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Bijection>)
+  {
+    auto __tmp = *this;
+    ++__current_;
+    return __tmp;
+  }
+
+  _CCCL_API constexpr shuffle_iterator& operator--() noexcept
+  {
+    --__current_;
+    return *this;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr shuffle_iterator
+  operator--(int) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Bijection>)
+  {
+    auto __tmp = *this;
+    --__current_;
+    return __tmp;
+  }
+
+  _CCCL_API constexpr shuffle_iterator& operator+=(difference_type __n) noexcept
+  {
+#if _CCCL_COMPILER(MSVC) // C4308: negative integral constant converted to unsigned type
+    __current_ = static_cast<value_type>(static_cast<difference_type>(__current_) + __n);
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+    __current_ += __n;
+#endif // !_CCCL_COMPILER(MSVC)
+    return *this;
+  }
+
+  _CCCL_API constexpr shuffle_iterator& operator-=(difference_type __n) noexcept
+  {
+#if _CCCL_COMPILER(MSVC) // C4308: negative integral constant converted to unsigned type
+    __current_ = static_cast<value_type>(static_cast<difference_type>(__current_) - __n);
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+    __current_ -= __n;
+#endif // !_CCCL_COMPILER(MSVC)
+    return *this;
+  }
+
+  [[nodiscard]] _CCCL_API friend constexpr shuffle_iterator operator+(shuffle_iterator __i, difference_type __n) noexcept
+  {
+#if _CCCL_COMPILER(MSVC) // C4308: negative integral constant converted to unsigned type
+    __i.__current_ = static_cast<value_type>(static_cast<difference_type>(__i.__current_) + __n);
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+    __i.__current_ += __n;
+#endif // !_CCCL_COMPILER(MSVC)
+    return __i;
+  }
+
+  [[nodiscard]] _CCCL_API friend constexpr shuffle_iterator operator+(difference_type __n, shuffle_iterator __i) noexcept
+  {
+#if _CCCL_COMPILER(MSVC) // C4308: negative integral constant converted to unsigned type
+    __i.__current_ = static_cast<value_type>(static_cast<difference_type>(__i.__current_) + __n);
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+    __i.__current_ += __n;
+#endif // !_CCCL_COMPILER(MSVC)
+    return __i;
+  }
+
+  [[nodiscard]] _CCCL_API friend constexpr shuffle_iterator operator-(shuffle_iterator __i, difference_type __n) noexcept
+  {
+#if _CCCL_COMPILER(MSVC) // C4308: negative integral constant converted to unsigned type
+    __i.__current_ = static_cast<value_type>(static_cast<difference_type>(__i.__current_) - __n);
+#else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
+    __i.__current_ -= __n;
+#endif // !_CCCL_COMPILER(MSVC)
+    return __i;
+  }
+
+  [[nodiscard]] _CCCL_API friend constexpr difference_type
+  operator-(const shuffle_iterator& __x, const shuffle_iterator& __y) noexcept
+  {
+    return static_cast<difference_type>(__x.__current_ - __y.__current_);
+  }
+
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator==(const shuffle_iterator& __x, const shuffle_iterator& __y) noexcept
+  {
+    return __x.__current_ == __y.__current_;
+  }
+
+#if _CCCL_STD_VER <= 2017
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator!=(const shuffle_iterator& __x, const shuffle_iterator& __y) noexcept
+  {
+    return __x.__current_ != __y.__current_;
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+  [[nodiscard]] _CCCL_API friend constexpr ::cuda::std::strong_ordering
+  operator<=>(const shuffle_iterator& __x, const shuffle_iterator& __y) noexcept
+  {
+    return __x.__current_ <=> __y.__current_;
+  }
+#else // ^^^ _LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR ^^^ / vvv !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR vvv
+
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator<(const shuffle_iterator& __x, const shuffle_iterator& __y) noexcept
+  {
+    return __x.__current_ < __y.__current_;
+  }
+
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator>(const shuffle_iterator& __x, const shuffle_iterator& __y) noexcept
+  {
+    return __x.__current_ > __y.__current_;
+  }
+
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator<=(const shuffle_iterator& __x, const shuffle_iterator& __y) noexcept
+  {
+    return __x.__current_ <= __y.__current_;
+  }
+
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator>=(const shuffle_iterator& __x, const shuffle_iterator& __y) noexcept
+  {
+    return __x.__current_ >= __y.__current_;
+  }
+#endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
+};
+
+_CCCL_TEMPLATE(class _Bijection)
+_CCCL_REQUIRES(__is_bijection<_Bijection>)
+_CCCL_HOST_DEVICE shuffle_iterator(_Bijection) -> shuffle_iterator<typename _Bijection::index_type, _Bijection>;
+
+_CCCL_TEMPLATE(class _Bijection, typename _Integral)
+_CCCL_REQUIRES(__is_bijection<_Bijection> _CCCL_AND ::cuda::std::is_integral_v<_Integral>)
+_CCCL_HOST_DEVICE shuffle_iterator(_Bijection, _Integral)
+  -> shuffle_iterator<typename _Bijection::index_type, _Bijection>;
+
+//! @brief make_shuffle_iterator creates a \p shuffle_iterator from an integer \p __num_elements and a bijection
+//! function \p __bijection
+//! @param __num_elements The number of elements we want to shuffle
+//! @param __fun The bijection function used for shuffling
+template <class _IndexType, class _Bijection>
+[[nodiscard]] _CCCL_API constexpr auto make_shuffle_iterator(_IndexType __num_elements, _Bijection __fun)
+{
+  return shuffle_iterator<_IndexType, _Bijection>{__num_elements, ::cuda::std::move(__fun)};
+}
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___ITERATOR_TRANSFORM_ITERATOR_H

--- a/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
@@ -56,7 +56,8 @@ _CCCL_CONCEPT __is_bijection = _CCCL_REQUIRES_EXPR((_Bijection), const _Bijectio
   requires(
     ::cuda::std::is_same_v<decltype(__fun(typename _Bijection::index_type(0))), typename _Bijection::index_type>));
 
-//! @brief shuffle_iterator is an iterator which generates a sequence of values representing a random permutation.
+//! @brief shuffle_iterator is an iterator which generates a sequence of integral values representing a random
+//! permutation.
 //! @tparam _IndexType The type of the index to shuffle. Defaults to uint64_t
 //! @tparam _BijectionFunc The bijection to use. This should be a bijective function that maps [0..n) -> [0..n). It must
 //! be deterministic and stateless. Defaults to cuda::random_biijection<_IndexType>
@@ -66,14 +67,14 @@ _CCCL_CONCEPT __is_bijection = _CCCL_REQUIRES_EXPR((_Bijection), const _Bijectio
 //! shuffle iterator is also useful for sampling from a range by selecting only a subset of the elements in the
 //! permutation.
 //!
-//! The following code snippet demonstrates how to create a @param shuffle_iterator which generates a random permutation
+//! The following code snippet demonstrates how to create a @c shuffle_iterator which generates a random permutation
 //! of the range[0, 4)
 //!
 //! @code
 //! #include <cuda/iterator>
 //! ...
 //! // create a shuffle iterator
-//! cuda::shuffle_iterator iterator{4, cuda::std::minstd_rand(0xDEADBEEF)};
+//! cuda::shuffle_iterator iterator{cuda::random_bijection{4, cuda::std::minstd_rand(0xDEADBEEF)}};
 //! // iterator[0] returns 1
 //! // iterator[1] returns 3
 //! // iterator[2] returns 2
@@ -260,12 +261,12 @@ _CCCL_HOST_DEVICE shuffle_iterator(_Bijection, _Integral)
 
 //! @brief make_shuffle_iterator creates a \p shuffle_iterator from an integer \p __num_elements and a bijection
 //! function \p __bijection
-//! @param __num_elements The number of elements we want to shuffle
 //! @param __fun The bijection function used for shuffling
-template <class _IndexType, class _Bijection>
-[[nodiscard]] _CCCL_API constexpr auto make_shuffle_iterator(_IndexType __num_elements, _Bijection __fun)
+//! @param __start The starting position of the shuffle_iterator
+template <class _Bijection, class _IndexType>
+[[nodiscard]] _CCCL_API constexpr auto make_shuffle_iterator(_Bijection __fun, _IndexType __start = 0)
 {
-  return shuffle_iterator<_IndexType, _Bijection>{__num_elements, ::cuda::std::move(__fun)};
+  return shuffle_iterator<_IndexType, _Bijection>{::cuda::std::move(__fun), __start};
 }
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__random/feistel_bijection.h
+++ b/libcudacxx/include/cuda/__random/feistel_bijection.h
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___RANDOM_FEISTEL_BIJECTION_H
+#define _CUDA___RANDOM_FEISTEL_BIJECTION_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__bit/bit_cast.h>
+#include <cuda/std/__bit/integral.h>
+#include <cuda/std/__random/uniform_int_distribution.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+//! @brief A Feistel cipher for operating on power of two sized problems
+class __feistel_bijection
+{
+private:
+  static constexpr uint32_t __num_rounds = 24;
+
+  uint64_t __right_side_bits{};
+  uint64_t __left_side_bits{};
+  uint64_t __right_side_mask{};
+  uint64_t __left_side_mask{};
+  uint32_t __keys[__num_rounds] = {};
+
+  struct __decomposed
+  {
+    uint32_t __low;
+    uint32_t __high;
+  };
+
+public:
+  using index_type = uint64_t;
+
+  _CCCL_HIDE_FROM_ABI constexpr __feistel_bijection() noexcept = default;
+
+  template <class _RNG>
+  _CCCL_API __feistel_bijection(uint64_t __num_elements, _RNG&& __gen)
+  {
+    const uint64_t __total_bits = (::cuda::std::max)(uint64_t{4}, ::cuda::std::bit_ceil(__num_elements));
+
+    // Half bits rounded down
+    __left_side_bits = __total_bits / 2;
+    __left_side_mask = (1ull << __left_side_bits) - 1;
+    // Half the bits rounded up
+    __right_side_bits = __total_bits - __left_side_bits;
+    __right_side_mask = (1ull << __right_side_bits) - 1;
+
+    ::cuda::std::uniform_int_distribution<uint32_t> dist{};
+    _CCCL_PRAGMA_UNROLL_FULL()
+    for (uint32_t i = 0; i < __num_rounds; i++)
+    {
+      __keys[i] = dist(__gen);
+    }
+  }
+
+  [[nodiscard]] _CCCL_API constexpr uint64_t size() const noexcept
+  {
+    return 1ull << (__left_side_bits + __right_side_bits);
+  }
+
+  [[nodiscard]] _CCCL_API constexpr uint64_t operator()(const uint64_t __val) const noexcept
+  {
+    __decomposed __state = {static_cast<uint32_t>(__val >> __right_side_bits),
+                            static_cast<uint32_t>(__val & __right_side_mask)};
+    for (uint32_t i = 0; i < __num_rounds; i++)
+    {
+      constexpr uint64_t __m0  = 0xD2B74407B1CE6E93;
+      const uint64_t __product = __m0 * __state.__high;
+      const uint32_t __high    = static_cast<uint32_t>(__product >> 32);
+      uint32_t __low           = static_cast<uint32_t>(__product);
+      __low                    = (__low << (__right_side_bits - __left_side_bits)) | __state.__low >> __left_side_bits;
+      __state.__high           = ((__high ^ __keys[i]) ^ __state.__low) & __left_side_mask;
+      __state.__low            = __low & __right_side_mask;
+    }
+    // Combine the left and right sides together to get result
+    return (static_cast<uint64_t>(__state.__high) << __right_side_bits) | static_cast<uint64_t>(__state.__low);
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___RANDOM_FEISTEL_BIJECTION_H

--- a/libcudacxx/include/cuda/__random/feistel_bijection.h
+++ b/libcudacxx/include/cuda/__random/feistel_bijection.h
@@ -57,7 +57,7 @@ public:
   template <class _RNG>
   _CCCL_API __feistel_bijection(uint64_t __num_elements, _RNG&& __gen)
   {
-    const uint64_t __total_bits = (::cuda::std::max)(uint64_t{4}, ::cuda::std::bit_ceil(__num_elements));
+    const uint64_t __total_bits = (::cuda::std::max) (uint64_t{4}, ::cuda::std::bit_ceil(__num_elements));
 
     // Half bits rounded down
     __left_side_bits = __total_bits / 2;

--- a/libcudacxx/include/cuda/__random/random_bijection.h
+++ b/libcudacxx/include/cuda/__random/random_bijection.h
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___RANDOM_RANDOM_BIJECTION_H
+#define _CUDA___RANDOM_RANDOM_BIJECTION_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__random/feistel_bijection.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+//! @brief Adaptor for a __bijection to work with any size problem. It achieves this by iterating the __bijection until
+//! the result is less than __num_elements. For a feistel bijection, the worst case number of iterations required for
+//! one call to operator() is O(__num_elements) with low probability. It has amortised O(1) complexity.
+//! @tparam _IndexType The type of the index to shuffle. Defaults to uint64_t.
+//! @tparam _Bijection The __bijection to use. A low quality random __bijection may lead to poor work balancing between
+//! calls to the operator(). Defaults to a feistel bijetion
+template <class _IndexType = ::cuda::std::uint64_t, class _Bijection = __feistel_bijection>
+class random_bijection
+{
+private:
+  static_assert(::cuda::std::is_integral_v<_IndexType>, "_IndexType must be an integral type");
+  static_assert(::cuda::std::is_integral_v<typename _Bijection::index_type>,
+                "_Bijection::index_type must be an integral type");
+  static_assert(::cuda::std::is_convertible_v<_IndexType, typename _Bijection::index_type>,
+                "_IndexType must be convertible to _Bijection::index_type");
+
+  _Bijection __bijection{};
+  _IndexType __num_elements{};
+
+public:
+  using index_type = _IndexType;
+
+  _CCCL_HIDE_FROM_ABI constexpr random_bijection() noexcept = default;
+
+  template <class _RNG>
+  _CCCL_API constexpr random_bijection(_IndexType __num_elements, _RNG&& __gen) noexcept
+      : __bijection(__num_elements, ::cuda::std::forward<_RNG>(__gen))
+      , __num_elements(__num_elements)
+  {}
+
+  [[nodiscard]] _CCCL_API constexpr _IndexType operator()(_IndexType __n) const noexcept
+  {
+    // The initial index must be be in the range [0, __num_elemments]
+    // If __n < __num_elements Iterating a __bijection like this will always terminate.
+    // If __n >= __num_elements, then this may loop forever.
+    _CCCL_ASSERT(__n < __num_elements, "random_bijection::operator(): index out of range");
+    do
+    {
+      __n = static_cast<_IndexType>(__bijection(__n));
+    } while (__n >= __num_elements);
+
+    return __n;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr _IndexType size() const noexcept
+  {
+    return __num_elements;
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___RANDOM_RANDOM_BIJECTION_H

--- a/libcudacxx/include/cuda/iterator
+++ b/libcudacxx/include/cuda/iterator
@@ -25,6 +25,7 @@
 #include <cuda/__iterator/counting_iterator.h>
 #include <cuda/__iterator/discard_iterator.h>
 #include <cuda/__iterator/permutation_iterator.h>
+#include <cuda/__iterator/shuffle_iterator.h>
 #include <cuda/__iterator/strided_iterator.h>
 #include <cuda/__iterator/tabulate_output_iterator.h>
 #include <cuda/__iterator/transform_input_output_iterator.h>

--- a/libcudacxx/include/cuda/std/__random/is_valid.h
+++ b/libcudacxx/include/cuda/std/__random/is_valid.h
@@ -92,9 +92,9 @@ inline constexpr bool __libcpp_random_is_valid_inttype<__uint128_t> = true;
 // handle such generator types.)
 
 template <class, class = void>
-inline constexpr bool __libcpp_random_is_valid_urng = false;
+inline constexpr bool __cccl_random_is_valid_urng = false;
 template <class _Gp>
-inline constexpr bool __libcpp_random_is_valid_urng<
+inline constexpr bool __cccl_random_is_valid_urng<
   _Gp,
   enable_if_t<is_unsigned_v<typename _Gp::result_type>
               && is_same_v<decltype(::cuda::std::declval<_Gp&>()()), typename _Gp::result_type>>> = true;

--- a/libcudacxx/include/cuda/std/__random/uniform_int_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/uniform_int_distribution.h
@@ -223,7 +223,7 @@ public:
   template <class _URng>
   [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p) noexcept
   {
-    static_assert(__libcpp_random_is_valid_urng<_URng>, "");
+    static_assert(__cccl_random_is_valid_urng<_URng>, "");
     using _UIntType = conditional_t<sizeof(result_type) <= sizeof(uint32_t), uint32_t, make_unsigned_t<result_type>>;
     const _UIntType __rp = _UIntType(__p.b()) - _UIntType(__p.a()) + _UIntType(1);
     if (__rp == 1)

--- a/libcudacxx/include/cuda/std/__random/uniform_real_distribution.h
+++ b/libcudacxx/include/cuda/std/__random/uniform_real_distribution.h
@@ -97,7 +97,7 @@ public:
   template <class _URng>
   [[nodiscard]] _CCCL_API result_type operator()(_URng& __g, const param_type& __p) noexcept
   {
-    static_assert(__libcpp_random_is_valid_urng<_URng>, "");
+    static_assert(__cccl_random_is_valid_urng<_URng>, "");
     return (__p.b() - __p.a()) * ::cuda::std::generate_canonical<_RealType, numeric_limits<_RealType>::digits>(__g)
          + __p.a();
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/compare.pass.cpp
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// shuffle_iterator::operator{<,>,<=,>=,==,!=,<=>}
+
+#include <cuda/iterator>
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#  include <cuda/std/compare>
+#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  cuda::shuffle_iterator iter1{fake_bijection{}, 0};
+  cuda::shuffle_iterator iter2{fake_bijection{}, 1};
+
+  assert(!(iter1 < iter1));
+  assert(iter1 < iter2);
+  assert(!(iter2 < iter1));
+  assert(iter1 <= iter1);
+  assert(iter1 <= iter2);
+  assert(!(iter2 <= iter1));
+  assert(!(iter1 > iter1));
+  assert(!(iter1 > iter2));
+  assert(iter2 > iter1);
+  assert(iter1 >= iter1);
+  assert(!(iter1 >= iter2));
+  assert(iter2 >= iter1);
+  assert(iter1 == iter1);
+  assert(!(iter1 == iter2));
+  assert(iter2 == iter2);
+  assert(!(iter1 != iter1));
+  assert(iter1 != iter2);
+  assert(!(iter2 != iter2));
+
+  static_assert(noexcept(iter1 == iter2));
+  static_assert(noexcept(iter1 != iter2));
+  static_assert(noexcept(iter1 < iter2));
+  static_assert(noexcept(iter1 > iter2));
+  static_assert(noexcept(iter1 <= iter2));
+  static_assert(noexcept(iter1 >= iter2));
+
+#if TEST_HAS_SPACESHIP()
+  static_assert(cuda::std::three_way_comparable<cuda::shuffle_iterator<int>>);
+  assert((iter1 <=> iter2) == cuda::std::strong_ordering::less);
+  assert((iter1 <=> iter1) == cuda::std::strong_ordering::equal);
+  assert((iter2 <=> iter1) == cuda::std::strong_ordering::greater);
+  static_assert(noexcept(iter1 <=> iter2));
+#endif // TEST_HAS_SPACESHIP()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.default.pass.cpp
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// iterator() requires default_initializable<W> = default;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  {
+    [[maybe_unused]] cuda::shuffle_iterator iter;
+    static_assert(
+      cuda::std::is_same_v<decltype(iter),
+                           cuda::shuffle_iterator<size_t, cuda::random_bijection<size_t, cuda::__feistel_bijection>>>);
+  }
+
+  {
+    [[maybe_unused]] cuda::shuffle_iterator iter{};
+    static_assert(
+      cuda::std::is_same_v<decltype(iter),
+                           cuda::shuffle_iterator<size_t, cuda::random_bijection<size_t, cuda::__feistel_bijection>>>);
+  }
+
+  {
+    [[maybe_unused]] cuda::shuffle_iterator<int> iter;
+    static_assert(
+      cuda::std::is_same_v<decltype(iter),
+                           cuda::shuffle_iterator<int, cuda::random_bijection<int, cuda::__feistel_bijection>>>);
+  }
+
+  {
+    [[maybe_unused]] cuda::shuffle_iterator<int> iter{};
+    static_assert(
+      cuda::std::is_same_v<decltype(iter),
+                           cuda::shuffle_iterator<int, cuda::random_bijection<int, cuda::__feistel_bijection>>>);
+  }
+
+  {
+    [[maybe_unused]] cuda::shuffle_iterator<int, cuda::random_bijection<size_t>> iter;
+    static_assert(
+      cuda::std::is_same_v<decltype(iter),
+                           cuda::shuffle_iterator<int, cuda::random_bijection<size_t, cuda::__feistel_bijection>>>);
+  }
+
+  {
+    [[maybe_unused]] cuda::shuffle_iterator<int, cuda::random_bijection<size_t>> iter{};
+    static_assert(
+      cuda::std::is_same_v<decltype(iter),
+                           cuda::shuffle_iterator<int, cuda::random_bijection<size_t, cuda::__feistel_bijection>>>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.value.pass.cpp
@@ -1,0 +1,133 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr explicit shuffle_iterator(Bijection, index_type = 0);
+// template<class RGN> constexpr explicit shuffle_iterator(index_type, RNG, index_type = 0);
+
+#include <cuda/iterator>
+#include <cuda/std/__random_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+#include "types.h"
+
+template <class>
+void print() = delete;
+
+template <class Bijection>
+__host__ __device__ constexpr bool test(Bijection fun)
+{
+  constexpr size_t num_elements{5};
+  { // shuffle_iterator(Bijection)
+    { // CTAD, with bijection
+      cuda::shuffle_iterator iter{fun};
+      using value_type = cuda::std::iter_value_t<decltype(iter)>;
+      // in the range of  [0, num_elements)
+      if constexpr (cuda::std::is_signed_v<value_type>)
+      {
+        assert(*iter >= 0);
+      }
+      assert((*iter < static_cast<value_type>(num_elements)));
+      if constexpr (!cuda::std::is_same_v<Bijection, cuda::random_bijection<short>>
+                    && !cuda::std::is_same_v<Bijection, cuda::random_bijection<int, cuda::__feistel_bijection>>)
+      {
+        assert(*iter == 4); // the fake bijection returns 4 as the first element
+      }
+      else
+      {
+        assert(*iter < 5); // some random element
+      }
+      static_assert(
+        cuda::std::is_same_v<decltype(iter), cuda::shuffle_iterator<typename Bijection::index_type, Bijection>>);
+    }
+
+    { // CTAD, with bijection
+      cuda::shuffle_iterator iter{fun, 3};
+      using value_type = cuda::std::iter_value_t<decltype(iter)>;
+      // in the range of  [0, num_elements)
+      if constexpr (cuda::std::is_signed_v<value_type>)
+      {
+        assert(*iter >= 0);
+      }
+      assert((*iter < static_cast<value_type>(num_elements)));
+      if constexpr (!cuda::std::is_same_v<Bijection, cuda::random_bijection<short>>
+                    && !cuda::std::is_same_v<Bijection, cuda::random_bijection<int, cuda::__feistel_bijection>>)
+      {
+        assert(*iter == 0); // the fake bijection returns 0 as the third element
+      }
+      else
+      {
+        assert(*iter < 5); // some random element
+      }
+      static_assert(
+        cuda::std::is_same_v<decltype(iter), cuda::shuffle_iterator<typename Bijection::index_type, Bijection>>);
+    }
+
+    {
+      cuda::shuffle_iterator<int, Bijection> iter{fun};
+      using value_type = cuda::std::iter_value_t<decltype(iter)>;
+      // in the range of  [0, num_elements)
+      assert(*iter >= 0);
+      assert((*iter < static_cast<value_type>(num_elements)));
+      if constexpr (!cuda::std::is_same_v<Bijection, cuda::random_bijection<short>>
+                    && !cuda::std::is_same_v<Bijection, cuda::random_bijection<int, cuda::__feistel_bijection>>)
+      {
+        assert(*iter == 4); // the fake bijection returns 4 as the first element
+      }
+      else
+      {
+        assert(*iter < 5); // some random element
+      }
+    }
+
+    {
+      cuda::shuffle_iterator<int, Bijection> iter{fun, 3};
+      using value_type = cuda::std::iter_value_t<decltype(iter)>;
+      // in the range of  [0, num_elements)
+      assert(*iter >= 0);
+      assert((*iter < static_cast<value_type>(num_elements)));
+      if constexpr (!cuda::std::is_same_v<Bijection, cuda::random_bijection<short>>
+                    && !cuda::std::is_same_v<Bijection, cuda::random_bijection<int, cuda::__feistel_bijection>>)
+      {
+        assert(*iter == 0); // the fake bijection returns 0 as the third element
+      }
+      else
+      {
+        assert(*iter < 5); // some random element
+      }
+    }
+  }
+
+  return true;
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test(fake_bijection<true>{});
+  test(fake_bijection<false>{});
+  test(cuda::random_bijection<int, fake_bijection<true>>{5, fake_rng{}});
+
+  if (!cuda::std::__cccl_default_is_constant_evaluated())
+  {
+    test(cuda::random_bijection<short>{5, cuda::std::minstd_rand{5}});
+    test(cuda::random_bijection{5, cuda::std::minstd_rand{5}});
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.value.pass.cpp
@@ -109,7 +109,7 @@ __host__ __device__ constexpr bool test(Bijection fun)
                 && !cuda::std::is_same_v<Bijection, cuda::random_bijection<int, cuda::__feistel_bijection>>)
   { // shuffle_iterator(index, RNG, index = 0)
     {
-      cuda::shuffle_iterator<int, Bijection> iter{num_elements, fake_rng{}};
+      cuda::shuffle_iterator<int, Bijection> iter{static_cast<int>(num_elements), fake_rng{}};
       using value_type = cuda::std::iter_value_t<decltype(iter)>;
       // in the range of  [0, num_elements)
       assert(*iter >= 0);
@@ -118,7 +118,7 @@ __host__ __device__ constexpr bool test(Bijection fun)
     }
 
     {
-      cuda::shuffle_iterator<int, Bijection> iter{num_elements, fake_rng{}, 3};
+      cuda::shuffle_iterator<int, Bijection> iter{static_cast<int>(num_elements), fake_rng{}, 3};
       using value_type = cuda::std::iter_value_t<decltype(iter)>;
       // in the range of  [0, num_elements)
       assert(*iter >= 0);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.value.pass.cpp
@@ -103,6 +103,30 @@ __host__ __device__ constexpr bool test(Bijection fun)
     }
   }
 
+  // feistel projection with our fake_rng takes a ton of time to converge so just sipit
+  if constexpr (cuda::std::is_constructible_v<Bijection, int, fake_rng>
+                && !cuda::std::is_same_v<Bijection, cuda::random_bijection<short>>
+                && !cuda::std::is_same_v<Bijection, cuda::random_bijection<int, cuda::__feistel_bijection>>)
+  { // shuffle_iterator(index, RNG, index = 0)
+    {
+      cuda::shuffle_iterator<int, Bijection> iter{num_elements, fake_rng{}};
+      using value_type = cuda::std::iter_value_t<decltype(iter)>;
+      // in the range of  [0, num_elements)
+      assert(*iter >= 0);
+      assert((*iter < static_cast<value_type>(num_elements)));
+      assert(*iter == 4); // the fake bijection returns 4 as the first element
+    }
+
+    {
+      cuda::shuffle_iterator<int, Bijection> iter{num_elements, fake_rng{}, 3};
+      using value_type = cuda::std::iter_value_t<decltype(iter)>;
+      // in the range of  [0, num_elements)
+      assert(*iter >= 0);
+      assert((*iter < static_cast<value_type>(num_elements)));
+      assert(*iter == 0); // the fake bijection returns 0 as the third element
+    }
+  }
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/ctor.value.pass.cpp
@@ -19,9 +19,6 @@
 #include "test_macros.h"
 #include "types.h"
 
-template <class>
-void print() = delete;
-
 template <class Bijection>
 __host__ __device__ constexpr bool test(Bijection fun)
 {

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/decrement.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/decrement.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr iterator& operator--() requires decrementable<W>;
+// constexpr iterator operator--(int) requires decrementable<W>;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "types.h"
+
+template <class T>
+_CCCL_CONCEPT Decrementable = _CCCL_REQUIRES_EXPR((T), T i)((--i), (i--));
+
+__host__ __device__ constexpr bool test()
+{
+  {
+    cuda::shuffle_iterator iter1{fake_bijection{}, 1};
+    cuda::shuffle_iterator iter2{fake_bijection{}, 1};
+    assert(iter1 == iter2);
+    assert(--iter1 != iter2--);
+    assert(iter1 == iter2);
+
+    static_assert(noexcept(--iter2));
+    static_assert(noexcept(iter2--));
+    static_assert(!cuda::std::is_reference_v<decltype(iter2--)>);
+    static_assert(cuda::std::is_reference_v<decltype(--iter2)>);
+    static_assert(cuda::std::same_as<cuda::std::remove_reference_t<decltype(--iter2)>, decltype(iter2--)>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/increment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/increment.pass.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr iterator& operator++();
+// constexpr void operator++(int);
+// constexpr iterator operator++(int) requires incrementable<W>;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  {
+    cuda::shuffle_iterator iter1{fake_bijection{}, 1};
+    cuda::shuffle_iterator iter2{fake_bijection{}, 1};
+    assert(iter1 == iter2);
+    assert(++iter1 != iter2++);
+    assert(iter1 == iter2);
+
+    static_assert(noexcept(++iter2));
+    static_assert(noexcept(iter2++));
+    static_assert(!cuda::std::is_reference_v<decltype(iter2++)>);
+    static_assert(cuda::std::is_reference_v<decltype(++iter2)>);
+    static_assert(cuda::std::same_as<cuda::std::remove_reference_t<decltype(++iter2)>, decltype(iter2++)>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/make_shuffle_iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/make_shuffle_iterator.pass.cpp
@@ -1,0 +1,54 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr explicit shuffle_iterator(Bijection, index_type = 0);
+// template<class RGN> constexpr explicit shuffle_iterator(index_type, RNG, index_type = 0);
+
+#include <cuda/iterator>
+#include <cuda/std/__random_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+#include "types.h"
+
+template <class Bijection>
+__host__ __device__ constexpr bool test(Bijection fun)
+{
+  auto iter1 = cuda::make_shuffle_iterator(fun, short{0});
+  auto iter2 = cuda::make_shuffle_iterator(fun, short{4});
+  assert(iter2 - iter1 == 4);
+  static_assert(cuda::std::is_same_v<decltype(iter1), cuda::shuffle_iterator<short, Bijection>>);
+
+  return true;
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test(fake_bijection<true>{});
+  test(fake_bijection<false>{});
+  test(cuda::random_bijection<int, fake_bijection<true>>{5, fake_rng{}});
+
+  if (!cuda::std::__cccl_default_is_constant_evaluated())
+  {
+    test(cuda::random_bijection<short>{5, cuda::std::minstd_rand{5}});
+    test(cuda::random_bijection{5, cuda::std::minstd_rand{5}});
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/member_typedefs.compile.pass.cpp
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Test iterator category and iterator concepts.
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ void test()
+{
+  {
+    using Iter = cuda::shuffle_iterator<char, fake_bijection<>>;
+    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::value_type, char>);
+    static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::make_signed_t<Iter::value_type>>);
+    static_assert(cuda::std::is_signed_v<Iter::difference_type>);
+    static_assert(cuda::std::same_as<Iter::difference_type, signed char>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+  }
+
+  {
+    using Iter = cuda::shuffle_iterator<short, fake_bijection<>>;
+    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::value_type, short>);
+    static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::make_signed_t<Iter::value_type>>);
+    static_assert(cuda::std::is_signed_v<Iter::difference_type>);
+    static_assert(cuda::std::same_as<Iter::difference_type, short>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+  }
+
+  {
+    using Iter = cuda::shuffle_iterator<size_t, fake_bijection<>>;
+    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::value_type, size_t>);
+    static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::make_signed_t<Iter::value_type>>);
+    static_assert(cuda::std::is_signed_v<Iter::difference_type>);
+    static_assert(cuda::std::same_as<Iter::difference_type, ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+  }
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/minus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/minus.pass.cpp
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// friend constexpr iterator operator-(iterator i, difference_type n)
+//   requires advanceable<W>;
+// friend constexpr difference_type operator-(const iterator& x, const iterator& y)
+//   requires advanceable<W>;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  // <iterator> - difference_type
+  {
+    cuda::shuffle_iterator iter1{fake_bijection{}, 3};
+    cuda::shuffle_iterator iter2{fake_bijection{}, 3};
+    assert(iter1 == iter2);
+    assert(iter1 - 0 == iter2);
+    assert(iter1 - 2 != iter2);
+    assert(iter1 - 2 == cuda::std::ranges::prev(iter2, 2));
+
+    static_assert(noexcept(iter2 - 2));
+    static_assert(!cuda::std::is_reference_v<decltype(iter2 - 2)>);
+  }
+
+  // <iterator> - <iterator>
+  {
+    cuda::shuffle_iterator iter1{fake_bijection{}, 5};
+    cuda::shuffle_iterator iter2{fake_bijection{}, 0};
+    assert(iter1 - iter2 == 5);
+    assert(iter1 - iter1 == 0);
+    assert(iter2 - iter1 == -5);
+
+    using shuffle_iter = decltype(iter1);
+    static_assert(noexcept(iter1 - iter2));
+    static_assert(cuda::std::same_as<decltype(iter1 - iter2), typename shuffle_iter::difference_type>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/minus_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/minus_eq.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr iterator& operator-=(difference_type n)
+//   requires advanceable<W>;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  cuda::shuffle_iterator iter1{fake_bijection{}, 3};
+  cuda::shuffle_iterator iter2{fake_bijection{}, 3};
+  assert(iter1 == iter2);
+  iter1 -= 0;
+  assert(iter1 == iter2);
+  iter1 -= 2;
+  assert(iter1 != iter2);
+  assert(iter1 == cuda::std::ranges::prev(iter2, 2));
+
+  static_assert(noexcept(iter2 -= 2));
+  static_assert(cuda::std::is_reference_v<decltype(iter2 -= 2)>);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/plus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/plus.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// friend constexpr iterator operator+(iterator i, difference_type n)
+//   requires advanceable<W>;
+// friend constexpr iterator operator+(difference_type n, iterator i)
+//   requires advanceable<W>;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  cuda::shuffle_iterator iter1{fake_bijection{}, 1};
+  cuda::shuffle_iterator iter2{fake_bijection{}, 1};
+  assert(iter1 == iter2);
+  assert(iter1 + 0 == iter1);
+  assert(iter1 + 2 != iter2);
+  assert(iter1 + 2 == cuda::std::ranges::next(iter2, 2));
+
+  static_assert(noexcept(iter2 + 2));
+  static_assert(cuda::std::is_same_v<decltype(iter2 + 2), decltype(iter2)>);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/plus_eq.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/plus_eq.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr iterator& operator+=(difference_type n)
+//   requires advanceable<W>;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  cuda::shuffle_iterator iter1{fake_bijection{}, 1};
+  cuda::shuffle_iterator iter2{fake_bijection{}, 1};
+  assert(iter1 == iter2);
+  iter1 += 0;
+  assert(iter1 == iter2);
+  iter1 += 2;
+  assert(iter1 != iter2);
+  assert(iter1 == cuda::std::ranges::next(iter2, 2));
+
+  static_assert(noexcept(iter2 += 2));
+  static_assert(cuda::std::is_reference_v<decltype(iter2 += 2)>);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/star.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/star.pass.cpp
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr W operator*() const noexcept(is_nothrow_copy_constructible_v<W>);
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  // taken from fake_bijection
+  constexpr int random_indices[] = {4, 1, 2, 0, 3};
+  {
+    cuda::shuffle_iterator iter{fake_bijection{}};
+    using value_type = cuda::std::iter_value_t<decltype(iter)>;
+
+    for (int i = 0; i < 5; ++i, ++iter)
+    {
+      assert(*iter == static_cast<value_type>(random_indices[i]));
+    }
+
+    static_assert(noexcept(*iter));
+    static_assert(cuda::std::is_same_v<decltype(*iter), value_type>);
+  }
+
+  {
+    cuda::shuffle_iterator iter{fake_bijection<true, false>{}};
+    using value_type = cuda::std::iter_value_t<decltype(iter)>;
+
+    for (int i = 0; i < 5; ++i, ++iter)
+    {
+      assert(*iter == static_cast<value_type>(random_indices[i]));
+    }
+
+    static_assert(!noexcept(*iter));
+    static_assert(cuda::std::is_same_v<decltype(*iter), value_type>);
+  }
+
+  {
+    const cuda::shuffle_iterator iter{fake_bijection{}, 3};
+    using value_type = cuda::std::iter_value_t<decltype(iter)>;
+    assert(*iter == static_cast<value_type>(random_indices[3]));
+
+    static_assert(noexcept(*iter));
+    static_assert(cuda::std::is_same_v<decltype(*iter), value_type>);
+  }
+
+  {
+    const cuda::shuffle_iterator iter{fake_bijection<true, false>{}, 3};
+    using value_type = cuda::std::iter_value_t<decltype(iter)>;
+    assert(*iter == static_cast<value_type>(random_indices[3]));
+
+    static_assert(!noexcept(*iter));
+    static_assert(cuda::std::is_same_v<decltype(*iter), value_type>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/subscript.pass.cpp
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr W operator[](difference_type n) const
+//   requires advanceable<W>;
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "types.h"
+
+__host__ __device__ constexpr bool test()
+{
+  // taken from fake_bijection
+  constexpr int random_indices[] = {4, 1, 2, 0, 3};
+  {
+    cuda::shuffle_iterator iter{fake_bijection{}};
+    using value_type = cuda::std::iter_value_t<decltype(iter)>;
+    for (int i = 0; i < 5; ++i)
+    {
+      assert(iter[i] == static_cast<value_type>(random_indices[i]));
+    }
+
+    static_assert(noexcept(iter[0]));
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), value_type>);
+  }
+
+  {
+    cuda::shuffle_iterator iter{fake_bijection<true, false>{}};
+    using value_type = cuda::std::iter_value_t<decltype(iter)>;
+    for (int i = 0; i < 5; ++i)
+    {
+      assert(iter[i] == static_cast<value_type>(random_indices[i]));
+    }
+
+    static_assert(!noexcept(iter[0]));
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), value_type>);
+  }
+
+  {
+    const cuda::shuffle_iterator iter{fake_bijection{}, 1};
+    using value_type = cuda::std::iter_value_t<decltype(iter)>;
+    assert(iter[2] == static_cast<value_type>(random_indices[3]));
+
+    static_assert(noexcept(iter[0]));
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), value_type>);
+  }
+
+  {
+    const cuda::shuffle_iterator iter{fake_bijection<true, false>{}, 1};
+    using value_type = cuda::std::iter_value_t<decltype(iter)>;
+    assert(iter[2] == static_cast<value_type>(random_indices[3]));
+
+    static_assert(!noexcept(iter[0]));
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), value_type>);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/types.h
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/types.h
@@ -25,6 +25,17 @@ struct fake_rng
     return __random_indices[__start++ % 5];
   }
 
+  // Needed for uniform_int_distribution
+  [[nodiscard]] __host__ __device__ static constexpr result_type min() noexcept
+  {
+    return 0;
+  }
+
+  [[nodiscard]] __host__ __device__ static constexpr result_type max() noexcept
+  {
+    return 5;
+  }
+
   uint32_t __start{0};
   uint32_t __random_indices[5] = {4, 1, 2, 0, 3};
 };

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/types.h
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/types.h
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef TEST_CUDA_ITERATOR_SHUFFLE_ITERATOR_H
+#define TEST_CUDA_ITERATOR_SHUFFLE_ITERATOR_H
+
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+
+struct fake_rng
+{
+  using result_type = uint32_t;
+
+  constexpr fake_rng() = default;
+
+  [[nodiscard]] __host__ __device__ constexpr result_type operator()() noexcept
+  {
+    return __random_indices[__start++ % 5];
+  }
+
+  uint32_t __start{0};
+  uint32_t __random_indices[5] = {4, 1, 2, 0, 3};
+};
+static_assert(cuda::std::__cccl_random_is_valid_urng<fake_rng>);
+
+template <bool HasConstructor = true, bool HasNothrowCallOperator = true>
+struct fake_bijection
+{
+  using index_type = uint32_t;
+
+  constexpr fake_bijection() = default;
+
+  _CCCL_TEMPLATE(class RNG, bool HasConstructor2 = HasConstructor)
+  _CCCL_REQUIRES(HasConstructor2)
+  __host__ __device__ constexpr fake_bijection(index_type, RNG&&) noexcept {}
+
+  [[nodiscard]] __host__ __device__ constexpr index_type size() const noexcept(HasNothrowCallOperator)
+  {
+    return 5;
+  }
+
+  [[nodiscard]] __host__ __device__ constexpr index_type operator()(index_type n) const noexcept(HasNothrowCallOperator)
+  {
+    return __random_indices[n];
+  }
+
+  uint32_t __random_indices[5] = {4, 1, 2, 0, 3};
+};
+
+#endif // TEST_CUDA_ITERATOR_SHUFFLE_ITERATOR_H


### PR DESCRIPTION
This ports `thrust::shuffle_iterator`. There is one thing I have changed, in that I removed the constructor from a size and an RNG.

The user can always just create the bijection function themselvs and this greatly simplifies CTAD
