### PR TITLE
Only download wheels artifacts for release

### DIFF
--- a/.github/workflows/release-wheels.yml
+++ b/.github/workflows/release-wheels.yml
@@ -50,9 +50,9 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUN_ID: ${{ inputs.run-id }}
         run: |
-          gh run download ${RUN_ID} -D dl -R ${{ github.repository }}
+          gh run download ${RUN_ID} -D dl -R ${{ github.repository }} -p 'wheel-*'
           mkdir dist
-          mv dl/*/*.whl dist/
+          mv dl/*/*/*.whl dist/
           rm -rf dl
           ls -lh dist/
 


### PR DESCRIPTION
## Description

The updated workflow uploads several other artifacts, for release we only need the artifacts prefixed with 'wheel-', use a simple glob pattern to fix current failure when attempting to release updated wheels. We also need to go one level deeper to get the wheels.
This closes #5541.

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
