### PR TITLE
Implement execution policies

### DIFF
--- a/cudax/include/cuda/experimental/__execution/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/bulk.cuh
@@ -270,7 +270,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __bulk_t
   [[nodiscard]] _CCCL_TRIVIAL_API auto operator()(_Policy __policy, _Shape __shape, _Fn __fn) const
   {
     static_assert(::cuda::std::integral<_Shape>);
-    static_assert(is_execution_policy_v<_Policy>);
+    static_assert(::cuda::std::is_execution_policy_v<_Policy>);
     using __closure_t = typename _BulkTag::template __closure_t<_Policy, _Shape, _Fn>;
     return __closure_t{{__policy, __shape, static_cast<_Fn&&>(__fn)}};
   }

--- a/cudax/include/cuda/experimental/__execution/policy.cuh
+++ b/cudax/include/cuda/experimental/__execution/policy.cuh
@@ -23,57 +23,20 @@
 
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__execution/env.h>
+#include <cuda/std/__execution/policy.h>
 #include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_execution_policy.h>
 
 #include <cuda/experimental/__execution/prologue.cuh>
 
-namespace cuda::experimental
+namespace cuda::experimental::execution
 {
-namespace execution
-{
-struct sequenced_policy;
-struct parallel_policy;
-struct parallel_unsequenced_policy;
-struct unsequenced_policy;
-struct any_execution_policy;
-} // namespace execution
 
-// execution policy type trait
-template <class _Ty>
-inline constexpr bool is_execution_policy_v = false;
-
-template <>
-inline constexpr bool is_execution_policy_v<execution::sequenced_policy> = true;
-
-template <>
-inline constexpr bool is_execution_policy_v<execution::parallel_policy> = true;
-
-template <>
-inline constexpr bool is_execution_policy_v<execution::parallel_unsequenced_policy> = true;
-
-template <>
-inline constexpr bool is_execution_policy_v<execution::unsequenced_policy> = true;
-
-template <>
-inline constexpr bool is_execution_policy_v<execution::any_execution_policy> = true;
-
-template <class _Ty>
-struct is_execution_policy : ::cuda::std::bool_constant<is_execution_policy_v<_Ty>>
-{};
-
-namespace execution
-{
-enum class __execution_policy
-{
-  invalid_execution_policy,
-  sequenced,
-  parallel,
-  parallel_unsequenced,
-  unsequenced,
-};
-
-template <__execution_policy _Policy>
-struct __policy;
+using ::cuda::std::execution::__execution_policy;
+using ::cuda::std::execution::par;
+using ::cuda::std::execution::par_unseq;
+using ::cuda::std::execution::seq;
+using ::cuda::std::execution::unseq;
 
 struct any_execution_policy
 {
@@ -83,8 +46,8 @@ struct any_execution_policy
   _CCCL_HIDE_FROM_ABI any_execution_policy() = default;
 
   template <__execution_policy _Policy>
-  _CCCL_HOST_API constexpr any_execution_policy(__policy<_Policy> __pol) noexcept
-      : value(__pol)
+  _CCCL_HOST_API constexpr any_execution_policy(::cuda::std::execution::__policy<_Policy>) noexcept
+      : value(_Policy)
   {}
 
   _CCCL_HOST_API constexpr operator __execution_policy() const noexcept
@@ -97,37 +60,38 @@ struct any_execution_policy
     return value;
   }
 
-  __execution_policy value = __execution_policy::invalid_execution_policy;
+  template <__execution_policy _Policy>
+  [[nodiscard]] _CCCL_HOST_API friend constexpr bool
+  operator==(const any_execution_policy& pol, const ::cuda::std::execution::__policy<_Policy>&) noexcept
+  {
+    return pol.value == _Policy;
+  }
+
+#if _CCCL_STD_VER <= 2017
+  template <__execution_policy _Policy>
+  [[nodiscard]] _CCCL_HOST_API friend constexpr bool
+  operator==(const ::cuda::std::execution::__policy<_Policy>&, const any_execution_policy& pol) noexcept
+  {
+    return pol.value == _Policy;
+  }
+
+  template <__execution_policy _Policy>
+  [[nodiscard]] _CCCL_HOST_API friend constexpr bool
+  operator!=(const any_execution_policy& pol, const ::cuda::std::execution::__policy<_Policy>&) noexcept
+  {
+    return pol.value != _Policy;
+  }
+
+  template <__execution_policy _Policy>
+  [[nodiscard]] _CCCL_HOST_API friend constexpr bool
+  operator!=(const ::cuda::std::execution::__policy<_Policy>&, const any_execution_policy& pol)
+  {
+    return pol.value != _Policy;
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+  __execution_policy value = __execution_policy::__invalid_execution_policy;
 };
-
-template <__execution_policy _Policy>
-struct _CCCL_DECLSPEC_EMPTY_BASES __policy : ::cuda::std::integral_constant<__execution_policy, _Policy>
-{};
-
-struct sequenced_policy : __policy<__execution_policy::sequenced>
-{};
-
-struct parallel_policy : __policy<__execution_policy::parallel>
-{};
-
-struct parallel_unsequenced_policy : __policy<__execution_policy::parallel_unsequenced>
-{};
-
-struct unsequenced_policy : __policy<__execution_policy::unsequenced>
-{};
-
-_CCCL_GLOBAL_CONSTANT sequenced_policy seq{};
-_CCCL_GLOBAL_CONSTANT parallel_policy par{};
-_CCCL_GLOBAL_CONSTANT parallel_unsequenced_policy par_unseq{};
-_CCCL_GLOBAL_CONSTANT unsequenced_policy unseq{};
-
-template <__execution_policy _Policy>
-inline constexpr bool __is_parallel_execution_policy =
-  _Policy == __execution_policy::parallel || _Policy == __execution_policy::parallel_unsequenced;
-
-template <__execution_policy _Policy>
-inline constexpr bool __is_unsequenced_execution_policy =
-  _Policy == __execution_policy::unsequenced || _Policy == __execution_policy::parallel_unsequenced;
 
 struct get_execution_policy_t;
 
@@ -161,8 +125,14 @@ struct get_execution_policy_t
 
 _CCCL_GLOBAL_CONSTANT get_execution_policy_t get_execution_policy{};
 
-} // namespace execution
-} // namespace cuda::experimental
+} // namespace cuda::experimental::execution
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <>
+inline constexpr bool is_execution_policy_v<::cuda::experimental::execution::any_execution_policy> = true;
+
+_CCCL_END_NAMESPACE_CUDA_STD
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/std/execution>
 #include <cuda/std/type_traits>
 
 #include <cuda/experimental/container.cuh>
@@ -84,9 +85,9 @@ C2H_TEST("env_t is constructible from an any_resource", "[execution][env]")
   SECTION("Passing an any_resource, a stream and a policy")
   {
     cudax::stream stream{cuda::device_ref{0}};
-    env_t env{mr, stream, cudax::execution::par_unseq};
+    env_t env{mr, stream, cuda::std::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK((env.query(cudax::execution::get_execution_policy) == cudax::execution::par_unseq));
+    CHECK((env.query(cudax::execution::get_execution_policy) == cuda::std::execution::par_unseq));
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
   }
 }
@@ -115,9 +116,10 @@ C2H_TEST("env_t is constructible from an any_resource passed as an rvalue", "[ex
   SECTION("Passing an any_resource, a stream and a policy")
   {
     cudax::stream stream{cuda::device_ref{0}};
-    env_t env{cudax::any_resource<cuda::mr::device_accessible>{test_resource{}}, stream, cudax::execution::par_unseq};
+    env_t env{
+      cudax::any_resource<cuda::mr::device_accessible>{test_resource{}}, stream, cuda::std::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::par_unseq);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cuda::std::execution::par_unseq);
     CHECK(env.query(cuda::mr::get_memory_resource)
           == cudax::any_resource<cuda::mr::device_accessible>{test_resource{}});
   }
@@ -147,9 +149,9 @@ C2H_TEST("env_t is constructible from a resource", "[execution][env]")
   SECTION("Passing an any_resource, a stream and a policy")
   {
     cudax::stream stream{cuda::device_ref{0}};
-    env_t env{mr, stream, cudax::execution::par_unseq};
+    env_t env{mr, stream, cuda::std::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::par_unseq);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cuda::std::execution::par_unseq);
     CHECK(env.query(cuda::mr::get_memory_resource) == mr);
   }
 }
@@ -176,9 +178,9 @@ C2H_TEST("env_t is constructible from a resource passed as an rvalue", "[executi
   SECTION("Passing an any_resource, a stream and a policy")
   {
     cudax::stream stream{cuda::device_ref{0}};
-    env_t env{test_resource{}, stream, cudax::execution::par_unseq};
+    env_t env{test_resource{}, stream, cuda::std::execution::par_unseq};
     CHECK(env.query(cuda::get_stream) == stream);
-    CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::par_unseq);
+    CHECK(env.query(cudax::execution::get_execution_policy) == cuda::std::execution::par_unseq);
     CHECK(env.query(cuda::mr::get_memory_resource) == test_resource{});
   }
 }
@@ -187,7 +189,7 @@ struct some_env_t
 {
   test_resource res_{};
   cudax::stream stream_{cuda::device_ref{0}};
-  cudax::execution::any_execution_policy policy_ = cudax::execution::par_unseq;
+  cudax::execution::any_execution_policy policy_ = cuda::std::execution::par_unseq;
 
   const test_resource& query(cuda::mr::get_memory_resource_t) const noexcept
   {
@@ -218,7 +220,7 @@ struct bad_env_t
 {
   test_resource res_{};
   cudax::stream stream_{cuda::device_ref{0}};
-  cudax::execution::any_execution_policy policy_ = cudax::execution::par_unseq;
+  cudax::execution::any_execution_policy policy_ = cuda::std::execution::par_unseq;
 
   template <bool Enable = WithResource, cuda::std::enable_if_t<Enable, int> = 0>
   const test_resource& query(cuda::mr::get_memory_resource_t) const noexcept

--- a/cudax/test/execution/policies/policies.cu
+++ b/cudax/test/execution/policies/policies.cu
@@ -8,6 +8,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/std/execution>
 #include <cuda/std/type_traits>
 
 #include <cuda/experimental/execution.cuh>
@@ -21,54 +22,13 @@ using is_same = cuda::std::is_same<cuda::std::remove_cvref_t<T>, U>;
 
 C2H_TEST("Execution policies", "[execution][policies]")
 {
-  namespace execution = cuda::experimental::execution;
+  namespace execution = cuda::std::execution;
   SECTION("Individual options")
   {
-    execution::any_execution_policy pol = execution::seq;
-    pol                                 = execution::par;
-    pol                                 = execution::par_unseq;
-    pol                                 = execution::unseq;
+    cudax::execution::any_execution_policy pol = execution::seq;
+    pol                                        = execution::par;
+    pol                                        = execution::par_unseq;
+    pol                                        = execution::unseq;
     CHECK(pol == execution::unseq);
-  }
-
-  SECTION("Global instances")
-  {
-    STATIC_CHECK(execution::seq == execution::seq);
-    STATIC_CHECK(execution::par == execution::par);
-    STATIC_CHECK(execution::par_unseq == execution::par_unseq);
-    STATIC_CHECK(execution::unseq == execution::unseq);
-
-    STATIC_CHECK_FALSE(execution::seq != execution::seq);
-    STATIC_CHECK_FALSE(execution::par != execution::par);
-    STATIC_CHECK_FALSE(execution::par_unseq != execution::par_unseq);
-    STATIC_CHECK_FALSE(execution::unseq != execution::unseq);
-
-    STATIC_CHECK_FALSE(execution::seq == execution::unseq);
-    STATIC_CHECK_FALSE(execution::par == execution::seq);
-    STATIC_CHECK_FALSE(execution::par_unseq == execution::par);
-    STATIC_CHECK_FALSE(execution::unseq == execution::par_unseq);
-
-    STATIC_CHECK(execution::seq != execution::unseq);
-    STATIC_CHECK(execution::par != execution::seq);
-    STATIC_CHECK(execution::par_unseq != execution::par);
-    STATIC_CHECK(execution::unseq != execution::par_unseq);
-  }
-
-  SECTION("is_parallel_execution_policy")
-  {
-    using execution::__is_parallel_execution_policy;
-    STATIC_CHECK(!__is_parallel_execution_policy<execution::seq>);
-    STATIC_CHECK(__is_parallel_execution_policy<execution::par>);
-    STATIC_CHECK(__is_parallel_execution_policy<execution::par_unseq>);
-    STATIC_CHECK(!__is_parallel_execution_policy<execution::unseq>);
-  }
-
-  SECTION("is_unsequenced_execution_policy")
-  {
-    using execution::__is_unsequenced_execution_policy;
-    STATIC_CHECK(!__is_unsequenced_execution_policy<execution::seq>);
-    STATIC_CHECK(!__is_unsequenced_execution_policy<execution::par>);
-    STATIC_CHECK(__is_unsequenced_execution_policy<execution::par_unseq>);
-    STATIC_CHECK(__is_unsequenced_execution_policy<execution::unseq>);
   }
 }

--- a/libcudacxx/include/cuda/std/__execution/policy.h
+++ b/libcudacxx/include/cuda/std/__execution/policy.h
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___EXECUTION_POLICY_H
+#define _LIBCUDACXX___EXECUTION_POLICY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/underlying_type.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_EXECUTION
+
+enum class __execution_policy : uint32_t
+{
+  __invalid_execution_policy = 0,
+  __sequenced                = 1 << 0,
+  __parallel                 = 1 << 1,
+  __unsequenced              = 1 << 2,
+  __parallel_unsequenced     = __execution_policy::__parallel | __execution_policy::__unsequenced,
+};
+
+[[nodiscard]] _CCCL_API constexpr bool
+__satisfies_execution_policy(__execution_policy __lhs, __execution_policy __rhs) noexcept
+{
+  return (static_cast<uint32_t>(__lhs) & static_cast<uint32_t>(__rhs)) != 0;
+}
+
+template <__execution_policy _Policy>
+struct __policy
+{
+  template <__execution_policy _OtherPolicy>
+  [[nodiscard]] _CCCL_API friend constexpr bool operator==(const __policy&, const __policy<_OtherPolicy>&) noexcept
+  {
+    using __underlying_t = underlying_type_t<__execution_policy>;
+    return (static_cast<__underlying_t>(_Policy) == static_cast<__underlying_t>(_OtherPolicy));
+  }
+
+#if _CCCL_STD_VER <= 2017
+  template <__execution_policy _OtherPolicy>
+  [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const __policy&, const __policy<_OtherPolicy>&) noexcept
+  {
+    using __underlying_t = underlying_type_t<__execution_policy>;
+    return (static_cast<__underlying_t>(_Policy) != static_cast<__underlying_t>(_OtherPolicy));
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+  static constexpr __execution_policy __policy_ = _Policy;
+};
+
+struct sequenced_policy : public __policy<__execution_policy::__sequenced>
+{};
+
+_CCCL_GLOBAL_CONSTANT sequenced_policy seq{};
+
+struct parallel_policy : public __policy<__execution_policy::__parallel>
+{};
+_CCCL_GLOBAL_CONSTANT parallel_policy par{};
+
+struct parallel_unsequenced_policy : public __policy<__execution_policy::__parallel_unsequenced>
+{};
+_CCCL_GLOBAL_CONSTANT parallel_unsequenced_policy par_unseq{};
+
+struct unsequenced_policy : public __policy<__execution_policy::__unsequenced>
+{};
+_CCCL_GLOBAL_CONSTANT unsequenced_policy unseq{};
+
+_CCCL_END_NAMESPACE_EXECUTION
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___EXECUTION_POLICY_H

--- a/libcudacxx/include/cuda/std/__internal/namespaces.h
+++ b/libcudacxx/include/cuda/std/__internal/namespaces.h
@@ -71,7 +71,7 @@
 #  define _CCCL_END_NAMESPACE_FILESYSTEM } } } } _LIBCUDACXX_PROLOGUE_INCLUDE_CHECK()
 
 // Shorthands for different qualifiers
-  // Namespaces related to execution
+// Namespaces related to execution
 #  define _CCCL_BEGIN_NAMESPACE_EXECUTION _LIBCUDACXX_PROLOGUE_INCLUDE_CHECK() namespace cuda::std::execution { inline namespace _LIBCUDACXX_ABI_NAMESPACE {
 #  define _CCCL_END_NAMESPACE_EXECUTION } } _LIBCUDACXX_PROLOGUE_INCLUDE_CHECK()
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_execution_policy.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_execution_policy.h
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _LIBCUDACXX___TYPE_TRAITS_IS_EXECUTION_POLICY_H
+#define _LIBCUDACXX___TYPE_TRAITS_IS_EXECUTION_POLICY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__execution/policy.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/void_t.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class>
+inline constexpr bool is_execution_policy_v = false;
+
+// Ensure we ignore cv qualifiers
+template <class _Tp>
+inline constexpr bool is_execution_policy_v<const _Tp> = is_execution_policy_v<_Tp>;
+
+template <class _Tp>
+inline constexpr bool is_execution_policy_v<volatile _Tp> = is_execution_policy_v<_Tp>;
+
+template <class _Tp>
+inline constexpr bool is_execution_policy_v<const volatile _Tp> = is_execution_policy_v<_Tp>;
+
+// Explicitly mark our execution policies as such
+template <>
+inline constexpr bool is_execution_policy_v<::cuda::std::execution::sequenced_policy> = true;
+
+template <>
+inline constexpr bool is_execution_policy_v<::cuda::std::execution::parallel_policy> = true;
+
+template <>
+inline constexpr bool is_execution_policy_v<::cuda::std::execution::parallel_unsequenced_policy> = true;
+
+template <>
+inline constexpr bool is_execution_policy_v<::cuda::std::execution::unsequenced_policy> = true;
+
+template <class _Tp>
+struct _CCCL_NO_SPECIALIZATIONS is_execution_policy : bool_constant<is_execution_policy_v<_Tp>>
+{};
+
+// Detect parallel policies
+template <class, class = void>
+inline constexpr bool __is_parallel_execution_policy_v = false;
+
+template <class _Policy>
+inline constexpr bool __is_parallel_execution_policy_v<_Policy, void_t<decltype(_Policy::__policy_)>> =
+  __satisfies_execution_policy(_Policy::__policy_, ::cuda::std::execution::__execution_policy::__parallel);
+
+// Detect unsequenced policies
+template <class, class = void>
+inline constexpr bool __is_unsequenced_execution_policy_v = false;
+
+template <class _Policy>
+inline constexpr bool __is_unsequenced_execution_policy_v<_Policy, void_t<decltype(_Policy::__policy_)>> =
+  __satisfies_execution_policy(_Policy::__policy_, ::cuda::std::execution::__execution_policy::__unsequenced);
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _LIBCUDACXX___TYPE_TRAITS_IS_EXECUTION_POLICY_H

--- a/libcudacxx/include/cuda/std/execution
+++ b/libcudacxx/include/cuda/std/execution
@@ -22,6 +22,8 @@
 #endif // no system header
 
 #include <cuda/std/__execution/env.h> // IWYU pragma: export
+#include <cuda/std/__execution/policy.h> // IWYU pragma: export
+#include <cuda/std/__type_traits/is_execution_policy.h> // IWYU pragma: export
 #include <cuda/std/version>
 
 #endif //_CUDA_STD_EXECUTION

--- a/libcudacxx/include/cuda/std/type_traits
+++ b/libcudacxx/include/cuda/std/type_traits
@@ -77,6 +77,7 @@
 #include <cuda/std/__type_traits/is_destructible.h>
 #include <cuda/std/__type_traits/is_empty.h>
 #include <cuda/std/__type_traits/is_enum.h>
+#include <cuda/std/__type_traits/is_execution_policy.h>
 #include <cuda/std/__type_traits/is_extended_floating_point.h>
 #include <cuda/std/__type_traits/is_final.h>
 #include <cuda/std/__type_traits/is_floating_point.h>

--- a/libcudacxx/test/libcudacxx/std/utilities/expol/is_execution_policy.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expol/is_execution_policy.compile.pass.cpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// template<class T> struct is_execution_policy;
+// template<class T> constexpr bool is_execution_policy_v = is_execution_policy<T>::value;
+
+#include <cuda/std/execution>
+
+#include "test_macros.h"
+
+static_assert(cuda::std::is_execution_policy<cuda::std::execution::sequenced_policy>::value);
+static_assert(cuda::std::is_execution_policy<cuda::std::execution::parallel_policy>::value);
+static_assert(cuda::std::is_execution_policy<cuda::std::execution::parallel_unsequenced_policy>::value);
+static_assert(cuda::std::is_execution_policy<cuda::std::execution::unsequenced_policy>::value);
+
+static_assert(cuda::std::is_execution_policy_v<cuda::std::execution::sequenced_policy>);
+static_assert(cuda::std::is_execution_policy_v<cuda::std::execution::unsequenced_policy>);
+static_assert(cuda::std::is_execution_policy_v<cuda::std::execution::parallel_policy>);
+static_assert(cuda::std::is_execution_policy_v<cuda::std::execution::parallel_unsequenced_policy>);
+
+static_assert(cuda::std::is_execution_policy_v<const cuda::std::execution::sequenced_policy>);
+static_assert(cuda::std::is_execution_policy_v<volatile cuda::std::execution::sequenced_policy>);
+static_assert(cuda::std::is_execution_policy_v<const volatile cuda::std::execution::sequenced_policy>);
+
+static_assert(!cuda::std::__is_parallel_execution_policy_v<cuda::std::execution::sequenced_policy>);
+static_assert(!cuda::std::__is_parallel_execution_policy_v<cuda::std::execution::unsequenced_policy>);
+static_assert(cuda::std::__is_parallel_execution_policy_v<cuda::std::execution::parallel_policy>);
+static_assert(cuda::std::__is_parallel_execution_policy_v<cuda::std::execution::parallel_unsequenced_policy>);
+
+static_assert(cuda::std::__is_parallel_execution_policy_v<const cuda::std::execution::parallel_unsequenced_policy>);
+static_assert(cuda::std::__is_parallel_execution_policy_v<volatile cuda::std::execution::parallel_unsequenced_policy>);
+static_assert(
+  cuda::std::__is_parallel_execution_policy_v<const volatile cuda::std::execution::parallel_unsequenced_policy>);
+
+static_assert(!cuda::std::__is_unsequenced_execution_policy_v<cuda::std::execution::sequenced_policy>);
+static_assert(cuda::std::__is_unsequenced_execution_policy_v<cuda::std::execution::unsequenced_policy>);
+static_assert(!cuda::std::__is_unsequenced_execution_policy_v<cuda::std::execution::parallel_policy>);
+static_assert(cuda::std::__is_unsequenced_execution_policy_v<cuda::std::execution::parallel_unsequenced_policy>);
+
+static_assert(cuda::std::__is_unsequenced_execution_policy_v<const cuda::std::execution::parallel_unsequenced_policy>);
+static_assert(
+  cuda::std::__is_unsequenced_execution_policy_v<volatile cuda::std::execution::parallel_unsequenced_policy>);
+static_assert(
+  cuda::std::__is_unsequenced_execution_policy_v<const volatile cuda::std::execution::parallel_unsequenced_policy>);
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/utilities/expol/policies.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/expol/policies.compile.pass.cpp
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// class sequenced_policy;
+// class parallel_policy;
+// class parallel_unsequenced_policy;
+// class unsequenced_policy; // since C++20
+//
+// inline constexpr sequenced_policy seq = implementation-defined;
+// inline constexpr parallel_policy par = implementation-defined;
+// inline constexpr parallel_unsequenced_policy par_unseq = implementation-defined;
+// inline constexpr unsequenced_policy unseq = implementation-defined; // since C++20
+
+// UNSUPPORTED: libcpp-has-no-incomplete-pstl
+
+#include <cuda/std/execution>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  namespace execution = cuda::std::execution;
+
+  assert(execution::seq == execution::seq);
+  assert(execution::par == execution::par);
+  assert(execution::par_unseq == execution::par_unseq);
+  assert(execution::unseq == execution::unseq);
+
+  assert(!(execution::seq != execution::seq));
+  assert(!(execution::par != execution::par));
+  assert(!(execution::par_unseq != execution::par_unseq));
+  assert(!(execution::unseq != execution::unseq));
+
+  assert(!(execution::seq == execution::unseq));
+  assert(!(execution::par == execution::seq));
+  assert(!(execution::par_unseq == execution::par));
+  assert(!(execution::unseq == execution::par_unseq));
+
+  assert(execution::seq != execution::unseq);
+  assert(execution::par != execution::seq);
+  assert(execution::par_unseq != execution::par);
+  assert(execution::unseq != execution::par_unseq);
+
+  return true;
+}
+
+template <class T, class Policy>
+inline constexpr bool is_same_v = cuda::std::is_same_v<cuda::std::remove_cvref_t<T>, Policy>;
+
+static_assert(is_same_v<decltype(cuda::std::execution::seq), cuda::std::execution::sequenced_policy>);
+static_assert(is_same_v<decltype(cuda::std::execution::par), cuda::std::execution::parallel_policy>);
+static_assert(is_same_v<decltype(cuda::std::execution::par_unseq), cuda::std::execution::parallel_unsequenced_policy>);
+static_assert(is_same_v<decltype(cuda::std::execution::unseq), cuda::std::execution::unsequenced_policy>);
+
+int main(int, char**)
+{
+  static_assert(test());
+
+  return 0;
+}


### PR DESCRIPTION
This implements the standard execution policies, mostly copying the design from `cuda::experimental::execution`

I slightly adopted it to be extensible for the case that we want to extend the policies with policies
