### PR TITLE
readability++ for cudax::execution code with aliases and using directives

### DIFF
--- a/cudax/include/cuda/experimental/__detail/type_traits.cuh
+++ b/cudax/include/cuda/experimental/__detail/type_traits.cuh
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>
@@ -31,58 +32,73 @@
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_valid_expansion.h>
-#include <cuda/std/__utility/declval.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
 namespace cuda::experimental
 {
-template <template <class...> class _Fn, class... _Ts>
-inline constexpr bool __is_instantiable_with_v = ::cuda::std::_IsValidExpansion<_Fn, _Ts...>::value;
+template <class _Ty, class _Uy>
+_CCCL_CONCEPT __same_as = ::cuda::std::_IsSame<_Ty, _Uy>::value;
 
-template <class _Ty>
-using __decay_copyable_ _CCCL_NODEBUG_ALIAS = decltype(::cuda::std::decay_t<_Ty>(::cuda::std::declval<_Ty>()));
+using ::cuda::std::decay_t;
+
+template <template <class...> class _Fn, class... _Ts>
+_CCCL_CONCEPT __is_instantiable_with = ::cuda::std::_IsValidExpansion<_Fn, _Ts...>::value;
+
+template <class _Fn, class... _As>
+_CCCL_CONCEPT __callable = ::cuda::std::__is_callable_v<_Fn, _As...>;
+
+template <class _Fn, class... _As>
+_CCCL_CONCEPT __constructible = ::cuda::std::is_constructible_v<_Fn, _As...>;
 
 template <class... _As>
-inline constexpr bool __decay_copyable = (::cuda::std::is_constructible_v<::cuda::std::decay_t<_As>, _As> && ...);
+_CCCL_CONCEPT __decay_copyable = (::cuda::std::is_constructible_v<decay_t<_As>, _As> && ...);
+
+template <class... _As>
+_CCCL_CONCEPT __movable = (::cuda::std::is_move_constructible_v<_As> && ...);
+
+template <class... _As>
+_CCCL_CONCEPT __copyable = (::cuda::std::is_copy_constructible_v<_As> && ...);
 
 #if _CCCL_HOST_COMPILATION()
 template <class _Fn, class... _As>
-inline constexpr bool __nothrow_callable = ::cuda::std::__is_nothrow_callable_v<_Fn, _As...>;
+_CCCL_CONCEPT __nothrow_callable = ::cuda::std::__is_nothrow_callable_v<_Fn, _As...>;
 
 template <class _Ty, class... _As>
-inline constexpr bool __nothrow_constructible = ::cuda::std::is_nothrow_constructible_v<_Ty, _As...>;
+_CCCL_CONCEPT __nothrow_constructible = ::cuda::std::is_nothrow_constructible_v<_Ty, _As...>;
 
 template <class... _As>
-inline constexpr bool __nothrow_decay_copyable =
-  (::cuda::std::is_nothrow_constructible_v<::cuda::std::decay_t<_As>, _As> && ...);
+_CCCL_CONCEPT __nothrow_decay_copyable = (::cuda::std::is_nothrow_constructible_v<decay_t<_As>, _As> && ...);
 
 template <class... _As>
-inline constexpr bool __nothrow_movable = (::cuda::std::is_nothrow_move_constructible_v<_As> && ...);
+_CCCL_CONCEPT __nothrow_movable = (::cuda::std::is_nothrow_move_constructible_v<_As> && ...);
 
 template <class... _As>
-inline constexpr bool __nothrow_copyable = (::cuda::std::is_nothrow_copy_constructible_v<_As> && ...);
+_CCCL_CONCEPT __nothrow_copyable = (::cuda::std::is_nothrow_copy_constructible_v<_As> && ...);
 #else // ^^^ _CCCL_HOST_COMPILATION() ^^^ / vvv !_CCCL_HOST_COMPILATION() vvv
 // There are no exceptions in device code:
 template <class _Fn, class... _As>
-inline constexpr bool __nothrow_callable = ::cuda::std::__is_callable_v<_Fn, _As...>;
+_CCCL_CONCEPT __nothrow_callable = ::cuda::std::__is_callable_v<_Fn, _As...>;
 
 template <class _Ty, class... _As>
-inline constexpr bool __nothrow_constructible = ::cuda::std::is_constructible_v<_Ty, _As...>;
+_CCCL_CONCEPT __nothrow_constructible = ::cuda::std::is_constructible_v<_Ty, _As...>;
 
 template <class... _As>
-inline constexpr bool __nothrow_decay_copyable = __decay_copyable<_As...>;
+_CCCL_CONCEPT __nothrow_decay_copyable = __decay_copyable<_As...>;
 
 template <class... _As>
-inline constexpr bool __nothrow_movable = (::cuda::std::is_move_constructible_v<_As> && ...);
+_CCCL_CONCEPT __nothrow_movable = (::cuda::std::is_move_constructible_v<_As> && ...);
 
 template <class... _As>
-inline constexpr bool __nothrow_copyable = (::cuda::std::is_copy_constructible_v<_As> && ...);
+_CCCL_CONCEPT __nothrow_copyable = (::cuda::std::is_copy_constructible_v<_As> && ...);
 #endif // ^^^ !_CCCL_HOST_COMPILATION() ^^^
 
 template <class... _As>
 using __nothrow_decay_copyable_t _CCCL_NODEBUG_ALIAS = ::cuda::std::bool_constant<__nothrow_decay_copyable<_As...>>;
+
+using ::cuda::std::__call_result_t;
 
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__execution/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/bulk.cuh
@@ -31,6 +31,7 @@
 #include <cuda/std/__type_traits/is_void.h>
 #include <cuda/std/__utility/forward_like.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/concepts.cuh>
 #include <cuda/experimental/__execution/domain.cuh>
 #include <cuda/experimental/__execution/env.cuh>
@@ -106,7 +107,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __bulk_t
       // different signatures, so we need to type-check them separately.
       if constexpr (_BulkTag::__is_chunked())
       {
-        if constexpr (::cuda::std::__is_callable_v<_Fn&, _Shape, _Shape, _Ts&...>)
+        if constexpr (__callable<_Fn&, _Shape, _Shape, _Ts&...>)
         {
           return completion_signatures<set_value_t(_Ts...)>{}
                + __eptr_completion_if<!__nothrow_callable<_Fn&, _Shape, _Shape, _Ts&...>>();
@@ -119,7 +120,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __bulk_t
                                               _WITH_ARGUMENTS(_Shape, _Shape, _Ts & ...)>();
         }
       }
-      else if constexpr (::cuda::std::__is_callable_v<_Fn&, _Shape, _Ts&...>)
+      else if constexpr (__callable<_Fn&, _Shape, _Ts&...>)
       {
         return completion_signatures<set_value_t(_Ts...)>{}
              + __eptr_completion_if<!__nothrow_callable<_Fn&, _Shape, _Ts&...>>();
@@ -407,7 +408,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT bulk_t : __bulk_t<bulk_t>
   template <class _Sndr>
   [[nodiscard]] _CCCL_API static auto transform_sender(_Sndr&& __sndr, ::cuda::std::__ignore_t)
   {
-    static_assert(::cuda::std::is_same_v<tag_of_t<_Sndr>, bulk_t>);
+    static_assert(__same_as<tag_of_t<_Sndr>, bulk_t>);
     auto& [__tag, __data, __child]  = __sndr;
     auto& [__policy, __shape, __fn] = __data;
 

--- a/cudax/include/cuda/experimental/__execution/completion_behavior.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_behavior.cuh
@@ -28,6 +28,7 @@
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__utility/rel_ops.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
 
 #include <cuda/experimental/__execution/prologue.cuh>
@@ -174,13 +175,13 @@ _CCCL_GLOBAL_CONSTANT min_t min{};
 template <class _Sndr, class... _Env>
 [[nodiscard]] _CCCL_API constexpr auto get_completion_behavior() noexcept
 {
-  using __behavior_t = ::cuda::std::__call_result_t<get_completion_behavior_t, env_of_t<_Sndr>, const _Env&...>;
+  using __behavior_t = __call_result_t<get_completion_behavior_t, env_of_t<_Sndr>, const _Env&...>;
   return __behavior_t{};
 }
 
 template <class _Attrs, class... _Env>
 _CCCL_CONCEPT __completes_inline =
-  (::cuda::std::__call_result_t<get_completion_behavior_t, const _Attrs&, const _Env&...>{}
+  (__call_result_t<get_completion_behavior_t, const _Attrs&, const _Env&...>{}
    == completion_behavior::inline_completion);
 
 } // namespace cuda::experimental::execution

--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -25,13 +25,13 @@
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/integral_constant.h>
-#include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/is_empty.h>
 #include <cuda/std/__type_traits/is_trivially_constructible.h>
 #include <cuda/std/__type_traits/remove_const.h>
 #include <cuda/std/__type_traits/type_list.h>
 #include <cuda/std/__type_traits/type_set.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
@@ -201,7 +201,7 @@ struct __concat_completion_signatures_impl;
 
 template <class... _Sigs>
 using __concat_completion_signatures_t _CCCL_NODEBUG_ALIAS =
-  ::cuda::std::__call_result_t<::cuda::std::__call_result_t<__concat_completion_signatures_impl, const _Sigs&...>>;
+  __call_result_t<__call_result_t<__concat_completion_signatures_impl, const _Sigs&...>>;
 
 struct __concat_completion_signatures_fn
 {
@@ -243,7 +243,7 @@ struct __concat_completion_signatures_impl
     const _Rest&...) const noexcept
   {
     using _Tmp                           = completion_signatures<_As..., _Bs..., _Cs..., _Ds...>;
-    using _SigsFnPtr _CCCL_NODEBUG_ALIAS = ::cuda::std::__call_result_t<_Self, const _Tmp&, const _Rest&...>;
+    using _SigsFnPtr _CCCL_NODEBUG_ALIAS = __call_result_t<_Self, const _Tmp&, const _Rest&...>;
     return static_cast<_SigsFnPtr>(nullptr);
   }
 
@@ -412,7 +412,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
   //! \return The result of calling __fn with all signatures as arguments.
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Fn>
-  _CCCL_API static _CCCL_CONSTEVAL auto apply(_Fn __fn) -> ::cuda::std::__call_result_t<_Fn, _Sigs*...>
+  _CCCL_API static _CCCL_CONSTEVAL auto apply(_Fn __fn) -> __call_result_t<_Fn, _Sigs*...>
   {
     return __fn(static_cast<_Sigs*>(nullptr)...);
   }
@@ -466,7 +466,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
   template <class _Transform, class _Reduce>
   [[nodiscard]]
   _CCCL_API static _CCCL_CONSTEVAL auto transform_reduce(_Transform __transform, _Reduce __reduce)
-    -> ::cuda::std::__call_result_t<_Reduce, ::cuda::std::__call_result_t<_Transform, _Sigs*>...>
+    -> __call_result_t<_Reduce, __call_result_t<_Transform, _Sigs*>...>
   {
     return __reduce(__transform(static_cast<_Sigs*>(nullptr))...);
   }

--- a/cudax/include/cuda/experimental/__execution/concepts.cuh
+++ b/cudax/include/cuda/experimental/__execution/concepts.cuh
@@ -26,10 +26,9 @@
 #include <cuda/std/__concepts/constructible.h>
 #include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/integral_constant.h>
-#include <cuda/std/__type_traits/is_callable.h>
-#include <cuda/std/__type_traits/is_move_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/get_completion_signatures.cuh>
 
@@ -49,17 +48,17 @@ template <class _Rcvr>
 _CCCL_CONCEPT receiver = //
   _CCCL_REQUIRES_EXPR((_Rcvr)) //
   ( //
-    requires(__is_receiver<::cuda::std::decay_t<_Rcvr>>), //
-    requires(::cuda::std::move_constructible<::cuda::std::decay_t<_Rcvr>>), //
-    requires(::cuda::std::constructible_from<::cuda::std::decay_t<_Rcvr>, _Rcvr>), //
-    requires(::cuda::std::is_nothrow_move_constructible_v<::cuda::std::decay_t<_Rcvr>>) //
+    requires(__is_receiver<decay_t<_Rcvr>>), //
+    requires(::cuda::std::move_constructible<decay_t<_Rcvr>>), //
+    requires(::cuda::std::constructible_from<decay_t<_Rcvr>, _Rcvr>), //
+    requires(__nothrow_movable<decay_t<_Rcvr>>) //
   );
 
 template <class _Rcvr, class _Sig>
 inline constexpr bool __valid_completion_for = false;
 
 template <class _Rcvr, class _Tag, class... _As>
-inline constexpr bool __valid_completion_for<_Rcvr, _Tag(_As...)> = ::cuda::std::__is_callable_v<_Tag, _Rcvr, _As...>;
+inline constexpr bool __valid_completion_for<_Rcvr, _Tag(_As...)> = __callable<_Tag, _Rcvr, _As...>;
 
 template <class _Rcvr, class _Completions>
 inline constexpr bool __has_completions = false;
@@ -73,7 +72,7 @@ _CCCL_CONCEPT receiver_of = //
   _CCCL_REQUIRES_EXPR((_Rcvr, _Completions)) //
   ( //
     requires(receiver<_Rcvr>), //
-    requires(__has_completions<::cuda::std::decay_t<_Rcvr>, _Completions>) //
+    requires(__has_completions<decay_t<_Rcvr>, _Completions>) //
   );
 
 // Queryable traits:
@@ -123,9 +122,9 @@ template <class _Sndr>
 _CCCL_CONCEPT sender = //
   _CCCL_REQUIRES_EXPR((_Sndr)) //
   ( //
-    requires(enable_sender<::cuda::std::decay_t<_Sndr>>), //
-    requires(::cuda::std::move_constructible<::cuda::std::decay_t<_Sndr>>), //
-    requires(::cuda::std::constructible_from<::cuda::std::decay_t<_Sndr>, _Sndr>) //
+    requires(enable_sender<decay_t<_Sndr>>), //
+    requires(::cuda::std::move_constructible<decay_t<_Sndr>>), //
+    requires(::cuda::std::constructible_from<decay_t<_Sndr>, _Sndr>) //
   );
 
 template <class _Sndr, class... _Env>

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -27,6 +27,7 @@
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/type_list.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/concepts.cuh>
@@ -82,14 +83,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional_t
     template <class... _As>
     [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto operator()() const
     {
-      if constexpr (!::cuda::std::__is_callable_v<_Pred, _As&...>)
+      if constexpr (!__callable<_Pred, _As&...>)
       {
         return invalid_completion_signature<_WHERE(_IN_ALGORITHM, conditional_t),
                                             _WHAT(_FUNCTION_IS_NOT_CALLABLE),
                                             _WITH_FUNCTION(_Pred),
                                             _WITH_ARGUMENTS(_As & ...)>();
       }
-      else if constexpr (!::cuda::std::is_convertible_v<::cuda::std::__call_result_t<_Pred, _As&...>, bool>)
+      else if constexpr (!::cuda::std::is_convertible_v<__call_result_t<_Pred, _As&...>, bool>)
       {
         return invalid_completion_signature<_WHERE(_IN_ALGORITHM, conditional_t),
                                             _WHAT(_FUNCTION_MUST_RETURN_A_BOOLEAN_TESTABLE_VALUE),
@@ -99,8 +100,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional_t
       else
       {
         return concat_completion_signatures(
-          get_completion_signatures<::cuda::std::__call_result_t<_Then, __just_from_t<_As...>>, _Env...>(),
-          get_completion_signatures<::cuda::std::__call_result_t<_Else, __just_from_t<_As...>>, _Env...>());
+          get_completion_signatures<__call_result_t<_Then, __just_from_t<_As...>>, _Env...>(),
+          get_completion_signatures<__call_result_t<_Else, __just_from_t<_As...>>, _Env...>());
       }
     }
   };
@@ -111,9 +112,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional_t
     using __params_t = __closure_base_t<_Pred, _Then, _Else>;
 
     template <class... _As>
-    using __opstate_list_t = ::cuda::std::__type_list<
-      connect_result_t<::cuda::std::__call_result_t<_Then, __just_from_t<_As...>>, __rcvr_ref_t<_Rcvr>>,
-      connect_result_t<::cuda::std::__call_result_t<_Else, __just_from_t<_As...>>, __rcvr_ref_t<_Rcvr>>>;
+    using __opstate_list_t =
+      ::cuda::std::__type_list<connect_result_t<__call_result_t<_Then, __just_from_t<_As...>>, __rcvr_ref_t<_Rcvr>>,
+                               connect_result_t<__call_result_t<_Else, __just_from_t<_As...>>, __rcvr_ref_t<_Rcvr>>>;
 
     using __next_ops_variant_t _CCCL_NODEBUG_ALIAS =
       __value_types<_Completions, __opstate_list_t, __type_concat_into_quote<__variant>::__call>;

--- a/cudax/include/cuda/experimental/__execution/cpos.cuh
+++ b/cudax/include/cuda/experimental/__execution/cpos.cuh
@@ -21,9 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/is_same.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/env.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
 #include <cuda/experimental/__execution/transform_sender.cuh>
@@ -58,8 +58,7 @@ struct set_value_t : __completion_tag<__disposition::__value>
   _CCCL_TRIVIAL_API constexpr auto operator()(_Rcvr&& __rcvr, _Ts&&... __ts) const noexcept
     -> decltype(static_cast<_Rcvr&&>(__rcvr).set_value(static_cast<_Ts&&>(__ts)...))
   {
-    static_assert(
-      ::cuda::std::is_same_v<decltype(static_cast<_Rcvr&&>(__rcvr).set_value(static_cast<_Ts&&>(__ts)...)), void>);
+    static_assert(__same_as<decltype(static_cast<_Rcvr&&>(__rcvr).set_value(static_cast<_Ts&&>(__ts)...)), void>);
     static_assert(noexcept(static_cast<_Rcvr&&>(__rcvr).set_value(static_cast<_Ts&&>(__ts)...)));
     static_cast<_Rcvr&&>(__rcvr).set_value(static_cast<_Ts&&>(__ts)...);
   }
@@ -72,8 +71,7 @@ struct set_error_t : __completion_tag<__disposition::__error>
   _CCCL_TRIVIAL_API constexpr auto operator()(_Rcvr&& __rcvr, _Ey&& __e) const noexcept
     -> decltype(static_cast<_Rcvr&&>(__rcvr).set_error(static_cast<_Ey&&>(__e)))
   {
-    static_assert(
-      ::cuda::std::is_same_v<decltype(static_cast<_Rcvr&&>(__rcvr).set_error(static_cast<_Ey&&>(__e))), void>);
+    static_assert(__same_as<decltype(static_cast<_Rcvr&&>(__rcvr).set_error(static_cast<_Ey&&>(__e))), void>);
     static_assert(noexcept(static_cast<_Rcvr&&>(__rcvr).set_error(static_cast<_Ey&&>(__e))));
     static_cast<_Rcvr&&>(__rcvr).set_error(static_cast<_Ey&&>(__e));
   }
@@ -86,7 +84,7 @@ struct set_stopped_t : __completion_tag<__disposition::__stopped>
   _CCCL_TRIVIAL_API constexpr auto operator()(_Rcvr&& __rcvr) const noexcept
     -> decltype(static_cast<_Rcvr&&>(__rcvr).set_stopped())
   {
-    static_assert(::cuda::std::is_same_v<decltype(static_cast<_Rcvr&&>(__rcvr).set_stopped()), void>);
+    static_assert(__same_as<decltype(static_cast<_Rcvr&&>(__rcvr).set_stopped()), void>);
     static_assert(noexcept(static_cast<_Rcvr&&>(__rcvr).set_stopped()));
     static_cast<_Rcvr&&>(__rcvr).set_stopped();
   }
@@ -98,7 +96,7 @@ struct start_t
   template <class _OpState>
   _CCCL_TRIVIAL_API constexpr auto operator()(_OpState& __opstate) const noexcept -> decltype(__opstate.start())
   {
-    static_assert(::cuda::std::is_same_v<decltype(__opstate.start()), void>);
+    static_assert(__same_as<decltype(__opstate.start()), void>);
     static_assert(noexcept(__opstate.start()));
     __opstate.start();
   }
@@ -138,8 +136,8 @@ private:
 public:
   template <class _Sndr, class _Rcvr>
   _CCCL_TRIVIAL_API constexpr auto operator()(_Sndr&& __sndr, _Rcvr __rcvr) const
-    noexcept(::cuda::std::__is_nothrow_callable_v<__impl_t<_Sndr, _Rcvr>, _Sndr, _Rcvr>)
-      -> ::cuda::std::__call_result_t<__impl_t<_Sndr, _Rcvr>, _Sndr, _Rcvr>
+    noexcept(__nothrow_callable<__impl_t<_Sndr, _Rcvr>, _Sndr, _Rcvr>)
+      -> __call_result_t<__impl_t<_Sndr, _Rcvr>, _Sndr, _Rcvr>
   {
     return __impl_t<_Sndr, _Rcvr>{}(static_cast<_Sndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr));
   }

--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -25,9 +25,9 @@
 #include <cuda/std/__functional/compose.h>
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/decay.h>
-#include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/type_list.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
@@ -121,7 +121,7 @@ struct get_domain_t
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Env>
   [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(const _Env&) const noexcept
-    -> ::cuda::std::decay_t<__query_result_t<_Env, get_domain_t>>
+    -> decay_t<__query_result_t<_Env, get_domain_t>>
   {
     return {};
   }
@@ -140,7 +140,7 @@ struct get_domain_override_t
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Env>
   [[nodiscard]] _CCCL_TRIVIAL_API constexpr auto operator()(const _Env&) const noexcept
-    -> ::cuda::std::decay_t<__query_result_t<_Env, get_domain_override_t>>
+    -> decay_t<__query_result_t<_Env, get_domain_override_t>>
   {
     return {};
   }
@@ -160,7 +160,7 @@ namespace __detail
 // - get_domain(_GetScheduler{}(env))
 // - _Default{}
 template <class _Env, class _GetScheduler, class _Default = default_domain>
-using __domain_of_t = ::cuda::std::decay_t<::cuda::std::__call_result_t<
+using __domain_of_t = decay_t<__call_result_t<
   __first_callable<get_domain_t, ::cuda::std::__compose_t<get_domain_t, _GetScheduler>, __always<_Default>>,
   _Env>>;
 
@@ -177,7 +177,7 @@ _CCCL_TRIVIAL_API constexpr auto __get_domain_late() noexcept
   // Otherwise, we fall back to using the domain from the receiver's environment.
   if constexpr (__queryable_with<env_of_t<_Sndr>, get_domain_override_t>)
   {
-    return ::cuda::std::decay_t<__query_result_t<env_of_t<_Sndr>, get_domain_override_t>>{};
+    return decay_t<__query_result_t<env_of_t<_Sndr>, get_domain_override_t>>{};
   }
   else
   {

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -29,12 +29,12 @@
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/conditional.h>
-#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/cstdint>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/policy.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
@@ -111,7 +111,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_ref_fn
 } // namespace __detail
 
 template <class _Env>
-using __env_ref_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__call_result_t<__detail::__env_ref_fn, _Env>;
+using __env_ref_t _CCCL_NODEBUG_ALIAS = __call_result_t<__detail::__env_ref_fn, _Env>;
 
 _CCCL_GLOBAL_CONSTANT __detail::__env_ref_fn __env_ref{};
 
@@ -166,7 +166,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __fwd_env_fn
 } // namespace __detail
 
 template <class _Env>
-using __fwd_env_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__call_result_t<__detail::__fwd_env_fn, _Env>;
+using __fwd_env_t _CCCL_NODEBUG_ALIAS = __call_result_t<__detail::__fwd_env_fn, _Env>;
 
 _CCCL_GLOBAL_CONSTANT __detail::__fwd_env_fn __fwd_env{};
 
@@ -228,7 +228,7 @@ public:
   //! @brief Construct from an environment that has the right queries
   //! @param __env The environment we are querying for the required information
   _CCCL_TEMPLATE(class _Env)
-  _CCCL_REQUIRES((!::cuda::std::is_same_v<_Env, env_t>) _CCCL_AND __is_compatible_env<_Env>)
+  _CCCL_REQUIRES((!__same_as<_Env, env_t>) _CCCL_AND __is_compatible_env<_Env>)
   _CCCL_HIDE_FROM_ABI env_t(const _Env& __env) noexcept
       : __mr_(__env.query(::cuda::mr::get_memory_resource))
       , __stream_(__env.query(::cuda::get_stream))

--- a/cudax/include/cuda/experimental/__execution/fwd.cuh
+++ b/cudax/include/cuda/experimental/__execution/fwd.cuh
@@ -100,16 +100,16 @@ using __operation_state_concept_t _CCCL_NODEBUG_ALIAS =
   typename ::cuda::std::remove_reference_t<_Ty>::operation_state_concept;
 
 template <class _Ty>
-inline constexpr bool __is_sender = __is_instantiable_with_v<__sender_concept_t, _Ty>;
+inline constexpr bool __is_sender = __is_instantiable_with<__sender_concept_t, _Ty>;
 
 template <class _Ty>
-inline constexpr bool __is_receiver = __is_instantiable_with_v<__receiver_concept_t, _Ty>;
+inline constexpr bool __is_receiver = __is_instantiable_with<__receiver_concept_t, _Ty>;
 
 template <class _Ty>
-inline constexpr bool __is_scheduler = __is_instantiable_with_v<__scheduler_concept_t, _Ty>;
+inline constexpr bool __is_scheduler = __is_instantiable_with<__scheduler_concept_t, _Ty>;
 
 template <class _Ty>
-inline constexpr bool __is_operation_state = __is_instantiable_with_v<__operation_state_concept_t, _Ty>;
+inline constexpr bool __is_operation_state = __is_instantiable_with<__operation_state_concept_t, _Ty>;
 
 struct _CCCL_TYPE_VISIBILITY_DEFAULT dependent_sender_error;
 
@@ -152,7 +152,7 @@ template <class _Sndr, class _Rcvr>
 inline constexpr bool __nothrow_connectable = noexcept(declval<connect_t>()(declval<_Sndr>(), declval<_Rcvr>()));
 #else // ^^^ _CCCL_HOST_COMPILATION() ^^^ / vvv !_CCCL_HOST_COMPILATION() vvv
 template <class _Sndr, class _Rcvr>
-inline constexpr bool __nothrow_connectable = __is_instantiable_with_v<connect_result_t, _Sndr, _Rcvr>;
+inline constexpr bool __nothrow_connectable = __is_instantiable_with<connect_result_t, _Sndr, _Rcvr>;
 #endif // ^^^ !_CCCL_HOST_COMPILATION() ^^^
 
 // sender factory algorithms:

--- a/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
@@ -299,7 +299,7 @@ template <class _Sndr, class... _Env>
   {
     // Apply a lazy sender transform if one exists before computing the completion signatures:
     using _NewSndr _CCCL_NODEBUG_ALIAS =
-      ::cuda::std::__call_result_t<transform_sender_t, __late_domain_of_t<_Sndr, _Env...>, _Sndr, _Env...>;
+      __call_result_t<transform_sender_t, __late_domain_of_t<_Sndr, _Env...>, _Sndr, _Env...>;
     return execution::__get_completion_signatures_helper<_NewSndr, _Env...>();
   }
 }

--- a/cudax/include/cuda/experimental/__execution/just_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/just_from.cuh
@@ -25,6 +25,7 @@
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__utility/pod_tuple.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/transform_completion_signatures.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
@@ -80,7 +81,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_from_t
   template <class _Rcvr, class _Fn>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
-    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using operation_state_concept = operation_state_t;
 
     _CCCL_EXEC_CHECK_DISABLE
     _CCCL_API constexpr void start() noexcept
@@ -122,12 +123,12 @@ template <class _JustFromTag, class _SetTag>
 template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_from_t<_JustFromTag, _SetTag>::__sndr_base_t
 {
-  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
+  using sender_concept = sender_t;
 
   template <class _Self, class...>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
   {
-    return ::cuda::std::__call_result_t<_Fn, __probe_fn>{};
+    return __call_result_t<_Fn, __probe_fn>{};
   }
 
   template <class _Rcvr>
@@ -167,7 +168,7 @@ template <class _Fn>
 _CCCL_TRIVIAL_API constexpr auto __just_from_t<_JustFromTag, _SetTag>::operator()(_Fn __fn) const noexcept
 {
   using __sndr_t                          = typename _JustFromTag::template __sndr_t<_Fn>;
-  using __completions _CCCL_NODEBUG_ALIAS = ::cuda::std::__call_result_t<_Fn, __probe_fn>;
+  using __completions _CCCL_NODEBUG_ALIAS = __call_result_t<_Fn, __probe_fn>;
   static_assert(__valid_completion_signatures<__completions>,
                 "The function passed to just_from must return an instance of a specialization of "
                 "completion_signatures<>.");

--- a/cudax/include/cuda/experimental/__execution/lazy.cuh
+++ b/cudax/include/cuda/experimental/__execution/lazy.cuh
@@ -27,6 +27,7 @@
 #include <cuda/std/__type_traits/copy_cvref.h>
 #include <cuda/std/__utility/integer_sequence.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/meta.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
 
@@ -91,7 +92,7 @@ struct __lazy_tupl<::cuda::std::index_sequence<>>
 {
   template <class _Fn, class _Self, class... _Us>
   _CCCL_TRIVIAL_API static auto __apply(_Fn&& __fn, _Self&&, _Us&&... __us) //
-    noexcept(__nothrow_callable<_Fn, _Us...>) -> ::cuda::std::__call_result_t<_Fn, _Us...>
+    noexcept(__nothrow_callable<_Fn, _Us...>) -> __call_result_t<_Fn, _Us...>
   {
     return static_cast<_Fn&&>(__fn)(static_cast<_Us&&>(__us)...);
   }
@@ -129,7 +130,7 @@ struct __lazy_tupl<::cuda::std::index_sequence<_Idx...>, _Ts...> : __detail::__l
   template <class _Fn, class _Self, class... _Us>
   _CCCL_TRIVIAL_API static auto __apply(_Fn&& __fn, _Self&& __self, _Us&&... __us) //
     noexcept(__nothrow_callable<_Fn, _Us..., ::cuda::std::__copy_cvref_t<_Self, _Ts>...>)
-      -> ::cuda::std::__call_result_t<_Fn, _Us..., ::cuda::std::__copy_cvref_t<_Self, _Ts>...>
+      -> __call_result_t<_Fn, _Us..., ::cuda::std::__copy_cvref_t<_Self, _Ts>...>
   {
     return static_cast<_Fn&&>(
       __fn)(static_cast<_Us&&>(__us)...,
@@ -155,7 +156,7 @@ using __lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tupl<::cuda::std::make_index_seq
 #endif // !_CCCL_COMPILER(MSVC)
 
 template <class... _Ts>
-using __decayed_lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tuple<::cuda::std::decay_t<_Ts>...>;
+using __decayed_lazy_tuple _CCCL_NODEBUG_ALIAS = __lazy_tuple<decay_t<_Ts>...>;
 
 } // namespace cuda::experimental::execution
 

--- a/cudax/include/cuda/experimental/__execution/on.cuh
+++ b/cudax/include/cuda/experimental/__execution/on.cuh
@@ -21,8 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__utility/pod_tuple.h>
-
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/concepts.cuh>
 #include <cuda/experimental/__execution/continues_on.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
@@ -240,7 +239,7 @@ public:
       auto __new_sch = __data;
       auto __old_sch = __query_or(__env, get_scheduler, __not_a_scheduler<_Env>{});
 
-      if constexpr (::cuda::std::is_same_v<decltype(__old_sch), __not_a_scheduler<_Env>>)
+      if constexpr (__same_as<decltype(__old_sch), __not_a_scheduler<_Env>>)
       {
         return __not_a_sender<_Env>{};
       }
@@ -257,7 +256,7 @@ public:
                                   get_completion_scheduler<set_value_t>,
                                   __query_or(__env, get_scheduler, __not_a_scheduler<_Env>{}));
 
-      if constexpr (::cuda::std::is_same_v<decltype(__old_sch), __not_a_scheduler<_Env>>)
+      if constexpr (__same_as<decltype(__old_sch), __not_a_scheduler<_Env>>)
       {
         return __not_a_sender<_Env>{};
       }
@@ -271,31 +270,15 @@ public:
   }
 };
 
-template <class _Sndr, class _NewSch, class _Env>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT on_t::__lowered_sndr_t<_Sndr, _NewSch, _Env>
-    : ::cuda::std::__call_result_t<on_t::__lower_sndr_fn, _Sndr, _NewSch, _Env>
+template <class _Sndr, class _NewSch, class _Env, class... _Closure>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT on_t::__lowered_sndr_t
+    : __call_result_t<on_t::__lower_sndr_fn, _Sndr, _NewSch, _Env, _Closure...>
 {
-  using __base_t = ::cuda::std::__call_result_t<on_t::__lower_sndr_fn, _Sndr, _NewSch, _Env>;
+  using __base_t = __call_result_t<on_t::__lower_sndr_fn, _Sndr, _NewSch, _Env, _Closure...>;
 
-  _CCCL_API constexpr __lowered_sndr_t(_Sndr&& __sndr, _NewSch __new_sch, _Env const& __env)
-      : __base_t{on_t::__lower_sndr_fn{}(static_cast<_Sndr&&>(__sndr), static_cast<_NewSch&&>(__new_sch), __env)}
-  {}
-
-  auto base() const noexcept -> __base_t const&
-  {
-    return *this;
-  }
-};
-
-template <class _Sndr, class _NewSch, class _Env, class _Closure>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT on_t::__lowered_sndr_t<_Sndr, _NewSch, _Env, _Closure>
-    : ::cuda::std::__call_result_t<on_t::__lower_sndr_fn, _Sndr, _NewSch, _Env, _Closure>
-{
-  using __base_t = ::cuda::std::__call_result_t<on_t::__lower_sndr_fn, _Sndr, _NewSch, _Env, _Closure>;
-
-  _CCCL_API constexpr __lowered_sndr_t(_Sndr&& __sndr, _NewSch __new_sch, _Env const& __env, _Closure __closure)
+  _CCCL_API constexpr __lowered_sndr_t(_Sndr&& __sndr, _NewSch __new_sch, _Env const& __env, _Closure... __closure)
       : __base_t{on_t::__lower_sndr_fn{}(
-          static_cast<_Sndr&&>(__sndr), static_cast<_NewSch&&>(__new_sch), __env, static_cast<_Closure&&>(__closure))}
+          static_cast<_Sndr&&>(__sndr), static_cast<_NewSch&&>(__new_sch), __env, static_cast<_Closure&&>(__closure)...)}
   {}
 };
 
@@ -327,7 +310,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT on_t::__sndr_t<_Sch, _Sndr, _Closure>
   }
 
   _CCCL_NO_UNIQUE_ADDRESS on_t __tag_;
-  ::cuda::std::__pair<_Sch, _Closure> __sch_closure_;
+  __closure_t<_Sch, _Closure> __sch_closure_;
   _Sndr __sndr_;
 };
 

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -30,6 +30,7 @@ _CCCL_SUPPRESS_DEPRECATED_POP
 #include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__utility/unreachable.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/completion_behavior.cuh>
 #include <cuda/experimental/__execution/domain.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
@@ -83,7 +84,7 @@ _CCCL_GLOBAL_CONSTANT struct get_stop_token_t
 } get_stop_token{};
 
 template <class _Ty>
-using stop_token_of_t _CCCL_NODEBUG_ALIAS = ::cuda::std::decay_t<::cuda::std::__call_result_t<get_stop_token_t, _Ty>>;
+using stop_token_of_t _CCCL_NODEBUG_ALIAS = decay_t<__call_result_t<get_stop_token_t, _Ty>>;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // get_scheduler
@@ -107,7 +108,7 @@ _CCCL_GLOBAL_CONSTANT struct get_scheduler_t
 } get_scheduler{};
 
 template <class _Env>
-using __scheduler_of_t _CCCL_NODEBUG_ALIAS = ::cuda::std::decay_t<::cuda::std::__call_result_t<get_scheduler_t, _Env>>;
+using __scheduler_of_t _CCCL_NODEBUG_ALIAS = decay_t<__call_result_t<get_scheduler_t, _Env>>;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // get_delegation_scheduler
@@ -164,9 +165,9 @@ struct get_completion_scheduler_t
   _CCCL_REQUIRES((!__queryable_with<_Attrs, get_completion_scheduler_t>) _CCCL_AND //
                  (!__queryable_with<_Attrs, get_completion_scheduler_t, const _Env&>) _CCCL_AND //
                    __completes_inline<_Attrs, _Env> _CCCL_AND //
-                 ::cuda::std::__is_callable_v<get_scheduler_t, const _Env&>)
+                     __callable<get_scheduler_t, const _Env&>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(const _Attrs&, const _Env& __env) const noexcept
-    -> ::cuda::std::__call_result_t<get_scheduler_t, const _Env&>
+    -> __call_result_t<get_scheduler_t, const _Env&>
   {
     return get_scheduler(__env);
   }

--- a/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
@@ -59,7 +59,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_with_env_t : _Rcvr
     {
       // If _Env has a value for the `get_scheduler` query, then we should not be
       // forwarding a get_domain query to the parent receiver's environment.
-      static_assert(!::cuda::std::is_same_v<_Query, get_domain_t> || !__queryable_with<_Env, get_scheduler_t>,
+      static_assert(!__same_as<_Query, get_domain_t> || !__queryable_with<_Env, get_scheduler_t>,
                     "_Env specifies a scheduler but not a domain.");
       return execution::get_env(__rcvr_->__base()).query(_Query{}, static_cast<_Args&&>(__args)...);
     }

--- a/cudax/include/cuda/experimental/__execution/read_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/read_env.cuh
@@ -26,6 +26,7 @@
 #include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/is_void.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
@@ -49,7 +50,7 @@ private:
   template <class _Rcvr, class _Query>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
-    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using operation_state_concept = operation_state_t;
 
     _Rcvr __rcvr_;
 
@@ -107,19 +108,19 @@ public:
 template <class _Query>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t::__sndr_t
 {
-  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
+  using sender_concept = sender_t;
 
   template <class _Self, class _Env>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
   {
-    if constexpr (!::cuda::std::__is_callable_v<_Query, _Env>)
+    if constexpr (!__callable<_Query, _Env>)
     {
       return invalid_completion_signature<_WHERE(_IN_ALGORITHM, read_env_t),
                                           _WHAT(_THE_CURRENT_ENVIRONMENT_LACKS_THIS_QUERY),
                                           _WITH_QUERY(_Query),
                                           _WITH_ENVIRONMENT(_Env)>();
     }
-    else if constexpr (::cuda::std::is_void_v<::cuda::std::__call_result_t<_Query, _Env>>)
+    else if constexpr (::cuda::std::is_void_v<__call_result_t<_Query, _Env>>)
     {
       return invalid_completion_signature<_WHERE(_IN_ALGORITHM, read_env_t),
                                           _WHAT(_THE_CURRENT_ENVIRONMENT_RETURNED_VOID_FOR_THIS_QUERY),
@@ -128,7 +129,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT read_env_t::__sndr_t
     }
     else
     {
-      return completion_signatures<set_value_t(::cuda::std::__call_result_t<_Query, _Env>)>{}
+      return completion_signatures<set_value_t(__call_result_t<_Query, _Env>)>{}
            + __eptr_completion_if<!__nothrow_callable<_Query, _Env>>();
     }
 

--- a/cudax/include/cuda/experimental/__execution/run_loop.cuh
+++ b/cudax/include/cuda/experimental/__execution/run_loop.cuh
@@ -137,11 +137,11 @@ public:
     run_loop* __loop_;
 
   public:
-    using scheduler_concept _CCCL_NODEBUG_ALIAS = scheduler_t;
+    using scheduler_concept = scheduler_t;
 
     struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
     {
-      using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
+      using sender_concept = sender_t;
 
       template <class _Rcvr>
       [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const noexcept -> __opstate_t<_Rcvr>

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -23,10 +23,10 @@
 
 #include <cuda/__utility/immovable.h>
 #include <cuda/std/__cccl/unreachable.h>
-#include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__utility/pod_tuple.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/cpos.cuh>
@@ -62,11 +62,11 @@ struct __decay_args
     }
     else if constexpr (!__nothrow_decay_copyable<_Ts...>)
     {
-      return completion_signatures<_Tag(::cuda::std::decay_t<_Ts>...), set_error_t(::std::exception_ptr)>{};
+      return completion_signatures<_Tag(decay_t<_Ts>...), set_error_t(::std::exception_ptr)>{};
     }
     else
     {
-      return completion_signatures<_Tag(::cuda::std::decay_t<_Ts>...)>{};
+      return completion_signatures<_Tag(decay_t<_Ts>...)>{};
     }
   }
 };
@@ -84,7 +84,7 @@ struct __transfer_sndr_t
   using __sched_domain_t _CCCL_NODEBUG_ALIAS = __query_result_or_t<_Sch, get_domain_t, default_domain>;
   using __sndr_domain_t _CCCL_NODEBUG_ALIAS  = __early_domain_of_t<_Sndr, __nil>;
   using __late_domain_t _CCCL_NODEBUG_ALIAS =
-    ::cuda::std::_If<::cuda::std::is_same_v<_Tag, schedule_from_t>, __sched_domain_t, __sndr_domain_t>;
+    ::cuda::std::_If<__same_as<_Tag, schedule_from_t>, __sched_domain_t, __sndr_domain_t>;
 
   // see SCHED-ATTRS here: https://eel.is/c++draft/exec#snd.expos-6
   struct __attrs_t
@@ -106,7 +106,7 @@ struct __transfer_sndr_t
     // schedule_from and continues_on have special rules for the domain used to transform
     // the sender.
     _CCCL_TEMPLATE(class _LateDomain = __late_domain_t)
-    _CCCL_REQUIRES((!::cuda::std::same_as<_LateDomain, __nil>) )
+    _CCCL_REQUIRES((!__same_as<_LateDomain, __nil>) )
     [[nodiscard]] _CCCL_API static constexpr auto query(get_domain_override_t) noexcept -> _LateDomain
     {
       return {};
@@ -123,7 +123,7 @@ struct __transfer_sndr_t
     // because get_domain_override_t is not a forwarding query.
     _CCCL_EXEC_CHECK_DISABLE
     _CCCL_TEMPLATE(class _Query, class... _Args)
-    _CCCL_REQUIRES((!::cuda::std::same_as<_Query, get_completion_behavior_t>)
+    _CCCL_REQUIRES((!__same_as<_Query, get_completion_behavior_t>)
                      _CCCL_AND __forwarding_query<_Query> _CCCL_AND __queryable_with<env_of_t<_Sndr>, _Query, _Args...>)
     [[nodiscard]] _CCCL_API constexpr auto query(_Query, _Args&&... __args) const
       noexcept(__nothrow_queryable_with<env_of_t<_Sndr>, _Query, _Args...>)
@@ -170,10 +170,10 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT schedule_from_t
 {
   _CUDAX_SEMI_PRIVATE :
   template <class... _As>
-  using __set_value_tuple_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__tuple<set_value_t, ::cuda::std::decay_t<_As>...>;
+  using __set_value_tuple_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__tuple<set_value_t, decay_t<_As>...>;
 
   template <class _Error>
-  using __set_error_tuple_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__tuple<set_error_t, ::cuda::std::decay_t<_Error>>;
+  using __set_error_tuple_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__tuple<set_error_t, decay_t<_Error>>;
 
   using __set_stopped_tuple_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__tuple<set_stopped_t>;
 
@@ -211,7 +211,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT schedule_from_t
   template <class _Rcvr, class _Results>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   {
-    using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
+    using receiver_concept = receiver_t;
 
     template <class _Tag, class... _As>
     _CCCL_API constexpr void operator()(_Tag, _As&... __as) noexcept
@@ -259,7 +259,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT schedule_from_t
     template <class _Tag, class... _As>
     _CCCL_API void __set_result(_Tag, _As&&... __as) noexcept
     {
-      using __tupl_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__tuple<_Tag, ::cuda::std::decay_t<_As>...>;
+      using __tupl_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__tuple<_Tag, decay_t<_As>...>;
       if constexpr (__nothrow_decay_copyable<_As...>)
       {
         __state_->__result_.template __emplace<__tupl_t>(_Tag{}, static_cast<_As&&>(__as)...);

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -91,7 +91,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t
   template <class _Rcvr, class _Sndr1, class _Sndr2>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
-    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using operation_state_concept = operation_state_t;
 
     _CCCL_API __opstate_t(_Sndr1&& __sndr1, _Sndr2&& __sndr2, _Rcvr&& __rcvr)
         : __state_(static_cast<_Rcvr&&>(__rcvr), static_cast<_Sndr2&&>(__sndr2))
@@ -120,7 +120,7 @@ public:
 template <class _Sndr1, class _Sndr2>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t::__sndr_t
 {
-  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
+  using sender_concept = sender_t;
 
   template <class _Self, class... _Env>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()

--- a/cudax/include/cuda/experimental/__execution/start_detached.cuh
+++ b/cudax/include/cuda/experimental/__execution/start_detached.cuh
@@ -42,7 +42,7 @@ private:
 
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   {
-    using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
+    using receiver_concept = receiver_t;
 
     __opstate_base_t* __opstate_;
     void (*__destroy)(__opstate_base_t*) noexcept;
@@ -68,7 +68,7 @@ private:
   template <class _Sndr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t : __opstate_base_t
   {
-    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using operation_state_concept = operation_state_t;
     connect_result_t<_Sndr, __rcvr_t> __opstate_;
 
     static void __destroy(__opstate_base_t* __ptr) noexcept

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -23,6 +23,7 @@
 
 #include <cuda/__utility/immovable.h>
 #include <cuda/std/__cccl/unreachable.h>
+#include <cuda/std/__type_traits/copy_cvref.h>
 #include <cuda/std/__utility/pod_tuple.h>
 
 #include <cuda/experimental/__detail/utility.cuh>
@@ -227,7 +228,7 @@ struct starts_on_t
   template <class _Sch, class _CvSndr, class _Rcvr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   {
-    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using operation_state_concept = operation_state_t;
 
     _CCCL_API constexpr explicit __opstate_t(_Sch __sch, _CvSndr&& __sndr, _Rcvr __rcvr)
         : __state_{__sch, static_cast<_CvSndr&&>(__sndr), static_cast<_Rcvr&&>(__rcvr)}

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -28,6 +28,7 @@
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/pod_tuple.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/domain.cuh>
 #include <cuda/experimental/__execution/get_completion_signatures.cuh>
@@ -186,7 +187,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   _CCCL_TRIVIAL_API constexpr void set_error(_Error&& __err) noexcept
   {
     // Map any exception_ptr error completions to cudaErrorUnknown:
-    if constexpr (::cuda::std::is_same_v<::cuda::std::remove_cvref_t<_Error>, ::std::exception_ptr>)
+    if constexpr (__same_as<::cuda::std::remove_cvref_t<_Error>, ::std::exception_ptr>)
     {
       __complete(execution::set_error, cudaErrorUnknown);
     }
@@ -237,8 +238,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   }
 
 private:
-  using __sndr_config_t       = ::cuda::std::__call_result_t<get_launch_config_t, env_of_t<_CvSndr>>;
-  using __rcvr_config_t       = ::cuda::std::__call_result_t<get_launch_config_t, env_of_t<_Rcvr>>;
+  using __sndr_config_t       = __call_result_t<get_launch_config_t, env_of_t<_CvSndr>>;
+  using __rcvr_config_t       = __call_result_t<get_launch_config_t, env_of_t<_Rcvr>>;
   using __env_t               = __stream::__env_t<env_of_t<_Rcvr>, __sndr_config_t>;
   using __child_completions_t = completion_signatures_of_t<_CvSndr, __env_t>;
   using __completions_t       = decltype(__stream::__with_cuda_error(__child_completions_t{}));
@@ -350,7 +351,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
   // If the child sender knows how to provide a stream, make it available via the stream
   // adapter's attributes.
   _CCCL_TEMPLATE(class _GetStream2 = _GetStream)
-  _CCCL_REQUIRES(::cuda::std::__is_callable_v<_GetStream2, _Sndr, env<>>)
+  _CCCL_REQUIRES(__callable<_GetStream2, _Sndr, env<>>)
   [[nodiscard]] _CCCL_API constexpr auto query(get_stream_t) const noexcept -> stream_ref
   {
     return __sndr_.__get_stream_(__sndr_.__sndr_, env{});
@@ -387,7 +388,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
   {
     using __cv_sndr_t _CCCL_NODEBUG_ALIAS     = ::cuda::std::__copy_cvref_t<_Self, _Sndr>;
-    using __sndr_config_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__call_result_t<get_launch_config_t, env_of_t<_Sndr>>;
+    using __sndr_config_t _CCCL_NODEBUG_ALIAS = __call_result_t<get_launch_config_t, env_of_t<_Sndr>>;
     using __env_t                             = __stream::__env_t<_Env, __sndr_config_t>;
     _CUDAX_LET_COMPLETIONS(auto(__completions) = execution::get_completion_signatures<__cv_sndr_t, __env_t>())
     {

--- a/cudax/include/cuda/experimental/__execution/stream/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/domain.cuh
@@ -26,6 +26,7 @@
 #include <cuda/std/__functional/compose.h>
 #include <cuda/std/__type_traits/is_callable.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/domain.cuh>
 #include <cuda/experimental/__execution/queries.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
@@ -72,11 +73,11 @@ using __get_stream_from_env_t   = decltype(__get_stream_from_env);
 struct __get_stream_fn
 {
   _CCCL_TEMPLATE(class _Sndr, class _Env)
-  _CCCL_REQUIRES((::cuda::std::__is_callable_v<__get_stream_from_attrs_t, env_of_t<_Sndr>, const _Env&>
-                  || ::cuda::std::__is_callable_v<__get_stream_from_env_t, _Env>) )
+  _CCCL_REQUIRES((__callable<__get_stream_from_attrs_t, env_of_t<_Sndr>, const _Env&>
+                  || __callable<__get_stream_from_env_t, _Env>) )
   _CCCL_API constexpr auto operator()(const _Sndr& __sndr, const _Env& __env) const noexcept -> stream_ref
   {
-    if constexpr (::cuda::std::__is_callable_v<__get_stream_from_attrs_t, env_of_t<_Sndr>, const _Env&>)
+    if constexpr (__callable<__get_stream_from_attrs_t, env_of_t<_Sndr>, const _Env&>)
     {
       // If the sender's attributes have a stream, use it.
       return __get_stream_from_attrs(execution::get_env(__sndr), __env);
@@ -156,19 +157,19 @@ struct stream_domain
 
 public:
   _CCCL_TEMPLATE(class _Tag, class _Sndr, class... _Args)
-  _CCCL_REQUIRES(::cuda::std::__is_callable_v<__apply_t<_Tag>, _Sndr, _Args...>)
+  _CCCL_REQUIRES(__callable<__apply_t<_Tag>, _Sndr, _Args...>)
   _CCCL_TRIVIAL_HOST_API static constexpr auto
   apply_sender(_Tag, _Sndr&& __sndr, _Args&&... __args) noexcept(__nothrow_callable<__apply_t<_Tag>, _Sndr, _Args...>)
-    -> ::cuda::std::__call_result_t<__apply_t<_Tag>, _Sndr, _Args...>
+    -> __call_result_t<__apply_t<_Tag>, _Sndr, _Args...>
   {
     return __apply_t<_Tag>{}(static_cast<_Sndr&&>(__sndr), static_cast<_Args&&>(__args)...);
   }
 
   _CCCL_TEMPLATE(class _Sndr, class _Env)
-  _CCCL_REQUIRES(::cuda::std::__is_callable_v<__transform_strategy_t<_Sndr, _Env>, _Sndr, const _Env&>)
+  _CCCL_REQUIRES(__callable<__transform_strategy_t<_Sndr, _Env>, _Sndr, const _Env&>)
   _CCCL_TRIVIAL_API static constexpr auto transform_sender(_Sndr&& __sndr, const _Env& __env) noexcept(
     __nothrow_callable<__transform_strategy_t<_Sndr, _Env>, _Sndr, const _Env&>)
-    -> ::cuda::std::__call_result_t<__transform_strategy_t<_Sndr, _Env>, _Sndr, const _Env&>
+    -> __call_result_t<__transform_strategy_t<_Sndr, _Env>, _Sndr, const _Env&>
   {
     return __transform_strategy_t<_Sndr, _Env>{}(static_cast<_Sndr&&>(__sndr), __env);
   }

--- a/cudax/include/cuda/experimental/__execution/stream/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/starts_on.cuh
@@ -26,6 +26,7 @@
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__utility/forward_like.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/env.cuh>
 #include <cuda/experimental/__execution/starts_on.cuh>
 #include <cuda/experimental/__execution/stream/adaptor.cuh>
@@ -68,7 +69,7 @@ struct __starts_on_t
   using __sndr_base_t = decltype(__starts_on_t::__mk_sndr_base(declval<_Sch>(), declval<_Sndr>()));
 
   template <class _Sch, class _Sndr>
-  using __with_sch_t = ::cuda::std::__call_result_t<write_env_t, _Sndr, __sch_env_t<_Sch>>;
+  using __with_sch_t = __call_result_t<write_env_t, _Sndr, __sch_env_t<_Sch>>;
 
   // Wrap the sender returned from __mk_sndr_base in a type that hides the complexity of
   // the sender's type name. This results in more readable diagnostics.

--- a/cudax/include/cuda/experimental/__execution/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/sync_wait.cuh
@@ -25,10 +25,10 @@
 #include <cuda/std/__type_traits/always_false.h>
 #include <cuda/std/__type_traits/conjunction.h>
 #include <cuda/std/__type_traits/decay.h>
-#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/optional>
 #include <cuda/std/tuple>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/apply_sender.cuh>
 #include <cuda/experimental/__execution/env.cuh>
 #include <cuda/experimental/__execution/exception.cuh>
@@ -103,7 +103,7 @@ struct sync_wait_t
   };
 
   template <class... _Ts>
-  using __decayed_tuple = ::cuda::std::tuple<::cuda::std::decay_t<_Ts>...>;
+  using __decayed_tuple = ::cuda::std::tuple<decay_t<_Ts>...>;
 
   template <class _Values, class _Errors, class _Env = env<>>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __state_t : __state_base_t<_Env>
@@ -171,15 +171,15 @@ struct sync_wait_t
     template <class _Error>
     _CCCL_HOST_API void operator()(_Error __err) const
     {
-      if constexpr (::cuda::std::is_same_v<_Error, ::std::exception_ptr>)
+      if constexpr (__same_as<_Error, ::std::exception_ptr>)
       {
         ::std::rethrow_exception(static_cast<_Error&&>(__err));
       }
-      else if constexpr (::cuda::std::is_same_v<_Error, ::std::error_code>)
+      else if constexpr (__same_as<_Error, ::std::error_code>)
       {
         throw ::std::system_error(__err);
       }
-      else if constexpr (::cuda::std::is_same_v<_Error, cudaError_t>)
+      else if constexpr (__same_as<_Error, cudaError_t>)
       {
         ::cuda::__throw_cuda_error(__err, "sync_wait failed with cudaError_t");
       }

--- a/cudax/include/cuda/experimental/__execution/transform_completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/transform_completion_signatures.cuh
@@ -23,10 +23,10 @@
 
 #include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/is_base_of.h>
-#include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/type_list.h>
 #include <cuda/std/__type_traits/type_set.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/completion_signatures.cuh> // IWYU pragma: export
 #include <cuda/experimental/__execution/fwd.cuh>
 #include <cuda/experimental/__execution/get_completion_signatures.cuh>
@@ -59,8 +59,7 @@ template <class _Tag>
 struct __decay_transform
 {
   template <class... _Ts>
-  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept
-    -> completion_signatures<_Tag(::cuda::std::decay_t<_Ts>...)>
+  _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto operator()() const noexcept -> completion_signatures<_Tag(decay_t<_Ts>...)>
   {
     return {};
   }
@@ -79,8 +78,7 @@ template <class _Ay, class... _As, class _Fn>
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Fn>
-[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __transform_expr(const _Fn& __fn)
-  -> ::cuda::std::__call_result_t<const _Fn&>
+[[nodiscard]] _CCCL_TRIVIAL_API _CCCL_CONSTEVAL auto __transform_expr(const _Fn& __fn) -> __call_result_t<const _Fn&>
 {
   return __fn();
 }
@@ -96,7 +94,7 @@ struct _COULD_NOT_CALL_THE_TRANSFORM_FUNCTION_WITH_THE_GIVEN_TEMPLATE_ARGUMENTS;
 template <class... _As, class _Fn>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL auto __apply_transform(const _Fn& __fn)
 {
-  if constexpr (__is_instantiable_with_v<__transform_expr_t, _Fn, _As...>)
+  if constexpr (__is_instantiable_with<__transform_expr_t, _Fn, _As...>)
   {
     using __completions _CCCL_NODEBUG_ALIAS = __transform_expr_t<_Fn, _As...>;
     if constexpr (__valid_completion_signatures<__completions> || __type_is_error<__completions>

--- a/cudax/include/cuda/experimental/__execution/variant.cuh
+++ b/cudax/include/cuda/experimental/__execution/variant.cuh
@@ -30,6 +30,7 @@
 #include <cuda/std/__type_traits/type_set.h>
 #include <cuda/std/__utility/integer_sequence.h>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__execution/meta.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
 #include <cuda/experimental/__execution/utility.cuh>
@@ -122,9 +123,9 @@ public:
   }
 
   template <class _Ty>
-  _CCCL_API auto __emplace(_Ty&& __value) noexcept(__nothrow_decay_copyable<_Ty>) -> ::cuda::std::decay_t<_Ty>&
+  _CCCL_API auto __emplace(_Ty&& __value) noexcept(__nothrow_decay_copyable<_Ty>) -> decay_t<_Ty>&
   {
-    return __emplace<::cuda::std::decay_t<_Ty>, _Ty>(static_cast<_Ty&&>(__value));
+    return __emplace<decay_t<_Ty>, _Ty>(static_cast<_Ty&&>(__value));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
@@ -155,9 +156,9 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Fn, class... _As>
   _CCCL_API auto __emplace_from(_Fn&& __fn, _As&&... __as) //
-    noexcept(__nothrow_callable<_Fn, _As...>) -> ::cuda::std::__call_result_t<_Fn, _As...>&
+    noexcept(__nothrow_callable<_Fn, _As...>) -> __call_result_t<_Fn, _As...>&
   {
-    using __result_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__call_result_t<_Fn, _As...>;
+    using __result_t _CCCL_NODEBUG_ALIAS = __call_result_t<_Fn, _As...>;
     constexpr size_t __new_index         = execution::__index_of<__result_t, _Ts...>();
     static_assert(__new_index != __npos, "_Type not in variant");
 
@@ -208,7 +209,7 @@ struct __variant : __variant_impl<::cuda::std::index_sequence_for<_Ts...>, _Ts..
 {};
 
 template <class... _Ts>
-using __decayed_variant _CCCL_NODEBUG_ALIAS = __variant<::cuda::std::decay_t<_Ts>...>;
+using __decayed_variant _CCCL_NODEBUG_ALIAS = __variant<decay_t<_Ts>...>;
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -27,7 +27,6 @@
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/common_type.h>
 #include <cuda/std/__type_traits/decay.h>
-#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/__type_traits/type_list.h>
 #include <cuda/std/__type_traits/underlying_type.h>
@@ -35,6 +34,7 @@
 #include <cuda/std/__utility/pod_tuple.h>
 #include <cuda/std/atomic>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/completion_signatures.cuh>
 #include <cuda/experimental/__execution/concepts.cuh>
@@ -109,8 +109,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t
   template <class _StateZip, size_t _Index>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_t
   {
-    using receiver_concept _CCCL_NODEBUG_ALIAS = receiver_t;
-    using __state_t _CCCL_NODEBUG_ALIAS        = __unzip<_StateZip>;
+    using receiver_concept              = receiver_t;
+    using __state_t _CCCL_NODEBUG_ALIAS = __unzip<_StateZip>;
 
     __state_t& __state_;
 
@@ -186,7 +186,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t
     template <size_t _Index, size_t... _Jdx, class... _Ts>
     _CCCL_API void __set_value(::cuda::std::index_sequence<_Jdx...>*, [[maybe_unused]] _Ts&&... __ts) noexcept
     {
-      if constexpr (!::cuda::std::is_same_v<__values_t, __nil>)
+      if constexpr (!__same_as<__values_t, __nil>)
       {
         constexpr size_t _Offset = __completions_and_offsets.second[_Index];
         if constexpr (__nothrow_decay_copyable<_Ts...>)
@@ -218,13 +218,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t
         // without worry.
         if constexpr (__nothrow_decay_copyable<_Error>)
         {
-          __errors_.template __emplace<::cuda::std::decay_t<_Error>>(static_cast<_Error&&>(__err));
+          __errors_.template __emplace<decay_t<_Error>>(static_cast<_Error&&>(__err));
         }
         else
         {
           _CCCL_TRY
           {
-            __errors_.template __emplace<::cuda::std::decay_t<_Error>>(static_cast<_Error&&>(__err));
+            __errors_.template __emplace<decay_t<_Error>>(static_cast<_Error&&>(__err));
           }
           _CCCL_CATCH_ALL
           {
@@ -263,7 +263,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t
       switch (__state_.load(::cuda::std::memory_order_relaxed))
       {
         case __started:
-          if constexpr (!::cuda::std::is_same_v<__values_t, __nil>)
+          if constexpr (!__same_as<__values_t, __nil>)
           {
             // All child operations completed successfully:
             __values_.__apply(execution::set_value, static_cast<__values_t&&>(__values_), static_cast<_Rcvr&&>(__rcvr_));
@@ -310,7 +310,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t
   struct _CCCL_TYPE_VISIBILITY_DEFAULT
   __opstate_t<_Rcvr, _CvFn, ::cuda::std::__tuple<_Ign0, _Ign1, _Sndrs...>, ::cuda::std::index_sequence<_Idx...>>
   {
-    using operation_state_concept _CCCL_NODEBUG_ALIAS = operation_state_t;
+    using operation_state_concept = operation_state_t;
     using __sndrs_t _CCCL_NODEBUG_ALIAS =
       ::cuda::std::__type_call<_CvFn, ::cuda::std::__tuple<_Ign0, _Ign1, _Sndrs...>>;
     using __state_t _CCCL_NODEBUG_ALIAS =
@@ -330,7 +330,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t
         // completions. All child senders can be connected to receivers
         // of the same type, saving template instantiations.
         [[maybe_unused]] constexpr bool __no_values =
-          ::cuda::std::is_same_v<decltype(__state_t::__completions_and_offsets.second), __nil>;
+          __same_as<decltype(__state_t::__completions_and_offsets.second), __nil>;
         // The offsets are used to determine which elements in the values
         // tuple each receiver is responsible for setting.
         return ::cuda::std::__tuple{execution::connect(
@@ -386,7 +386,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t
   };
 
   template <class... _Ts>
-  using __decay_all _CCCL_NODEBUG_ALIAS = ::cuda::std::__type_list<::cuda::std::decay_t<_Ts>...>;
+  using __decay_all _CCCL_NODEBUG_ALIAS = ::cuda::std::__type_list<decay_t<_Ts>...>;
 
 public:
   template <class... _Sndrs>
@@ -464,8 +464,8 @@ template <class... _Sndrs>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t::__sndr_t
     : ::cuda::std::__tuple<when_all_t, ::cuda::std::__ignore_t, _Sndrs...>
 {
-  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
-  using __sndrs_t _CCCL_NODEBUG_ALIAS      = ::cuda::std::__tuple<when_all_t, ::cuda::std::__ignore_t, _Sndrs...>;
+  using sender_concept                = sender_t;
+  using __sndrs_t _CCCL_NODEBUG_ALIAS = ::cuda::std::__tuple<when_all_t, ::cuda::std::__ignore_t, _Sndrs...>;
 
   template <class _Self, class... _Env>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto __get_completions_and_offsets()
@@ -525,9 +525,9 @@ _CCCL_TRIVIAL_API constexpr auto when_all_t::operator()(_Sndrs... __sndrs) const
   {
     return __sndr_t{};
   }
-  else if constexpr (!__is_instantiable_with_v<::cuda::std::common_type_t, __early_domain_of_t<_Sndrs>...>)
+  else if constexpr (!__is_instantiable_with<::cuda::std::common_type_t, __early_domain_of_t<_Sndrs>...>)
   {
-    static_assert(__is_instantiable_with_v<::cuda::std::common_type_t, __early_domain_of_t<_Sndrs>...>,
+    static_assert(__is_instantiable_with<::cuda::std::common_type_t, __early_domain_of_t<_Sndrs>...>,
                   "when_all: all child senders must have the same domain");
   }
   else

--- a/cudax/include/cuda/experimental/__execution/write_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_env.cuh
@@ -133,7 +133,7 @@ public:
 template <class _Sndr, class _Env>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__sndr_t
 {
-  using sender_concept _CCCL_NODEBUG_ALIAS = sender_t;
+  using sender_concept = sender_t;
 
   template <class _Self, class... _RcvrEnv>
   [[nodiscard]] _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()

--- a/cudax/include/cuda/experimental/__stream/device_transform.cuh
+++ b/cudax/include/cuda/experimental/__stream/device_transform.cuh
@@ -127,7 +127,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __device_transform_t
     -> decltype(auto)
   {
     // Calls to transform_device_argument are intentionally unqualified so as to use ADL.
-    if constexpr (__is_instantiable_with_v<__transformed_argument_t, __transform_result_t<_Arg>>)
+    if constexpr (__is_instantiable_with<__transformed_argument_t, __transform_result_t<_Arg>>)
     {
       return _CCCL_MOVE(__storage.__emplace_from([&] {
                return transform_device_argument(__stream, ::cuda::std::forward<_Arg>(__arg));
@@ -151,7 +151,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __device_transform_t
   [[nodiscard]] _CCCL_HOST_API auto operator()(_Stream&& __stream, _Arg&& __arg) const -> decltype(auto)
   {
     // Calls to transform_device_argument are intentionally unqualified so as to use ADL.
-    if constexpr (__is_instantiable_with_v<__transformed_argument_t, __transform_result_t<_Arg>>)
+    if constexpr (__is_instantiable_with<__transformed_argument_t, __transform_result_t<_Arg>>)
     {
       return transform_device_argument(__stream, ::cuda::std::forward<_Arg>(__arg)).transformed_argument();
     }
@@ -164,7 +164,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __device_transform_t
   template <typename _Arg>
   [[nodiscard]] _CCCL_HOST_API auto operator()(::cuda::std::__ignore_t, _Arg&& __arg) const -> decltype(auto)
   {
-    if constexpr (__is_instantiable_with_v<__transformed_argument_t, _Arg>)
+    if constexpr (__is_instantiable_with<__transformed_argument_t, _Arg>)
     {
       return ::cuda::std::forward<_Arg>(__arg).transformed_argument();
     }


### PR DESCRIPTION
## Description

code in `cuda::experimental::` often has need of entities in `cuda::std::` and so names must be qualified. all of the qualification makes the code harder to read imo. i'm finding it helpful in my development to have aliases in `cuda::experimental::` for the most commonly used entities in `cuda::std::`

this pr is mostly just renames.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
