### PR TITLE
[CUB] Fix `DeviceScan` to avoid passing invalid elements to the scan op

### DIFF
--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -1302,7 +1302,10 @@ struct TilePrefixCallbackOp
 
       // Update exclusive tile prefix with the window prefix
       ProcessWindow(predecessor_idx, predecessor_status, window_aggregate, construct_delay());
-      exclusive_prefix = scan_op(window_aggregate, exclusive_prefix);
+      if (threadIdx.x == 0)
+      {
+        exclusive_prefix = scan_op(window_aggregate, exclusive_prefix);
+      }
     }
 
     // Compute the inclusive tile prefix and update the status for this tile

--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -1303,7 +1303,7 @@ struct TilePrefixCallbackOp
 
       // Update exclusive tile prefix with the window prefix
       ProcessWindow(predecessor_idx, predecessor_status, window_aggregate, construct_delay());
-      if (threadIdx.x == 0)
+      if (cub::detail::has_no_side_effects<ScanOpT, T> || threadIdx.x == 0)
       {
         exclusive_prefix = scan_op(window_aggregate, exclusive_prefix);
       }

--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -1267,7 +1267,8 @@ struct TilePrefixCallbackOp
     // Perform a segmented reduction to get the prefix for the current window.
     // Use the swizzled scan operator because we are now scanning *down* towards thread0.
 
-    int tail_flag = (predecessor_status == StatusWord(SCAN_TILE_INCLUSIVE));
+    int tail_flag =
+      (predecessor_status == StatusWord(SCAN_TILE_INCLUSIVE) || predecessor_status == StatusWord(SCAN_TILE_OOB));
     window_aggregate =
       WarpReduceT(temp_storage.warp_reduce).TailSegmentedReduce(value, tail_flag, SwizzleScanOp<ScanOpT>(scan_op));
   }

--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -1268,7 +1268,8 @@ struct TilePrefixCallbackOp
     // Use the swizzled scan operator because we are now scanning *down* towards thread0.
 
     int tail_flag =
-      (predecessor_status == StatusWord(SCAN_TILE_INCLUSIVE) || predecessor_status == StatusWord(SCAN_TILE_OOB));
+      (predecessor_status == StatusWord(SCAN_TILE_INCLUSIVE)
+       || (!cub::detail::has_no_side_effects<ScanOpT, T> && predecessor_status == StatusWord(SCAN_TILE_OOB)));
     window_aggregate =
       WarpReduceT(temp_storage.warp_reduce).TailSegmentedReduce(value, tail_flag, SwizzleScanOp<ScanOpT>(scan_op));
   }

--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -1631,14 +1631,15 @@ public:
 
     // Reduce consecutive thread items in registers
     const int thread_valid_items = valid_items - static_cast<int>(linear_tid) * items_per_thread;
-    T thread_prefix              = cub::detail::ThreadReducePartial(input, scan_op, thread_valid_items);
+    T thread_prefix = cub::detail::ThreadReducePartial<Input, ScanOp, T, T>(input, scan_op, thread_valid_items);
 
     // Exclusive thread block-scan
     const int valid_threads = ::cuda::ceil_div(::cuda::std::max(valid_items, 0), items_per_thread);
     ExclusiveScanPartialTile(thread_prefix, thread_prefix, initial_value, scan_op, valid_threads);
 
     // Exclusive scan in registers with prefix as seed
-    cub::detail::ThreadScanExclusivePartial(input, output, scan_op, thread_valid_items, thread_prefix);
+    cub::detail::ThreadScanExclusivePartial<Input, Output, ScanOp, T, T, T>(
+      input, output, scan_op, thread_valid_items, thread_prefix);
   }
 
   //! @rst
@@ -1733,14 +1734,15 @@ public:
 
     // Reduce consecutive thread items in registers
     const int thread_valid_items = valid_items - static_cast<int>(linear_tid) * items_per_thread;
-    T thread_prefix              = cub::detail::ThreadReducePartial(input, scan_op, thread_valid_items);
+    T thread_prefix = cub::detail::ThreadReducePartial<Input, ScanOp, T, T>(input, scan_op, thread_valid_items);
 
     // Exclusive thread block-scan
     const int valid_threads = ::cuda::ceil_div(::cuda::std::max(valid_items, 0), items_per_thread);
     ExclusiveScanPartialTile(thread_prefix, thread_prefix, initial_value, scan_op, valid_threads, block_aggregate);
 
     // Exclusive scan in registers with prefix as seed
-    cub::detail::ThreadScanExclusivePartial(input, output, scan_op, thread_valid_items, thread_prefix);
+    cub::detail::ThreadScanExclusivePartial<Input, Output, ScanOp, T, T, T>(
+      input, output, scan_op, thread_valid_items, thread_prefix);
   }
 
   //! @rst
@@ -1876,14 +1878,15 @@ public:
 
     // Reduce consecutive thread items in registers
     const int thread_valid_items = valid_items - static_cast<int>(linear_tid) * items_per_thread;
-    T thread_prefix              = cub::detail::ThreadReducePartial(input, scan_op, thread_valid_items);
+    T thread_prefix = cub::detail::ThreadReducePartial<Input, ScanOp, T, T>(input, scan_op, thread_valid_items);
 
     // Exclusive thread block-scan
     const int valid_threads = ::cuda::ceil_div(::cuda::std::max(valid_items, 0), items_per_thread);
     ExclusiveScanPartialTile(thread_prefix, thread_prefix, scan_op, valid_threads, block_prefix_callback_op);
 
     // Exclusive scan in registers with prefix as seed
-    cub::detail::ThreadScanExclusivePartial(input, output, scan_op, thread_valid_items, thread_prefix);
+    cub::detail::ThreadScanExclusivePartial<Input, Output, ScanOp, T, T, T>(
+      input, output, scan_op, thread_valid_items, thread_prefix);
   }
 
   //! @} end member group // Exclusive prefix scans (multiple data per thread)
@@ -2151,14 +2154,14 @@ public:
 
     // Reduce consecutive thread items in registers
     const int thread_valid_items = valid_items - static_cast<int>(linear_tid) * items_per_thread;
-    T thread_partial             = cub::detail::ThreadReducePartial(input, scan_op, thread_valid_items);
+    T thread_partial = cub::detail::ThreadReducePartial<Input, ScanOp, T, T>(input, scan_op, thread_valid_items);
 
     // Exclusive thread block-scan
     const int valid_threads = ::cuda::ceil_div(::cuda::std::max(valid_items, 0), items_per_thread);
     ExclusiveScanPartialTile(thread_partial, thread_partial, scan_op, valid_threads);
 
     // Exclusive scan in registers with prefix
-    cub::detail::ThreadScanExclusivePartial(
+    cub::detail::ThreadScanExclusivePartial<Input, Output, ScanOp, T, T, T>(
       input, output, scan_op, thread_valid_items, thread_partial, (linear_tid != 0u));
   }
 
@@ -2210,14 +2213,14 @@ public:
 
     // Reduce consecutive thread items in registers
     const int thread_valid_items = valid_items - static_cast<int>(linear_tid) * items_per_thread;
-    T thread_partial             = cub::detail::ThreadReducePartial(input, scan_op, thread_valid_items);
+    T thread_partial = cub::detail::ThreadReducePartial<Input, ScanOp, T, T>(input, scan_op, thread_valid_items);
 
     // Exclusive thread block-scan
     const int valid_threads = ::cuda::ceil_div(::cuda::std::max(valid_items, 0), items_per_thread);
     ExclusiveScanPartialTile(thread_partial, thread_partial, scan_op, valid_threads, block_aggregate);
 
     // Exclusive scan in registers with prefix
-    cub::detail::ThreadScanExclusivePartial(
+    cub::detail::ThreadScanExclusivePartial<Input, Output, ScanOp, T, T, T>(
       input, output, scan_op, thread_valid_items, thread_partial, (linear_tid != 0u));
   }
 
@@ -3680,14 +3683,14 @@ public:
     {
       // Reduce consecutive thread items in registers
       const int thread_valid_items = valid_items - static_cast<int>(linear_tid) * items_per_thread;
-      T thread_prefix              = cub::detail::ThreadReducePartial(input, scan_op, thread_valid_items);
+      T thread_prefix = cub::detail::ThreadReducePartial<Input, ScanOp, T, T>(input, scan_op, thread_valid_items);
 
       // Exclusive thread block-scan
       const int valid_threads = ::cuda::ceil_div(::cuda::std::max(valid_items, 0), items_per_thread);
       ExclusiveScanPartialTile(thread_prefix, thread_prefix, scan_op, valid_threads);
 
       // Inclusive scan in registers with prefix as seed (first thread does not seed)
-      cub::detail::ThreadScanInclusivePartial(
+      cub::detail::ThreadScanInclusivePartial<Input, Output, ScanOp, T, T, T>(
         input, output, scan_op, thread_valid_items, thread_prefix, (linear_tid != 0u));
     }
   }
@@ -3753,14 +3756,15 @@ public:
 
     // Reduce consecutive thread items in registers
     const int thread_valid_items = valid_items - static_cast<int>(linear_tid) * items_per_thread;
-    T thread_prefix              = cub::detail::ThreadReducePartial(input, scan_op, thread_valid_items);
+    T thread_prefix = cub::detail::ThreadReducePartial<Input, ScanOp, T, T>(input, scan_op, thread_valid_items);
 
     // Exclusive thread block-scan
     const int valid_threads = ::cuda::ceil_div(::cuda::std::max(valid_items, 0), items_per_thread);
     ExclusiveScanPartialTile(thread_prefix, thread_prefix, initial_value, scan_op, valid_threads);
 
     // Exclusive scan in registers with prefix as seed
-    cub::detail::ThreadScanInclusivePartial(input, output, scan_op, thread_valid_items, thread_prefix);
+    cub::detail::ThreadScanInclusivePartial<Input, Output, ScanOp, T, T, T>(
+      input, output, scan_op, thread_valid_items, thread_prefix);
   }
 
   //! @rst
@@ -3851,14 +3855,14 @@ public:
     {
       // Reduce consecutive thread items in registers
       const int thread_valid_items = valid_items - static_cast<int>(linear_tid) * items_per_thread;
-      T thread_prefix              = cub::detail::ThreadReducePartial(input, scan_op, thread_valid_items);
+      T thread_prefix = cub::detail::ThreadReducePartial<Input, ScanOp, T, T>(input, scan_op, thread_valid_items);
 
       // Exclusive thread block-scan (with no initial value)
       const int valid_threads = ::cuda::ceil_div(::cuda::std::max(valid_items, 0), items_per_thread);
       ExclusiveScanPartialTile(thread_prefix, thread_prefix, scan_op, valid_threads, block_aggregate);
 
       // Inclusive scan in registers with prefix as seed (first thread does not seed)
-      cub::detail::ThreadScanInclusivePartial(
+      cub::detail::ThreadScanInclusivePartial<Input, Output, ScanOp, T, T, T>(
         input, output, scan_op, thread_valid_items, thread_prefix, (linear_tid != 0u));
     }
   }
@@ -3933,14 +3937,15 @@ public:
 
     // Reduce consecutive thread items in registers
     const int thread_valid_items = valid_items - static_cast<int>(linear_tid) * items_per_thread;
-    T thread_prefix              = cub::detail::ThreadReducePartial(input, scan_op, thread_valid_items);
+    T thread_prefix = cub::detail::ThreadReducePartial<Input, ScanOp, T, T>(input, scan_op, thread_valid_items);
 
     // Exclusive thread block-scan
     const int valid_threads = ::cuda::ceil_div(::cuda::std::max(valid_items, 0), items_per_thread);
     ExclusiveScanPartialTile(thread_prefix, thread_prefix, initial_value, scan_op, valid_threads, block_aggregate);
 
     // Exclusive scan in registers with prefix as seed
-    cub::detail::ThreadScanInclusivePartial(input, output, scan_op, thread_valid_items, thread_prefix);
+    cub::detail::ThreadScanInclusivePartial<Input, Output, ScanOp, T, T, T>(
+      input, output, scan_op, thread_valid_items, thread_prefix);
   }
 
   //! @rst
@@ -4080,14 +4085,15 @@ public:
     {
       // Reduce consecutive thread items in registers
       const int thread_valid_items = valid_items - static_cast<int>(linear_tid) * items_per_thread;
-      T thread_prefix              = cub::detail::ThreadReducePartial(input, scan_op, thread_valid_items);
+      T thread_prefix = cub::detail::ThreadReducePartial<Input, ScanOp, T, T>(input, scan_op, thread_valid_items);
 
       // Exclusive thread block-scan
       const int valid_threads = ::cuda::ceil_div(::cuda::std::max(valid_items, 0), items_per_thread);
       ExclusiveScanPartialTile(thread_prefix, thread_prefix, scan_op, valid_threads, block_prefix_callback_op);
 
       // Inclusive scan in registers with prefix as seed
-      cub::detail::ThreadScanInclusivePartial(input, output, scan_op, thread_valid_items, thread_prefix);
+      cub::detail::ThreadScanInclusivePartial<Input, Output, ScanOp, T, T, T>(
+        input, output, scan_op, thread_valid_items, thread_prefix);
     }
   }
 

--- a/cub/cub/block/specializations/block_scan_raking.cuh
+++ b/cub/cub/block/specializations/block_scan_raking.cuh
@@ -264,7 +264,8 @@ struct BlockScanRaking
       cached_segment[iteration] = smem_raking_ptr[iteration];
     }
 
-    return cub::detail::ThreadReducePartial(cached_segment, scan_op, segment_valid_items);
+    return cub::detail::ThreadReducePartial<T[SEGMENT_LENGTH], ScanOp, T, T>(
+      cached_segment, scan_op, segment_valid_items);
   }
 
   /// Performs exclusive downsweep raking scan
@@ -284,7 +285,7 @@ struct BlockScanRaking
       }
     }
 
-    cub::detail::ThreadScanExclusivePartial(
+    cub::detail::ThreadScanExclusivePartial<T[SEGMENT_LENGTH], T[SEGMENT_LENGTH], ScanOp, T, T, T>(
       cached_segment, cached_segment, scan_op, segment_valid_items, raking_partial, apply_prefix);
 
     // Write data back to smem

--- a/cub/cub/block/specializations/block_scan_warp_scans.cuh
+++ b/cub/cub/block/specializations/block_scan_warp_scans.cuh
@@ -241,16 +241,25 @@ struct BlockScanWarpScans
   ComputeWarpPrefix(ScanOp scan_op, T warp_aggregate, T& block_aggregate, const T& initial_value)
   {
     T warp_prefix = ComputeWarpPrefix(scan_op, warp_aggregate, block_aggregate);
-
-    if (warp_id == 0)
+    if constexpr (cub::detail::has_no_side_effects<ScanOp, T>)
     {
-      warp_prefix = initial_value;
+      warp_prefix = scan_op(initial_value, warp_prefix);
+      if (warp_id == 0)
+      {
+        warp_prefix = initial_value;
+      }
     }
     else
     {
-      warp_prefix = scan_op(initial_value, warp_prefix);
+      if (warp_id == 0)
+      {
+        warp_prefix = initial_value;
+      }
+      else
+      {
+        warp_prefix = scan_op(initial_value, warp_prefix);
+      }
     }
-
     return warp_prefix;
   }
 

--- a/cub/cub/block/specializations/block_scan_warp_scans.cuh
+++ b/cub/cub/block/specializations/block_scan_warp_scans.cuh
@@ -242,11 +242,13 @@ struct BlockScanWarpScans
   {
     T warp_prefix = ComputeWarpPrefix(scan_op, warp_aggregate, block_aggregate);
 
-    warp_prefix = scan_op(initial_value, warp_prefix);
-
     if (warp_id == 0)
     {
       warp_prefix = initial_value;
+    }
+    else
+    {
+      warp_prefix = scan_op(initial_value, warp_prefix);
     }
 
     return warp_prefix;

--- a/cub/cub/thread/thread_operators.cuh
+++ b/cub/cub/thread/thread_operators.cuh
@@ -566,6 +566,49 @@ inline constexpr bool is_cuda_binary_operator =
   is_cuda_std_bitwise_v<Op, T> || //
   is_cuda_std_logical_v<Op, T>;
 
+template <typename Op, typename T>
+inline constexpr bool has_no_side_effects = false;
+
+template <template <typename> typename Op, typename T>
+inline constexpr bool has_no_side_effects<Op<void>, T> =
+  cub::detail::is_cuda_binary_operator<Op<void>> && ::cuda::std::is_arithmetic_v<T>;
+
+template <template <typename> typename Op, typename U, typename T>
+inline constexpr bool has_no_side_effects<Op<U>, T> =
+  cub::detail::is_cuda_binary_operator<Op<U>> && ::cuda::std::is_arithmetic_v<U> && ::cuda::std::is_arithmetic_v<T>;
+
+template <typename Wrapped, typename Key, typename T>
+inline constexpr bool has_no_side_effects<cub::detail::ScanBySegmentOp<Wrapped>, cub::KeyValuePair<Key, T>> =
+  cub::detail::has_no_side_effects<Wrapped, T> && ::cuda::std::is_arithmetic_v<Key>;
+
+template <typename Wrapped, typename T>
+inline constexpr bool has_no_side_effects<cub::SwizzleScanOp<Wrapped>, T> =
+  cub::detail::has_no_side_effects<Wrapped, T>;
+
+template <typename Wrapped, typename Key, typename T>
+inline constexpr bool has_no_side_effects<cub::ReduceBySegmentOp<Wrapped>, cub::KeyValuePair<Key, T>> =
+  cub::detail::has_no_side_effects<Wrapped, T> && ::cuda::std::is_arithmetic_v<Key>;
+
+template <typename Wrapped, typename Key, typename T>
+inline constexpr bool has_no_side_effects<cub::ReduceByKeyOp<Wrapped>, cub::KeyValuePair<Key, T>> =
+  cub::detail::has_no_side_effects<Wrapped, T> && ::cuda::std::is_arithmetic_v<Key>;
+
+template <typename OffsetT, typename T>
+inline constexpr bool has_no_side_effects<cub::ArgMax, cub::KeyValuePair<OffsetT, T>> =
+  ::cuda::std::is_arithmetic_v<T> && ::cuda::std::is_arithmetic_v<OffsetT>;
+
+template <typename OffsetT, typename T>
+inline constexpr bool has_no_side_effects<cub::ArgMin, cub::KeyValuePair<OffsetT, T>> =
+  ::cuda::std::is_arithmetic_v<T> && ::cuda::std::is_arithmetic_v<OffsetT>;
+
+template <typename OffsetT, typename T>
+inline constexpr bool has_no_side_effects<cub::detail::arg_max, ::cuda::std::pair<OffsetT, T>> =
+  ::cuda::std::is_arithmetic_v<T> && ::cuda::std::is_arithmetic_v<OffsetT>;
+
+template <typename OffsetT, typename T>
+inline constexpr bool has_no_side_effects<cub::detail::arg_min, ::cuda::std::pair<OffsetT, T>> =
+  ::cuda::std::is_arithmetic_v<T> && ::cuda::std::is_arithmetic_v<OffsetT>;
+
 //----------------------------------------------------------------------------------------------------------------------
 // Generalize Operator
 

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -412,10 +412,14 @@ struct WarpScanShfl
     _T temp = ShuffleUp<LOGICAL_WARP_THREADS>(input, offset, first_lane, member_mask);
 
     // Perform scan op if from a valid peer
-    _T output = scan_op(temp, input);
+    _T output;
     if (static_cast<int>(lane_id) < first_lane + offset)
     {
       output = input;
+    }
+    else
+    {
+      output = scan_op(temp, input);
     }
 
     return output;

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -413,15 +413,25 @@ struct WarpScanShfl
 
     // Perform scan op if from a valid peer
     _T output;
-    if (static_cast<int>(lane_id) < first_lane + offset)
+    if constexpr (cub::detail::has_no_side_effects<ScanOpT, T>)
     {
-      output = input;
+      output = scan_op(temp, input);
+      if (static_cast<int>(lane_id) < first_lane + offset)
+      {
+        output = input;
+      }
     }
     else
     {
-      output = scan_op(temp, input);
+      if (static_cast<int>(lane_id) < first_lane + offset)
+      {
+        output = input;
+      }
+      else
+      {
+        output = scan_op(temp, input);
+      }
     }
-
     return output;
   }
 

--- a/cub/test/catch2_test_block_scan_api.cu
+++ b/cub/test/catch2_test_block_scan_api.cu
@@ -28,10 +28,11 @@
 #include <cub/block/block_scan.cuh>
 
 #include <thrust/detail/raw_pointer_cast.h>
-#include <thrust/device_vector.h>
-#include <thrust/host_vector.h>
 
-#include <cuda/std/numeric>
+#include <cuda/cmath>
+#include <cuda/functional>
+#include <cuda/std/__algorithm/clamp.h>
+#include <cuda/std/__algorithm/max.h>
 
 #include <c2h/catch2_test_helper.h>
 

--- a/cub/test/catch2_test_block_scan_api.cu
+++ b/cub/test/catch2_test_block_scan_api.cu
@@ -159,7 +159,7 @@ __global__ void InclusiveBlockScanPartialTileKernel(int* output)
   __shared__ temp_storage_t temp_storage;
 
   int initial_value = 1;
-  int thread_data[] = {
+  cuda::std::array<int, 2> thread_data{
     +1 * ((int) threadIdx.x * 2), // item 0
     -1 * ((int) threadIdx.x * 2 + 1) // item 1
   };
@@ -221,7 +221,7 @@ __global__ void InclusiveBlockScanPartialTileKernelAggregate(int* output, int* d
   __shared__ temp_storage_t temp_storage;
 
   int initial_value = 1;
-  int thread_data[] = {
+  cuda::std::array<int, 2> thread_data{
     +1 * ((int) threadIdx.x * 2), // item 0
     -1 * ((int) threadIdx.x * 2 + 1) // item 1
   };

--- a/cub/test/catch2_test_block_scan_partial.cu
+++ b/cub/test/catch2_test_block_scan_partial.cu
@@ -1,0 +1,677 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/block/block_scan.cuh>
+
+#include <cuda/functional>
+
+#include <climits>
+
+#include "catch2_test_block_scan_partial_helper.cuh"
+#include <c2h/catch2_test_helper.h>
+
+template <scan_mode Mode>
+struct sum_op_t
+{
+  template <int ItemsPerThread, class BlockScanT, class T>
+  __device__ void operator()(BlockScanT& scan, T (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, cuda::std::plus<>{}, valid_items);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, cuda::std::plus<>{}, valid_items);
+    }
+  }
+};
+
+template <scan_mode Mode>
+struct sum_single_op_t
+{
+  template <class BlockScanT, class T>
+  __device__ void operator()(BlockScanT& scan, T& thread_data, int valid_items) const
+  {
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, cuda::std::plus<>{}, valid_items);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, cuda::std::plus<>{}, valid_items);
+    }
+  }
+};
+
+template <class T, scan_mode Mode>
+struct min_init_value_op_t
+{
+  T initial_value;
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, T (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, initial_value, cuda::minimum<>{}, valid_items);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, initial_value, cuda::minimum<>{}, valid_items);
+    }
+  }
+};
+
+template <scan_mode Mode>
+struct min_op_t
+{
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, int (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, ::cuda::minimum<>{}, valid_items);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, ::cuda::minimum<>{}, valid_items);
+    }
+  }
+};
+
+template <class T, scan_mode Mode>
+struct min_init_value_aggregate_op_t
+{
+  int m_target_thread_id;
+  T initial_value;
+  T* m_d_block_aggregate;
+
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, T (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    T block_aggregate{};
+
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(
+        thread_data, thread_data, initial_value, ::cuda::minimum<>{}, valid_items, block_aggregate);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(
+        thread_data, thread_data, initial_value, ::cuda::minimum<>{}, valid_items, block_aggregate);
+    }
+
+    const int tid = cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z);
+
+    if (tid == m_target_thread_id)
+    {
+      *m_d_block_aggregate = block_aggregate;
+    }
+  }
+};
+
+template <class T, scan_mode Mode>
+struct sum_aggregate_op_t
+{
+  int m_target_thread_id;
+  T* m_d_block_aggregate;
+
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, T (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    T block_aggregate{};
+
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, cuda::std::plus<>{}, valid_items, block_aggregate);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, cuda::std::plus<>{}, valid_items, block_aggregate);
+    }
+
+    const int tid = static_cast<int>(cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z));
+
+    if (tid == m_target_thread_id)
+    {
+      *m_d_block_aggregate = block_aggregate;
+    }
+  }
+};
+
+template <class T, scan_mode Mode>
+struct sum_prefix_op_t
+{
+  T m_prefix;
+
+  struct block_prefix_op_t
+  {
+    int linear_tid;
+    T prefix;
+
+    __device__ block_prefix_op_t(int linear_tid, T prefix)
+        : linear_tid(linear_tid)
+        , prefix(prefix)
+    {}
+
+    __device__ T operator()(T block_aggregate)
+    {
+      T retval = (linear_tid == 0) ? prefix : T{};
+      prefix   = prefix + block_aggregate;
+      return retval;
+    }
+  };
+
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, T (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    const int tid = static_cast<int>(cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z));
+    block_prefix_op_t prefix_op{tid, m_prefix};
+
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, cuda::std::plus<>{}, valid_items, prefix_op);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, cuda::std::plus<>{}, valid_items, prefix_op);
+    }
+  }
+};
+
+template <class T, scan_mode Mode>
+struct min_prefix_op_t
+{
+  T m_prefix;
+  static constexpr T min_identity = ::cuda::std::numeric_limits<T>::max();
+
+  struct block_prefix_op_t
+  {
+    int linear_tid;
+    T prefix;
+
+    __device__ block_prefix_op_t(int linear_tid, T prefix)
+        : linear_tid(linear_tid)
+        , prefix(prefix)
+    {}
+
+    __device__ T operator()(T block_aggregate)
+    {
+      T retval = (linear_tid == 0) ? prefix : min_identity;
+      prefix   = ::cuda::minimum<>{}(prefix, block_aggregate);
+      return retval;
+    }
+  };
+
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, T (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    const int tid = static_cast<int>(cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z));
+    block_prefix_op_t prefix_op{tid, m_prefix};
+
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, ::cuda::minimum<>{}, valid_items, prefix_op);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, ::cuda::minimum<>{}, valid_items, prefix_op);
+    }
+  }
+};
+
+// %PARAM% ALGO_TYPE alg 0:1:2
+// %PARAM% TEST_MODE mode 0:1
+
+using types = c2h::type_list<std::uint8_t, std::uint16_t, std::int32_t, std::int64_t>;
+// FIXME(bgruber): uchar3 fails the test, see #3835
+using vec_types = c2h::type_list<
+#if _CCCL_CTK_AT_LEAST(13, 0)
+  ulonglong4_16a,
+#else // _CCCL_CTK_AT_LEAST(13, 0)
+  ulonglong4,
+#endif // _CCCL_CTK_AT_LEAST(13, 0)
+  /*uchar3,*/ short2>;
+using block_dim_x            = c2h::enum_type_list<int, 17, 32, 65, 96>;
+using block_dim_yz           = c2h::enum_type_list<int, 1, 2>;
+using items_per_thread       = c2h::enum_type_list<int, 1, 9>;
+using single_item_per_thread = c2h::enum_type_list<int, 1>;
+using algorithms =
+  c2h::enum_type_list<cub::BlockScanAlgorithm,
+                      cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
+                      cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS,
+                      cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING_MEMOIZE>;
+using algorithm = c2h::enum_type_list<cub::BlockScanAlgorithm, c2h::get<ALGO_TYPE, algorithms>::value>;
+
+#if TEST_MODE == 0
+using modes = c2h::enum_type_list<scan_mode, scan_mode::inclusive>;
+#else
+using modes = c2h::enum_type_list<scan_mode, scan_mode::exclusive>;
+#endif
+
+using int_gen_t = Catch::Generators::GeneratorWrapper<int>;
+
+template <typename T, int tile_size>
+int_gen_t valid_items_fixed_vals(cub::BlockScanAlgorithm algorithm, int items_per_thread) noexcept
+{
+  const int items_per_warp           = cub::detail::warp_threads * items_per_thread;
+  const int items_per_raking_segment = cub::BlockRakingLayout<T, tile_size>::SEGMENT_LENGTH;
+  const int items_per_segment =
+    algorithm == cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS ? items_per_warp : items_per_raking_segment;
+
+  using namespace Catch::Generators;
+  return values({-1, 0, 1, items_per_segment - 1, items_per_segment, items_per_segment + 1, tile_size, tile_size + 1});
+}
+int_gen_t valid_items_rand_below() noexcept
+{
+  using namespace Catch::Generators;
+  return take(1, random(cuda::std::numeric_limits<int>::min(), -2));
+}
+int_gen_t valid_items_rand_inside(int tile_size) noexcept
+{
+  using namespace Catch::Generators;
+  return take(1, random(2, cuda::std::max(tile_size - 1, 2)));
+}
+int_gen_t valid_items_rand_above(int tile_size) noexcept
+{
+  using namespace Catch::Generators;
+  return take(1, random(tile_size + 2, cuda::std::numeric_limits<int>::max()));
+}
+
+C2H_TEST("Partial block scan works with custom sum",
+         "[scan][block]",
+         types,
+         block_dim_x,
+         block_dim_yz,
+         items_per_thread,
+         algorithm,
+         modes)
+{
+  using params = params_t<TestType>;
+  using type   = typename params::type;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside(params::tile_size),
+    valid_items_rand_above(params::tile_size),
+    valid_items_fixed_vals<type, params::tile_size>(params::algorithm, params::items_per_thread));
+  c2h::device_vector<type> d_out(params::tile_size);
+  c2h::device_vector<type> d_in(params::tile_size);
+  c2h::gen(C2H_SEED(10), d_in);
+
+  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+    d_in, d_out, sum_op_t<params::mode>{}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(params::mode, h_out, std::plus<type>{}, valid_items);
+
+  REQUIRE_APPROX_EQ(h_out, d_out);
+}
+
+C2H_TEST("Partial block scan works with custom sum single",
+         "[scan][block]",
+         types,
+         block_dim_x,
+         block_dim_yz,
+         single_item_per_thread,
+         algorithm,
+         modes)
+{
+  using params = params_t<TestType>;
+  using type   = typename params::type;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside(params::tile_size),
+    valid_items_rand_above(params::tile_size),
+    valid_items_fixed_vals<type, params::tile_size>(params::algorithm, params::items_per_thread));
+  c2h::device_vector<type> d_out(params::tile_size);
+  c2h::device_vector<type> d_in(params::tile_size);
+  c2h::gen(C2H_SEED(10), d_in);
+
+  block_scan_single<params::algorithm, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+    d_in, d_out, sum_single_op_t<params::mode>{}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(params::mode, h_out, std::plus<type>{}, valid_items);
+
+  if constexpr (params::mode == scan_mode::exclusive)
+  {
+    // Undefined
+    h_out[0] = d_out[0];
+  }
+  REQUIRE_APPROX_EQ(h_out, d_out);
+}
+
+C2H_TEST("Partial block scan works with vec types", "[scan][block]", vec_types, algorithm, modes)
+{
+  constexpr int items_per_thread              = 3;
+  constexpr int block_dim_x                   = 256;
+  constexpr int block_dim_y                   = 1;
+  constexpr int block_dim_z                   = 1;
+  constexpr int tile_size                     = items_per_thread * block_dim_x * block_dim_y * block_dim_z;
+  constexpr cub::BlockScanAlgorithm algorithm = c2h::get<1, TestType>::value;
+  constexpr scan_mode mode                    = c2h::get<2, TestType>::value;
+
+  using type = typename c2h::get<0, TestType>;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside(tile_size),
+    valid_items_rand_above(tile_size),
+    valid_items_fixed_vals<type, tile_size>(algorithm, items_per_thread));
+  c2h::device_vector<type> d_out(tile_size);
+  c2h::device_vector<type> d_in(tile_size);
+  c2h::gen(C2H_SEED(10), d_in);
+  CAPTURE(valid_items, c2h::type_name<type>(), d_in);
+
+  block_scan<algorithm, items_per_thread, block_dim_x, block_dim_y, block_dim_z>(
+    d_in, d_out, sum_op_t<mode>{}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(mode, h_out, std::plus<type>{}, valid_items);
+
+  if constexpr (mode == scan_mode::exclusive)
+  {
+    // Undefined
+    h_out[0] = d_out[0];
+  }
+  REQUIRE(h_out == d_out);
+}
+
+C2H_TEST("Partial block scan works with custom types", "[scan][block]", algorithm, modes)
+{
+  constexpr int items_per_thread              = 3;
+  constexpr int block_dim_x                   = 256;
+  constexpr int block_dim_y                   = 1;
+  constexpr int block_dim_z                   = 1;
+  constexpr int tile_size                     = items_per_thread * block_dim_x * block_dim_y * block_dim_z;
+  constexpr cub::BlockScanAlgorithm algorithm = c2h::get<0, TestType>::value;
+  constexpr scan_mode mode                    = c2h::get<1, TestType>::value;
+
+  using type = c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_comparable_t>;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside(tile_size),
+    valid_items_rand_above(tile_size),
+    valid_items_fixed_vals<type, tile_size>(algorithm, items_per_thread));
+  c2h::device_vector<type> d_out(tile_size);
+  c2h::device_vector<type> d_in(tile_size);
+  c2h::gen(C2H_SEED(10), d_in);
+
+  block_scan<algorithm, items_per_thread, block_dim_x, block_dim_y, block_dim_z>(
+    d_in, d_out, sum_op_t<mode>{}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(mode, h_out, std::plus<type>{}, valid_items);
+
+  if constexpr (mode == scan_mode::exclusive)
+  {
+    // Undefined
+    h_out[0] = d_out[0];
+  }
+  REQUIRE(h_out == d_out);
+}
+
+C2H_TEST("Partial block scan returns valid block aggregate", "[scan][block]", algorithm, modes, block_dim_yz)
+{
+  constexpr int items_per_thread              = 3;
+  constexpr int block_dim_x                   = 64;
+  constexpr int block_dim_y                   = c2h::get<2, TestType>::value;
+  constexpr int block_dim_z                   = block_dim_y;
+  constexpr int threads_in_block              = block_dim_x * block_dim_y * block_dim_z;
+  constexpr int tile_size                     = items_per_thread * threads_in_block;
+  constexpr cub::BlockScanAlgorithm algorithm = c2h::get<0, TestType>::value;
+  constexpr scan_mode mode                    = c2h::get<1, TestType>::value;
+
+  using type = c2h::custom_type_t<c2h::accumulateable_t, c2h::equal_comparable_t>;
+
+  const int target_thread_id = GENERATE_COPY(take(2, random(0, threads_in_block - 1)));
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside(tile_size),
+    valid_items_rand_above(tile_size),
+    valid_items_fixed_vals<type, tile_size>(algorithm, items_per_thread));
+  c2h::device_vector<type> d_block_aggregate(1);
+  c2h::device_vector<type> d_out(tile_size);
+  c2h::device_vector<type> d_in(tile_size);
+  c2h::gen(C2H_SEED(10), d_in);
+
+  block_scan<algorithm, items_per_thread, block_dim_x, block_dim_y, block_dim_z>(
+    d_in,
+    d_out,
+    sum_aggregate_op_t<type, mode>{target_thread_id, thrust::raw_pointer_cast(d_block_aggregate.data())},
+    valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  type block_aggregate         = host_scan(mode, h_out, std::plus<type>{}, valid_items);
+
+  if constexpr (mode == scan_mode::exclusive)
+  {
+    // Undefined
+    h_out[0] = d_out[0];
+  }
+  REQUIRE(h_out == d_out);
+  if (valid_items > 0)
+  {
+    REQUIRE(block_aggregate == d_block_aggregate[0]);
+  }
+}
+
+C2H_TEST("Partial block scan supports prefix op", "[scan][block]", algorithm, modes, block_dim_yz)
+{
+  constexpr int items_per_thread              = 3;
+  constexpr int block_dim_x                   = 64;
+  constexpr int block_dim_y                   = c2h::get<2, TestType>::value;
+  constexpr int block_dim_z                   = block_dim_y;
+  constexpr int threads_in_block              = block_dim_x * block_dim_y * block_dim_z;
+  constexpr int tile_size                     = items_per_thread * threads_in_block;
+  constexpr cub::BlockScanAlgorithm algorithm = c2h::get<0, TestType>::value;
+  constexpr scan_mode mode                    = c2h::get<1, TestType>::value;
+
+  using type = int;
+
+  const type prefix = GENERATE_COPY(take(2, random(0, tile_size)));
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside(tile_size),
+    valid_items_rand_above(tile_size),
+    valid_items_fixed_vals<type, tile_size>(algorithm, items_per_thread));
+  c2h::device_vector<type> d_out(tile_size);
+  c2h::device_vector<type> d_in(tile_size);
+  c2h::gen(C2H_SEED(10), d_in);
+
+  block_scan<algorithm, items_per_thread, block_dim_x, block_dim_y, block_dim_z>(
+    d_in, d_out, sum_prefix_op_t<type, mode>{prefix}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(mode, h_out, std::plus<type>{}, valid_items, prefix);
+
+  REQUIRE(h_out == d_out);
+}
+
+C2H_TEST("Partial block scan supports custom scan op", "[scan][block]", algorithm, modes, block_dim_yz)
+{
+  constexpr int items_per_thread              = 3;
+  constexpr int block_dim_x                   = 64;
+  constexpr int block_dim_y                   = c2h::get<2, TestType>::value;
+  constexpr int block_dim_z                   = block_dim_y;
+  constexpr int threads_in_block              = block_dim_x * block_dim_y * block_dim_z;
+  constexpr int tile_size                     = items_per_thread * threads_in_block;
+  constexpr cub::BlockScanAlgorithm algorithm = c2h::get<0, TestType>::value;
+  constexpr scan_mode mode                    = c2h::get<1, TestType>::value;
+
+  using type = int;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside(tile_size),
+    valid_items_rand_above(tile_size),
+    valid_items_fixed_vals<type, tile_size>(algorithm, items_per_thread));
+  c2h::device_vector<type> d_out(tile_size);
+  c2h::device_vector<type> d_in(tile_size);
+  c2h::gen(C2H_SEED(10), d_in);
+
+  block_scan<algorithm, items_per_thread, block_dim_x, block_dim_y, block_dim_z>(
+    d_in, d_out, min_op_t<mode>{}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(
+    mode,
+    h_out,
+    [](type l, type r) {
+      return std::min(l, r);
+    },
+    valid_items,
+    INT_MAX);
+
+  if constexpr (mode == scan_mode::exclusive)
+  {
+    //! With no initial value, the output computed for *thread*\ :sub:`0` is undefined.
+    d_out.erase(d_out.begin());
+    h_out.erase(h_out.begin());
+  }
+
+  REQUIRE(h_out == d_out);
+}
+
+C2H_TEST("Partial block custom op scan works with initial value", "[scan][block]", algorithm, modes, block_dim_yz)
+{
+  constexpr int items_per_thread              = 3;
+  constexpr int block_dim_x                   = 64;
+  constexpr int block_dim_y                   = c2h::get<2, TestType>::value;
+  constexpr int block_dim_z                   = block_dim_y;
+  constexpr int threads_in_block              = block_dim_x * block_dim_y * block_dim_z;
+  constexpr int tile_size                     = items_per_thread * threads_in_block;
+  constexpr cub::BlockScanAlgorithm algorithm = c2h::get<0, TestType>::value;
+  constexpr scan_mode mode                    = c2h::get<1, TestType>::value;
+
+  using type = int;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside(tile_size),
+    valid_items_rand_above(tile_size),
+    valid_items_fixed_vals<type, tile_size>(algorithm, items_per_thread));
+  c2h::device_vector<type> d_out(tile_size);
+  c2h::device_vector<type> d_in(tile_size);
+  c2h::gen(C2H_SEED(10), d_in);
+
+  const type initial_value = static_cast<type>(GENERATE_COPY(take(2, random(0, tile_size))));
+
+  block_scan<algorithm, items_per_thread, block_dim_x, block_dim_y, block_dim_z>(
+    d_in, d_out, min_init_value_op_t<type, mode>{initial_value}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(
+    mode,
+    h_out,
+    [](type l, type r) {
+      return std::min(l, r);
+    },
+    valid_items,
+    initial_value);
+
+  REQUIRE(h_out == d_out);
+}
+
+C2H_TEST("Partial block custom op scan with initial value returns valid block aggregate",
+         "[scan][block]",
+         algorithm,
+         modes,
+         block_dim_yz)
+{
+  constexpr int items_per_thread              = 3;
+  constexpr int block_dim_x                   = 64;
+  constexpr int block_dim_y                   = c2h::get<2, TestType>::value;
+  constexpr int block_dim_z                   = block_dim_y;
+  constexpr int threads_in_block              = block_dim_x * block_dim_y * block_dim_z;
+  constexpr int tile_size                     = items_per_thread * threads_in_block;
+  constexpr cub::BlockScanAlgorithm algorithm = c2h::get<0, TestType>::value;
+  constexpr scan_mode mode                    = c2h::get<1, TestType>::value;
+
+  using type = int;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside(tile_size),
+    valid_items_rand_above(tile_size),
+    valid_items_fixed_vals<type, tile_size>(algorithm, items_per_thread));
+  c2h::device_vector<type> d_out(tile_size);
+  c2h::device_vector<type> d_in(tile_size);
+  c2h::gen(C2H_SEED(10), d_in, 0, 1);
+
+  const type initial_value = static_cast<type>(GENERATE_COPY(take(2, random(0, tile_size))));
+
+  const int target_thread_id = GENERATE_COPY(take(2, random(0, threads_in_block - 1)));
+  CAPTURE(valid_items, initial_value, target_thread_id, tile_size, d_in);
+
+  c2h::device_vector<type> d_block_aggregate(1);
+
+  block_scan<algorithm, items_per_thread, block_dim_x, block_dim_y, block_dim_z>(
+    d_in,
+    d_out,
+    min_init_value_aggregate_op_t<type, mode>{
+      target_thread_id, initial_value, thrust::raw_pointer_cast(d_block_aggregate.data())},
+    valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  type h_block_aggregate       = host_scan(
+    mode,
+    h_out,
+    [](type l, type r) {
+      return std::min(l, r);
+    },
+    valid_items,
+    initial_value);
+
+  REQUIRE(h_out == d_out);
+  if (valid_items > 0)
+  {
+    REQUIRE(h_block_aggregate == d_block_aggregate[0]);
+  }
+}
+
+C2H_TEST("Partial block scan supports prefix op and custom scan op", "[scan][block]", algorithm, modes, block_dim_yz)
+{
+  constexpr int items_per_thread              = 3;
+  constexpr int block_dim_x                   = 64;
+  constexpr int block_dim_y                   = c2h::get<2, TestType>::value;
+  constexpr int block_dim_z                   = block_dim_y;
+  constexpr int threads_in_block              = block_dim_x * block_dim_y * block_dim_z;
+  constexpr int tile_size                     = items_per_thread * threads_in_block;
+  constexpr cub::BlockScanAlgorithm algorithm = c2h::get<0, TestType>::value;
+  constexpr scan_mode mode                    = c2h::get<1, TestType>::value;
+
+  using type = int;
+
+  const type prefix = GENERATE_COPY(take(2, random(0, tile_size)));
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside(tile_size),
+    valid_items_rand_above(tile_size),
+    valid_items_fixed_vals<type, tile_size>(algorithm, items_per_thread));
+  c2h::device_vector<type> d_out(tile_size);
+  c2h::device_vector<type> d_in(tile_size);
+  c2h::gen(C2H_SEED(10), d_in);
+
+  block_scan<algorithm, items_per_thread, block_dim_x, block_dim_y, block_dim_z>(
+    d_in, d_out, min_prefix_op_t<type, mode>{prefix}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(
+    mode,
+    h_out,
+    [](type a, type b) {
+      return std::min(a, b);
+    },
+    valid_items,
+    prefix);
+
+  REQUIRE(h_out == d_out);
+}

--- a/cub/test/catch2_test_block_scan_partial_containers.cu
+++ b/cub/test/catch2_test_block_scan_partial_containers.cu
@@ -1,0 +1,492 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/block/block_scan.cuh>
+
+#include <cuda/functional>
+#include <cuda/std/array>
+#include <cuda/std/mdspan>
+#include <cuda/std/span>
+
+#include <climits>
+
+#include "catch2_test_block_scan_partial_helper.cuh"
+#include <c2h/catch2_test_helper.h>
+
+enum class container
+{
+  array,
+  span,
+  mdspan
+};
+
+template <int ItemsPerThread, int BlockDim, class T, class ActionT>
+__global__ void block_scan_kernel_array(T* in, T* out, ActionT action, int valid_items)
+{
+  using block_scan_t = cub::BlockScan<T, BlockDim>;
+  using storage_t    = typename block_scan_t::TempStorage;
+
+  __shared__ storage_t storage;
+
+  cuda::std::array<T, ItemsPerThread> thread_data;
+
+  const int tid           = static_cast<int>(cub::RowMajorTid(BlockDim, 1, 1));
+  const int thread_offset = tid * ItemsPerThread;
+
+  for (int item = 0; item < ItemsPerThread; item++)
+  {
+    const int idx     = thread_offset + item;
+    thread_data[item] = in[idx];
+  }
+
+  block_scan_t scan(storage);
+
+  action(scan, thread_data, valid_items);
+
+  for (int item = 0; item < ItemsPerThread; item++)
+  {
+    const int idx = thread_offset + item;
+    out[idx]      = thread_data[item];
+  }
+}
+
+template <int ItemsPerThread, int BlockDim, class T, class ActionT>
+__global__ void block_scan_kernel_span(T* in, T* out, ActionT action, int valid_items)
+{
+  using block_scan_t = cub::BlockScan<T, BlockDim>;
+  using storage_t    = typename block_scan_t::TempStorage;
+
+  __shared__ storage_t storage;
+
+  T thread_data[ItemsPerThread];
+
+  const int tid           = static_cast<int>(cub::RowMajorTid(BlockDim, 1, 1));
+  const int thread_offset = tid * ItemsPerThread;
+
+  for (int item = 0; item < ItemsPerThread; item++)
+  {
+    const int idx     = thread_offset + item;
+    thread_data[item] = in[idx];
+  }
+
+  block_scan_t scan(storage);
+
+  cuda::std::span<T, ItemsPerThread> span{thread_data};
+  action(scan, span, valid_items);
+
+  for (int item = 0; item < ItemsPerThread; item++)
+  {
+    const int idx = thread_offset + item;
+    out[idx]      = thread_data[item];
+  }
+}
+
+#if _CCCL_STD_VER >= 2023
+
+template <int ItemsPerThread, int BlockDim, class T, class ActionT>
+__global__ void block_scan_kernel_mdspan(T* in, T* out, ActionT action, int valid_items)
+{
+  using block_scan_t = cub::BlockScan<T, BlockDim>;
+  using storage_t    = typename block_scan_t::TempStorage;
+
+  __shared__ storage_t storage;
+
+  T thread_data[ItemsPerThread];
+
+  const int tid           = static_cast<int>(cub::RowMajorTid(BlockDim, 1, 1));
+  const int thread_offset = tid * ItemsPerThread;
+
+  for (int item = 0; item < ItemsPerThread; item++)
+  {
+    const int idx     = thread_offset + item;
+    thread_data[item] = in[idx];
+  }
+
+  block_scan_t scan(storage);
+
+  using Extents = cuda::std::extents<int, ItemsPerThread>;
+  cuda::std::mdspan<T, Extents> mdspan{thread_data, Extents{}};
+  action(scan, mdspan, valid_items);
+
+  for (int item = 0; item < ItemsPerThread; item++)
+  {
+    const int idx = thread_offset + item;
+    out[idx]      = thread_data[item];
+  }
+}
+
+#endif // _CCCL_STD_VER >= 2023
+
+template <container cont, int ItemsPerThread, int BlockDim, class T, class ActionT>
+void block_scan_container(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT action, int valid_items)
+{
+  dim3 block_dims(BlockDim);
+
+  switch (cont)
+  {
+    case container::array:
+      block_scan_kernel_array<ItemsPerThread, BlockDim, T, ActionT><<<1, block_dims>>>(
+        thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action, valid_items);
+      break;
+    case container::span:
+      block_scan_kernel_span<ItemsPerThread, BlockDim, T, ActionT><<<1, block_dims>>>(
+        thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action, valid_items);
+      break;
+#if _CCCL_STD_VER >= 2023
+    case container::mdspan:
+      block_scan_kernel_mdspan<ItemsPerThread, BlockDim, T, ActionT><<<1, block_dims>>>(
+        thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action, valid_items);
+      break;
+#endif // _CCCL_STD_VER >= 2023
+  }
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+}
+
+template <scan_mode Mode>
+struct min_op_t
+{
+  template <typename Container, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, Container& thread_data, int valid_items) const
+  {
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, ::cuda::minimum<>{}, valid_items);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, ::cuda::minimum<>{}, valid_items);
+    }
+  }
+};
+
+template <class T, scan_mode Mode>
+struct min_init_value_op_t
+{
+  T initial_value;
+  template <typename Container, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, Container& thread_data, int valid_items) const
+  {
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, initial_value, cuda::minimum<>{}, valid_items);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, initial_value, cuda::minimum<>{}, valid_items);
+    }
+  }
+};
+
+template <class T, scan_mode Mode>
+struct min_init_value_aggregate_op_t
+{
+  int m_target_thread_id;
+  T initial_value;
+  T* m_d_block_aggregate;
+
+  template <typename Container, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, Container& thread_data, int valid_items) const
+  {
+    T block_aggregate{};
+
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(
+        thread_data, thread_data, initial_value, ::cuda::minimum<>{}, valid_items, block_aggregate);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(
+        thread_data, thread_data, initial_value, ::cuda::minimum<>{}, valid_items, block_aggregate);
+    }
+
+    const int tid = cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z);
+
+    if (tid == m_target_thread_id)
+    {
+      *m_d_block_aggregate = block_aggregate;
+    }
+  }
+};
+
+template <class T, scan_mode Mode>
+struct min_aggregate_op_t
+{
+  int m_target_thread_id;
+  T* m_d_block_aggregate;
+
+  template <typename Container, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, Container& thread_data, int valid_items) const
+  {
+    T block_aggregate{};
+
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, cuda::minimum<>{}, valid_items, block_aggregate);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, cuda::minimum<>{}, valid_items, block_aggregate);
+    }
+
+    const int tid = static_cast<int>(cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z));
+
+    if (tid == m_target_thread_id)
+    {
+      *m_d_block_aggregate = block_aggregate;
+    }
+  }
+};
+
+template <class T, scan_mode Mode>
+struct min_prefix_op_t
+{
+  T m_prefix;
+  static constexpr T min_identity = ::cuda::std::numeric_limits<T>::max();
+
+  struct block_prefix_op_t
+  {
+    int linear_tid;
+    T prefix;
+
+    __device__ block_prefix_op_t(int linear_tid, T prefix)
+        : linear_tid(linear_tid)
+        , prefix(prefix)
+    {}
+
+    __device__ T operator()(T block_aggregate)
+    {
+      T retval = (linear_tid == 0) ? prefix : min_identity;
+      prefix   = ::cuda::minimum<>{}(prefix, block_aggregate);
+      return retval;
+    }
+  };
+
+  template <typename Container, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, Container& thread_data, int valid_items) const
+  {
+    const int tid = static_cast<int>(cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z));
+    block_prefix_op_t prefix_op{tid, m_prefix};
+
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, ::cuda::minimum<>{}, valid_items, prefix_op);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, ::cuda::minimum<>{}, valid_items, prefix_op);
+    }
+  }
+};
+
+// %PARAM% TEST_MODE mode 0:1
+
+#if TEST_MODE == 0
+using modes = c2h::enum_type_list<scan_mode, scan_mode::inclusive>;
+#else
+using modes = c2h::enum_type_list<scan_mode, scan_mode::exclusive>;
+#endif
+
+using containers =
+  c2h::enum_type_list<container,
+                      container::array,
+                      container::span
+#if _CCCL_STD_VER >= 2023
+                      ,
+                      container::mdspan
+#endif // _CCCL_STD_VER >= 2023
+                      >;
+
+template <class TestType>
+struct mode_params_t
+{
+  using type = int;
+
+  static constexpr int threads_in_block = 256;
+  static constexpr int items_per_thread = 3;
+  static constexpr int tile_size        = items_per_thread * threads_in_block;
+
+  static constexpr scan_mode mode = c2h::get<0, TestType>::value;
+  static constexpr container cont = c2h::get<1, TestType>::value;
+};
+
+C2H_TEST("Partial block scan supports containers", "[scan][block]", modes, containers)
+{
+  using params          = mode_params_t<TestType>;
+  using type            = typename params::type;
+  using valid_items_gen = valid_items_generators_t<params>;
+
+  const int valid_items = GENERATE_COPY(valid_items_gen::rand_inside());
+  c2h::device_vector<type> d_out(params::tile_size);
+  c2h::device_vector<type> d_in(params::tile_size);
+  c2h::gen(C2H_SEED(1), d_in);
+
+  block_scan_container<params::cont, params::items_per_thread, params::threads_in_block>(
+    d_in, d_out, min_op_t<params::mode>{}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(
+    params::mode,
+    h_out,
+    [](type l, type r) {
+      return std::min(l, r);
+    },
+    valid_items,
+    INT_MAX);
+
+  if constexpr (params::mode == scan_mode::exclusive)
+  {
+    //! With no initial value, the output computed for *thread*\ :sub:`0` is undefined.
+    d_out.erase(d_out.begin());
+    h_out.erase(h_out.begin());
+  }
+
+  REQUIRE(h_out == d_out);
+}
+
+C2H_TEST("Partial block scan supports containers and returns valid block aggregate", "[scan][block]", modes, containers)
+{
+  using params          = mode_params_t<TestType>;
+  using type            = typename params::type;
+  using valid_items_gen = valid_items_generators_t<params>;
+
+  const int target_thread_id = GENERATE_COPY(take(1, random(0, params::threads_in_block - 1)));
+
+  const int valid_items = GENERATE_COPY(valid_items_gen::rand_inside());
+  c2h::device_vector<type> d_block_aggregate(1);
+  c2h::device_vector<type> d_out(params::tile_size);
+  c2h::device_vector<type> d_in(params::tile_size);
+  c2h::gen(C2H_SEED(1), d_in);
+
+  block_scan_container<params::cont, params::items_per_thread, params::threads_in_block>(
+    d_in,
+    d_out,
+    min_aggregate_op_t<type, params::mode>{target_thread_id, thrust::raw_pointer_cast(d_block_aggregate.data())},
+    valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  type block_aggregate         = host_scan(
+    params::mode,
+    h_out,
+    [](type l, type r) {
+      return std::min(l, r);
+    },
+    valid_items,
+    INT_MAX);
+
+  if constexpr (params::mode == scan_mode::exclusive)
+  {
+    // Undefined
+    h_out[0] = d_out[0];
+  }
+  REQUIRE(h_out == d_out);
+  if (valid_items > 0)
+  {
+    REQUIRE(block_aggregate == d_block_aggregate[0]);
+  }
+}
+
+C2H_TEST("Partial block scan supports containers and works with initial value", "[scan][block]", modes, containers)
+{
+  using params          = mode_params_t<TestType>;
+  using type            = typename params::type;
+  using valid_items_gen = valid_items_generators_t<params>;
+
+  const int valid_items = GENERATE_COPY(valid_items_gen::rand_inside());
+  c2h::device_vector<type> d_out(params::tile_size);
+  c2h::device_vector<type> d_in(params::tile_size);
+  c2h::gen(C2H_SEED(1), d_in);
+
+  const auto initial_value = static_cast<type>(GENERATE_COPY(take(1, random(0, params::tile_size))));
+
+  block_scan_container<params::cont, params::items_per_thread, params::threads_in_block>(
+    d_in, d_out, min_init_value_op_t<type, params::mode>{initial_value}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(
+    params::mode,
+    h_out,
+    [](type l, type r) {
+      return std::min(l, r);
+    },
+    valid_items,
+    initial_value);
+
+  REQUIRE(h_out == d_out);
+}
+
+C2H_TEST("Partial block scan with initial value supports containers and returns valid block aggregate",
+         "[scan][block]",
+         modes,
+         containers)
+{
+  using params          = mode_params_t<TestType>;
+  using type            = typename params::type;
+  using valid_items_gen = valid_items_generators_t<params>;
+
+  const int valid_items = GENERATE_COPY(valid_items_gen::rand_above());
+  c2h::device_vector<type> d_out(params::tile_size);
+  c2h::device_vector<type> d_in(params::tile_size);
+  c2h::gen(C2H_SEED(1), d_in, 0, 1);
+
+  const auto initial_value = static_cast<type>(GENERATE_COPY(take(2, random(0, params::tile_size))));
+
+  const int target_thread_id = GENERATE_COPY(take(1, random(0, params::threads_in_block - 1)));
+  CAPTURE(valid_items, initial_value, target_thread_id, params::tile_size, d_in);
+
+  c2h::device_vector<type> d_block_aggregate(1);
+
+  block_scan_container<params::cont, params::items_per_thread, params::threads_in_block>(
+    d_in,
+    d_out,
+    min_init_value_aggregate_op_t<type, params::mode>{
+      target_thread_id, initial_value, thrust::raw_pointer_cast(d_block_aggregate.data())},
+    valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  type h_block_aggregate       = host_scan(
+    params::mode,
+    h_out,
+    [](type l, type r) {
+      return std::min(l, r);
+    },
+    valid_items,
+    initial_value);
+
+  REQUIRE(h_out == d_out);
+  if (valid_items > 0)
+  {
+    REQUIRE(h_block_aggregate == d_block_aggregate[0]);
+  }
+}
+
+C2H_TEST("Partial block scan supports prefix op and containers", "[scan][block]", modes, containers)
+{
+  using params          = mode_params_t<TestType>;
+  using type            = typename params::type;
+  using valid_items_gen = valid_items_generators_t<params>;
+
+  const type prefix = GENERATE_COPY(take(1, random(0, params::tile_size)));
+
+  const int valid_items = GENERATE_COPY(valid_items_gen::rand_inside());
+  c2h::device_vector<type> d_out(params::tile_size);
+  c2h::device_vector<type> d_in(params::tile_size);
+  c2h::gen(C2H_SEED(1), d_in);
+
+  block_scan_container<params::cont, params::items_per_thread, params::threads_in_block>(
+    d_in, d_out, min_prefix_op_t<type, params::mode>{prefix}, valid_items);
+
+  c2h::host_vector<type> h_out = d_in;
+  host_scan(
+    params::mode,
+    h_out,
+    [](type a, type b) {
+      return std::min(a, b);
+    },
+    valid_items,
+    prefix);
+
+  REQUIRE(h_out == d_out);
+}

--- a/cub/test/catch2_test_block_scan_partial_helper.cuh
+++ b/cub/test/catch2_test_block_scan_partial_helper.cuh
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+#include <cub/block/block_scan.cuh>
+
+#include <cuda/functional>
+
+#include <climits>
+
+#include <c2h/catch2_test_helper.h>
+
+template <cub::BlockScanAlgorithm Algorithm,
+          int ItemsPerThread,
+          int BlockDimX,
+          int BlockDimY,
+          int BlockDimZ,
+          class T,
+          class ActionT>
+__global__ void block_scan_kernel(T* in, T* out, ActionT action, int valid_items)
+{
+  using block_scan_t = cub::BlockScan<T, BlockDimX, Algorithm, BlockDimY, BlockDimZ>;
+  using storage_t    = typename block_scan_t::TempStorage;
+
+  __shared__ storage_t storage;
+
+  T thread_data[ItemsPerThread];
+
+  const int tid           = static_cast<int>(cub::RowMajorTid(BlockDimX, BlockDimY, BlockDimZ));
+  const int thread_offset = tid * ItemsPerThread;
+
+  for (int item = 0; item < ItemsPerThread; item++)
+  {
+    const int idx     = thread_offset + item;
+    thread_data[item] = in[idx];
+  }
+  __syncthreads();
+
+  block_scan_t scan(storage);
+
+  action(scan, thread_data, valid_items);
+
+  for (int item = 0; item < ItemsPerThread; item++)
+  {
+    const int idx = thread_offset + item;
+    out[idx]      = thread_data[item];
+  }
+}
+
+template <cub::BlockScanAlgorithm Algorithm, int BlockDimX, int BlockDimY, int BlockDimZ, class T, class ActionT>
+__global__ void block_scan_single_kernel(T* in, T* out, ActionT action, int valid_items)
+{
+  using block_scan_t = cub::BlockScan<T, BlockDimX, Algorithm, BlockDimY, BlockDimZ>;
+  using storage_t    = typename block_scan_t::TempStorage;
+
+  __shared__ storage_t storage;
+
+  const int tid = static_cast<int>(cub::RowMajorTid(BlockDimX, BlockDimY, BlockDimZ));
+
+  T thread_data = in[tid];
+
+  block_scan_t scan(storage);
+
+  action(scan, thread_data, valid_items);
+
+  out[tid] = thread_data;
+}
+
+template <cub::BlockScanAlgorithm Algorithm,
+          int ItemsPerThread,
+          int BlockDimX,
+          int BlockDimY,
+          int BlockDimZ,
+          class T,
+          class ActionT>
+void block_scan(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT action, int valid_items)
+{
+  dim3 block_dims(BlockDimX, BlockDimY, BlockDimZ);
+
+  block_scan_kernel<Algorithm, ItemsPerThread, BlockDimX, BlockDimY, BlockDimZ, T, ActionT>
+    <<<1, block_dims>>>(thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action, valid_items);
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+}
+
+template <cub::BlockScanAlgorithm Algorithm, int BlockDimX, int BlockDimY, int BlockDimZ, class T, class ActionT>
+void block_scan_single(c2h::device_vector<T>& in, c2h::device_vector<T>& out, ActionT action, int valid_items)
+{
+  dim3 block_dims(BlockDimX, BlockDimY, BlockDimZ);
+
+  block_scan_single_kernel<Algorithm, BlockDimX, BlockDimY, BlockDimZ, T, ActionT>
+    <<<1, block_dims>>>(thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), action, valid_items);
+
+  REQUIRE(cudaSuccess == cudaPeekAtLastError());
+  REQUIRE(cudaSuccess == cudaDeviceSynchronize());
+}
+
+enum class scan_mode
+{
+  exclusive,
+  inclusive
+};
+
+template <class T, class ScanOpT>
+T host_scan(scan_mode mode, c2h::host_vector<T>& result, ScanOpT scan_op, int valid_items, T initial_value = T{})
+{
+  if (result.empty())
+  {
+    return {};
+  }
+
+  T accumulator       = static_cast<T>(scan_op(initial_value, result[0]));
+  T block_accumulator = result[0];
+
+  if (mode == scan_mode::exclusive)
+  {
+    if (valid_items > 0)
+    {
+      result[0] = initial_value;
+    }
+
+    for (int i = 1; i < cuda::std::clamp(valid_items, 0, static_cast<int>(result.size())); i++)
+    {
+      T tmp             = result[i];
+      result[i]         = accumulator;
+      accumulator       = static_cast<T>(scan_op(accumulator, tmp));
+      block_accumulator = static_cast<T>(scan_op(block_accumulator, tmp));
+    }
+  }
+  else
+  {
+    if (valid_items > 0)
+    {
+      result[0] = accumulator;
+    }
+
+    for (int i = 1; i < cuda::std::clamp(valid_items, 0, static_cast<int>(result.size())); i++)
+    {
+      accumulator       = static_cast<T>(scan_op(accumulator, result[i]));
+      block_accumulator = static_cast<T>(scan_op(block_accumulator, result[i]));
+      result[i]         = accumulator;
+    }
+  }
+
+  return block_accumulator;
+}
+
+template <class TestType>
+struct params_t
+{
+  using type = typename c2h::get<0, TestType>;
+
+  static constexpr int block_dim_x      = c2h::get<1, TestType>::value;
+  static constexpr int block_dim_y      = c2h::get<2, TestType>::value;
+  static constexpr int block_dim_z      = block_dim_y;
+  static constexpr int threads_in_block = block_dim_x * block_dim_y * block_dim_z;
+  static constexpr int items_per_thread = c2h::get<3, TestType>::value;
+  static constexpr int tile_size        = items_per_thread * threads_in_block;
+
+  static constexpr cub::BlockScanAlgorithm algorithm = c2h::get<4, TestType>::value;
+  static constexpr scan_mode mode                    = c2h::get<5, TestType>::value;
+};

--- a/cub/test/catch2_test_block_scan_partial_helper.cuh
+++ b/cub/test/catch2_test_block_scan_partial_helper.cuh
@@ -35,7 +35,6 @@ __global__ void block_scan_kernel(T* in, T* out, ActionT action, int valid_items
     const int idx     = thread_offset + item;
     thread_data[item] = in[idx];
   }
-  __syncthreads();
 
   block_scan_t scan(storage);
 

--- a/cub/test/catch2_test_block_scan_partial_helper.cuh
+++ b/cub/test/catch2_test_block_scan_partial_helper.cuh
@@ -159,6 +159,6 @@ struct params_t
   static constexpr int items_per_thread = c2h::get<3, TestType>::value;
   static constexpr int tile_size        = items_per_thread * threads_in_block;
 
-  static constexpr cub::BlockScanAlgorithm algorithm = c2h::get<4, TestType>::value;
-  static constexpr scan_mode mode                    = c2h::get<5, TestType>::value;
+  static constexpr cub::BlockScanAlgorithm algo = c2h::get<4, TestType>::value;
+  static constexpr scan_mode mode               = c2h::get<5, TestType>::value;
 };

--- a/cub/test/catch2_test_block_scan_partial_invalid.cu
+++ b/cub/test/catch2_test_block_scan_partial_invalid.cu
@@ -204,7 +204,7 @@ int_gen_t valid_items_fixed_vals() noexcept
   const int items_per_warp           = cub::detail::warp_threads * Params::items_per_thread;
   const int items_per_raking_segment = cub::BlockRakingLayout<typename Params::type, Params::tile_size>::SEGMENT_LENGTH;
   const int items_per_segment =
-    Params::algorithm == cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS ? items_per_warp : items_per_raking_segment;
+    Params::algo == cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS ? items_per_warp : items_per_raking_segment;
 
   using namespace Catch::Generators;
   return values(
@@ -265,7 +265,7 @@ C2H_TEST("Partial block scan (single) does not apply op to invalid items",
   thrust::copy(in_it, in_it + bounded_valid_items, d_in.begin());
 
   c2h::device_vector<bool> error_flag(1);
-  block_scan_single<params::algorithm, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+  block_scan_single<params::algo, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
     d_in, d_out, merge_single_op_t<params::mode>{thrust::raw_pointer_cast(error_flag.data())}, valid_items);
   REQUIRE(false == error_flag.front());
 
@@ -306,7 +306,7 @@ C2H_TEST("Partial block scan (multi) does not apply op to invalid elements",
   thrust::copy(in_it, in_it + bounded_valid_items, d_in.begin());
 
   c2h::device_vector<bool> error_flag(1);
-  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+  block_scan<params::algo, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
     d_in, d_out, merge_op_t<params::mode>{thrust::raw_pointer_cast(error_flag.data())}, valid_items);
   REQUIRE(false == error_flag.front());
 
@@ -351,7 +351,7 @@ C2H_TEST("Partial block scan (multi) does not apply op to invalid elements and r
   thrust::copy(in_it, in_it + bounded_valid_items, d_in.begin());
 
   c2h::device_vector<bool> error_flag(1);
-  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+  block_scan<params::algo, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
     d_in,
     d_out,
     merge_aggregate_op_t<params::mode>{
@@ -402,7 +402,7 @@ C2H_TEST("Partial block scan (multi) does not apply op to invalid elements and w
   const segment initial_value = segment{0, 1};
 
   c2h::device_vector<bool> error_flag(1);
-  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+  block_scan<params::algo, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
     d_in,
     d_out,
     merge_init_value_op_t<params::mode>{initial_value, thrust::raw_pointer_cast(error_flag.data())},
@@ -449,7 +449,7 @@ C2H_TEST("Partial block scan (multi) with initial value does not apply op to inv
   c2h::device_vector<segment> d_block_aggregate(1);
 
   c2h::device_vector<bool> error_flag(1);
-  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+  block_scan<params::algo, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
     d_in,
     d_out,
     merge_init_value_aggregate_op_t<params::mode>{
@@ -499,7 +499,7 @@ C2H_TEST("Partial block scan (multi) supports prefix op and does not apply op to
   thrust::copy(in_it, in_it + bounded_valid_items, d_in.begin());
 
   c2h::device_vector<bool> error_flag(1);
-  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+  block_scan<params::algo, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
     d_in, d_out, merge_prefix_op_t<params::mode>{prefix, thrust::raw_pointer_cast(error_flag.data())}, valid_items);
   REQUIRE(false == error_flag.front());
 

--- a/cub/test/catch2_test_block_scan_partial_invalid.cu
+++ b/cub/test/catch2_test_block_scan_partial_invalid.cu
@@ -1,0 +1,510 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <cub/block/block_scan.cuh>
+
+#include <cuda/functional>
+
+#include <climits>
+
+#include "catch2_test_block_scan_partial_helper.cuh"
+#include "thread_reduce/catch2_test_thread_reduce_helper.cuh"
+#include <c2h/catch2_test_helper.h>
+
+template <scan_mode Mode>
+struct merge_op_t
+{
+  bool* error_flag_ptr;
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, segment (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, merge_segments_op{error_flag_ptr}, valid_items);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, merge_segments_op{error_flag_ptr}, valid_items);
+    }
+  }
+};
+
+template <scan_mode Mode>
+struct merge_single_op_t
+{
+  bool* error_flag_ptr;
+
+  template <class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, segment& thread_data, int valid_items) const
+  {
+    merge_segments_op merge_op{error_flag_ptr};
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, merge_op, valid_items);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, merge_op, valid_items);
+    }
+  }
+};
+
+template <scan_mode Mode>
+struct merge_init_value_op_t
+{
+  segment initial_value;
+  bool* error_flag_ptr;
+
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, segment (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    merge_segments_op merge_op{error_flag_ptr};
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, initial_value, merge_op, valid_items);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, initial_value, merge_op, valid_items);
+    }
+  }
+};
+
+template <scan_mode Mode>
+struct merge_init_value_aggregate_op_t
+{
+  int m_target_thread_id;
+  segment initial_value;
+  segment* m_d_block_aggregate;
+  bool* error_flag_ptr;
+
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, segment (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    segment block_aggregate{};
+    merge_segments_op merge_op{error_flag_ptr};
+
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, initial_value, merge_op, valid_items, block_aggregate);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, initial_value, merge_op, valid_items, block_aggregate);
+    }
+
+    const int tid = cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z);
+
+    if (tid == m_target_thread_id)
+    {
+      *m_d_block_aggregate = block_aggregate;
+    }
+  }
+};
+
+template <scan_mode Mode>
+struct merge_aggregate_op_t
+{
+  int m_target_thread_id;
+  segment* m_d_block_aggregate;
+  bool* error_flag_ptr;
+
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, segment (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    segment block_aggregate{};
+    merge_segments_op merge_op{error_flag_ptr};
+
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, merge_op, valid_items, block_aggregate);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, merge_op, valid_items, block_aggregate);
+    }
+
+    const int tid = static_cast<int>(cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z));
+
+    if (tid == m_target_thread_id)
+    {
+      *m_d_block_aggregate = block_aggregate;
+    }
+  }
+};
+
+template <scan_mode Mode>
+struct merge_prefix_op_t
+{
+  segment m_prefix;
+  bool* error_flag_ptr;
+
+  struct block_prefix_op_t
+  {
+    int linear_tid;
+    segment prefix;
+    int valid_items;
+    bool* error_flag_ptr;
+
+    __device__ segment operator()(segment block_aggregate)
+    {
+      segment retval = (linear_tid == 0) ? prefix : segment{};
+      if (linear_tid == 0 && valid_items > 0)
+      {
+        prefix = merge_segments_op{error_flag_ptr}(prefix, block_aggregate);
+      }
+      return retval;
+    }
+  };
+
+  template <int ItemsPerThread, class BlockScanT>
+  __device__ void operator()(BlockScanT& scan, segment (&thread_data)[ItemsPerThread], int valid_items) const
+  {
+    const int tid = static_cast<int>(cub::RowMajorTid(blockDim.x, blockDim.y, blockDim.z));
+    block_prefix_op_t prefix_op{tid, m_prefix, valid_items, error_flag_ptr};
+    merge_segments_op merge_op{error_flag_ptr};
+
+    if constexpr (Mode == scan_mode::exclusive)
+    {
+      scan.ExclusiveScanPartialTile(thread_data, thread_data, merge_op, valid_items, prefix_op);
+    }
+    else
+    {
+      scan.InclusiveScanPartialTile(thread_data, thread_data, merge_op, valid_items, prefix_op);
+    }
+  }
+};
+
+// %PARAM% ALGO_TYPE alg 0:1:2
+// %PARAM% TEST_MODE mode 0:1
+
+using invalid_types          = c2h::type_list<segment>;
+using block_dim_x            = c2h::enum_type_list<int, 17, 32, 65, 96>;
+using block_dim_yz           = c2h::enum_type_list<int, 1, 2>;
+using items_per_thread       = c2h::enum_type_list<int, 1, 9>;
+using single_item_per_thread = c2h::enum_type_list<int, 1>;
+using algorithms =
+  c2h::enum_type_list<cub::BlockScanAlgorithm,
+                      cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING,
+                      cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS,
+                      cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING_MEMOIZE>;
+using algorithm = c2h::enum_type_list<cub::BlockScanAlgorithm, c2h::get<ALGO_TYPE, algorithms>::value>;
+
+#if TEST_MODE == 0
+using modes = c2h::enum_type_list<scan_mode, scan_mode::inclusive>;
+#else
+using modes = c2h::enum_type_list<scan_mode, scan_mode::exclusive>;
+#endif
+
+using int_gen_t = Catch::Generators::GeneratorWrapper<int>;
+
+template <typename Params>
+int_gen_t valid_items_fixed_vals() noexcept
+{
+  const int items_per_warp           = cub::detail::warp_threads * Params::items_per_thread;
+  const int items_per_raking_segment = cub::BlockRakingLayout<typename Params::type, Params::tile_size>::SEGMENT_LENGTH;
+  const int items_per_segment =
+    Params::algorithm == cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS ? items_per_warp : items_per_raking_segment;
+
+  using namespace Catch::Generators;
+  return values(
+    {-1,
+     0,
+     1,
+     items_per_segment - 1,
+     items_per_segment,
+     items_per_segment + 1,
+     Params::tile_size,
+     Params::tile_size + 1});
+}
+
+int_gen_t valid_items_rand_below() noexcept
+{
+  using namespace Catch::Generators;
+  return take(1, random(cuda::std::numeric_limits<int>::min(), -2));
+}
+
+template <typename Params>
+int_gen_t valid_items_rand_inside() noexcept
+{
+  using namespace Catch::Generators;
+  return take(1, random(2, cuda::std::max(Params::tile_size - 1, 2)));
+}
+
+template <typename Params>
+int_gen_t valid_items_rand_above() noexcept
+{
+  using namespace Catch::Generators;
+  return take(1, random(Params::tile_size + 2, cuda::std::numeric_limits<int>::max()));
+}
+
+C2H_TEST("Partial block scan (single) does not apply op to invalid items",
+         "[scan][block]",
+         invalid_types,
+         block_dim_x,
+         block_dim_yz,
+         single_item_per_thread,
+         algorithm,
+         modes)
+{
+  using params = params_t<TestType>;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside<params>(),
+    valid_items_rand_above<params>(),
+    valid_items_fixed_vals<params>());
+  const int bounded_valid_items = cuda::std::clamp(valid_items, 0, params::tile_size);
+  CAPTURE(params::tile_size, valid_items);
+  c2h::device_vector<segment> d_out(params::tile_size);
+  c2h::device_vector<segment> d_in(params::tile_size);
+  const auto in_it = cuda::make_transform_iterator(
+    thrust::make_zip_iterator(cuda::counting_iterator<segment::offset_t>{1},
+                              cuda::counting_iterator<segment::offset_t>{2}),
+    tuple_to_segment_op{});
+  thrust::copy(in_it, in_it + bounded_valid_items, d_in.begin());
+
+  c2h::device_vector<bool> error_flag(1);
+  block_scan_single<params::algorithm, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+    d_in, d_out, merge_single_op_t<params::mode>{thrust::raw_pointer_cast(error_flag.data())}, valid_items);
+  REQUIRE(false == error_flag.front());
+
+  c2h::host_vector<segment> h_out = d_in;
+  host_scan(params::mode, h_out, merge_segments_op{}, valid_items, segment{1, 1});
+
+  if constexpr (params::mode == scan_mode::exclusive)
+  {
+    //! With no initial value, the output computed for *thread*\ :sub:`0` is undefined.
+    h_out[0] = d_out[0];
+  }
+  REQUIRE(h_out == d_out);
+}
+
+C2H_TEST("Partial block scan (multi) does not apply op to invalid elements",
+         "[scan][block]",
+         invalid_types,
+         block_dim_x,
+         block_dim_yz,
+         items_per_thread,
+         algorithm,
+         modes)
+{
+  using params = params_t<TestType>;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside<params>(),
+    valid_items_rand_above<params>(),
+    valid_items_fixed_vals<params>());
+  const int bounded_valid_items = cuda::std::clamp(valid_items, 0, params::tile_size);
+  c2h::device_vector<segment> d_out(params::tile_size);
+  c2h::device_vector<segment> d_in(params::tile_size);
+  const auto in_it = cuda::make_transform_iterator(
+    thrust::make_zip_iterator(cuda::counting_iterator<segment::offset_t>{1},
+                              cuda::counting_iterator<segment::offset_t>{2}),
+    tuple_to_segment_op{});
+  thrust::copy(in_it, in_it + bounded_valid_items, d_in.begin());
+
+  c2h::device_vector<bool> error_flag(1);
+  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+    d_in, d_out, merge_op_t<params::mode>{thrust::raw_pointer_cast(error_flag.data())}, valid_items);
+  REQUIRE(false == error_flag.front());
+
+  c2h::host_vector<segment> h_out = d_in;
+  host_scan(params::mode, h_out, merge_segments_op{}, valid_items, segment{1, 1});
+
+  if constexpr (params::mode == scan_mode::exclusive)
+  {
+    //! With no initial value, the output computed for *thread*\ :sub:`0` is undefined.
+    h_out[0] = d_out[0];
+  }
+
+  REQUIRE(h_out == d_out);
+}
+
+C2H_TEST("Partial block scan (multi) does not apply op to invalid elements and returns valid block aggregate",
+         "[scan][block]",
+         invalid_types,
+         block_dim_x,
+         block_dim_yz,
+         items_per_thread,
+         algorithm,
+         modes)
+{
+  using params = params_t<TestType>;
+
+  const int target_thread_id = GENERATE_COPY(take(2, random(0, params::threads_in_block - 1)));
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside<params>(),
+    valid_items_rand_above<params>(),
+    valid_items_fixed_vals<params>());
+  const int bounded_valid_items = cuda::std::clamp(valid_items, 0, params::tile_size);
+  c2h::device_vector<segment> d_block_aggregate(1);
+  c2h::device_vector<segment> d_out(params::tile_size);
+  c2h::device_vector<segment> d_in(params::tile_size);
+  const auto in_it = cuda::make_transform_iterator(
+    thrust::make_zip_iterator(cuda::counting_iterator<segment::offset_t>{1},
+                              cuda::counting_iterator<segment::offset_t>{2}),
+    tuple_to_segment_op{});
+  thrust::copy(in_it, in_it + bounded_valid_items, d_in.begin());
+
+  c2h::device_vector<bool> error_flag(1);
+  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+    d_in,
+    d_out,
+    merge_aggregate_op_t<params::mode>{
+      target_thread_id, thrust::raw_pointer_cast(d_block_aggregate.data()), thrust::raw_pointer_cast(error_flag.data())},
+    valid_items);
+  REQUIRE(false == error_flag.front());
+
+  c2h::host_vector<segment> h_out = d_in;
+  segment block_aggregate         = host_scan(params::mode, h_out, merge_segments_op{}, valid_items, segment{1, 1});
+
+  if constexpr (params::mode == scan_mode::exclusive)
+  {
+    //! With no initial value, the output computed for *thread*\ :sub:`0` is undefined.
+    h_out[0] = d_out[0];
+  }
+  REQUIRE(h_out == d_out);
+  if (valid_items > 0)
+  {
+    REQUIRE(block_aggregate == d_block_aggregate[0]);
+  }
+}
+
+C2H_TEST("Partial block scan (multi) does not apply op to invalid elements and works with initial value",
+         "[scan][block]",
+         invalid_types,
+         block_dim_x,
+         block_dim_yz,
+         items_per_thread,
+         algorithm,
+         modes)
+{
+  using params = params_t<TestType>;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside<params>(),
+    valid_items_rand_above<params>(),
+    valid_items_fixed_vals<params>());
+  const int bounded_valid_items = cuda::std::clamp(valid_items, 0, params::tile_size);
+  c2h::device_vector<segment> d_out(params::tile_size);
+  c2h::device_vector<segment> d_in(params::tile_size);
+  const auto in_it = cuda::make_transform_iterator(
+    thrust::make_zip_iterator(cuda::counting_iterator<segment::offset_t>{1},
+                              cuda::counting_iterator<segment::offset_t>{2}),
+    tuple_to_segment_op{});
+  thrust::copy(in_it, in_it + bounded_valid_items, d_in.begin());
+
+  const segment initial_value = segment{0, 1};
+
+  c2h::device_vector<bool> error_flag(1);
+  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+    d_in,
+    d_out,
+    merge_init_value_op_t<params::mode>{initial_value, thrust::raw_pointer_cast(error_flag.data())},
+    valid_items);
+  REQUIRE(false == error_flag.front());
+
+  c2h::host_vector<segment> h_out = d_in;
+  host_scan(params::mode, h_out, merge_segments_op{}, valid_items, initial_value);
+
+  REQUIRE(h_out == d_out);
+}
+
+C2H_TEST("Partial block scan (multi) with initial value does not apply op to invalid elements and returns valid block "
+         "aggregate",
+         "[scan][block]",
+         invalid_types,
+         block_dim_x,
+         block_dim_yz,
+         items_per_thread,
+         algorithm,
+         modes)
+{
+  using params = params_t<TestType>;
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside<params>(),
+    valid_items_rand_above<params>(),
+    valid_items_fixed_vals<params>());
+  const int bounded_valid_items = cuda::std::clamp(valid_items, 0, params::tile_size);
+  c2h::device_vector<segment> d_out(params::tile_size);
+  c2h::device_vector<segment> d_in(params::tile_size);
+  const auto in_it = cuda::make_transform_iterator(
+    thrust::make_zip_iterator(cuda::counting_iterator<segment::offset_t>{1},
+                              cuda::counting_iterator<segment::offset_t>{2}),
+    tuple_to_segment_op{});
+  thrust::copy(in_it, in_it + bounded_valid_items, d_in.begin());
+
+  const segment initial_value = segment{0, 1};
+
+  const int target_thread_id = GENERATE_COPY(take(2, random(0, params::threads_in_block - 1)));
+  CAPTURE(valid_items, initial_value, target_thread_id, params::tile_size);
+
+  c2h::device_vector<segment> d_block_aggregate(1);
+
+  c2h::device_vector<bool> error_flag(1);
+  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+    d_in,
+    d_out,
+    merge_init_value_aggregate_op_t<params::mode>{
+      target_thread_id,
+      initial_value,
+      thrust::raw_pointer_cast(d_block_aggregate.data()),
+      thrust::raw_pointer_cast(error_flag.data())},
+    valid_items);
+  REQUIRE(false == error_flag.front());
+
+  c2h::host_vector<segment> h_out = d_in;
+  segment h_block_aggregate       = host_scan(params::mode, h_out, merge_segments_op{}, valid_items, initial_value);
+
+  REQUIRE(h_out == d_out);
+  if (valid_items > 0)
+  {
+    REQUIRE(h_block_aggregate == d_block_aggregate[0]);
+  }
+}
+
+C2H_TEST("Partial block scan (multi) supports prefix op and does not apply op to invalid items",
+         "[scan][block]",
+         invalid_types,
+         block_dim_x,
+         block_dim_yz,
+         items_per_thread,
+         algorithm,
+         modes)
+{
+  using params = params_t<TestType>;
+
+  const segment prefix = segment{0, 1};
+
+  const int valid_items = GENERATE_COPY(
+    valid_items_rand_below(),
+    valid_items_rand_inside<params>(),
+    valid_items_rand_above<params>(),
+    valid_items_fixed_vals<params>());
+  const int bounded_valid_items = cuda::std::clamp(valid_items, 0, params::tile_size);
+  CAPTURE(params::tile_size, valid_items);
+  c2h::device_vector<segment> d_out(params::tile_size);
+  c2h::device_vector<segment> d_in(params::tile_size);
+  const auto in_it = cuda::make_transform_iterator(
+    thrust::make_zip_iterator(cuda::counting_iterator<segment::offset_t>{1},
+                              cuda::counting_iterator<segment::offset_t>{2}),
+    tuple_to_segment_op{});
+  thrust::copy(in_it, in_it + bounded_valid_items, d_in.begin());
+
+  c2h::device_vector<bool> error_flag(1);
+  block_scan<params::algorithm, params::items_per_thread, params::block_dim_x, params::block_dim_y, params::block_dim_z>(
+    d_in, d_out, merge_prefix_op_t<params::mode>{prefix, thrust::raw_pointer_cast(error_flag.data())}, valid_items);
+  REQUIRE(false == error_flag.front());
+
+  c2h::host_vector<segment> h_out = d_in;
+  host_scan(params::mode, h_out, merge_segments_op{}, valid_items, prefix);
+
+  REQUIRE(h_out == d_out);
+}

--- a/cub/test/catch2_test_device_scan_invalid.cu
+++ b/cub/test/catch2_test_device_scan_invalid.cu
@@ -141,7 +141,7 @@ struct merge_segments_op
 };
 
 // Expected to fail for the current implementation.
-C2H_TEST("Device scan avoids invalid data with all device interfaces", "[scan][device][!mayfail]", element_types)
+C2H_TEST("Device scan avoids invalid data with all device interfaces", "[scan][device]", element_types)
 {
   using input_t  = c2h::get<0, TestType>;
   using output_t = input_t;


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #5017

<!-- Provide a standalone description of changes in this PR. -->
Fixes all root causes identified in #5019

TODO:

- [x] Fix all root causes
- [x] Remove `mayfail` from existing test 
- [x] Benchmark
- [x] Go back to old implementation for known side-effect-free scan operators on arithmetic types (can't introduce side effects through operator overloading).
- [ ] Decide which fixes to apply independent of knowledge of the operator for perf and readability benefits.
- [ ] Re-Tune?
- [ ] Change base branch to main and rebase onto main once #5433 has been merged
- ~~Expand invalid-items tests to regular block and warp scan interfaces instead of only the new `Partial[Tile]` ones.~~ (out of scope for this PR)

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
