### PR TITLE
[libcu++] Rename resource_ref to match the new async by default naming

### DIFF
--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -114,7 +114,7 @@ public:
   using __policy_t       = ::cuda::experimental::execution::any_execution_policy;
   using __buffer_t       = ::cuda::experimental::uninitialized_async_buffer<_Tp, _Properties...>;
   using __resource_t     = ::cuda::experimental::any_async_resource<_Properties...>;
-  using __resource_ref_t = _CUDA_VMR::async_resource_ref<_Properties...>;
+  using __resource_ref_t = _CUDA_VMR::resource_ref<_Properties...>;
 
   template <class, class...>
   friend class async_buffer;

--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -163,11 +163,11 @@ _CCCL_PUBLIC_HOST_API const _CUDA_VMR::_Alloc_vtable* __get_resource_vptr(_Resou
 {
   if constexpr (_CUDA_VMR::resource<_Resource>)
   {
-    return &_CUDA_VMR::__alloc_vtable<_CUDA_VMR::_AllocType::_Async, _CUDA_VMR::_WrapperType::_Reference, _Resource>;
+    return &_CUDA_VMR::__alloc_vtable<_CUDA_VMR::_AllocType::_Default, _CUDA_VMR::_WrapperType::_Reference, _Resource>;
   }
   else if constexpr (_CUDA_VMR::synchronous_resource<_Resource>)
   {
-    return &_CUDA_VMR::__alloc_vtable<_CUDA_VMR::_AllocType::_Default, _CUDA_VMR::_WrapperType::_Reference, _Resource>;
+    return &_CUDA_VMR::__alloc_vtable<_CUDA_VMR::_AllocType::_Synchronous, _CUDA_VMR::_WrapperType::_Reference, _Resource>;
   }
   else
   {
@@ -208,7 +208,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __iresource_ref_conversions
   template <_CUDA_VMR::_AllocType _Alloc_type>
   using __iresource = __rebind_interface<
     _CUDA_VSTD::
-      conditional_t<_Alloc_type == _CUDA_VMR::_AllocType::_Default, __ibasic_resource<>, __ibasic_async_resource<>>,
+      conditional_t<_Alloc_type == _CUDA_VMR::_AllocType::_Synchronous, __ibasic_resource<>, __ibasic_async_resource<>>,
     _Super...>;
 
   _CCCL_TEMPLATE(_CUDA_VMR::_AllocType _Alloc_type, class... _Properties)
@@ -357,10 +357,10 @@ struct _CCCL_DECLSPEC_EMPTY_BASES resource_ref
 
   // Conversions from the resource_ref types in cuda::mr is not supported.
   template <class... _OtherProperties>
-  resource_ref(_CUDA_VMR::resource_ref<_OtherProperties...>) = delete;
+  resource_ref(_CUDA_VMR::synchronous_resource_ref<_OtherProperties...>) = delete;
 
   template <class... _OtherProperties>
-  resource_ref(_CUDA_VMR::async_resource_ref<_OtherProperties...>) = delete;
+  resource_ref(_CUDA_VMR::resource_ref<_OtherProperties...>) = delete;
 
   using default_queries = properties_list<_Properties...>;
 
@@ -380,7 +380,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES async_resource_ref
 {
   // Conversions from the resource_ref types in cuda::mr is not supported.
   template <class... _OtherProperties>
-  async_resource_ref(_CUDA_VMR::async_resource_ref<_OtherProperties...>) = delete;
+  async_resource_ref(_CUDA_VMR::resource_ref<_OtherProperties...>) = delete;
 
   // Inherit other constructors from __basic_any
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(
@@ -424,7 +424,7 @@ resource_ref<_Properties...> __as_resource_ref(async_resource_ref<_Properties...
 }
 
 template <class... _Properties, mr::_AllocType _Alloc_type>
-mr::resource_ref<_Properties...>
+mr::synchronous_resource_ref<_Properties...>
 __as_resource_ref(mr::basic_resource_ref<_Alloc_type, _Properties...> const __mr) noexcept
 {
   return __mr;

--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -167,7 +167,8 @@ _CCCL_PUBLIC_HOST_API const _CUDA_VMR::_Alloc_vtable* __get_resource_vptr(_Resou
   }
   else if constexpr (_CUDA_VMR::synchronous_resource<_Resource>)
   {
-    return &_CUDA_VMR::__alloc_vtable<_CUDA_VMR::_AllocType::_Synchronous, _CUDA_VMR::_WrapperType::_Reference, _Resource>;
+    return &_CUDA_VMR::
+      __alloc_vtable<_CUDA_VMR::_AllocType::_Synchronous, _CUDA_VMR::_WrapperType::_Reference, _Resource>;
   }
   else
   {

--- a/cudax/test/memory_resource/any_resource.cu
+++ b/cudax/test/memory_resource/any_resource.cu
@@ -138,11 +138,11 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      // conversion from any_resource to cuda::mr::resource_ref:
-      cuda::mr::resource_ref<cudax::host_accessible, cudax::device_accessible, get_data> ref = mr;
+      // conversion from any_resource to cuda::mr::synchronous_resource_ref:
+      cudax::resource_ref<cudax::host_accessible, cudax::device_accessible, get_data> ref = mr;
 
-      // conversion from any_resource to cuda::mr::resource_ref with narrowing:
-      cuda::mr::resource_ref<cudax::host_accessible, get_data> ref2 = mr;
+      // conversion from any_resource to cuda::mr::synchronous_resource_ref with narrowing:
+      cudax::resource_ref<cudax::host_accessible, get_data> ref2 = mr;
       CHECK(get_property(ref2, get_data{}) == 42);
 
       CHECK(this->counts == expected);
@@ -159,7 +159,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
     CHECK(this->counts == expected);
   }
 
-  SECTION("conversion from any_resource to cuda::mr::resource_ref")
+  SECTION("conversion from any_resource to cuda::mr::synchronous_resource_ref")
   {
     Counts expected{};
     {
@@ -169,11 +169,11 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      // conversion from any_resource to cuda::mr::resource_ref:
-      cuda::mr::resource_ref<cudax::host_accessible, cudax::device_accessible, get_data> ref = mr;
+      // conversion from any_resource to cuda::mr::synchronous_resource_ref:
+      cuda::mr::synchronous_resource_ref<cudax::host_accessible, cudax::device_accessible, get_data> ref = mr;
 
-      // conversion from any_resource to cuda::mr::resource_ref with narrowing:
-      cuda::mr::resource_ref<cudax::host_accessible, get_data> ref2 = mr;
+      // conversion from any_resource to cuda::mr::synchronous_resource_ref with narrowing:
+      cuda::mr::synchronous_resource_ref<cudax::host_accessible, get_data> ref2 = mr;
       CHECK(get_property(ref2, get_data{}) == 42);
 
       CHECK(this->counts == expected);

--- a/docs/libcudacxx/extended_api/memory_resource.rst
+++ b/docs/libcudacxx/extended_api/memory_resource.rst
@@ -32,7 +32,7 @@ At a high level, the header provides:
        :ref:`cuda::mr::{synchronous_}resource_with <libcudacxx-extended-api-memory-resources-resource>`
      - Concepts that provide proper constraints for arbitrary memory resources.
      - stable CCCL 3.1.0 / CUDA 13.1, experimental CCCL 2.2.0 / CUDA 12.3
-   * - :ref:`cuda::mr::{async_}resource_ref <libcudacxx-extended-api-memory-resources-resource-ref>`
+   * - :ref:`cuda::mr::{synchronous_}resource_ref <libcudacxx-extended-api-memory-resources-resource-ref>`
      - A non-owning type-erased memory resource wrapper that enables consumers to specify properties of resources that they expect.
        ``resource_ref`` is still an experimental design, only available if ``LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE`` is defined
      - experimental CCCL 2.2.0 / CUDA 12.3

--- a/docs/libcudacxx/extended_api/memory_resource/resource.rst
+++ b/docs/libcudacxx/extended_api/memory_resource/resource.rst
@@ -123,7 +123,7 @@ concept. The ``{synchronous_}resource_with`` concept allows checking resources f
 
    template<class MemoryResource>
        requires cuda::mr::resource<MemoryResource>
-   void* allocate_maybe_sync_check_alignment(MemoryResource& resource, std::size_t size, cuda::stream_ref stream) {
+   void* allocate_maybe_sync_check_alignment(MemoryResource& resource, cuda::stream_ref stream, std::size_t size) {
        if constexpr(cuda::mr::resource_with<MemoryResource, required_alignment>) {
            return resource.allocate(stream, size, get_property(resource, required_alignment));
        } else if constexpr (cuda::mr::resource<MemoryResource>) {
@@ -138,7 +138,7 @@ concept. The ``{synchronous_}resource_with`` concept allows checking resources f
    // Potentially more concise
    template<class MemoryResource>
        requires cuda::mr::resource<MemoryResource>
-   void* allocate_maybe_sync_check_alignment2(MemoryResource& resource, std::size_t size, cuda::stream_ref stream) {
+   void* allocate_maybe_sync_check_alignment2(MemoryResource& resource, cuda::stream_ref stream, std::size_t size) {
        constexpr std::size_t align = cuda::mr::resource_with<MemoryResource, required_alignment>
                                    ? get_property(resource, required_alignment)
                                    : my_default_alignment;

--- a/libcudacxx/include/cuda/__memory_resource/resource_ref.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource_ref.h
@@ -78,8 +78,8 @@ enum class _WrapperType
 
 enum class _AllocType
 {
+  _Synchronous,
   _Default,
-  _Async,
 };
 
 struct _Alloc_vtable
@@ -263,7 +263,7 @@ struct _Resource_vtable_builder
   }
 
   _CCCL_TEMPLATE(class _Resource, _AllocType _Alloc_type, _WrapperType _Wrapper_type)
-  _CCCL_REQUIRES((_Alloc_type == _AllocType::_Default))
+  _CCCL_REQUIRES((_Alloc_type == _AllocType::_Synchronous))
   static constexpr _Alloc_vtable _Create() noexcept
   {
     return {_IsSmall<_Resource>(),
@@ -276,7 +276,7 @@ struct _Resource_vtable_builder
   }
 
   _CCCL_TEMPLATE(class _Resource, _AllocType _Alloc_type, _WrapperType _Wrapper_type)
-  _CCCL_REQUIRES((_Alloc_type == _AllocType::_Async))
+  _CCCL_REQUIRES((_Alloc_type == _AllocType::_Default))
   static constexpr _Async_alloc_vtable _Create() noexcept
   {
     return {_IsSmall<_Resource>(),
@@ -453,12 +453,12 @@ _CCCL_CONCEPT _Is_resource_ref = _CUDA_VSTD::convertible_to<_Resource&, _Resourc
 
 template <_AllocType _Alloc_type, _WrapperType _Wrapper_type>
 using _Resource_base =
-  _CUDA_VSTD::_If<_Alloc_type == _AllocType::_Default,
+  _CUDA_VSTD::_If<_Alloc_type == _AllocType::_Synchronous,
                   _Alloc_base<_Alloc_vtable, _Wrapper_type>,
                   _Async_alloc_base<_Async_alloc_vtable, _Wrapper_type>>;
 
 template <_AllocType _Alloc_type>
-using _Vtable_store = _CUDA_VSTD::_If<_Alloc_type == _AllocType::_Default, _Alloc_vtable, _Async_alloc_vtable>;
+using _Vtable_store = _CUDA_VSTD::_If<_Alloc_type == _AllocType::_Synchronous, _Alloc_vtable, _Async_alloc_vtable>;
 
 template <_AllocType _Alloc_type, _WrapperType _Wrapper_type, class _Resource>
 inline constexpr _Vtable_store<_Alloc_type> __alloc_vtable =
@@ -510,11 +510,11 @@ private:
   {}
 
 public:
-  //! @brief Constructs a \c basic_resource_ref from a type that satisfies the \c resource or \c resource concept
+  //! @brief Constructs a \c basic_resource_ref from a type that satisfies the \c synchronous_resource concept
   //! as well as all properties
   //! @param __res The resource to be wrapped within the \c basic_resource_ref
   _CCCL_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
-  _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Default)
+  _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Synchronous)
                    _CCCL_AND synchronous_resource_with<_Resource, _Properties...>)
   basic_resource_ref(_Resource& __res) noexcept
       : _Resource_base<_Alloc_type, _WrapperType::_Reference>(
@@ -522,11 +522,11 @@ public:
       , __vtable(__vtable::template _Create<_Resource>())
   {}
 
-  //! @brief Constructs a \c resource_ref from a type that satisfies the \c resource concept  as well as all
+  //! @brief Constructs a \c synchronous_resource_ref from a type that satisfies the \c resource concept as well as all
   //! properties. This ignores the async interface of the passed in resource
-  //! @param __res The resource to be wrapped within the \c resource_ref
+  //! @param __res The resource to be wrapped within the \c synchronous_resource_ref
   _CCCL_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
-  _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Async)
+  _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Default)
                    _CCCL_AND resource_with<_Resource, _Properties...>)
   basic_resource_ref(_Resource& __res) noexcept
       : _Resource_base<_Alloc_type, _WrapperType::_Reference>(
@@ -534,11 +534,11 @@ public:
       , __vtable(__vtable::template _Create<_Resource>())
   {}
 
-  //! @brief Constructs a \c basic_resource_ref from a type that satisfies the \c resource or \c resource concept
+  //! @brief Constructs a \c basic_resource_ref from a type that satisfies the \c synchronous_resource concept
   //! as well as all properties
   //! @param __res Pointer to a resource to be wrapped within the \c basic_resource_ref
   _CCCL_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
-  _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Default)
+  _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Synchronous)
                    _CCCL_AND synchronous_resource_with<_Resource, _Properties...>)
   basic_resource_ref(_Resource* __res) noexcept
       : _Resource_base<_Alloc_type, _WrapperType::_Reference>(
@@ -546,11 +546,11 @@ public:
       , __vtable(__vtable::template _Create<_Resource>())
   {}
 
-  //! @brief Constructs a \c resource_ref from a type that satisfies the \c resource concept  as well as all
+  //! @brief Constructs a \c basic_resource_ref from a type that satisfies the \c resource concept as well as all
   //! properties. This ignores the async interface of the passed in resource
-  //! @param __res Pointer to a resource to be wrapped within the \c resource_ref
+  //! @param __res Pointer to a resource to be wrapped within the \c basic_resource_ref
   _CCCL_TEMPLATE(class _Resource, _AllocType _Alloc_type2 = _Alloc_type)
-  _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Async)
+  _CCCL_REQUIRES((!_Is_resource_ref<_Resource>) _CCCL_AND(_Alloc_type2 == _AllocType::_Default)
                    _CCCL_AND resource_with<_Resource, _Properties...>)
   basic_resource_ref(_Resource* __res) noexcept
       : _Resource_base<_Alloc_type, _WrapperType::_Reference>(
@@ -567,11 +567,11 @@ public:
       , __vtable(static_cast<const _Filtered_vtable<_OtherProperties...>&>(__ref))
   {}
 
-  //! @brief Conversion from a \c async_resource_ref with the same set of properties but in a different order to a
-  //! \c resource_ref
-  //! @param __ref The other \c async_resource_ref
+  //! @brief Conversion from a \c resource_ref with the same set of properties but in a different order to a
+  //! \c synchronous_resource_ref
+  //! @param __ref The other \c resource_ref
   _CCCL_TEMPLATE(_AllocType _OtherAllocType, class... _OtherProperties)
-  _CCCL_REQUIRES((_OtherAllocType == _AllocType::_Async) _CCCL_AND(_OtherAllocType != _Alloc_type)
+  _CCCL_REQUIRES((_OtherAllocType == _AllocType::_Default) _CCCL_AND(_OtherAllocType != _Alloc_type)
                    _CCCL_AND __properties_match<_OtherProperties...>)
   basic_resource_ref(basic_resource_ref<_OtherAllocType, _OtherProperties...> __ref) noexcept
       : _Resource_base<_Alloc_type, _WrapperType::_Reference>(__ref.__object, __ref.__static_vtable)
@@ -635,14 +635,14 @@ public:
 };
 
 //! @brief Type erased wrapper around a `resource` that satisfies \tparam _Properties
-//! @tparam _Properties The properties that any resource wrapped within the `resource_ref` needs to satisfy
+//! @tparam _Properties The properties that any resource wrapped within the `synchronous_resource_ref` needs to satisfy
 template <class... _Properties>
-using resource_ref = basic_resource_ref<_AllocType::_Default, _Properties...>;
+using synchronous_resource_ref = basic_resource_ref<_AllocType::_Synchronous, _Properties...>;
 
 //! @brief Type erased wrapper around a `resource` that satisfies \tparam _Properties
-//! @tparam _Properties The properties that any async resource wrapped within the `async_resource_ref` needs to satisfy
+//! @tparam _Properties The properties that any async resource wrapped within the `resource_ref` needs to satisfy
 template <class... _Properties>
-using async_resource_ref = basic_resource_ref<_AllocType::_Async, _Properties...>;
+using resource_ref = basic_resource_ref<_AllocType::_Default, _Properties...>;
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_MR
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/allocate.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::async_resource_ref properties
+// cuda::mr::resource_ref properties
 
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
@@ -22,7 +22,7 @@ void test_allocate()
 {
   { // allocate_sync(size)
     test_resource<cuda::mr::host_accessible> input{42};
-    cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
+    cuda::mr::resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
     assert(input.allocate_sync(0, 0) == ref.allocate_sync(0));
@@ -34,7 +34,7 @@ void test_allocate()
 
   { // allocate_sync(size, alignment)
     test_resource<cuda::mr::host_accessible> input{42};
-    cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
+    cuda::mr::resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
     assert(input.allocate_sync(0, 0) == ref.allocate_sync(0, 0));
@@ -49,7 +49,7 @@ void test_allocate_async()
 {
   { // allocate_sync(size)
     test_resource<cuda::mr::host_accessible> input{42};
-    cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
+    cuda::mr::resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
     assert(input.allocate(::cudaStream_t{}, 0, 0) == ref.allocate(::cudaStream_t{}, 0, 0));
@@ -61,7 +61,7 @@ void test_allocate_async()
 
   { // allocate_sync(size, alignment)
     test_resource<cuda::mr::host_accessible> input{42};
-    cuda::mr::async_resource_ref<cuda::mr::host_accessible> ref{input};
+    cuda::mr::resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
     assert(input.allocate(::cudaStream_t{}, 0, 0) == ref.allocate(::cudaStream_t{}, 0, 0));

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/construction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/construction.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::async_resource_ref construction
+// cuda::mr::resource_ref construction
 
 #include <cuda/memory_resource>
 #include <cuda/std/cstdint>
@@ -20,10 +20,10 @@
 
 namespace constructible
 {
-using ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible,
-                                         property_with_value<int>,
-                                         property_with_value<double>,
-                                         property_without_value<std::size_t>>;
+using ref = cuda::mr::resource_ref<cuda::mr::host_accessible,
+                                   property_with_value<int>,
+                                   property_with_value<double>,
+                                   property_without_value<std::size_t>>;
 
 using matching_properties =
   test_resource<cuda::mr::host_accessible,
@@ -58,10 +58,10 @@ static_assert(cuda::std::is_move_constructible<ref>::value, "");
 
 namespace assignable
 {
-using ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible,
-                                         property_with_value<int>,
-                                         property_with_value<double>,
-                                         property_without_value<std::size_t>>;
+using ref = cuda::mr::resource_ref<cuda::mr::host_accessible,
+                                   property_with_value<int>,
+                                   property_with_value<double>,
+                                   property_without_value<std::size_t>>;
 
 using res = test_resource<cuda::mr::host_accessible,
                           property_with_value<int>,

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/conversion.pass.cpp
@@ -28,10 +28,10 @@ template <class PropA, class PropB>
 void test_conversion_from_async_resource_ref()
 {
   test_resource<cuda::mr::host_accessible, PropA, PropB> input{42};
-  cuda::mr::async_resource_ref<cuda::mr::host_accessible, PropA, PropB> ref_input{input};
+  cuda::mr::resource_ref<cuda::mr::host_accessible, PropA, PropB> ref_input{input};
 
   { // lvalue
-    cuda::mr::async_resource_ref<cuda::mr::host_accessible, PropB> ref{ref_input};
+    cuda::mr::resource_ref<cuda::mr::host_accessible, PropB> ref{ref_input};
 
     // Ensure that we properly "punch through" the resource_ref
     const auto fake_orig = reinterpret_cast<Fake_alloc_base*>(&ref_input);
@@ -49,8 +49,8 @@ void test_conversion_from_async_resource_ref()
   }
 
   { // prvalue
-    cuda::mr::async_resource_ref<cuda::mr::host_accessible, PropB> ref{
-      cuda::mr::async_resource_ref<cuda::mr::host_accessible, PropA, PropB>{input}};
+    cuda::mr::resource_ref<cuda::mr::host_accessible, PropB> ref{
+      cuda::mr::resource_ref<cuda::mr::host_accessible, PropA, PropB>{input}};
 
     // Ensure that we properly "punch through" the resource_ref
     const auto fake_orig = reinterpret_cast<Fake_alloc_base*>(&ref_input);

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.fail.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::async_resource_ref equality
+// cuda::mr::resource_ref equality
 
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
@@ -19,15 +19,15 @@
 
 #include "types.h"
 
-using ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible,
-                                         property_with_value<int>,
-                                         property_with_value<double>,
-                                         property_without_value<std::size_t>>;
+using ref = cuda::mr::resource_ref<cuda::mr::host_accessible,
+                                   property_with_value<int>,
+                                   property_with_value<double>,
+                                   property_without_value<std::size_t>>;
 using different_properties =
-  cuda::mr::async_resource_ref<cuda::mr::host_accessible,
-                               property_with_value<short>,
-                               property_with_value<int>,
-                               property_without_value<std::size_t>>;
+  cuda::mr::resource_ref<cuda::mr::host_accessible,
+                         property_with_value<short>,
+                         property_with_value<int>,
+                         property_without_value<std::size_t>>;
 
 using res = test_resource<cuda::mr::host_accessible,
                           property_with_value<int>,

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/equality.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::async_resource_ref equality
+// cuda::mr::resource_ref equality
 
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
@@ -19,16 +19,16 @@
 
 #include "types.h"
 
-using ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible,
-                                         property_with_value<int>,
-                                         property_with_value<double>,
-                                         property_without_value<std::size_t>>;
+using ref = cuda::mr::resource_ref<cuda::mr::host_accessible,
+                                   property_with_value<int>,
+                                   property_with_value<double>,
+                                   property_without_value<std::size_t>>;
 
 using pertubed_properties =
-  cuda::mr::async_resource_ref<cuda::mr::host_accessible,
-                               property_with_value<double>,
-                               property_with_value<int>,
-                               property_without_value<std::size_t>>;
+  cuda::mr::resource_ref<cuda::mr::host_accessible,
+                         property_with_value<double>,
+                         property_with_value<int>,
+                         property_without_value<std::size_t>>;
 
 using res = test_resource<cuda::mr::host_accessible,
                           property_with_value<int>,

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/inheritance.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/inheritance.pass.cpp
@@ -135,8 +135,8 @@ void test_async_resource_ref()
   async_resource_derived_first<cuda::mr::host_accessible, Properties...> first{42};
   async_resource_derived_second<cuda::mr::host_accessible, Properties...> second{&input};
 
-  cuda::mr::async_resource_ref<cuda::mr::host_accessible, Properties...> ref_first{first};
-  cuda::mr::async_resource_ref<cuda::mr::host_accessible, Properties...> ref_second{second};
+  cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref_first{first};
+  cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref_second{second};
 
   // Ensure that we properly pass on the allocate function
   assert(ref_first.allocate(::cudaStream_t{}, 0, 0) == first.allocate(::cudaStream_t{}, 0, 0));
@@ -148,7 +148,7 @@ void test_async_resource_ref()
 }
 
 template <class... Properties>
-cuda::mr::async_resource_ref<cuda::mr::host_accessible, Properties...>
+cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...>
 indirection(async_resource_base<cuda::mr::host_accessible, Properties...>* res)
 {
   return {res};
@@ -161,8 +161,8 @@ void test_async_resource_ref_from_pointer()
   async_resource_derived_first<cuda::mr::host_accessible, Properties...> first{42};
   async_resource_derived_second<cuda::mr::host_accessible, Properties...> second{&input};
 
-  cuda::mr::async_resource_ref<cuda::mr::host_accessible, Properties...> ref_first  = indirection(&first);
-  cuda::mr::async_resource_ref<cuda::mr::host_accessible, Properties...> ref_second = indirection(&second);
+  cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref_first  = indirection(&first);
+  cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref_second = indirection(&second);
 
   // Ensure that we properly pass on the allocate function
   assert(ref_first.allocate(::cudaStream_t{}, 0, 0) == first.allocate(::cudaStream_t{}, 0, 0));

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/async_resource_ref/properties.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::async_resource_ref properties
+// cuda::mr::resource_ref properties
 
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
@@ -37,22 +37,19 @@ namespace resource_test
 
 // Ensure we have the right size
 static_assert(
-  sizeof(cuda::mr::async_resource_ref<cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>)
+  sizeof(cuda::mr::resource_ref<cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>)
     == (4 * sizeof(void*)),
   "");
 static_assert(
-  sizeof(
-    cuda::mr::async_resource_ref<cuda::mr::host_accessible, property_with_value<short>, property_without_value<int>>)
+  sizeof(cuda::mr::resource_ref<cuda::mr::host_accessible, property_with_value<short>, property_without_value<int>>)
     == (3 * sizeof(void*)),
   "");
 static_assert(
-  sizeof(
-    cuda::mr::async_resource_ref<cuda::mr::host_accessible, property_without_value<short>, property_with_value<int>>)
+  sizeof(cuda::mr::resource_ref<cuda::mr::host_accessible, property_without_value<short>, property_with_value<int>>)
     == (3 * sizeof(void*)),
   "");
 static_assert(
-  sizeof(
-    cuda::mr::async_resource_ref<cuda::mr::host_accessible, property_without_value<short>, property_without_value<int>>)
+  sizeof(cuda::mr::resource_ref<cuda::mr::host_accessible, property_without_value<short>, property_without_value<int>>)
     == (2 * sizeof(void*)),
   "");
 
@@ -90,7 +87,7 @@ void test_async_resource_ref()
 {
   constexpr int expected_initially = 42;
   test_resource<cuda::mr::host_accessible, Properties...> input{expected_initially};
-  cuda::mr::async_resource_ref<cuda::mr::host_accessible, Properties...> ref{input};
+  cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref{input};
 
   // Check all the potentially stateful properties
   const int properties_with_value[] = {InvokeIfWithValue<Properties>(ref)...};
@@ -122,7 +119,7 @@ void test_async_resource_ref()
 void test_property_forwarding()
 {
   using res = test_resource<cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>;
-  using ref = cuda::mr::async_resource_ref<cuda::mr::host_accessible, property_with_value<short>>;
+  using ref = cuda::mr::resource_ref<cuda::mr::host_accessible, property_with_value<short>>;
 
   static_assert(cuda::mr::resource_with<res, property_with_value<short>, property_with_value<int>>, "");
   static_assert(!cuda::mr::resource_with<ref, property_with_value<short>, property_with_value<int>>, "");

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/allocate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/allocate.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::resource_ref properties
+// cuda::mr::synchronous_resource_ref properties
 
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
@@ -22,7 +22,7 @@ void test_allocate()
 {
   { // allocate_sync(size)
     resource<cuda::mr::host_accessible> input{42};
-    cuda::mr::resource_ref<cuda::mr::host_accessible> ref{input};
+    cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
     assert(input.allocate_sync(0, 0) == ref.allocate_sync(0));
@@ -34,7 +34,7 @@ void test_allocate()
 
   { // allocate_sync(size, alignment)
     resource<cuda::mr::host_accessible> input{42};
-    cuda::mr::resource_ref<cuda::mr::host_accessible> ref{input};
+    cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible> ref{input};
 
     // Ensure that we properly pass on the allocate function
     assert(input.allocate_sync(0, 0) == ref.allocate_sync(0, 0));

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/construction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/construction.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::resource_ref construction
+// cuda::mr::synchronous_resource_ref construction
 
 #include <cuda/memory_resource>
 #include <cuda/std/cstdint>
@@ -20,10 +20,10 @@
 
 namespace constructible
 {
-using ref = cuda::mr::resource_ref<cuda::mr::host_accessible,
-                                   property_with_value<int>,
-                                   property_with_value<double>,
-                                   property_without_value<std::size_t>>;
+using ref = cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible,
+                                               property_with_value<int>,
+                                               property_with_value<double>,
+                                               property_without_value<std::size_t>>;
 
 using matching_properties =
   resource<cuda::mr::host_accessible,
@@ -58,10 +58,10 @@ static_assert(cuda::std::is_move_constructible<ref>::value, "");
 
 namespace assignable
 {
-using ref = cuda::mr::resource_ref<cuda::mr::host_accessible,
-                                   property_with_value<int>,
-                                   property_with_value<double>,
-                                   property_without_value<std::size_t>>;
+using ref = cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible,
+                                               property_with_value<int>,
+                                               property_with_value<double>,
+                                               property_without_value<std::size_t>>;
 
 using res = resource<cuda::mr::host_accessible,
                      property_with_value<int>,

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/conversion.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/conversion.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::resource_ref properties
+// cuda::mr::synchronous_resource_ref properties
 
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
@@ -28,10 +28,10 @@ template <class PropA, class PropB>
 void test_conversion_from_resource_ref()
 {
   resource<cuda::mr::host_accessible, PropA, PropB> input{42};
-  cuda::mr::resource_ref<cuda::mr::host_accessible, PropA, PropB> ref_input{input};
+  cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, PropA, PropB> ref_input{input};
 
   { // lvalue
-    cuda::mr::resource_ref<cuda::mr::host_accessible, PropB> ref{ref_input};
+    cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, PropB> ref{ref_input};
 
     // Ensure that we properly "punch through" the resource ref
     const auto fake_orig = *reinterpret_cast<Fake_alloc_base*>(&ref_input);
@@ -49,8 +49,8 @@ void test_conversion_from_resource_ref()
   }
 
   { // prvalue
-    cuda::mr::resource_ref<cuda::mr::host_accessible, PropB> ref{
-      cuda::mr::resource_ref<cuda::mr::host_accessible, PropA, PropB>{input}};
+    cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, PropB> ref{
+      cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, PropA, PropB>{input}};
 
     // Ensure that we properly "punch through" the resource ref
     const auto fake_orig = *reinterpret_cast<Fake_alloc_base*>(&ref_input);
@@ -72,10 +72,10 @@ template <class PropA, class PropB>
 void test_conversion_from_async_resource_ref()
 {
   resource<cuda::mr::host_accessible, PropA, PropB> input{42};
-  cuda::mr::async_resource_ref<cuda::mr::host_accessible, PropA, PropB> ref_input{input};
+  cuda::mr::resource_ref<cuda::mr::host_accessible, PropA, PropB> ref_input{input};
 
   { // lvalue
-    cuda::mr::resource_ref<cuda::mr::host_accessible, PropB> ref{ref_input};
+    cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, PropB> ref{ref_input};
 
     // Ensure that we properly "punch through" the resource ref
     const auto fake_orig = reinterpret_cast<Fake_alloc_base*>(&ref_input);
@@ -93,8 +93,8 @@ void test_conversion_from_async_resource_ref()
   }
 
   { // prvalue
-    cuda::mr::resource_ref<cuda::mr::host_accessible, PropB> ref{
-      cuda::mr::async_resource_ref<cuda::mr::host_accessible, PropA, PropB>{input}};
+    cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, PropB> ref{
+      cuda::mr::resource_ref<cuda::mr::host_accessible, PropA, PropB>{input}};
 
     // Ensure that we properly "punch through" the resource ref
     const auto fake_orig = reinterpret_cast<Fake_alloc_base*>(&ref_input);

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/equality.fail.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/equality.fail.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::resource_ref equality
+// cuda::mr::synchronous_resource_ref equality
 
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
@@ -18,16 +18,16 @@
 
 #include "types.h"
 
-using ref = cuda::mr::resource_ref<cuda::mr::host_accessible,
-                                   property_with_value<int>,
-                                   property_with_value<double>,
-                                   property_without_value<std::size_t>>;
+using ref = cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible,
+                                               property_with_value<int>,
+                                               property_with_value<double>,
+                                               property_without_value<std::size_t>>;
 
 using different_properties =
-  cuda::mr::resource_ref<cuda::mr::host_accessible,
-                         property_with_value<short>,
-                         property_with_value<int>,
-                         property_without_value<std::size_t>>;
+  cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible,
+                                     property_with_value<short>,
+                                     property_with_value<int>,
+                                     property_without_value<std::size_t>>;
 
 using res = resource<cuda::mr::host_accessible,
                      property_with_value<int>,

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/equality.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/equality.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::resource_ref equality
+// cuda::mr::synchronous_resource_ref equality
 
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
@@ -18,16 +18,16 @@
 
 #include "types.h"
 
-using ref = cuda::mr::resource_ref<cuda::mr::host_accessible,
-                                   property_with_value<int>,
-                                   property_with_value<double>,
-                                   property_without_value<std::size_t>>;
+using ref = cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible,
+                                               property_with_value<int>,
+                                               property_with_value<double>,
+                                               property_without_value<std::size_t>>;
 
 using pertubed_properties =
-  cuda::mr::resource_ref<cuda::mr::host_accessible,
-                         property_with_value<double>,
-                         property_with_value<int>,
-                         property_without_value<std::size_t>>;
+  cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible,
+                                     property_with_value<double>,
+                                     property_with_value<int>,
+                                     property_without_value<std::size_t>>;
 
 using res = resource<cuda::mr::host_accessible,
                      property_with_value<int>,

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/inheritance.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/inheritance.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::resource_ref properties
+// cuda::mr::synchronous_resource_ref properties
 
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
@@ -117,8 +117,8 @@ void test_resource_ref()
   resource_derived_first<cuda::mr::host_accessible, Properties...> first{42};
   resource_derived_second<cuda::mr::host_accessible, Properties...> second{&input};
 
-  cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref_first{first};
-  cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref_second{second};
+  cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, Properties...> ref_first{first};
+  cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, Properties...> ref_second{second};
 
   // Ensure that we properly pass on the allocate function
   assert(ref_first.allocate_sync(0, 0) == first.allocate_sync(0, 0));
@@ -130,7 +130,7 @@ void test_resource_ref()
 }
 
 template <class... Properties>
-cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...>
+cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, Properties...>
 indirection(resource_base<cuda::mr::host_accessible, Properties...>* res)
 {
   return {res};
@@ -143,8 +143,8 @@ void test_resource_ref_from_pointer()
   resource_derived_first<cuda::mr::host_accessible, Properties...> first{42};
   resource_derived_second<cuda::mr::host_accessible, Properties...> second{&input};
 
-  cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref_first  = indirection(&first);
-  cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref_second = indirection(&second);
+  cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, Properties...> ref_first  = indirection(&first);
+  cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, Properties...> ref_second = indirection(&second);
 
   // Ensure that we properly pass on the allocate function
   assert(ref_first.allocate_sync(0, 0) == first.allocate_sync(0, 0));

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resource_ref/properties.pass.cpp
@@ -10,7 +10,7 @@
 // UNSUPPORTED: msvc-19.16
 // UNSUPPORTED: nvrtc
 
-// cuda::mr::resource_ref properties
+// cuda::mr::synchronous_resource_ref properties
 
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
@@ -36,21 +36,25 @@ namespace resource_test
 
 // Ensure we have the right size
 static_assert(
-  sizeof(cuda::mr::resource_ref<cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>)
+  sizeof(
+    cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>)
     == (4 * sizeof(void*)),
   "");
 static_assert(
-  sizeof(cuda::mr::resource_ref<cuda::mr::host_accessible, property_with_value<short>, property_without_value<int>>)
+  sizeof(cuda::mr::
+           synchronous_resource_ref<cuda::mr::host_accessible, property_with_value<short>, property_without_value<int>>)
     == (3 * sizeof(void*)),
   "");
 static_assert(
-  sizeof(cuda::mr::resource_ref<cuda::mr::host_accessible, property_without_value<short>, property_with_value<int>>)
+  sizeof(cuda::mr::
+           synchronous_resource_ref<cuda::mr::host_accessible, property_without_value<short>, property_with_value<int>>)
     == (3 * sizeof(void*)),
   "");
-static_assert(
-  sizeof(cuda::mr::resource_ref<cuda::mr::host_accessible, property_without_value<short>, property_without_value<int>>)
-    == (2 * sizeof(void*)),
-  "");
+static_assert(sizeof(cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible,
+                                                        property_without_value<short>,
+                                                        property_without_value<int>>)
+                == (2 * sizeof(void*)),
+              "");
 
 _CCCL_TEMPLATE(class Property, class Ref)
 _CCCL_REQUIRES((!cuda::property_with_value<Property>) ) //
@@ -86,7 +90,7 @@ void test_resource_ref()
 {
   constexpr int expected_initially = 42;
   resource<cuda::mr::host_accessible, Properties...> input{expected_initially};
-  cuda::mr::resource_ref<cuda::mr::host_accessible, Properties...> ref{input};
+  cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, Properties...> ref{input};
 
   // Check all the potentially stateful properties
   const int properties_with_value[] = {InvokeIfWithValue<Properties>(ref)...};
@@ -118,7 +122,7 @@ void test_resource_ref()
 void test_property_forwarding()
 {
   using res = resource<cuda::mr::host_accessible, property_with_value<short>, property_with_value<int>>;
-  using ref = cuda::mr::resource_ref<cuda::mr::host_accessible, property_with_value<short>>;
+  using ref = cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, property_with_value<short>>;
 
   static_assert(
     cuda::mr::


### PR DESCRIPTION
This PR updates the `cuda::mr::resource_ref` to the new naming where async is the default.

There are some inconsistencies in the inline comments that I noticed, but whole implementation is going to be replaced with the experimental version soon, so I did not try to fix them now.