### PR TITLE
Implement `cuda::std::basic_format_string`

### DIFF
--- a/libcudacxx/include/cuda/std/__format/format_string.h
+++ b/libcudacxx/include/cuda/std/__format/format_string.h
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___FORMAT_FORMAT_STRING_H
+#define _CUDA_STD___FORMAT_FORMAT_STRING_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__concepts/convertible_to.h>
+#include <cuda/std/__format/format_arg.h>
+#include <cuda/std/__format/format_arg_store.h>
+#include <cuda/std/__format/format_parse_context.h>
+#include <cuda/std/__format/validation.h>
+#include <cuda/std/__format/vformat.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/string_view>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class _CharT, class... _Args>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_string
+{
+  _CCCL_TEMPLATE(class _Tp)
+  _CCCL_REQUIRES(convertible_to<const _Tp&, basic_string_view<_CharT>>)
+  _CCCL_API _CCCL_CONSTEVAL basic_format_string(const _Tp& __str)
+      : __str_{__str}
+  {
+    if constexpr (sizeof...(_Args) > 0)
+    {
+      constexpr __fmt_arg_t __types[] = {::cuda::std::__fmt_determine_arg_t<_FmtContext, remove_cvref_t<_Args>>()...};
+      constexpr _FmtArgHandle __handles[] = {
+        ::cuda::std::__fmt_make_validation_format_arg_handle<_FmtContext, remove_cvref_t<_Args>>()...};
+
+      ::cuda::std::__fmt_vformat_to(basic_format_parse_context<_CharT>{__str_, sizeof...(_Args)},
+                                    _FmtContext{__types, __handles, sizeof...(_Args)});
+    }
+    else
+    {
+      ::cuda::std::__fmt_vformat_to(
+        basic_format_parse_context<_CharT>{__str_, sizeof...(_Args)}, _FmtContext{nullptr, nullptr, sizeof...(_Args)});
+    }
+  }
+
+  [[nodiscard]] _CCCL_API constexpr basic_string_view<_CharT> get() const noexcept
+  {
+    return __str_;
+  }
+
+private:
+  basic_string_view<_CharT> __str_;
+
+  using _FmtContext   = __fmt_validation_format_context<_CharT>;
+  using _FmtArgHandle = __fmt_validation_format_arg_handle<_CharT>;
+};
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___FORMAT_FORMAT_STRING_H

--- a/libcudacxx/include/cuda/std/__format/formatters/bool.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/bool.h
@@ -3,12 +3,12 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD__FORMAT_FORMATERS_BOOL_H
-#define _CUDA_STD__FORMAT_FORMATERS_BOOL_H
+#ifndef _CUDA_STD___FORMAT_FORMATERS_BOOL_H
+#define _CUDA_STD___FORMAT_FORMATERS_BOOL_H
 
 #include <cuda/std/detail/__config>
 
@@ -80,7 +80,6 @@ struct __fmt_formatter_bool
     }
   }
 
-private:
   __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.
 };
 

--- a/libcudacxx/include/cuda/std/__format/formatters/char.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/char.h
@@ -3,12 +3,12 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD__FORMAT_FORMATERS_CHAR_H
-#define _CUDA_STD__FORMAT_FORMATERS_CHAR_H
+#ifndef _CUDA_STD___FORMAT_FORMATERS_CHAR_H
+#define _CUDA_STD___FORMAT_FORMATERS_CHAR_H
 
 #include <cuda/std/detail/__config>
 
@@ -100,7 +100,6 @@ struct __fmt_formatter_char
   }
 #endif // _CCCL_HAS_WCHAR_T()
 
-private:
   __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.
 };
 

--- a/libcudacxx/include/cuda/std/__format/formatters/fp.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/fp.h
@@ -3,12 +3,12 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD__FORMAT_FORMATERS_FP_H
-#define _CUDA_STD__FORMAT_FORMATERS_FP_H
+#ifndef _CUDA_STD___FORMAT_FORMATERS_FP_H
+#define _CUDA_STD___FORMAT_FORMATERS_FP_H
 
 #include <cuda/std/detail/__config>
 
@@ -64,7 +64,6 @@ struct __fmt_formatter_fp
     return __ctx.out();
   }
 
-private:
   __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.
 };
 

--- a/libcudacxx/include/cuda/std/__format/formatters/int.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/int.h
@@ -3,12 +3,12 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD__FORMAT_FORMATERS_INT_H
-#define _CUDA_STD__FORMAT_FORMATERS_INT_H
+#ifndef _CUDA_STD___FORMAT_FORMATERS_INT_H
+#define _CUDA_STD___FORMAT_FORMATERS_INT_H
 
 #include <cuda/std/detail/__config>
 
@@ -79,7 +79,6 @@ struct __fmt_formatter_int
     return ::cuda::std::__fmt_format_int(static_cast<_Type>(__value), __ctx, __specs);
   }
 
-private:
   __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.
 };
 

--- a/libcudacxx/include/cuda/std/__format/formatters/ptr.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/ptr.h
@@ -3,12 +3,12 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD__FORMAT_FORMATERS_PTR_H
-#define _CUDA_STD__FORMAT_FORMATERS_PTR_H
+#ifndef _CUDA_STD___FORMAT_FORMATERS_PTR_H
+#define _CUDA_STD___FORMAT_FORMATERS_PTR_H
 
 #include <cuda/std/detail/__config>
 
@@ -71,7 +71,6 @@ struct __fmt_formatter_ptr
     return ::cuda::std::__fmt_format_int(reinterpret_cast<uintptr_t>(__value), __ctx, __specs);
   }
 
-private:
   __fmt_spec_parser<_CharT> __parser_; //!< The parser for format specifications.
 };
 

--- a/libcudacxx/include/cuda/std/__format/formatters/str.h
+++ b/libcudacxx/include/cuda/std/__format/formatters/str.h
@@ -3,12 +3,12 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD__FORMAT_FORMATERS_STR_H
-#define _CUDA_STD__FORMAT_FORMATERS_STR_H
+#ifndef _CUDA_STD___FORMAT_FORMATERS_STR_H
+#define _CUDA_STD___FORMAT_FORMATERS_STR_H
 
 #include <cuda/std/detail/__config>
 
@@ -33,52 +33,22 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+template <class _CharT>
+[[nodiscard]] _CCCL_API constexpr __fmt_spec_parser<_CharT> __fmt_formatter_str_make_parser() noexcept
+{
+  __fmt_spec_parser<_CharT> __parser{};
+  __parser.__alignment_ = ::cuda::std::to_underlying(__fmt_spec_alignment::__left);
+  return __parser;
+}
+
 //!
 //! @brief Formatter for string types.
 //!
 //! @tparam _CharT The character type used for formatting.
 //!
 template <class _CharT>
-struct __fmt_formatter_str
+class __fmt_formatter_str
 {
-  //!
-  //! @brief Parses the formatting specifications for string types.
-  //!
-  //! @param __ctx The parsing context containing the format specification.
-  //! @return An iterator pointing to the end of the parsed format specification.
-  //!
-  template <class _ParseCtx>
-  _CCCL_HOST_DEVICE_API constexpr typename _ParseCtx::iterator parse(_ParseCtx& __ctx)
-  {
-    typename _ParseCtx::iterator __result = __parser_.__parse(__ctx, ::cuda::std::__fmt_spec_fields_str());
-    ::cuda::std::__fmt_process_display_type_str(__parser_.__type_);
-    return __result;
-  }
-
-  //!
-  //! @brief Formats a string value according to the parsed specifications.
-  //!
-  //! @param __value The string value to format.
-  //! @param __ctx The formatting context where the formatted output will be stored.
-  //! @return An iterator pointing to the end of the formatted output.
-  //!
-  template <class _Tp, class _FmtCtx>
-  _CCCL_HOST_DEVICE_API typename _FmtCtx::iterator format(_Tp __value, _FmtCtx& __ctx) const
-  {
-    return __format(__value, __ctx);
-  }
-
-private:
-  //!
-  //! @brief Creates a parser for string formatting specifications.
-  //!
-  [[nodiscard]] _CCCL_HOST_DEVICE_API static constexpr __fmt_spec_parser<_CharT> __make_parser()
-  {
-    __fmt_spec_parser<_CharT> __parser{};
-    __parser.__alignment_ = ::cuda::std::to_underlying(__fmt_spec_alignment::__left);
-    return __parser;
-  }
-
   //!
   //! @brief Formats a C-string according to the parsed specifications.
   //!
@@ -123,7 +93,36 @@ private:
     return ::cuda::std::__fmt_write_string(__str2, __ctx.out(), __parser_.__get_parsed_std_spec(__ctx));
   }
 
-  __fmt_spec_parser<_CharT> __parser_ = __make_parser(); //!< The parser for format specifications.
+public:
+  //!
+  //! @brief Parses the formatting specifications for string types.
+  //!
+  //! @param __ctx The parsing context containing the format specification.
+  //! @return An iterator pointing to the end of the parsed format specification.
+  //!
+  template <class _ParseCtx>
+  _CCCL_API constexpr typename _ParseCtx::iterator parse(_ParseCtx& __ctx)
+  {
+    typename _ParseCtx::iterator __result = __parser_.__parse(__ctx, ::cuda::std::__fmt_spec_fields_str());
+    ::cuda::std::__fmt_process_display_type_str(__parser_.__type_);
+    return __result;
+  }
+
+  //!
+  //! @brief Formats a string value according to the parsed specifications.
+  //!
+  //! @param __value The string value to format.
+  //! @param __ctx The formatting context where the formatted output will be stored.
+  //! @return An iterator pointing to the end of the formatted output.
+  //!
+  template <class _Tp, class _FmtCtx>
+  _CCCL_API typename _FmtCtx::iterator format(_Tp __value, _FmtCtx& __ctx) const
+  {
+    return __format(__value, __ctx);
+  }
+
+  //!< The parser for format specifications.
+  __fmt_spec_parser<_CharT> __parser_ = ::cuda::std::__fmt_formatter_str_make_parser<_CharT>();
 };
 
 template <>

--- a/libcudacxx/include/cuda/std/__format/validation.h
+++ b/libcudacxx/include/cuda/std/__format/validation.h
@@ -1,0 +1,242 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___FORMAT_VALIDATION_H
+#define _CUDA_STD___FORMAT_VALIDATION_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__format/format_arg.h>
+#include <cuda/std/__format/format_arg_store.h>
+#include <cuda/std/__format/format_error.h>
+#include <cuda/std/__format/format_parse_context.h>
+#include <cuda/std/__format/formatter.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+//! @brief Helper class parse and handle argument.
+//!
+//! When parsing a handle which is not enabled the code is ill-formed.
+//! This helper uses the parser of the appropriate formatter for the stored type.
+template <class _CharT>
+struct __fmt_validation_format_arg_handle
+{
+  void (*__parse_)(basic_format_parse_context<_CharT>&);
+
+  template <class _Tp>
+  _CCCL_API static constexpr void __formatter_invoker(basic_format_parse_context<_CharT>& __parse_ctx)
+  {
+    formatter<_Tp, _CharT> __f;
+    __parse_ctx.advance_to(__f.parse(__parse_ctx));
+  }
+
+  _CCCL_API static constexpr void __formatter_invoker_invalid(basic_format_parse_context<_CharT>&)
+  {
+    ::cuda::std::__throw_format_error("Not a handle");
+  }
+
+  template <class _ParseCtx>
+  _CCCL_API constexpr void __parse(_ParseCtx& __parse_ctx) const
+  {
+    __parse_(__parse_ctx);
+  }
+};
+
+template <class _Context, class _Tp>
+[[nodiscard]] _CCCL_API constexpr __fmt_validation_format_arg_handle<typename _Context::char_type>
+__fmt_make_validation_format_arg_handle()
+{
+  using _CharT = typename _Context::char_type;
+  if constexpr (::cuda::std::__fmt_determine_arg_t<_Context, _Tp>() == __fmt_arg_t::__handle)
+  {
+    return {__fmt_validation_format_arg_handle<_CharT>::template __formatter_invoker<_Tp>};
+  }
+  else
+  {
+    return {__fmt_validation_format_arg_handle<_CharT>::__formatter_invoker_invalid};
+  }
+}
+
+//! @brief Dummy format_context only providing the parts used during compile-time validation of the basic_format_string.
+template <class _CharT>
+class __fmt_validation_format_context
+{
+  using _FmtArgHandle = __fmt_validation_format_arg_handle<_CharT>;
+
+  const __fmt_arg_t* __args_;
+  const _FmtArgHandle* __handles_;
+  size_t __size_;
+
+public:
+  using char_type = _CharT;
+  template <class _Tp>
+  using formatter_type = formatter<_Tp, _CharT>;
+
+  //! @brief Dummy iterator. During the compile-time validation nothing needs to be written. Therefore all operations of
+  //!        this iterator are a NOP.
+  struct iterator
+  {
+    _CCCL_API constexpr iterator& operator=(_CharT)
+    {
+      return *this;
+    }
+    _CCCL_API constexpr iterator& operator*()
+    {
+      return *this;
+    }
+    _CCCL_API constexpr iterator operator++(int)
+    {
+      return *this;
+    }
+  };
+
+  _CCCL_API constexpr explicit __fmt_validation_format_context(
+    const __fmt_arg_t* __args, const _FmtArgHandle* __handles, size_t __size)
+      : __args_{__args}
+      , __handles_{__handles}
+      , __size_{__size}
+  {}
+
+  [[nodiscard]] _CCCL_API constexpr __fmt_arg_t arg(size_t __id) const
+  {
+    if (__id >= __size_)
+    {
+      ::cuda::std::__throw_format_error("The argument index value is too large for the number of arguments supplied");
+    }
+    return __args_[__id];
+  }
+
+  [[nodiscard]] _CCCL_API constexpr const _FmtArgHandle& __handle(size_t __id) const
+  {
+    if (__id >= __size_)
+    {
+      ::cuda::std::__throw_format_error("The argument index value is too large for the number of arguments supplied");
+    }
+    return __handles_[__id];
+  }
+
+  [[nodiscard]] _CCCL_API constexpr iterator out()
+  {
+    return {};
+  }
+  _CCCL_API constexpr void advance_to(iterator) {}
+};
+
+// [format.string.std]/8
+// If { arg-idopt } is used in a width or precision, the value of the
+// corresponding formatting argument is used in its place. If the
+// corresponding formatting argument is not of standard signed or unsigned
+// integer type, or its value is negative for precision or non-positive for
+// width, an exception of type format_error is thrown.
+//
+// _HasPrecision does the formatter have a precision?
+template <class _CharT, class _Tp, bool _HasPrecision = false>
+_CCCL_API constexpr void __fmt_validate_format_arg(basic_format_parse_context<_CharT>& __parse_ctx,
+                                                   __fmt_validation_format_context<_CharT>& __ctx)
+{
+  // LWG3720 originally allowed "signed or unsigned integer types", however
+  // the final version explicitly changed it to "*standard* signed or unsigned
+  // integer types". It's trivial to use 128-bit integrals in libc++'s
+  // implementation, but other implementations may not implement it.
+  // (Using a width or precision, that does not fit in 64-bits, sounds very
+  // unlikely in real world code.)
+
+  formatter<_Tp, _CharT> __formatter;
+  __parse_ctx.advance_to(__formatter.parse(__parse_ctx));
+  if (__formatter.__parser_.__width_as_arg_)
+  {
+    switch (__ctx.arg(__formatter.__parser_.__width_))
+    {
+      case __fmt_arg_t::__int:
+      case __fmt_arg_t::__long_long:
+      case __fmt_arg_t::__unsigned:
+      case __fmt_arg_t::__unsigned_long_long:
+        break;
+      default:
+        ::cuda::std::__throw_format_error("Replacement argument isn't a standard signed or unsigned integer type");
+    }
+  }
+
+  if constexpr (_HasPrecision)
+  {
+    if (__formatter.__parser_.__precision_as_arg_)
+    {
+      switch (__ctx.arg(__formatter.__parser_.__precision_))
+      {
+        case __fmt_arg_t::__int:
+        case __fmt_arg_t::__long_long:
+        case __fmt_arg_t::__unsigned:
+        case __fmt_arg_t::__unsigned_long_long:
+          break;
+        default:
+          ::cuda::std::__throw_format_error("Replacement argument isn't a standard signed or unsigned integer type");
+      }
+    }
+  }
+}
+
+template <class _CharT>
+_CCCL_API constexpr void __fmt_validate_visit_format_arg(
+  basic_format_parse_context<_CharT>& __parse_ctx, __fmt_validation_format_context<_CharT>& __ctx, __fmt_arg_t __type)
+{
+  switch (__type)
+  {
+    case __fmt_arg_t::__none:
+      ::cuda::std::__throw_format_error("Invalid argument");
+    case __fmt_arg_t::__boolean:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, bool>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__char_type:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, _CharT>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__int:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, int>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__long_long:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, long long>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__unsigned:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, unsigned>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__unsigned_long_long:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, unsigned long long>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__float:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, float, true>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__double:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, double, true>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__long_double:
+#if _CCCL_HAS_LONG_DOUBLE()
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, long double, true>(__parse_ctx, __ctx);
+#else // ^^^ _CCCL_HAS_LONG_DOUBLE() ^^^ / vvv _CCCL_HAS_LONG_DOUBLE() vvv
+      ::cuda::std::__throw_format_error("long double is disabled");
+#endif // ^^^ _CCCL_HAS_LONG_DOUBLE() ^^^
+    case __fmt_arg_t::__const_char_type_ptr:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, const _CharT*, true>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__string_view:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, basic_string_view<_CharT>, true>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__ptr:
+      return ::cuda::std::__fmt_validate_format_arg<_CharT, const void*>(__parse_ctx, __ctx);
+    case __fmt_arg_t::__handle:
+      ::cuda::std::__throw_format_error("Handle should use __fmt_validation_format_arg_handle");
+    default:
+      _CCCL_UNREACHABLE();
+  }
+}
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___FORMAT_VALIDATION_H

--- a/libcudacxx/include/cuda/std/__format/vformat.h
+++ b/libcudacxx/include/cuda/std/__format/vformat.h
@@ -1,0 +1,173 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___FORMAT_VFORMAT_H
+#define _CUDA_STD___FORMAT_VFORMAT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__format/format_arg.h>
+#include <cuda/std/__format/format_error.h>
+#include <cuda/std/__format/formatter.h>
+#include <cuda/std/__format/parse_arg_id.h>
+#include <cuda/std/__format/validation.h>
+#include <cuda/std/__iterator/iterator_traits.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class _CharT, class _ParseCtx, class _FormatCtx>
+struct __fmt_replacement_field_visitor
+{
+  _ParseCtx& __parse_ctx_;
+  _FormatCtx& __format_ctx_;
+  bool __parse_;
+
+  template <class _Tp>
+  _CCCL_API constexpr void operator()(_Tp __arg)
+  {
+    if constexpr (is_same_v<_Tp, monostate>)
+    {
+      ::cuda::std::__throw_format_error("The argument index value is too large for the number of arguments supplied");
+    }
+    else if constexpr (is_same_v<_Tp, typename basic_format_arg<_FormatCtx>::handle>)
+    {
+      __arg.format(__parse_ctx_, __format_ctx_);
+    }
+    else
+    {
+      formatter<_Tp, _CharT> __formatter;
+      if (__parse_)
+      {
+        __parse_ctx_.advance_to(__formatter.parse(__parse_ctx_));
+      }
+      __format_ctx_.advance_to(__formatter.format(__arg, __format_ctx_));
+    }
+  }
+};
+
+template <class _It, class _ParseCtx, class _Ctx>
+[[nodiscard]] _CCCL_API constexpr _It
+__fmt_handle_replacement_field(_It __begin, _It __end, _ParseCtx& __parse_ctx, _Ctx& __ctx)
+{
+  using _CharT = iter_value_t<_It>;
+
+  const auto __r = ::cuda::std::__fmt_parse_arg_id(__begin, __end, __parse_ctx);
+  if (__r.__last == __end)
+  {
+    ::cuda::std::__throw_format_error("The argument index should end with a ':' or a '}'");
+  }
+
+  const bool __parse = (*__r.__last == _CharT{':'});
+  switch (*__r.__last)
+  {
+    case _CharT{':'}:
+      // The arg-id has a format-specifier, advance the input to the format-spec.
+      __parse_ctx.advance_to(__r.__last + 1);
+      break;
+    case _CharT{'}'}:
+      // The arg-id has no format-specifier.
+      __parse_ctx.advance_to(__r.__last);
+      break;
+    default:
+      ::cuda::std::__throw_format_error("The argument index should end with a ':' or a '}'");
+  }
+
+  if constexpr (is_same_v<_Ctx, __fmt_validation_format_context<_CharT>>)
+  {
+    const __fmt_arg_t __type = __ctx.arg(__r.__value);
+    if (__type == __fmt_arg_t::__none)
+    {
+      ::cuda::std::__throw_format_error("The argument index value is too large for the number of arguments supplied");
+    }
+    else if (__type == __fmt_arg_t::__handle)
+    {
+      __ctx.__handle(__r.__value).__parse(__parse_ctx);
+    }
+    else if (__parse)
+    {
+      ::cuda::std::__fmt_validate_visit_format_arg(__parse_ctx, __ctx, __type);
+    }
+  }
+  else
+  {
+    ::cuda::std::visit_format_arg(
+      __fmt_replacement_field_visitor<_CharT, _ParseCtx, _Ctx>{__parse_ctx, __ctx, __parse}, __ctx.arg(__r.__value));
+  }
+
+  __begin = __parse_ctx.begin();
+  if (__begin == __end || *__begin != _CharT{'}'})
+  {
+    ::cuda::std::__throw_format_error("The replacement field misses a terminating '}'");
+  }
+  return ++__begin;
+}
+
+template <class _ParseCtx, class _Ctx>
+_CCCL_API constexpr typename _Ctx::iterator __fmt_vformat_to(_ParseCtx&& __parse_ctx, _Ctx&& __ctx)
+{
+  using _CharT = typename _ParseCtx::char_type;
+  static_assert(is_same_v<typename _Ctx::char_type, _CharT>);
+
+  auto __begin                     = __parse_ctx.begin();
+  auto __end                       = __parse_ctx.end();
+  typename _Ctx::iterator __out_it = __ctx.out();
+  while (__begin != __end)
+  {
+    switch (*__begin)
+    {
+      case _CharT{'{'}:
+        ++__begin;
+        if (__begin == __end)
+        {
+          ::cuda::std::__throw_format_error("The format string terminates at a '{'");
+        }
+
+        if (*__begin != _CharT{'{'})
+        {
+          __ctx.advance_to(::cuda::std::move(__out_it));
+          __begin  = ::cuda::std::__fmt_handle_replacement_field(__begin, __end, __parse_ctx, __ctx);
+          __out_it = __ctx.out();
+
+          // The output is written and __begin points to the next character. So
+          // start the next iteration.
+          continue;
+        }
+        // The string is an escape character.
+        break;
+
+      case _CharT{'}'}:
+        ++__begin;
+        if (__begin == __end || *__begin != _CharT{'}'})
+        {
+          ::cuda::std::__throw_format_error("The format string contains an invalid escape sequence");
+        }
+        break;
+    }
+
+    // Copy the character to the output verbatim.
+    *__out_it++ = *__begin++;
+  }
+  return __out_it;
+}
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___FORMAT_VFORMAT_H

--- a/libcudacxx/include/cuda/std/__format_
+++ b/libcudacxx/include/cuda/std/__format_
@@ -31,6 +31,7 @@
 #include <cuda/std/__format/format_integral.h>
 #include <cuda/std/__format/format_parse_context.h>
 #include <cuda/std/__format/format_spec_parser.h>
+#include <cuda/std/__format/format_string.h>
 #include <cuda/std/__format/formatter.h>
 #include <cuda/std/__format/formatters/bool.h>
 #include <cuda/std/__format/formatters/char.h>
@@ -40,6 +41,8 @@
 #include <cuda/std/__format/formatters/str.h>
 #include <cuda/std/__format/output_utils.h>
 #include <cuda/std/__format/parse_arg_id.h>
+#include <cuda/std/__format/validation.h>
+#include <cuda/std/__format/vformat.h>
 #include <cuda/std/version>
 
 #endif // _CUDA_STD_FORMAT

--- a/libcudacxx/include/cuda/std/__fwd/format.h
+++ b/libcudacxx/include/cuda/std/__fwd/format.h
@@ -21,6 +21,7 @@
 #endif // no system header
 
 #include <cuda/std/__fwd/iterator.h>
+#include <cuda/std/__type_traits/type_identity.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -87,6 +88,17 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_PREFERRED_NAME(format_args)
   _CCCL_PREFERRED_NAME(wformat_args)
 #endif // _CCCL_HAS_WCHAR_T()
     basic_format_args;
+
+template <class _CharT, class... _Args>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT basic_format_string;
+
+template <class... _Args>
+using format_string = basic_format_string<char, type_identity_t<_Args>...>;
+
+#if _CCCL_HAS_WCHAR_T()
+template <class... _Args>
+using wformat_string = basic_format_string<wchar_t, type_identity_t<_Args>...>;
+#endif // _CCCL_HAS_WCHAR_T()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class charT, class... Args>
+// class basic_format_string<charT, type_identity_t<Args>...>
+//
+// template<class T> consteval basic_format_string(const T& s);
+//
+// This constructor does the compile-time format string validation for the
+// std::format* functions.
+
+#include <cuda/std/__format_>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ void test_constructor()
+{
+  [[maybe_unused]] constexpr auto fmt1 = cuda::std::basic_format_string<CharT>{TEST_STRLIT(CharT, "foo")};
+  [[maybe_unused]] constexpr auto fmt2 = cuda::std::basic_format_string<CharT, int>{TEST_STRLIT(CharT, "{0:{0}}")};
+}
+
+__host__ __device__ void test()
+{
+  test_constructor<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_constructor<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor_fails/1.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor_fails/1.fail.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class charT, class... Args>
+// class basic_format_string<charT, type_identity_t<Args>...>
+//
+// template<class T> consteval basic_format_string(const T& s);
+//
+// This constructor does the compile-time format string validation for the
+// std::format* functions.
+
+#include <cuda/std/__format_>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ void test_constructor()
+{
+  [[maybe_unused]] constexpr cuda::std::basic_format_string<CharT> fmt{TEST_STRLIT(CharT, "{}")};
+}
+
+__host__ __device__ void test()
+{
+  test_constructor<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_constructor<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor_fails/2.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor_fails/2.fail.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class charT, class... Args>
+// class basic_format_string<charT, type_identity_t<Args>...>
+//
+// template<class T> consteval basic_format_string(const T& s);
+//
+// This constructor does the compile-time format string validation for the
+// std::format* functions.
+
+#include <cuda/std/__format_>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ void test_constructor()
+{
+  [[maybe_unused]] constexpr cuda::std::basic_format_string<CharT, int> fmt{TEST_STRLIT(CharT, "{0:{0}P}")};
+}
+
+__host__ __device__ void test()
+{
+  test_constructor<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_constructor<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor_fails/3.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor_fails/3.fail.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class charT, class... Args>
+// class basic_format_string<charT, type_identity_t<Args>...>
+//
+// template<class T> consteval basic_format_string(const T& s);
+//
+// This constructor does the compile-time format string validation for the
+// std::format* functions.
+
+#include <cuda/std/__format_>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ void test_constructor()
+{
+  [[maybe_unused]] constexpr cuda::std::basic_format_string<CharT, bool> fmt{TEST_STRLIT(CharT, "{0:{0}}")};
+}
+
+__host__ __device__ void test()
+{
+  test_constructor<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_constructor<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor_fails/4.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/ctor_fails/4.fail.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class charT, class... Args>
+// class basic_format_string<charT, type_identity_t<Args>...>
+//
+// template<class T> consteval basic_format_string(const T& s);
+//
+// This constructor does the compile-time format string validation for the
+// std::format* functions.
+
+#include <cuda/std/__format_>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ void test_constructor()
+{
+  [[maybe_unused]] constexpr cuda::std::basic_format_string<CharT, int> fmt{TEST_STRLIT(CharT, "{.3}")};
+}
+
+__host__ __device__ void test()
+{
+  test_constructor<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_constructor<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/get.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/get.pass.cpp
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+// template<class charT, class... Args>
+// class basic_format_string<charT, type_identity_t<Args>...>
+//
+// constexpr basic_string_view<charT> get() const noexcept { return str; }
+
+#include <cuda/std/__format_>
+#include <cuda/std/cassert>
+#include <cuda/std/string_view>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <class CharT>
+__host__ __device__ constexpr void test_get()
+{
+  using SV = cuda::std::basic_string_view<CharT>;
+
+  static_assert(cuda::std::is_same_v<SV, decltype(cuda::std::declval<cuda::std::basic_format_string<CharT>>().get())>);
+  static_assert(noexcept(cuda::std::declval<cuda::std::basic_format_string<CharT>>().get()));
+
+  assert((cuda::std::basic_format_string<CharT>{TEST_STRLIT(CharT, "foo")}.get() == TEST_STRLIT(CharT, "foo")));
+  assert((cuda::std::basic_format_string<CharT, int>{TEST_STRLIT(CharT, "{}")}.get() == TEST_STRLIT(CharT, "{}")));
+  assert((cuda::std::basic_format_string<CharT, int, char>{TEST_STRLIT(CharT, "{} {:*>6}")}.get()
+          == TEST_STRLIT(CharT, "{} {:*>6}")));
+
+  // Embedded NUL character
+  assert((cuda::std::basic_format_string<CharT, void*, bool>{TEST_STRLIT(CharT, "{}\0{}")}.get()
+          == TEST_STRLIT(CharT, "{}\0{}")));
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_get<char>();
+#if _CCCL_HAS_WCHAR_T()
+  test_get<wchar_t>();
+#endif // _CCCL_HAS_WCHAR_T()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/format/format.fmt.string/types.compile.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/format>
+
+//  template<class... Args>
+//    using format_string =
+//      basic_format_string<char, type_identity_t<Args>...>;
+//  template<class... Args>
+//    using wformat_string =
+//      basic_format_string<wchar_t, type_identity_t<Args>...>;
+
+#include <cuda/std/__format_>
+#include <cuda/std/type_traits>
+
+static_assert(cuda::std::is_same_v<cuda::std::format_string<>, cuda::std::basic_format_string<char>>);
+static_assert(cuda::std::is_same_v<cuda::std::format_string<int>, cuda::std::basic_format_string<char, int>>);
+static_assert(
+  cuda::std::is_same_v<cuda::std::format_string<int, bool>, cuda::std::basic_format_string<char, int, bool>>);
+static_assert(cuda::std::is_same_v<cuda::std::format_string<int, bool, void*>,
+                                   cuda::std::basic_format_string<char, int, bool, void*>>);
+#if _CCCL_HAS_WCHAR_T()
+static_assert(cuda::std::is_same_v<cuda::std::wformat_string<>, cuda::std::basic_format_string<wchar_t>>);
+static_assert(cuda::std::is_same_v<cuda::std::wformat_string<int>, cuda::std::basic_format_string<wchar_t, int>>);
+static_assert(
+  cuda::std::is_same_v<cuda::std::wformat_string<int, bool>, cuda::std::basic_format_string<wchar_t, int, bool>>);
+static_assert(cuda::std::is_same_v<cuda::std::wformat_string<int, bool, void*>,
+                                   cuda::std::basic_format_string<wchar_t, int, bool, void*>>);
+#endif // _CCCL_HAS_WCHAR_T()
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
This PR implements `cuda::std::basic_format_string` with format string validation. It is a followup to #5368