### PR TITLE
fix device definition of cudax execution's `__nothrow_fooable` traits

### DIFF
--- a/cudax/include/cuda/experimental/__detail/type_traits.cuh
+++ b/cudax/include/cuda/experimental/__detail/type_traits.cuh
@@ -26,6 +26,8 @@
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/is_constructible.h>
+#include <cuda/std/__type_traits/is_copy_constructible.h>
+#include <cuda/std/__type_traits/is_move_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
@@ -45,23 +47,7 @@ using __decay_copyable_ _CCCL_NODEBUG_ALIAS = decltype(_CUDA_VSTD::decay_t<_Ty>(
 template <class... _As>
 inline constexpr bool __decay_copyable = (_CUDA_VSTD::is_constructible_v<_CUDA_VSTD::decay_t<_As>, _As> && ...);
 
-#if _CCCL_DEVICE_COMPILATION() && !_CCCL_CUDA_COMPILER(NVHPC)
-template <class _Fn, class... _As>
-inline constexpr bool __nothrow_callable = true;
-
-template <class _Ty, class... _As>
-inline constexpr bool __nothrow_constructible = true;
-
-template <class... _As>
-inline constexpr bool __nothrow_decay_copyable = true;
-
-template <class... _As>
-inline constexpr bool __nothrow_movable = true;
-
-template <class... _As>
-inline constexpr bool __nothrow_copyable = true;
-#else // ^^^ _CCCL_DEVICE_COMPILATION() && !_CCCL_CUDA_COMPILER(NVHPC) ^^^ /
-      // vvv !_CCCL_DEVICE_COMPILATION() || _CCCL_CUDA_COMPILER(NVHPC) vvv
+#if _CCCL_HOST_COMPILATION()
 template <class _Fn, class... _As>
 inline constexpr bool __nothrow_callable = _CUDA_VSTD::__is_nothrow_callable_v<_Fn, _As...>;
 
@@ -77,7 +63,23 @@ inline constexpr bool __nothrow_movable = (_CUDA_VSTD::is_nothrow_move_construct
 
 template <class... _As>
 inline constexpr bool __nothrow_copyable = (_CUDA_VSTD::is_nothrow_copy_constructible_v<_As> && ...);
-#endif // ^^^ !_CCCL_DEVICE_COMPILATION() || _CCCL_CUDA_COMPILER(NVHPC) ^^^
+#else // ^^^ _CCCL_HOST_COMPILATION() ^^^ / vvv !_CCCL_HOST_COMPILATION() vvv
+// There are no exceptions in device code:
+template <class _Fn, class... _As>
+inline constexpr bool __nothrow_callable = _CUDA_VSTD::__is_callable_v<_Fn, _As...>;
+
+template <class _Ty, class... _As>
+inline constexpr bool __nothrow_constructible = _CUDA_VSTD::is_constructible_v<_Ty, _As...>;
+
+template <class... _As>
+inline constexpr bool __nothrow_decay_copyable = __decay_copyable<_As...>;
+
+template <class... _As>
+inline constexpr bool __nothrow_movable = (_CUDA_VSTD::is_move_constructible_v<_As> && ...);
+
+template <class... _As>
+inline constexpr bool __nothrow_copyable = (_CUDA_VSTD::is_copy_constructible_v<_As> && ...);
+#endif // ^^^ !_CCCL_HOST_COMPILATION() ^^^
 
 template <class... _As>
 using __nothrow_decay_copyable_t _CCCL_NODEBUG_ALIAS = _CUDA_VSTD::bool_constant<__nothrow_decay_copyable<_As...>>;

--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -123,8 +123,13 @@ using schedule_result_t _CCCL_NODEBUG_ALIAS = decltype(declval<schedule_t>()(dec
 template <class _Sndr, class _Rcvr>
 using connect_result_t _CCCL_NODEBUG_ALIAS = decltype(declval<connect_t>()(declval<_Sndr>(), declval<_Rcvr>()));
 
+#if _CCCL_HOST_COMPILATION()
 template <class _Sndr, class _Rcvr>
 inline constexpr bool __nothrow_connectable = noexcept(declval<connect_t>()(declval<_Sndr>(), declval<_Rcvr>()));
+#else // ^^^ _CCCL_HOST_COMPILATION() ^^^ / vvv !_CCCL_HOST_COMPILATION() vvv
+template <class _Sndr, class _Rcvr>
+inline constexpr bool __nothrow_connectable = __is_instantiable_with_v<connect_result_t, _Sndr, _Rcvr>;
+#endif // ^^^ !_CCCL_HOST_COMPILATION() ^^^
 
 // sender factory algorithms:
 struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t;

--- a/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_ref.cuh
@@ -115,7 +115,7 @@ template <class _Env = void, class _Rcvr>
   {
     return __rcvr_ref<_Rcvr, _Env>{__rcvr};
   }
-  else if constexpr (__nothrow_constructible<_Rcvr, const _Rcvr&> && _CUDA_VSTD::is_copy_constructible_v<_Rcvr>)
+  else if constexpr (__nothrow_constructible<_Rcvr, const _Rcvr&>)
   {
     return const_cast<const _Rcvr&>(__rcvr);
   }


### PR DESCRIPTION
## Description

device code has no exceptions, so the execution library gives type traits like `__nothrow_movable<T>` the value `true`. but that's incorrect if `T` is not movable at all. after this change, in device code `__nothrow_movable<T>` will be equal to `cuda::std::is_move_constructible_v<T>`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
