### PR TITLE
Improve interoperability of `span` with host types

### DIFF
--- a/cub/test/catch2_test_device_histogram.cu
+++ b/cub/test/catch2_test_device_histogram.cu
@@ -304,8 +304,7 @@ void test_even_and_range(LevelT max_level, int max_level_count, OffsetT width, O
     CAPTURE(lower_level, upper_level);
 
     // Compute reference result
-    auto fp_scales = array<LevelT, ActiveChannels>{}; // only used when LevelT is floating point
-    std::ignore    = fp_scales; // casting to void was insufficient. TODO(bgruber): use [[maybe_unsued]] in C++17
+    [[maybe_unused]] auto fp_scales = array<LevelT, ActiveChannels>{}; // only used when LevelT is floating point
     for (size_t c = 0; c < ActiveChannels; ++c)
     {
       if constexpr (!cs::is_integral<LevelT>::value)

--- a/libcudacxx/include/cuda/std/__fwd/array.h
+++ b/libcudacxx/include/cuda/std/__fwd/array.h
@@ -53,6 +53,14 @@ inline constexpr bool __is_cuda_std_array_v = false;
 template <class _Tp, size_t _Sz>
 inline constexpr bool __is_cuda_std_array_v<array<_Tp, _Sz>> = true;
 
+#if _CCCL_HAS_HOST_STD_LIB()
+template <class _Tp>
+inline constexpr bool __is_std_array_v = false;
+
+template <class _Tp, size_t _Sz>
+inline constexpr bool __is_std_array_v<::std::array<_Tp, _Sz>> = true;
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
 _CCCL_END_NAMESPACE_CUDA_STD
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -68,30 +68,23 @@ template <class _From, class _To>
 _CCCL_CONCEPT __span_array_convertible = is_convertible_v<_From (*)[], _To (*)[]>;
 
 template <class _Range, class _ElementType>
-_CCCL_CONCEPT __span_compatible_range = _CCCL_REQUIRES_EXPR((_Range, _ElementType)) //
-  ( //
-    requires(::cuda::std::ranges::contiguous_range<_Range>), //
-    requires(::cuda::std::ranges::sized_range<_Range>), //
-    requires(::cuda::std::ranges::borrowed_range<_Range> || is_const_v<_ElementType>), //
-    requires(!is_array_v<remove_cvref_t<_Range>>), //
-    requires(!__is_cuda_std_span_v<remove_cvref_t<_Range>>), //
-    requires(!__is_cuda_std_array_v<remove_cvref_t<_Range>>), //
-    requires(
-      is_convertible_v<remove_reference_t<::cuda::std::ranges::range_reference_t<_Range>> (*)[], _ElementType (*)[]>));
+_CCCL_CONCEPT __span_compatible_range = _CCCL_REQUIRES_EXPR((_Range, _ElementType))(
+  requires(::cuda::std::ranges::contiguous_range<_Range>),
+  requires(::cuda::std::ranges::sized_range<_Range>),
+  requires((::cuda::std::ranges::borrowed_range<_Range> || is_const_v<_ElementType>) ),
+  requires((!is_array_v<remove_cvref_t<_Range>>) ),
+  requires((!__is_cuda_std_span_v<remove_cvref_t<_Range>> && !__is_cuda_std_array_v<remove_cvref_t<_Range>>) ),
+  requires(
+    is_convertible_v<remove_reference_t<::cuda::std::ranges::range_reference_t<_Range>> (*)[], _ElementType (*)[]>));
 
 template <class _It, class _Tp>
 _CCCL_CONCEPT __span_compatible_iterator = _CCCL_REQUIRES_EXPR((_It, _Tp)) //
-  ( //
-    requires(contiguous_iterator<_It>), //
-    requires(__span_array_convertible<remove_reference_t<iter_reference_t<_It>>, _Tp>) //
-  );
+  (requires(contiguous_iterator<_It>),
+   requires(__span_array_convertible<remove_reference_t<iter_reference_t<_It>>, _Tp>));
 
 template <class _Sentinel, class _It>
 _CCCL_CONCEPT __span_compatible_sentinel_for = _CCCL_REQUIRES_EXPR((_Sentinel, _It)) //
-  ( //
-    requires(sized_sentinel_for<_Sentinel, _It>), //
-    requires(!is_convertible_v<_Sentinel, size_t>) //
-  );
+  (requires(sized_sentinel_for<_Sentinel, _It>), requires(!is_convertible_v<_Sentinel, size_t>));
 
 template <class _Tp, bool = __integral_constant_like<_Tp>>
 inline constexpr size_t __maybe_static_ext = dynamic_extent;

--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -120,6 +120,7 @@ public:
   _CCCL_HIDE_FROM_ABI span(const span&) noexcept            = default;
   _CCCL_HIDE_FROM_ABI span& operator=(const span&) noexcept = default;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _It)
   _CCCL_REQUIRES(__span_compatible_iterator<_It, element_type>)
   _CCCL_API constexpr explicit span(_It __first, [[maybe_unused]] size_type __count)
@@ -128,6 +129,7 @@ public:
     _CCCL_ASSERT(_Extent == __count, "size mismatch in span's constructor (iterator, len)");
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _It, class _End)
   _CCCL_REQUIRES(__span_compatible_iterator<_It, element_type> _CCCL_AND __span_compatible_sentinel_for<_End, _It>)
   _CCCL_API constexpr explicit span(_It __first, [[maybe_unused]] _End __last)
@@ -156,6 +158,23 @@ public:
       : __data_{__arr.data()}
   {}
 
+#if _CCCL_HAS_HOST_STD_LIB()
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _OtherElementType)
+  _CCCL_REQUIRES(__span_array_convertible<_OtherElementType, element_type>)
+  _CCCL_HOST_API constexpr span(::std::array<_OtherElementType, _Extent>& __arr) noexcept
+      : __data_{__arr.data()}
+  {}
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _OtherElementType)
+  _CCCL_REQUIRES(__span_array_convertible<const _OtherElementType, element_type>)
+  _CCCL_HOST_API constexpr span(const ::std::array<_OtherElementType, _Extent>& __arr) noexcept
+      : __data_{__arr.data()}
+  {}
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__span_compatible_range<_Range, element_type>)
   _CCCL_API constexpr explicit span(_Range&& __r)
@@ -353,6 +372,7 @@ public:
   _CCCL_HIDE_FROM_ABI span(const span&) noexcept            = default;
   _CCCL_HIDE_FROM_ABI span& operator=(const span&) noexcept = default;
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _It)
   _CCCL_REQUIRES(__span_compatible_iterator<_It, element_type>)
   _CCCL_API constexpr span(_It __first, size_type __count)
@@ -360,6 +380,7 @@ public:
       , __size_{__count}
   {}
 
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _It, class _End)
   _CCCL_REQUIRES(__span_compatible_iterator<_It, element_type> _CCCL_AND __span_compatible_sentinel_for<_End, _It>)
   _CCCL_API constexpr span(_It __first, _End __last)
@@ -389,6 +410,23 @@ public:
       , __size_{_Sz}
   {}
 
+#if _CCCL_HAS_HOST_STD_LIB()
+  _CCCL_TEMPLATE(class _OtherElementType, size_t _Sz)
+  _CCCL_REQUIRES(__span_array_convertible<_OtherElementType, element_type>)
+  _CCCL_HOST_API constexpr span(::std::array<_OtherElementType, _Sz>& __arr) noexcept
+      : __data_{__arr.data()}
+      , __size_{_Sz}
+  {}
+
+  _CCCL_TEMPLATE(class _OtherElementType, size_t _Sz)
+  _CCCL_REQUIRES(__span_array_convertible<const _OtherElementType, element_type>)
+  _CCCL_HOST_API constexpr span(const ::std::array<_OtherElementType, _Sz>& __arr) noexcept
+      : __data_{__arr.data()}
+      , __size_{_Sz}
+  {}
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Range)
   _CCCL_REQUIRES(__span_compatible_range<_Range, element_type>)
   _CCCL_API constexpr span(_Range&& __r)
@@ -572,6 +610,14 @@ _CCCL_DEDUCTION_GUIDE_ATTRIBUTES span(array<_Tp, _Sz>&) -> span<_Tp, _Sz>;
 
 template <class _Tp, size_t _Sz>
 _CCCL_DEDUCTION_GUIDE_ATTRIBUTES span(const array<_Tp, _Sz>&) -> span<const _Tp, _Sz>;
+
+#if _CCCL_HAS_HOST_STD_LIB()
+template <class _Tp, size_t _Sz>
+_CCCL_HOST_DEVICE span(::std::array<_Tp, _Sz>&) -> span<_Tp, _Sz>;
+
+template <class _Tp, size_t _Sz>
+_CCCL_HOST_DEVICE span(const ::std::array<_Tp, _Sz>&) -> span<const _Tp, _Sz>;
+#endif // _CCCL_HAS_HOST_STD_LIB()
 
 _CCCL_TEMPLATE(class _It, class _EndOrSize)
 _CCCL_REQUIRES(contiguous_iterator<_It>)

--- a/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/deduct.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/deduct.pass.cpp
@@ -36,6 +36,10 @@
 #include <cuda/std/span>
 #include <cuda/std/type_traits>
 
+#if !_CCCL_COMPILER(NVRTC)
+#  include <array>
+#endif // !_CCCL_COMPILER(NVRTC)
+
 #include "test_macros.h"
 
 TEST_FUNC void test_iterator_sentinel()
@@ -82,7 +86,7 @@ TEST_FUNC void test_c_array()
   }
 }
 
-TEST_FUNC void test_std_array()
+TEST_FUNC void test_cuda_std_array()
 {
   {
     cuda::std::array<double, 4> arr = {1.0, 2.0, 3.0, 4.0};
@@ -101,11 +105,35 @@ TEST_FUNC void test_std_array()
   }
 }
 
+#if !TEST_COMPILER(NVRTC)
+void test_std_array()
+{
+  {
+    std::array<double, 4> arr = {1.0, 2.0, 3.0, 4.0};
+    cuda::std::span s{arr};
+    static_assert(cuda::std::is_same_v<decltype(s), cuda::std::span<double, 4>>);
+    assert(s.size() == arr.size());
+    assert(s.data() == arr.data());
+  }
+
+  {
+    const std::array<long, 5> arr = {4, 5, 6, 7, 8};
+    cuda::std::span s{arr};
+    static_assert(cuda::std::is_same_v<decltype(s), cuda::std::span<const long, 5>>);
+    assert(s.size() == arr.size());
+    assert(s.data() == arr.data());
+  }
+}
+#endif // !TEST_COMPILER(NVRTC)
+
 int main(int, char**)
 {
   test_iterator_sentinel();
   test_c_array();
-  test_std_array();
+  test_cuda_std_array();
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test_std_array();))
+#endif // !TEST_COMPILER(NVRTC)
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/range.pass.cpp
@@ -26,8 +26,14 @@
 #include "test_macros.h"
 
 #if !TEST_COMPILER(NVRTC)
+#  if defined(__cpp_lib_span)
+#    include <span>
+#  endif //__cpp_lib_span
 #  include <vector>
 #endif // !TEST_COMPILER(NVRTC)
+
+struct A
+{};
 
 //  Look ma - I'm a container!
 template <typename T>
@@ -78,109 +84,87 @@ TEST_FUNC void checkCV()
 
   //  Types the same
   {
-    cuda::std::span<int> s1{v}; // a span<               int> pointing at int.
-    unused(s1);
+    [[maybe_unused]] cuda::std::span<int> s1{v}; // a span<int> pointing at int.
   }
 
   //  types different
   {
-    cuda::std::span<const int> s1{v}; // a span<const          int> pointing at int.
-    cuda::std::span<volatile int> s2{v}; // a span<      volatile int> pointing at int.
-    cuda::std::span<volatile int> s3{v}; // a span<      volatile int> pointing at const int.
-    cuda::std::span<const volatile int> s4{v}; // a span<const volatile int> pointing at int.
-    unused(s1);
-    unused(s2);
-    unused(s3);
-    unused(s4);
+    [[maybe_unused]] cuda::std::span<const int> s1{v}; // a span<const int> pointing at int.
+    [[maybe_unused]] cuda::std::span<volatile int> s2{v}; // a span<volatile int> pointing at int.
+    [[maybe_unused]] cuda::std::span<volatile int> s3{v}; // a span<volatile int> pointing at const int.
+    [[maybe_unused]] cuda::std::span<const volatile int> s4{v}; // a span<const volatile int> pointing at int.
   }
 
   //  Constructing a const view from a temporary
   {
-    cuda::std::span<const int> s1{IsAContainer<int>()};
-    unused(s1);
+    [[maybe_unused]] cuda::std::span<const int> s1{IsAContainer<int>()};
   }
 }
 
 template <typename T>
-TEST_FUNC constexpr bool testConstexprSpan()
+TEST_FUNC constexpr void test()
 {
-  constexpr IsAContainer<const T> val{};
-  cuda::std::span<const T> s1{val};
-  return s1.data() == val.getV() && s1.size() == 1;
-}
+  {
+    IsAContainer<T> val{};
+    const IsAContainer<T> cVal;
+    cuda::std::span<T> s1{val};
+    cuda::std::span<const T> s2{cVal};
+    assert(s1.data() == val.getV() && s1.size() == 1);
+    assert(s2.data() == cVal.getV() && s2.size() == 1);
+  }
 
-template <typename T>
-TEST_FUNC constexpr bool testConstexprSpanStatic()
-{
-  constexpr IsAContainer<const T> val{};
-  cuda::std::span<const T, 1> s1{val};
-  return s1.data() == val.getV() && s1.size() == 1;
-}
-
-template <typename T>
-TEST_FUNC void testRuntimeSpan()
-{
-  IsAContainer<T> val{};
-  const IsAContainer<T> cVal;
-  cuda::std::span<T> s1{val};
-  cuda::std::span<const T> s2{cVal};
-  assert(s1.data() == val.getV() && s1.size() == 1);
-  assert(s2.data() == cVal.getV() && s2.size() == 1);
-}
-
-template <typename T>
-TEST_FUNC void testRuntimeSpanStatic()
-{
-  IsAContainer<T> val{};
-  const IsAContainer<T> cVal;
-  cuda::std::span<T, 1> s1{val};
-  cuda::std::span<const T, 1> s2{cVal};
-  assert(s1.data() == val.getV() && s1.size() == 1);
-  assert(s2.data() == cVal.getV() && s2.size() == 1);
+  {
+    IsAContainer<T> val{};
+    const IsAContainer<T> cVal;
+    cuda::std::span<T, 1> s1{val};
+    cuda::std::span<const T, 1> s2{cVal};
+    assert(s1.data() == val.getV() && s1.size() == 1);
+    assert(s2.data() == cVal.getV() && s2.size() == 1);
+  }
 }
 
 #if !TEST_COMPILER(NVRTC)
 template <typename T>
-void testContainers()
+void test_std()
 {
   ::std::vector<T> val(1);
   const ::std::vector<T> cVal(1);
-  cuda::std::span<T> s1{val};
-  cuda::std::span<const T> s2{cVal};
-  assert(s1.data() == val.data() && s1.size() == 1);
-  assert(s2.data() == cVal.data() && s2.size() == 1);
+  { // from container
+    cuda::std::span<T> s1{val};
+    cuda::std::span<const T> s2{cVal};
+    assert(s1.data() == val.data() && s1.size() == 1);
+    assert(s2.data() == cVal.data() && s2.size() == 1);
+  }
+#  if defined(__cpp_lib_span)
+  { // from std::span
+    // we are requiring `cuda::std::enable_borrowed_range` but only get `std::enable_borrowed_range`
+    // cuda::std::span<T> s1{std::span{val}};
+    cuda::std::span<const T> s2{std::span{cVal}};
+    // assert(s1.data() == val.data() && s1.size() == 1);
+    assert(s2.data() == cVal.data() && s2.size() == 1);
+  }
+#  endif // __cpp_lib_span
 }
 #endif // !TEST_COMPILER(NVRTC)
 
-struct A
-{};
+TEST_FUNC constexpr bool test()
+{
+  test<int>();
+  test<long>();
+  test<double>();
+  test<A>();
+
+  return true;
+}
 
 int main(int, char**)
 {
-  static_assert(testConstexprSpan<int>());
-  static_assert(testConstexprSpan<long>());
-  static_assert(testConstexprSpan<double>());
-  static_assert(testConstexprSpan<A>());
-
-  static_assert(testConstexprSpanStatic<int>());
-  static_assert(testConstexprSpanStatic<long>());
-  static_assert(testConstexprSpanStatic<double>());
-  static_assert(testConstexprSpanStatic<A>());
-
-  testRuntimeSpan<int>();
-  testRuntimeSpan<long>();
-  testRuntimeSpan<double>();
-  testRuntimeSpan<A>();
-
-  testRuntimeSpanStatic<int>();
-  testRuntimeSpanStatic<long>();
-  testRuntimeSpanStatic<double>();
-  testRuntimeSpanStatic<A>();
-
+  test();
+  static_assert(test());
   checkCV();
 
 #if !TEST_COMPILER(NVRTC)
-  NV_IF_TARGET(NV_IS_HOST, (testContainers<int>(); testContainers<A>();))
+  NV_IF_TARGET(NV_IS_HOST, (test_std<int>(); test_std<A>();))
 #endif // !TEST_COMPILER(NVRTC)
 
   return 0;

--- a/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/stdarray.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/views.span/span.cons/stdarray.pass.cpp
@@ -23,11 +23,19 @@
 #include <cuda/std/cassert>
 #include <cuda/std/span>
 
+#if !_CCCL_COMPILER(NVRTC)
+#  include <array>
+#endif // !_CCCL_COMPILER(NVRTC)
+
 #include "test_macros.h"
 
-TEST_FUNC void checkCV()
+struct A
+{};
+
+template <template <class, size_t> class array>
+TEST_FUNC constexpr void checkCV()
 {
-  cuda::std::array<int, 3> arr = {1, 2, 3};
+  array<int, 3> arr = {1, 2, 3};
   //  STL says these are not cromulent
   //  std::array<const int,3> carr = {4,5,6};
   //  std::array<volatile int, 3> varr = {7,8,9};
@@ -35,82 +43,97 @@ TEST_FUNC void checkCV()
 
   //  Types the same (dynamic sized)
   {
-    cuda::std::span<int> s1{arr}; // a cuda::std::span<               int> pointing at int.
+    [[maybe_unused]] cuda::std::span<int> s1{arr}; // a cuda::std::span<               int> pointing at int.
   }
 
   //  Types the same (static sized)
   {
-    cuda::std::span<int, 3> s1{arr}; // a cuda::std::span<               int> pointing at int.
+    [[maybe_unused]] cuda::std::span<int, 3> s1{arr}; // a cuda::std::span<               int> pointing at int.
   }
 
   //  types different (dynamic sized)
   {
-    cuda::std::span<const int> s1{arr}; // a cuda::std::span<const          int> pointing at int.
-    cuda::std::span<volatile int> s2{arr}; // a cuda::std::span<      volatile int> pointing at int.
-    cuda::std::span<volatile int> s3{arr}; // a cuda::std::span<      volatile int> pointing at const int.
-    cuda::std::span<const volatile int> s4{arr}; // a cuda::std::span<const volatile int> pointing at int.
+    [[maybe_unused]] cuda::std::span<const int> s1{arr}; // a cuda::std::span<const int> pointing at int.
+    [[maybe_unused]] cuda::std::span<volatile int> s2{arr}; // a cuda::std::span<volatile int> pointing at int.
+    [[maybe_unused]] cuda::std::span<volatile int> s3{arr}; // a cuda::std::span<volatile int> pointing at const int.
+    [[maybe_unused]] cuda::std::span<const volatile int> s4{arr}; // a cuda::std::span<const volatile int> pointing at
+                                                                  // int.
   }
 
   //  types different (static sized)
   {
-    cuda::std::span<const int, 3> s1{arr}; // a cuda::std::span<const          int> pointing at int.
-    cuda::std::span<volatile int, 3> s2{arr}; // a cuda::std::span<      volatile int> pointing at int.
-    cuda::std::span<volatile int, 3> s3{arr}; // a cuda::std::span<      volatile int> pointing at const int.
-    cuda::std::span<const volatile int, 3> s4{arr}; // a cuda::std::span<const volatile int> pointing at int.
+    [[maybe_unused]] cuda::std::span<const int, 3> s1{arr}; // a cuda::std::span<const int> pointing at int.
+    [[maybe_unused]] cuda::std::span<volatile int, 3> s2{arr}; // a cuda::std::span<volatile int> pointing at int.
+    [[maybe_unused]] cuda::std::span<volatile int, 3> s3{arr}; // a cuda::std::span<volatile int> pointing at const int.
+    [[maybe_unused]] cuda::std::span<const volatile int, 3> s4{arr}; // a cuda::std::span<const volatile int> pointing
+                                                                     // at int.
   }
 }
 
-template <typename T, typename U>
-TEST_FUNC constexpr bool testConstructorArray()
+template <template <class, size_t> class array, typename T, typename U>
+TEST_FUNC constexpr void test()
 {
-  cuda::std::array<U, 2> val = {U(), U()};
-  static_assert(noexcept(cuda::std::span<T>{val}));
-  static_assert(noexcept(cuda::std::span<T, 2>{val}));
-  cuda::std::span<T> s1{val};
-  cuda::std::span<T, 2> s2{val};
-  return s1.data() == &val[0] && s1.size() == 2 && s2.data() == &val[0] && s2.size() == 2;
+  {
+    array<U, 2> val = {U(), U()};
+    static_assert(noexcept(cuda::std::span<T>{val}));
+    static_assert(noexcept(cuda::std::span<T, 2>{val}));
+    cuda::std::span<T> s1{val};
+    cuda::std::span<T, 2> s2{val};
+    assert(s1.data() == &val[0]);
+    assert(s1.size() == 2);
+    assert(s2.data() == &val[0]);
+    assert(s2.size() == 2);
+  }
+
+  {
+    const array<U, 2> val = {U(), U()};
+    static_assert(noexcept(cuda::std::span<const T>{val}));
+    static_assert(noexcept(cuda::std::span<const T, 2>{val}));
+    cuda::std::span<const T> s1{val};
+    cuda::std::span<const T, 2> s2{val};
+    assert(s1.data() == &val[0]);
+    assert(s1.size() == 2);
+    assert(s2.data() == &val[0]);
+    assert(s2.size() == 2);
+  }
 }
 
-template <typename T, typename U>
-TEST_FUNC constexpr bool testConstructorConstArray()
+template <template <class, size_t> class array, typename T>
+TEST_FUNC constexpr void test()
 {
-  const cuda::std::array<U, 2> val = {U(), U()};
-  static_assert(noexcept(cuda::std::span<const T>{val}));
-  static_assert(noexcept(cuda::std::span<const T, 2>{val}));
-  cuda::std::span<const T> s1{val};
-  cuda::std::span<const T, 2> s2{val};
-  return s1.data() == &val[0] && s1.size() == 2 && s2.data() == &val[0] && s2.size() == 2;
+  test<array, T, T>();
+  test<array, const T, const T>();
+  test<array, const T, T>();
 }
 
-template <typename T>
-TEST_FUNC constexpr bool testConstructors()
+template <template <class, size_t> class array>
+TEST_FUNC constexpr void test()
 {
-  static_assert((testConstructorArray<T, T>()));
-  static_assert((testConstructorArray<const T, const T>()));
-  static_assert((testConstructorArray<const T, T>()));
-  static_assert((testConstructorConstArray<T, T>()));
-  static_assert((testConstructorConstArray<const T, const T>()));
-  static_assert((testConstructorConstArray<const T, T>()));
+  test<array, int>();
+  test<array, long>();
+  test<array, double>();
+  test<array, A>();
 
-  return testConstructorArray<T, T>() && testConstructorArray<const T, const T>() && testConstructorArray<const T, T>()
-      && testConstructorConstArray<T, T>() && testConstructorConstArray<const T, const T>()
-      && testConstructorConstArray<const T, T>();
+  test<array, int*>();
+  test<array, const int*>();
+
+  checkCV<array>();
 }
 
-struct A
-{};
+__host__ __device__ constexpr bool test()
+{
+  test<cuda::std::array>();
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test<std::array>();));
+#endif // !TEST_COMPILER(NVRTC)
+
+  return true;
+}
 
 int main(int, char**)
 {
-  assert(testConstructors<int>());
-  assert(testConstructors<long>());
-  assert(testConstructors<double>());
-  assert(testConstructors<A>());
-
-  assert(testConstructors<int*>());
-  assert(testConstructors<const int*>());
-
-  checkCV();
+  test();
+  static_assert(test());
 
   return 0;
 }


### PR DESCRIPTION
Currently `cuda::std::span` has some limitations regarding std library types, especially `std::array` and `std::span`

We can improve the situation here a bit by adding some hacky constructors