### PR TITLE
use `auto(expr)` for `_LIBCUDACXX_AUTO_CAST` when it is available

### DIFF
--- a/libcudacxx/include/cuda/std/__utility/auto_cast.h
+++ b/libcudacxx/include/cuda/std/__utility/auto_cast.h
@@ -23,7 +23,9 @@
 
 #include <cuda/std/__type_traits/decay.h>
 
-#if _CCCL_STD_VER < 2020 && _CCCL_COMPILER(MSVC)
+#if _CCCL_STD_VER >= 2023 && __cpp_auto_cast >= 202110L
+#  define _LIBCUDACXX_AUTO_CAST(expr) auto(expr)
+#elif _CCCL_STD_VER < 2020 && _CCCL_COMPILER(MSVC)
 #  define _LIBCUDACXX_AUTO_CAST(expr) (_CUDA_VSTD::decay_t<decltype((expr))>) (expr)
 #else
 #  define _LIBCUDACXX_AUTO_CAST(expr) static_cast<_CUDA_VSTD::decay_t<decltype((expr))>>(expr)


### PR DESCRIPTION
## Description

drive-by: change `_LIBCUDACXX_AUTO_CAST` to use the C++23 feature `auto(expr)` ([P0849R8](https://wg21.link/P0849R8)) when it is available.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
