### PR TITLE
Use a custom git describe command for setuptools-scm

### DIFF
--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -60,6 +60,8 @@ provider = "scikit_build_core.metadata.setuptools_scm"
 
 [tool.setuptools_scm]
 root = "../.."
+git_describe_command = ["git", "describe", "--tags", "--match", "v[0-9]*"]
+
 
 [tool.scikit-build.wheel.packages]
 "cuda" = "cuda"


### PR DESCRIPTION
## Description

Since tagging and making the v0.1.3.2.0.dev128 [release](https://github.com/NVIDIA/cccl/releases/tag/cccl-python-0.1.3.2.0.dev128), I'm having issues with `setuptools_scm` refusing to build `cuda.cccl`.

```bash
$ pip install -e ".[test]"

...

  ValueError: choosing custom numbers for the `.devX` distance is not supported.
   The 0.1.3.2.0.dev128 can't be bumped
  Please drop the tag or create a new supported one ending in .dev0
  error: subprocess-exited-with-error
  
  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
``` 

There may be more elegant, robust solutions to this problem, but for now I am configuring `setuptools_scm` to only consider tags that begin with `v` (ignoring tags like `cccl-python-0.1.3.2.0.dev128`). This simply maintains the status quo in terms of how `setuptools_scm` computes version numbers, ignoring any tags we create for publishing `cccl-python` as GitHub releases.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
