### PR TITLE
[DRAFT] Shared Memory Span

### DIFF
--- a/libcudacxx/include/cuda/smem_span
+++ b/libcudacxx/include/cuda/smem_span
@@ -1,0 +1,590 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_SHARED_MEMORY_SPAN
+#define _CUDA_SHARED_MEMORY_SPAN
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_CUDA_COMPILATION()
+
+#  include <cuda/__memory/address_space.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__exception/terminate.h>
+#  include <cuda/std/__iterator/reverse_iterator.h>
+#  include <cuda/std/__iterator/wrap_iter.h>
+#  include <cuda/std/__limits/numeric_limits.h>
+#  include <cuda/std/__memory/pointer_traits.h>
+#  include <cuda/std/__type_traits/is_const.h>
+#  include <cuda/std/__type_traits/remove_cv.h>
+#  include <cuda/std/array>
+#  include <cuda/std/cstddef>
+#  include <cuda/std/cstdint>
+#  include <cuda/std/initializer_list>
+#  include <cuda/std/span>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_LIBCUDACXX_BEGIN_NAMESPACE_CUDA_DEVICE
+
+template <typename _Tp>
+[[nodiscard]] _CCCL_DEVICE_API static constexpr _Tp* __smem_to_pointer(uint32_t __raw_smem_ptr) noexcept
+{
+  auto __ptr = reinterpret_cast<_Tp*>(::__cvta_shared_to_generic(__raw_smem_ptr));
+  _CCCL_ASSUME(::__isShared(__ptr));
+  return __ptr;
+}
+
+[[nodiscard]] _CCCL_DEVICE_API static constexpr _CUDA_VSTD::uint32_t __pointer_to_smem(const void* __smem_ptr) noexcept
+{
+  _CCCL_ASSERT(::cuda::is_address_from(__smem_ptr, ::cuda::address_space::shared), "invalid smem pointer");
+  // TODO: _CCCL_ASSERT(__is_valid_smem_pointer(__smem_ptr), "invalid smem pointer");
+  return static_cast<_CUDA_VSTD::uint32_t>(::__cvta_generic_to_shared(__smem_ptr));
+}
+
+inline constexpr _CUDA_VSTD::uint32_t dynamic_extent_shared_mem =
+  _CUDA_VSTD::numeric_limits<_CUDA_VSTD::uint32_t>::max();
+
+template <typename _Tp, _CUDA_VSTD::uint32_t _Extent>
+class _CCCL_TYPE_VISIBILITY_DEFAULT shared_mem_span
+{
+public:
+  //  constants and types
+  using element_type     = _Tp;
+  using value_type       = _CUDA_VSTD::remove_cv_t<_Tp>;
+  using size_type        = _CUDA_VSTD::uint32_t;
+  using difference_type  = _CUDA_VSTD::int32_t;
+  using pointer          = _Tp*;
+  using const_pointer    = const _Tp*;
+  using reference        = _Tp&;
+  using const_reference  = const _Tp&;
+  using iterator         = _CUDA_VSTD::__wrap_iter<pointer>;
+  using reverse_iterator = _CUDA_VSTD::reverse_iterator<iterator>;
+
+  static constexpr size_type extent = _Extent;
+
+  // [shared_mem_span.cons], shared_mem_span constructors, copy, assignment, and destructor
+  _CCCL_TEMPLATE(size_type _Sz = _Extent)
+  _CCCL_REQUIRES((_Sz == 0))
+  _CCCL_DEVICE_API constexpr shared_mem_span() noexcept
+      : __data_{0}
+  {}
+
+  _CCCL_TEMPLATE(typename _Tp2 = _Tp)
+  _CCCL_REQUIRES(_CUDA_VSTD::is_const_v<_Tp2>)
+  _CCCL_DEVICE_API constexpr explicit shared_mem_span(_CUDA_VSTD::initializer_list<value_type> __il) noexcept
+      : __data_{__il.begin()}
+  {
+    _CCCL_ASSERT(_Extent == __il.size(), "size mismatch in shared_mem_span's constructor (initializer_list).");
+  }
+
+  _CCCL_HIDE_FROM_ABI shared_mem_span(const shared_mem_span&) noexcept            = default;
+  _CCCL_HIDE_FROM_ABI shared_mem_span& operator=(const shared_mem_span&) noexcept = default;
+
+  _CCCL_TEMPLATE(typename _It)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_compatible_iterator<_It, element_type>)
+  _CCCL_DEVICE_API constexpr explicit shared_mem_span(_It __first, [[maybe_unused]] size_type __count)
+      : __data_{::cuda::device::__pointer_to_smem(_CUDA_VSTD::to_address(__first))}
+  {
+    _CCCL_ASSERT(_Extent == __count, "size mismatch in shared_mem_span's constructor (iterator, len)");
+  }
+
+  _CCCL_TEMPLATE(typename _It, typename _End)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_compatible_iterator<_It, element_type> _CCCL_AND
+                   _CUDA_VSTD::__span_compatible_sentinel_for<_End, _It>)
+  _CCCL_DEVICE_API constexpr explicit shared_mem_span(_It __first, [[maybe_unused]] _End __last)
+      : __data_{::cuda::device::__pointer_to_smem(_CUDA_VSTD::to_address(__first))}
+  {
+    _CCCL_ASSERT((__last - __first >= 0), "invalid range in shared_mem_span's constructor (iterator, sentinel)");
+    _CCCL_ASSERT(__last - __first == _Extent,
+                 "invalid range in shared_mem_span's constructor (iterator, sentinel): last - first != extent");
+  }
+
+  _CCCL_TEMPLATE(size_type _Sz = _Extent)
+  _CCCL_REQUIRES((_Sz != 0))
+  _CCCL_DEVICE_API constexpr shared_mem_span(_CUDA_VSTD::type_identity_t<element_type> (&__arr)[_Sz]) noexcept
+      : __data_{::cuda::device::__pointer_to_smem(__arr)}
+  {}
+
+  _CCCL_TEMPLATE(typename _OtherElementType)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_array_convertible<_OtherElementType, element_type>)
+  _CCCL_DEVICE_API constexpr shared_mem_span(_CUDA_VSTD::array<_OtherElementType, _Extent>& __arr) noexcept
+      : __data_{::cuda::device::__pointer_to_smem(__arr.data())}
+  {}
+
+  _CCCL_TEMPLATE(typename _OtherElementType)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_array_convertible<const _OtherElementType, element_type>)
+  _CCCL_DEVICE_API constexpr shared_mem_span(const _CUDA_VSTD::array<_OtherElementType, _Extent>& __arr) noexcept
+      : __data_{::cuda::device::__pointer_to_smem(__arr.data())}
+  {}
+
+  _CCCL_TEMPLATE(typename _Range)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_compatible_range<_Range, element_type>)
+  _CCCL_DEVICE_API constexpr explicit shared_mem_span(_Range&& __r)
+      : __data_{::cuda::device::__pointer_to_smem(_CUDA_VRANGES::data(__r))}
+  {
+    _CCCL_ASSERT(_CUDA_VRANGES::size(__r) == _Extent, "size mismatch in shared_mem_span's constructor (range)");
+  }
+
+  _CCCL_TEMPLATE(typename _OtherElementType, size_type _Extent2 = _Extent)
+  _CCCL_REQUIRES((_Extent2 != dynamic_extent_shared_mem)
+                   _CCCL_AND _CUDA_VSTD::__span_array_convertible<_OtherElementType, element_type>)
+  _CCCL_DEVICE_API constexpr shared_mem_span(const shared_mem_span<_OtherElementType, _Extent2>& __other) noexcept
+      : __data_{__other.__data_}
+  {}
+
+  _CCCL_TEMPLATE(typename _OtherElementType)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_array_convertible<_OtherElementType, element_type>)
+  _CCCL_DEVICE_API constexpr explicit shared_mem_span(
+    const shared_mem_span<_OtherElementType, dynamic_extent_shared_mem>& __other) noexcept
+      : __data_{__other.__data_}
+  {
+    _CCCL_ASSERT(_Extent == __other.size(), "size mismatch in shared_mem_span's constructor (other shared_mem_span)");
+  }
+
+  //  ~shared_mem_span() noexcept = default;
+
+  template <size_type _Count>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr shared_mem_span<element_type, _Count> first() const noexcept
+  {
+    static_assert(_Count <= _Extent, "shared_mem_span<T, N>::first<Count>(): Count out of range");
+    return shared_mem_span<element_type, _Count>{__data_, _Count};
+  }
+
+  template <size_type _Count>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr shared_mem_span<element_type, _Count> last() const noexcept
+  {
+    static_assert(_Count <= _Extent, "shared_mem_span<T, N>::last<Count>(): Count out of range");
+    return shared_mem_span<element_type, _Count>{__data_ + size() - _Count, _Count};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr shared_mem_span<element_type, dynamic_extent_shared_mem>
+  first(size_type __count) const noexcept
+  {
+    _CCCL_ASSERT(__count <= size(), "shared_mem_span<T, N>::first(count): count out of range");
+    return {__data_, __count};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr shared_mem_span<element_type, dynamic_extent_shared_mem>
+  last(size_type __count) const noexcept
+  {
+    _CCCL_ASSERT(__count <= size(), "shared_mem_span<T, N>::last(count): count out of range");
+    return {__data_ + size() - __count, __count};
+  }
+
+  template <size_type _Offset, size_type _Count>
+  using __subspan_t = shared_mem_span<element_type, _Count != dynamic_extent_shared_mem ? _Count : _Extent - _Offset>;
+
+  template <size_type _Offset, size_type _Count = dynamic_extent_shared_mem>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr __subspan_t<_Offset, _Count> subspan() const noexcept
+  {
+    static_assert(_Offset <= _Extent, "shared_mem_span<T, N>::subspan<Offset, Count>(): Offset out of range");
+    static_assert(_Count == dynamic_extent_shared_mem || _Count <= _Extent - _Offset,
+                  "shared_mem_span<T, N>::subspan<Offset, Count>(): Offset + Count out of range");
+    return __subspan_t<_Offset, _Count>{
+      __data_ + _Offset, _Count == dynamic_extent_shared_mem ? size() - _Offset : _Count};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr shared_mem_span<element_type, dynamic_extent_shared_mem>
+  subspan(size_type __offset, size_type __count = dynamic_extent_shared_mem) const noexcept
+  {
+    _CCCL_ASSERT(__offset <= size(), "shared_mem_span<T, N>::subspan(offset, count): offset out of range");
+    _CCCL_ASSERT(__count <= size() || __count == dynamic_extent_shared_mem,
+                 "shared_mem_span<T, N>::subspan(offset, count): count out of range");
+    if (__count == dynamic_extent_shared_mem)
+    {
+      return {__data_ + __offset, size() - __offset};
+    }
+    _CCCL_ASSERT(__count <= size() - __offset,
+                 "shared_mem_span<T, N>::subspan(offset, count): offset + count out of range");
+    return {__data_ + __offset, __count};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr size_type size() const noexcept
+  {
+    return _Extent;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr size_t size_bytes() const noexcept
+  {
+    return _Extent * sizeof(element_type);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr bool empty() const noexcept
+  {
+    return (_Extent == 0);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reference operator[](size_type __idx) const noexcept
+  {
+    _CCCL_ASSERT(__idx < size(), "shared_mem_span<T, N>::operator[](index): index out of range");
+    return *::cuda::device::__smem_to_pointer<_Tp>(__data_ + __idx);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reference at(size_type __idx) const
+  {
+    if (__idx >= size())
+    {
+      _CCCL_ASSERT(false, "shared_mem_span::at");
+      _CUDA_VSTD_NOVERSION::terminate();
+    }
+    return operator[](__idx);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reference front() const noexcept
+  {
+    _CCCL_ASSERT(!empty(), "shared_mem_span<T, N>::front() on empty shared_mem_span");
+    return operator[](0);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reference back() const noexcept
+  {
+    _CCCL_ASSERT(!empty(), "shared_mem_span<T, N>::back() on empty shared_mem_span");
+    return operator[](size() - 1);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr pointer data() const noexcept
+  {
+    return ::cuda::device::__smem_to_pointer<_Tp>(__data_);
+  }
+
+  // [shared_mem_span.iter], shared_mem_span iterator support
+  [[nodiscard]] _CCCL_DEVICE_API constexpr iterator begin() const noexcept
+  {
+    return iterator(data());
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr iterator end() const noexcept
+  {
+    return iterator(::cuda::device::__smem_to_pointer<_Tp>(__data_ + size()));
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reverse_iterator rbegin() const noexcept
+  {
+    return reverse_iterator(end());
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reverse_iterator rend() const noexcept
+  {
+    return reverse_iterator(begin());
+  }
+
+private:
+  _CUDA_VSTD::uint32_t __data_;
+
+  _CCCL_DEVICE_API constexpr shared_mem_span(size_type __data, [[maybe_unused]] size_type __count) noexcept
+      : __data_{__data}
+  {
+    _CCCL_ASSERT(_Extent == __count, "size mismatch in shared_mem_span's constructor (iterator, len)");
+  }
+};
+
+template <typename _Tp>
+class _CCCL_TYPE_VISIBILITY_DEFAULT shared_mem_span<_Tp, dynamic_extent_shared_mem>
+{
+public:
+  //  constants and types
+  using element_type     = _Tp;
+  using value_type       = _CUDA_VSTD::remove_cv_t<_Tp>;
+  using size_type        = _CUDA_VSTD::uint32_t;
+  using difference_type  = _CUDA_VSTD::int32_t;
+  using pointer          = _Tp*;
+  using const_pointer    = const _Tp*;
+  using reference        = _Tp&;
+  using const_reference  = const _Tp&;
+  using iterator         = _CUDA_VSTD::__wrap_iter<pointer>;
+  using reverse_iterator = _CUDA_VSTD::reverse_iterator<iterator>;
+
+  static constexpr size_type extent = dynamic_extent_shared_mem;
+
+  // [shared_mem_span.cons], shared_mem_span constructors, copy, assignment, and destructor
+  _CCCL_DEVICE_API constexpr shared_mem_span() noexcept
+      : __data_{0}
+      , __size_{0}
+  {}
+
+  _CCCL_TEMPLATE(typename _Tp2 = _Tp)
+  _CCCL_REQUIRES(_CUDA_VSTD::is_const_v<_Tp2>)
+  _CCCL_DEVICE_API constexpr shared_mem_span(_CUDA_VSTD::initializer_list<value_type> __il) noexcept
+      : __data_{__il.begin()}
+      , __size_{static_cast<size_type>(__il.size())}
+  {
+    _CCCL_ASSERT(__il.size() < dynamic_extent_shared_mem,
+                 "size mismatch in shared_mem_span's constructor (initializer_list).");
+  }
+
+  _CCCL_HIDE_FROM_ABI shared_mem_span(const shared_mem_span&) noexcept            = default;
+  _CCCL_HIDE_FROM_ABI shared_mem_span& operator=(const shared_mem_span&) noexcept = default;
+
+  _CCCL_TEMPLATE(typename _It)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_compatible_iterator<_It, element_type>)
+  _CCCL_DEVICE_API constexpr shared_mem_span(_It __first, size_type __count)
+      : __data_{::cuda::device::__pointer_to_smem(_CUDA_VSTD::to_address(__first))}
+      , __size_{__count}
+  {
+    _CCCL_ASSERT(__count < dynamic_extent_shared_mem, "size mismatch in shared_mem_span's constructor (iterator, len)");
+  }
+
+  _CCCL_TEMPLATE(typename _It, typename _End)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_compatible_iterator<_It, element_type> _CCCL_AND
+                   _CUDA_VSTD::__span_compatible_sentinel_for<_End, _It>)
+  _CCCL_DEVICE_API constexpr shared_mem_span(_It __first, _End __last)
+      : __data_(::cuda::device::__pointer_to_smem(_CUDA_VSTD::to_address(__first)))
+      , __size_(__last - __first)
+  {
+    _CCCL_ASSERT(__last - __first >= 0, "invalid range in shared_mem_span's constructor (iterator, sentinel)");
+    _CCCL_ASSERT(__last - __first < dynamic_extent_shared_mem,
+                 "size mismatch in shared_mem_span's constructor (iterator, sentinel)");
+  }
+
+  template <size_type _Sz>
+  _CCCL_DEVICE_API constexpr shared_mem_span(_CUDA_VSTD::type_identity_t<element_type> (&__arr)[_Sz]) noexcept
+      : __data_{::cuda::device::__pointer_to_smem(__arr)}
+      , __size_{_Sz}
+  {
+    _CCCL_ASSERT(_Sz < dynamic_extent_shared_mem, "size mismatch in shared_mem_span's constructor (array).");
+  }
+
+  _CCCL_TEMPLATE(typename _OtherElementType, size_type _Sz)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_array_convertible<_OtherElementType, element_type>)
+  _CCCL_DEVICE_API constexpr shared_mem_span(_CUDA_VSTD::array<_OtherElementType, _Sz>& __arr) noexcept
+      : __data_{::cuda::device::__pointer_to_smem(__arr.data())}
+      , __size_{_Sz}
+  {
+    _CCCL_ASSERT(_Sz < dynamic_extent_shared_mem, "size mismatch in shared_mem_span's constructor (array).");
+  }
+
+  _CCCL_TEMPLATE(typename _OtherElementType, size_type _Sz)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_array_convertible<const _OtherElementType, element_type>)
+  _CCCL_DEVICE_API constexpr shared_mem_span(const _CUDA_VSTD::array<_OtherElementType, _Sz>& __arr) noexcept
+      : __data_{::cuda::device::__pointer_to_smem(__arr.data())}
+      , __size_{_Sz}
+  {
+    _CCCL_ASSERT(_Sz < dynamic_extent_shared_mem, "size mismatch in shared_mem_span's constructor (array).");
+  }
+
+  _CCCL_TEMPLATE(typename _Range)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_compatible_range<_Range, element_type>)
+  _CCCL_DEVICE_API constexpr shared_mem_span(_Range&& __r)
+      : __data_{::cuda::device::__pointer_to_smem(_CUDA_VRANGES::data(__r))}
+      , __size_{_CUDA_VRANGES::size(__r)}
+  {
+    _CCCL_ASSERT(_CUDA_VRANGES::size(__r) < dynamic_extent_shared_mem,
+                 "size mismatch in shared_mem_span's constructor (range).");
+  }
+
+  _CCCL_TEMPLATE(typename _OtherElementType, size_type _OtherExtent)
+  _CCCL_REQUIRES(_CUDA_VSTD::__span_array_convertible<_OtherElementType, element_type>)
+  _CCCL_DEVICE_API constexpr shared_mem_span(const shared_mem_span<_OtherElementType, _OtherExtent>& __other) noexcept
+      : __data_{__other.__data_}
+      , __size_{__other.size()}
+  {}
+
+  //    ~shared_mem_span() noexcept = default;
+
+  template <size_type _Count>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr shared_mem_span<element_type, _Count> first() const noexcept
+  {
+    // ternary avoids "pointless comparison of unsigned integer with zero" warning
+    _CCCL_ASSERT(_Count == 0 ? true : _Count <= size(), "shared_mem_span<T>::first<Count>(): Count out of range");
+    return shared_mem_span<element_type, _Count>{__data_, _Count};
+  }
+
+  template <size_type _Count>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr shared_mem_span<element_type, _Count> last() const noexcept
+  {
+    // ternary avoids "pointless comparison of unsigned integer with zero" warning
+    _CCCL_ASSERT(_Count == 0 ? true : _Count <= size(), "shared_mem_span<T>::last<Count>(): Count out of range");
+    return shared_mem_span<element_type, _Count>{__data_ + size() - _Count, _Count};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr shared_mem_span<element_type, dynamic_extent_shared_mem>
+  first(size_type __count) const noexcept
+  {
+    _CCCL_ASSERT(__count <= size(), "shared_mem_span<T>::first(count): count out of range");
+    return {__data_, __count};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr shared_mem_span<element_type, dynamic_extent_shared_mem>
+  last(size_type __count) const noexcept
+  {
+    _CCCL_ASSERT(__count <= size(), "shared_mem_span<T>::last(count): count out of range");
+    return {__data_ + size() - __count, __count};
+  }
+
+  template <size_type _Offset, size_type _Count>
+  using __subspan_t = shared_mem_span<element_type, _Count>;
+
+  template <size_type _Offset, size_type _Count = dynamic_extent_shared_mem>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr __subspan_t<_Offset, _Count> subspan() const noexcept
+  {
+    // ternary avoids "pointless comparison of unsigned integer with zero" warning
+    _CCCL_ASSERT(_Offset == 0 ? true : _Offset <= size(),
+                 "shared_mem_span<T>::subspan<Offset, Count>(): Offset out of range");
+    _CCCL_ASSERT(_Count == dynamic_extent_shared_mem || _Count == 0 ? true : _Count <= size() - _Offset,
+                 "shared_mem_span<T>::subspan<Offset, Count>(): Offset + Count out of range");
+    return __subspan_t<_Offset, _Count>{
+      __data_ + _Offset, _Count == dynamic_extent_shared_mem ? size() - _Offset : _Count};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr inline shared_mem_span<element_type, dynamic_extent_shared_mem>
+  subspan(size_type __offset, size_type __count = dynamic_extent_shared_mem) const noexcept
+  {
+    _CCCL_ASSERT(__offset <= size(), "shared_mem_span<T>::subspan(offset, count): offset out of range");
+    _CCCL_ASSERT(__count <= size() || __count == dynamic_extent_shared_mem,
+                 "shared_mem_span<T>::subspan(offset, count): count out of range");
+    if (__count == dynamic_extent_shared_mem)
+    {
+      return {__data_ + __offset, size() - __offset};
+    }
+    _CCCL_ASSERT(__count <= size() - __offset,
+                 "shared_mem_span<T>::subspan(offset, count): offset + count out of range");
+    return {__data_ + __offset, __count};
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr size_type size() const noexcept
+  {
+    return __size_;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr size_t size_bytes() const noexcept
+  {
+    return __size_ * sizeof(element_type);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr bool empty() const noexcept
+  {
+    return __size_ == 0;
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reference operator[](size_type __idx) const noexcept
+  {
+    _CCCL_ASSERT(__idx < size(), "shared_mem_span<T>::operator[](index): index out of range");
+    return *::cuda::device::__smem_to_pointer<_Tp>(__data_ + __idx);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reference at(size_type __idx) const
+  {
+    if (__idx >= size())
+    {
+      _CCCL_ASSERT(false, "shared_mem_span::at");
+      _CUDA_VSTD_NOVERSION::terminate();
+    }
+    return operator[](__idx);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reference front() const noexcept
+  {
+    _CCCL_ASSERT(!empty(), "shared_mem_span<T>::front() on empty shared_mem_span");
+    return operator[](0);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reference back() const noexcept
+  {
+    _CCCL_ASSERT(!empty(), "shared_mem_span<T>::back() on empty shared_mem_span");
+    return operator[](size() - 1);
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr pointer data() const noexcept
+  {
+    return ::cuda::device::__smem_to_pointer<_Tp>(__data_);
+  }
+
+  // [shared_mem_span.iter], shared_mem_span iterator support
+  [[nodiscard]] _CCCL_DEVICE_API constexpr iterator begin() const noexcept
+  {
+    return iterator(data());
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr iterator end() const noexcept
+  {
+    return iterator(data() + size());
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reverse_iterator rbegin() const noexcept
+  {
+    return reverse_iterator(end());
+  }
+
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reverse_iterator rend() const noexcept
+  {
+    return reverse_iterator(begin());
+  }
+
+private:
+  _CUDA_VSTD::uint32_t __data_;
+  size_type __size_;
+
+  _CCCL_DEVICE_API constexpr shared_mem_span(size_type __data, [[maybe_unused]] size_type __count) noexcept
+      : __data_{__data}
+  {
+    _CCCL_ASSERT(__count < dynamic_extent_shared_mem,
+                 "shared_mem_span<T>::shared_mem_span(data, count): count too large");
+  }
+};
+
+//  as_bytes & as_writable_bytes
+// template <class _Tp, size_t _Extent>
+//_CCCL_DEVICE_API inline auto as_bytes(shared_mem_span<_Tp, _Extent> __s) noexcept
+//{
+//  return __s.__as_bytes();
+//}
+//
+//_CCCL_TEMPLATE(typename _Tp, size_t _Extent)
+//_CCCL_REQUIRES((!is_const<_Tp>::value))
+//_CCCL_DEVICE_API inline auto as_writable_bytes(shared_mem_span<_Tp, _Extent> __s) noexcept
+//{
+//  return __s.__as_writable_bytes();
+//}
+
+//  Deduction guides
+template <class _Tp, _CUDA_VSTD::uint32_t _Sz>
+_CCCL_HOST_DEVICE shared_mem_span(_Tp (&)[_Sz]) -> shared_mem_span<_Tp, _Sz>;
+
+template <class _Tp, _CUDA_VSTD::uint32_t _Sz>
+_CCCL_HOST_DEVICE shared_mem_span(_CUDA_VSTD::array<_Tp, _Sz>&) -> shared_mem_span<_Tp, _Sz>;
+
+template <class _Tp, _CUDA_VSTD::uint32_t _Sz>
+_CCCL_HOST_DEVICE shared_mem_span(const _CUDA_VSTD::array<_Tp, _Sz>&) -> shared_mem_span<const _Tp, _Sz>;
+
+//_CCCL_TEMPLATE(typename _It, typename _EndOrSize)
+//_CCCL_REQUIRES(_CUDA_VSTD::contiguous_iterator<_It>)
+//_CCCL_HOST_DEVICE shared_mem_span(_It, _EndOrSize)
+//  -> shared_mem_span<_CUDA_VSTD::remove_reference_t<_CUDA_VSTD::iter_reference_t<_It>>,
+//  __maybe_static_ext<_EndOrSize>>;
+//
+//_CCCL_TEMPLATE(typename _Range)
+//_CCCL_REQUIRES(_CUDA_VRANGES::contiguous_range<_Range>)
+//_CCCL_HOST_DEVICE shared_mem_span(_Range&&)
+//  -> shared_mem_span<_CUDA_VSTD::remove_reference_t<_CUDA_VRANGES::range_reference_t<_Range>>>;
+
+_LIBCUDACXX_END_NAMESPACE_CUDA_DEVICE
+
+//_LIBCUDACXX_BEGIN_NAMESPACE_RANGES
+// template <class _Tp, size_t _Extent>
+// inline constexpr bool enable_borrowed_range<shared_mem_span<_Tp, _Extent>> = true;
+//
+// template <class _Tp, size_t _Extent>
+// inline constexpr bool enable_view<shared_mem_span<_Tp, _Extent>> = true;
+//_LIBCUDACXX_END_NAMESPACE_RANGES
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_CUDA_COMPILATION()
+
+#endif // _CUDA_SHARED_MEMORY_SPAN


### PR DESCRIPTION
## Description

This is a follow-up of internal `#467`.
The PR proposes a modified `cuda::std::span` to efficiently handle static and dynamic shared memory.

The motivations come from the limitations of  `cuda::std::span`:

1. It doesn't propagate the memory address space.
2. It is based on 64-bit pointers, which are less efficient than 32-bit used by shared memory.
3. Memory footprint is 128-bit, while a shared memory span requires 64-bit of local memory.

The PR is a **DRAFT** to collect feedback.