### PR TITLE
Disable LDL/STL checks for CTK < 13.1 (nvbug 5243118)

### DIFF
--- a/c/parallel/test/test_scan.cpp
+++ b/c/parallel/test/test_scan.cpp
@@ -77,8 +77,8 @@ struct scan_build
     // Check compute capability (existing logic)
     bool cc_allows_check = (!Disable75SassCheck || cc_major > 7) && cc_major < 9;
 
-    // Check for nvrtc-specific LDL/STL bug (resolves nvbug 5243118)
-    bool ctk_allows_check = is_nvrtc_sass_check_allowed();
+    // Disable SASS checks for CTK < 13.1 due to nvrtc bug (nvbug 5243118)
+    bool ctk_allows_check = is_ctk_version_allows_sass_check();
 
     return cc_allows_check && ctk_allows_check;
   }

--- a/c/parallel/test/test_scan.cpp
+++ b/c/parallel/test/test_scan.cpp
@@ -78,7 +78,7 @@ struct scan_build
     bool cc_allows_check = (!Disable75SassCheck || cc_major > 7) && cc_major < 9;
 
     // Disable SASS checks for CTK < 13.1 due to nvrtc bug (nvbug 5243118)
-    bool ctk_allows_check = is_ctk_version_allows_sass_check();
+    bool ctk_allows_check = ctk_version_allows_sass_check();
 
     return cc_allows_check && ctk_allows_check;
   }

--- a/c/parallel/test/test_scan.cpp
+++ b/c/parallel/test/test_scan.cpp
@@ -74,8 +74,13 @@ struct scan_build
 
   static bool should_check_sass(int cc_major)
   {
-    // TODO: add a check for NVRTC version; ref nvbug 5243118
-    return (!Disable75SassCheck || cc_major > 7) && cc_major < 9;
+    // Check compute capability (existing logic)
+    bool cc_allows_check = (!Disable75SassCheck || cc_major > 7) && cc_major < 9;
+
+    // Check for nvrtc-specific LDL/STL bug (resolves nvbug 5243118)
+    bool ctk_allows_check = is_nvrtc_sass_check_allowed();
+
+    return cc_allows_check && ctk_allows_check;
   }
 };
 

--- a/c/parallel/test/test_unique_by_key.cpp
+++ b/c/parallel/test/test_unique_by_key.cpp
@@ -81,8 +81,8 @@ struct unique_by_key_build
     // Check compute capability (existing logic)
     bool cc_allows_check = cc_major < 9;
 
-    // Check for nvrtc-specific LDL/STL bug (resolves nvbug 5243118)
-    bool ctk_allows_check = is_nvrtc_sass_check_allowed();
+    // Disable SASS checks for CTK < 13.1 due to nvrtc bug (nvbug 5243118)
+    bool ctk_allows_check = is_ctk_version_allows_sass_check();
 
     return cc_allows_check && ctk_allows_check;
   }

--- a/c/parallel/test/test_unique_by_key.cpp
+++ b/c/parallel/test/test_unique_by_key.cpp
@@ -82,7 +82,7 @@ struct unique_by_key_build
     bool cc_allows_check = cc_major < 9;
 
     // Disable SASS checks for CTK < 13.1 due to nvrtc bug (nvbug 5243118)
-    bool ctk_allows_check = is_ctk_version_allows_sass_check();
+    bool ctk_allows_check = ctk_version_allows_sass_check();
 
     return cc_allows_check && ctk_allows_check;
   }

--- a/c/parallel/test/test_unique_by_key.cpp
+++ b/c/parallel/test/test_unique_by_key.cpp
@@ -78,8 +78,13 @@ struct unique_by_key_build
 
   static bool should_check_sass(int cc_major)
   {
-    // TODO: add a check for NVRTC version; ref nvbug 5243118
-    return cc_major < 9;
+    // Check compute capability (existing logic)
+    bool cc_allows_check = cc_major < 9;
+
+    // Check for nvrtc-specific LDL/STL bug (resolves nvbug 5243118)
+    bool ctk_allows_check = is_nvrtc_sass_check_allowed();
+
+    return cc_allows_check && ctk_allows_check;
   }
 };
 

--- a/c/parallel/test/test_util.h
+++ b/c/parallel/test/test_util.h
@@ -30,24 +30,18 @@
 #include <c2h/catch2_test_helper.h>
 #include <cccl/c/types.h>
 
-// Check if we should allow SASS checks based on nvrtc version
+// Check if CTK version allows SASS checks for LDL/STL instructions
 // This addresses nvbug 5243118: nvrtc generates LDL/STL instructions prior to CTK 13.1
-// where nvcc would not generate them
-inline bool is_nvrtc_sass_check_allowed()
+// where nvcc would not generate them. Since c.parallel ALWAYS uses nvrtc internally to compile
+// kernel template instantiations (not nvcc), we must disable SASS checks for CTK versions prior to 13.1.
+inline bool is_ctk_version_allows_sass_check()
 {
-#ifdef __CUDACC_RTC__
-  // We're compiling with nvrtc - check CTK version for the bug
-#  if defined(__CUDACC_VER_MAJOR__) && defined(__CUDACC_VER_MINOR__)
+#if defined(__CUDACC_VER_MAJOR__) && defined(__CUDACC_VER_MINOR__)
   // Bug is fixed in CTK 13.1+
   return (__CUDACC_VER_MAJOR__ > 13) || (__CUDACC_VER_MAJOR__ == 13 && __CUDACC_VER_MINOR__ >= 1);
-#  else
+#else
   // Conservative: disable if version unknown
   return false;
-#  endif
-#else
-  // We're compiling with nvcc - no CTK version restriction needed
-  // nvbug 5243118 does not affect nvcc compilation
-  return true;
 #endif
 }
 

--- a/c/parallel/test/test_util.h
+++ b/c/parallel/test/test_util.h
@@ -34,7 +34,7 @@
 // This addresses nvbug 5243118: nvrtc generates LDL/STL instructions prior to CTK 13.1
 // where nvcc would not generate them. Since c.parallel ALWAYS uses nvrtc internally to compile
 // kernel template instantiations (not nvcc), we must disable SASS checks for CTK versions prior to 13.1.
-inline bool is_ctk_version_allows_sass_check()
+inline bool ctk_version_allows_sass_check()
 {
 #if defined(__CUDACC_VER_MAJOR__) && defined(__CUDACC_VER_MINOR__)
   // Bug is fixed in CTK 13.1+

--- a/python/cuda_cccl/cuda/cccl/parallel/experimental/_cccl_interop.py
+++ b/python/cuda_cccl/cuda/cccl/parallel/experimental/_cccl_interop.py
@@ -17,6 +17,8 @@ import numpy as np
 from numba import cuda, types
 from numba.core.extending import as_numba_type, intrinsic
 
+import cuda.bindings.runtime as cudart  # type: ignore
+
 # TODO: adding a type-ignore here because `cuda` being a
 # namespace package confuses mypy when `cuda.<something_else>`
 # is installed, but not `cuda.cccl`. For namespace packages,
@@ -354,63 +356,20 @@ def _should_check_sass_for_ctk_version() -> bool:
     Returns True if CTK version is 13.1 or higher, False otherwise.
     If version detection fails, returns False (disable SASS checks).
     """
-    try:
-        # Try multiple approaches to get CUDA runtime version
-        runtime_version = None
+    err, runtime_version = cudart.cudaRuntimeGetVersion()
 
-        # Method 1: Try importing cuda-python package
-        try:
-            import cuda.cudart as cudart  # type: ignore[import-not-found]
-
-            err, runtime_version = cudart.cudaRuntimeGetVersion()
-            if err != cudart.cudaError_t.cudaSuccess:
-                runtime_version = None
-        except (ImportError, AttributeError):
-            pass
-
-        # Method 2: Try alternative cuda package structure
-        if runtime_version is None:
-            try:
-                import cuda  # type: ignore[import-not-found]
-
-                runtime_version = cuda.cudart.cudaRuntimeGetVersion()[1]
-            except (ImportError, AttributeError, TypeError, IndexError):
-                pass
-
-        # Method 3: Try using numba's cuda detection
-        if runtime_version is None:
-            try:
-                import numba.cuda
-
-                if numba.cuda.is_available():
-                    # Use numba's internal CUDA version detection
-                    # This is a fallback and may not be as reliable
-                    pass
-            except (ImportError, AttributeError):
-                pass
-
-        # If we couldn't get version, disable SASS checks
-        if runtime_version is None:
-            warnings.warn(
-                "Could not detect CUDA runtime version. "
-                "Disabling SASS verification for LDL/STL instructions.",
-                UserWarning,
-            )
-            return False
-
-        major = runtime_version // 1000
-        minor = (runtime_version % 1000) // 10
-        # Bug is fixed in CTK 13.1+
-        return (major > 13) or (major == 13 and minor >= 1)
-
-    except Exception as e:
-        # If anything goes wrong, disable SASS checks and warn
+    if err != cudart.cudaError_t.cudaSuccess:
         warnings.warn(
-            f"Error detecting CUDA toolkit version: {e}. "
+            f"CUDA runtime version query failed with error {err}. "
             "Disabling SASS verification for LDL/STL instructions.",
             UserWarning,
         )
         return False
+
+    major = runtime_version // 1000
+    minor = (runtime_version % 1000) // 10
+    # Bug is fixed in CTK 13.1+
+    return (major > 13) or (major == 13 and minor >= 1)
 
 
 # this global variable controls whether the compile result is checked

--- a/python/cuda_cccl/tests/parallel/test_scan.py
+++ b/python/cuda_cccl/tests/parallel/test_scan.py
@@ -4,8 +4,6 @@
 
 
 import cupy as cp
-import numba.cuda
-import numba.types
 import numpy as np
 import pytest
 
@@ -40,12 +38,10 @@ def scan_device(d_input, d_output, num_items, op, h_init, force_inclusive, strea
     [True, False],
 )
 def test_scan_array_input(force_inclusive, input_array, monkeypatch):
-    cc_major, _ = numba.cuda.get_current_device().compute_capability
     # Skip sass verification if input is complex
     # as LDL/STL instructions are emitted for complex types.
-    # Also skip for CC 9.0+, due to a bug in NVRTC.
-    # TODO: add NVRTC version check, ref nvbug 5243118
-    if np.issubdtype(input_array.dtype, np.complexfloating) or cc_major >= 9:
+    # Note: CTK version check for nvbug 5243118 is handled in conftest.py
+    if np.issubdtype(input_array.dtype, np.complexfloating):
         import cuda.cccl.parallel.experimental._cccl_interop
 
         monkeypatch.setattr(


### PR DESCRIPTION
## Problem statement

Issue #5560: c.parallel tests incorrectly perform SASS validation for LDL/STL instructions on CTK < 13.1, causing false positives due to nvbug 5243118 where nvrtc generates these instructions when nvcc would not.

## Solution

Since c.parallel **always** uses nvrtc internally for kernel compilation (not nvcc), the fix unconditionally applies CTK version checks:

### C++ Changes
- Added `is_ctk_version_allows_sass_check()` helper function in `test_util.h` that checks CTK version using `__CUDACC_VER_MAJOR__` and `__CUDACC_VER_MINOR__` macros
- Returns `true` for CTK ≥ 13.1 (where bug is fixed), `false` otherwise
- Updated `should_check_sass()` in `test_scan.cpp` and `test_unique_by_key.cpp` to use this helper

### Python Changes  
- Added `_should_check_sass_for_ctk_version()` in `_cccl_interop.py` that checks runtime CTK version
- Modified `call_build()` to only perform SASS checks when both `_check_sass` is enabled AND CTK ≥ 13.1
- Updated `conftest.py` fixture to emit warning when SASS checks are disabled due to CTK version
- Simplified `test_scan.py` to remove CC 9.0+ check (now handled by CTK version check)

## Testing guide

**Expected behavior:**
- CTK < 13.1: SASS validation disabled (with warning), tests pass without false positives
- CTK ≥ 13.1: SASS validation enabled, properly catches real LDL/STL issues
- Complex types still skip SASS checks via existing logic

## Breaking Changes

**None** - This is a backward-compatible fix that only affects internal test validation logic. No changes to public APIs, library functionality, build system, or dependencies.

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
