### PR TITLE
Implement `cuda::complex`

### DIFF
--- a/libcudacxx/include/cuda/__complex/complex.h
+++ b/libcudacxx/include/cuda/__complex/complex.h
@@ -70,11 +70,11 @@ public:
   //!
   //! @tparam _Up The type of the other complex number.
   //! @param __other The other complex number.
-  _CCCL_TEMPLATE(class _Up)
+  _CCCL_TEMPLATE(class _Up, class _UpValT = typename _Up::value_type)
   _CCCL_REQUIRES(__is_any_complex_v<_Up> _CCCL_AND //
                  ::cuda::std::__is_fp_v<_Tp> _CCCL_AND //
-                 ::cuda::std::__is_fp_v<typename _Up::value_type> _CCCL_AND //
-                 ::cuda::std::__fp_is_implicit_conversion_v<typename _Up::value_type, _Tp>)
+                 ::cuda::std::__is_fp_v<_UpValT> _CCCL_AND //
+                 ::cuda::std::__fp_is_implicit_conversion_v<_UpValT, _Tp>)
   _CCCL_API constexpr complex(const _Up& __other) noexcept
       : __re_{static_cast<_Tp>(::cuda::__get_real(__other))}
       , __im_{static_cast<_Tp>(::cuda::__get_imag(__other))}
@@ -84,11 +84,11 @@ public:
   //!
   //! @tparam _Up The type of the other complex number.
   //! @param __other The other complex number.
-  _CCCL_TEMPLATE(class _Up)
+  _CCCL_TEMPLATE(class _Up, class _UpValT = typename _Up::value_type)
   _CCCL_REQUIRES(__is_any_complex_v<_Up> _CCCL_AND //
                  ::cuda::std::__is_fp_v<_Tp> _CCCL_AND //
-                 ::cuda::std::__is_fp_v<typename _Up::value_type> _CCCL_AND //
-                 ::cuda::std::__fp_is_explicit_conversion_v<typename _Up::value_type, _Tp>)
+                 ::cuda::std::__is_fp_v<_UpValT> _CCCL_AND //
+                 ::cuda::std::__fp_is_explicit_conversion_v<_UpValT, _Tp>)
   _CCCL_API explicit constexpr complex(const _Up& __other) noexcept
       : __re_{static_cast<_Tp>(::cuda::__get_real(__other))}
       , __im_{static_cast<_Tp>(::cuda::__get_imag(__other))}
@@ -98,9 +98,9 @@ public:
   //!
   //! @tparam _Up The type of the other complex number.
   //! @param __other The other complex number.
-  _CCCL_TEMPLATE(class _Up)
+  _CCCL_TEMPLATE(class _Up, class _UpValT = typename _Up::value_type)
   _CCCL_REQUIRES(__is_any_complex_v<_Up> _CCCL_AND //
-                 (!::cuda::std::__is_fp_v<_Tp> || !::cuda::std::__is_fp_v<typename _Up::value_type>))
+                 (!::cuda::std::__is_fp_v<_Tp> || !::cuda::std::__is_fp_v<_UpValT>))
   _CCCL_API constexpr complex(const _Up& __other) noexcept
       : __re_{static_cast<_Tp>(::cuda::__get_real(__other))}
       , __im_{static_cast<_Tp>(::cuda::__get_imag(__other))}

--- a/libcudacxx/include/cuda/__complex/complex.h
+++ b/libcudacxx/include/cuda/__complex/complex.h
@@ -1,0 +1,237 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___COMPLEX_COMPLEX_H
+#define _CUDA___COMPLEX_COMPLEX_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__complex/get_real_imag.h>
+#include <cuda/__complex/traits.h>
+#include <cuda/__fwd/complex.h>
+#include <cuda/std/__complex/complex.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__floating_point/conversion_rank_order.h>
+#include <cuda/std/__floating_point/traits.h>
+#include <cuda/std/__type_traits/is_same.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+//! @brief Class representing a complex number.
+//!
+//! @tparam _Tp The type of the real and imaginary parts. Must be a NumericType.
+//!
+//! @note Compared to std::complex, this type is trivially default constructible and is aligned to 2 * sizeof(_Tp).
+template <class _Tp>
+class _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_ALIGNAS(2 * sizeof(_Tp)) complex
+{
+  static_assert(!::cuda::std::__is_ext_nv_fp_v<_Tp>, "Extended NVIDIA floating point types are not supported yet.");
+
+  _Tp __re_; //!< The real part of the complex number.
+  _Tp __im_; //!< The imaginary part of the complex number.
+
+public:
+  using value_type = _Tp; //!< The type of the values.
+
+  //! @brief Trivial default constructor.
+  _CCCL_HIDE_FROM_ABI constexpr complex() noexcept = default;
+
+  //! @brief Constructs a complex number with the given real and imaginary parts.
+  //!
+  //! @param __re The real part of the complex number.
+  //! @param __im The imaginary part of the complex number, defaults to 0.
+  _CCCL_API constexpr complex(const _Tp& __re, const _Tp& __im = _Tp{}) noexcept
+      : __re_{__re}
+      , __im_{__im}
+  {}
+
+  //! @brief Defaulted copy constructor.
+  _CCCL_HIDE_FROM_ABI constexpr complex(const complex&) noexcept = default;
+
+  //! @brief Constructs a complex number from another complex number of a different type.
+  //!
+  //! @tparam _Up The type of the other complex number.
+  //! @param __other The other complex number.
+  _CCCL_TEMPLATE(class _Up)
+  _CCCL_REQUIRES(__is_any_complex_v<_Up> _CCCL_AND //
+                 ::cuda::std::__is_fp_v<_Tp> _CCCL_AND //
+                 ::cuda::std::__is_fp_v<typename _Up::value_type> _CCCL_AND //
+                 ::cuda::std::__fp_is_implicit_conversion_v<typename _Up::value_type, _Tp>)
+  _CCCL_API constexpr complex(const _Up& __other) noexcept
+      : __re_{static_cast<_Tp>(::cuda::__get_real(__other))}
+      , __im_{static_cast<_Tp>(::cuda::__get_imag(__other))}
+  {}
+
+  //! @brief Constructs a complex number from another complex number of a different type.
+  //!
+  //! @tparam _Up The type of the other complex number.
+  //! @param __other The other complex number.
+  _CCCL_TEMPLATE(class _Up)
+  _CCCL_REQUIRES(__is_any_complex_v<_Up> _CCCL_AND //
+                 ::cuda::std::__is_fp_v<_Tp> _CCCL_AND //
+                 ::cuda::std::__is_fp_v<typename _Up::value_type> _CCCL_AND //
+                 ::cuda::std::__fp_is_explicit_conversion_v<typename _Up::value_type, _Tp>)
+  _CCCL_API explicit constexpr complex(const _Up& __other) noexcept
+      : __re_{static_cast<_Tp>(::cuda::__get_real(__other))}
+      , __im_{static_cast<_Tp>(::cuda::__get_imag(__other))}
+  {}
+
+  //! @brief Constructs a complex number from another complex number of a different type.
+  //!
+  //! @tparam _Up The type of the other complex number.
+  //! @param __other The other complex number.
+  _CCCL_TEMPLATE(class _Up)
+  _CCCL_REQUIRES(__is_any_complex_v<_Up> _CCCL_AND //
+                 (!::cuda::std::__is_fp_v<_Tp> || !::cuda::std::__is_fp_v<typename _Up::value_type>))
+  _CCCL_API constexpr complex(const _Up& __other) noexcept
+      : __re_{static_cast<_Tp>(::cuda::__get_real(__other))}
+      , __im_{static_cast<_Tp>(::cuda::__get_imag(__other))}
+  {}
+
+#if _CCCL_STD_VER >= 2020
+  //! @brief Constructs a complex number from a tuple-like object.
+  //!
+  //! @tparam _Up The type of the tuple-like object.
+  //! @param __other The tuple-like object.
+  //!
+  //! @note The tuple-like object must have two elements of the same type (ignoring cvref-qualifiers).
+  //!       The tuple element type must be the same as the complex type's value type (ignoring cvref-qualifiers)
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Up)
+  _CCCL_REQUIRES((!__is_any_complex_v<_Up>) _CCCL_AND //
+                   __is_complex_compatible_tuple_like<_Up> _CCCL_AND //
+                 ::cuda::std::is_same_v<__complex_tuple_like_value_type_t<_Up>, _Tp>)
+  _CCCL_API explicit constexpr complex(const _Up& __other) noexcept(
+    noexcept(get<0>(__other)) && noexcept(get<1>(__other)))
+      : __re_{static_cast<_Tp>(get<0>(__other))}
+      , __im_{static_cast<_Tp>(get<1>(__other))}
+  {}
+#endif // _CCCL_STD_VER >= 2020
+
+  //! @brief Defaulted copy assignment operator.
+  _CCCL_HIDE_FROM_ABI constexpr complex& operator=(const complex&) noexcept = default;
+
+  //! @brief Assigns a value to the complex number.
+  //!
+  //! @param __v The value to assign to the complex number.
+  //! @return A reference to this complex number.
+  _CCCL_API constexpr complex& operator=(const _Tp& __v) noexcept
+  {
+    __re_ = __v;
+    __im_ = _Tp{};
+    return *this;
+  }
+
+  //! @brief Assigns another complex number to this complex number.
+  //!
+  //! @tparam _Up The type of the other complex number.
+  //! @param __v The other complex number.
+  //! @return A reference to this complex number.
+  template <class _Up>
+  _CCCL_API constexpr complex& operator=(const complex<_Up>& __v) noexcept
+  {
+    __re_ = static_cast<_Tp>(__v.real());
+    __im_ = static_cast<_Tp>(__v.imag());
+    return *this;
+  }
+
+  //! @brief Returns the real part of the complex number.
+  //!
+  //! @return The real part of the complex number.
+  [[nodiscard]] _CCCL_API constexpr _Tp real() const noexcept
+  {
+    return __re_;
+  }
+
+  //! @brief Returns the real part of the complex number.
+  //!
+  //! @return The real part of the complex number.
+  [[nodiscard]] _CCCL_API constexpr _Tp real() const volatile noexcept
+  {
+    return __re_;
+  }
+
+  //! @brief Returns the imaginary part of the complex number.
+  //!
+  //! @return The imaginary part of the complex number.
+  [[nodiscard]] _CCCL_API constexpr _Tp imag() const noexcept
+  {
+    return __im_;
+  }
+
+  //! @brief Returns the imaginary part of the complex number.
+  //!
+  //! @return The imaginary part of the complex number.
+  [[nodiscard]] _CCCL_API constexpr _Tp imag() const volatile noexcept
+  {
+    return __im_;
+  }
+
+  //! @brief Sets the real part of the complex number.
+  //!
+  //! @param __re The new real part of the complex number.
+  _CCCL_API constexpr void real(_Tp __re) noexcept
+  {
+    __re_ = __re;
+  }
+
+  //! @brief Sets the real part of the complex number.
+  //!
+  //! @param __re The new real part of the complex number.
+  _CCCL_API constexpr void real(_Tp __re) volatile noexcept
+  {
+    __re_ = __re;
+  }
+
+  //! @brief Sets the imaginary part of the complex number.
+  //!
+  //! @param __im The new imaginary part of the complex number.
+  _CCCL_API constexpr void imag(_Tp __im) noexcept
+  {
+    __im_ = __im;
+  }
+
+  //! @brief Sets the imaginary part of the complex number.
+  //!
+  //! @param __im The new imaginary part of the complex number.
+  _CCCL_API constexpr void imag(_Tp __im) volatile noexcept
+  {
+    __im_ = __im;
+  }
+};
+
+//! @brief Deduction guide for construction from complex types.
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES(__is_any_complex_v<_Tp>)
+_CCCL_HOST_DEVICE complex(const _Tp&) -> complex<typename _Tp::value_type>;
+
+#if _CCCL_STD_VER >= 2020
+//! @brief Deduction guide for construction from a tuple-like object.
+_CCCL_TEMPLATE(class _Tp)
+_CCCL_REQUIRES((!__is_any_complex_v<_Tp>) _CCCL_AND __is_complex_compatible_tuple_like<_Tp>)
+_CCCL_HOST_DEVICE complex(const _Tp&) -> complex<__complex_tuple_like_value_type_t<_Tp>>;
+#endif // _CCCL_STD_VER >= 2020
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___COMPLEX_COMPLEX_H

--- a/libcudacxx/include/cuda/__complex/get_real_imag.h
+++ b/libcudacxx/include/cuda/__complex/get_real_imag.h
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___COMPLEX_GET_REAL_IMAG_H
+#define _CUDA___COMPLEX_GET_REAL_IMAG_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/complex.h>
+#include <cuda/std/__fwd/complex.h>
+
+#if !_CCCL_COMPILER(NVRTC)
+#  include <complex>
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __get_real(const complex<_Tp>& __c) noexcept
+{
+  return __c.real();
+}
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __get_imag(const complex<_Tp>& __c) noexcept
+{
+  return __c.imag();
+}
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __get_real(const ::cuda::std::complex<_Tp>& __c) noexcept
+{
+  return __c.real();
+}
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __get_imag(const ::cuda::std::complex<_Tp>& __c) noexcept
+{
+  return __c.imag();
+}
+
+#if !_CCCL_COMPILER(NVRTC)
+
+// Unless `--expt-relaxed-constexpr` is specified, obtaining values from std::complex is not constexpr :(
+#  if defined(__CUDACC_RELAXED_CONSTEXPR__)
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __get_real(const ::std::complex<_Tp>& __c) noexcept
+{
+  return __c.real();
+}
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __get_imag(const ::std::complex<_Tp>& __c) noexcept
+{
+  return __c.imag();
+}
+#  else // ^^^ __CUDACC_RELAXED_CONSTEXPR__ ^^^ / vvv !__CUDACC_RELAXED_CONSTEXPR__ vvv
+template <class _Tp>
+[[nodiscard]] _CCCL_API _Tp __get_real(const ::std::complex<_Tp>& __c) noexcept
+{
+  return reinterpret_cast<const _Tp(&)[2]>(__c)[0];
+}
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API _Tp __get_imag(const ::std::complex<_Tp>& __c) noexcept
+{
+  return reinterpret_cast<const _Tp(&)[2]>(__c)[1];
+}
+#  endif // ^^^ !__CUDACC_RELAXED_CONSTEXPR__ ^^^
+#endif // !_CCCL_COMPILER(NVRTC)
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___COMPLEX_GET_REAL_IMAG_H

--- a/libcudacxx/include/cuda/__complex/traits.h
+++ b/libcudacxx/include/cuda/__complex/traits.h
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___COMPLEX_TRAITS_H
+#define _CUDA___COMPLEX_TRAITS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/complex.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__fwd/complex.h>
+#include <cuda/std/__tuple_dir/tuple_element.h>
+#include <cuda/std/__tuple_dir/tuple_like.h>
+#include <cuda/std/__tuple_dir/tuple_size.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+// __is_complex_compatible_tuple_like
+
+template <class _Tp>
+_CCCL_CONCEPT __is_complex_compatible_tuple_like = _CCCL_REQUIRES_EXPR(
+  (_Tp))(requires(::cuda::std::tuple_size<_Tp>::value == 2),
+         requires(::cuda::std::is_same_v<::cuda::std::remove_cvref_t<::cuda::std::tuple_element_t<0, _Tp>>,
+                                         ::cuda::std::remove_cvref_t<::cuda::std::tuple_element_t<1, _Tp>>>));
+
+// __complex_tuple_like_value_type
+
+template <class _Tp>
+using __complex_tuple_like_value_type_t = ::cuda::std::remove_cvref_t<::cuda::std::tuple_element_t<0, _Tp>>;
+
+// __is_cccl_complex_v
+
+template <class _Tp>
+inline constexpr bool __is_cccl_complex_v = __is_cuda_complex_v<_Tp> || ::cuda::std::__is_cuda_std_complex_v<_Tp>;
+
+// __is_any_complex_v
+
+template <class _Tp>
+inline constexpr bool __is_any_complex_v = ::cuda::std::__is_std_complex_v<_Tp> || __is_cccl_complex_v<_Tp>;
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___COMPLEX_TRAITS_H

--- a/libcudacxx/include/cuda/__complex_
+++ b/libcudacxx/include/cuda/__complex_
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_COMPLEX
+#define _CUDA_COMPLEX
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__complex/complex.h>
+#include <cuda/std/complex>
+#include <cuda/version>
+
+#endif // _CUDA_COMPLEX

--- a/libcudacxx/include/cuda/__fwd/complex.h
+++ b/libcudacxx/include/cuda/__fwd/complex.h
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___FWD_COMPLEX_H
+#define _CUDA___FWD_COMPLEX_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+template <class _Tp>
+class _CCCL_TYPE_VISIBILITY_DEFAULT complex;
+
+// __is_cuda_complex_v
+
+template <class _Tp>
+inline constexpr bool __is_cuda_complex_v = false;
+template <class _Tp>
+inline constexpr bool __is_cuda_complex_v<const _Tp> = __is_cuda_complex_v<_Tp>;
+template <class _Tp>
+inline constexpr bool __is_cuda_complex_v<volatile _Tp> = __is_cuda_complex_v<_Tp>;
+template <class _Tp>
+inline constexpr bool __is_cuda_complex_v<const volatile _Tp> = __is_cuda_complex_v<_Tp>;
+template <class _Tp>
+inline constexpr bool __is_cuda_complex_v<complex<_Tp>> = true;
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___FWD_COMPLEX_H

--- a/libcudacxx/include/cuda/std/__fwd/complex.h
+++ b/libcudacxx/include/cuda/std/__fwd/complex.h
@@ -20,12 +20,44 @@
 #  pragma system_header
 #endif // no system header
 
+#if !_CCCL_COMPILER(NVRTC)
+#  include <complex>
+#endif // !_CCCL_COMPILER(NVRTC)
+
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
 class _CCCL_TYPE_VISIBILITY_DEFAULT complex;
+
+// __is_std_complex_v
+
+template <class _Tp>
+inline constexpr bool __is_std_complex_v = false;
+template <class _Tp>
+inline constexpr bool __is_std_complex_v<const _Tp> = __is_std_complex_v<_Tp>;
+template <class _Tp>
+inline constexpr bool __is_std_complex_v<volatile _Tp> = __is_std_complex_v<_Tp>;
+template <class _Tp>
+inline constexpr bool __is_std_complex_v<const volatile _Tp> = __is_std_complex_v<_Tp>;
+#if !_CCCL_COMPILER(NVRTC)
+template <class _Tp>
+inline constexpr bool __is_std_complex_v<::std::complex<_Tp>> = true;
+#endif // !_CCCL_COMPILER(NVRTC)
+
+// __is_cuda_std_complex_v
+
+template <class _Tp>
+inline constexpr bool __is_cuda_std_complex_v = false;
+template <class _Tp>
+inline constexpr bool __is_cuda_std_complex_v<const _Tp> = __is_cuda_std_complex_v<_Tp>;
+template <class _Tp>
+inline constexpr bool __is_cuda_std_complex_v<volatile _Tp> = __is_cuda_std_complex_v<_Tp>;
+template <class _Tp>
+inline constexpr bool __is_cuda_std_complex_v<const volatile _Tp> = __is_cuda_std_complex_v<_Tp>;
+template <class _Tp>
+inline constexpr bool __is_cuda_std_complex_v<complex<_Tp>> = true;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/assignment_operators/from_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/assignment_operators/from_complex.pass.cpp
@@ -27,9 +27,11 @@ __host__ __device__ constexpr void test_assignment_from_complex()
   // 2. Test that the assignment is noexcept
   static_assert(noexcept(cuda::std::declval<cuda::complex<T>&>() = cuda::std::declval<const cuda::complex<U>&>()));
 
-  // 3. If T and U are the same, cuda::complex<U> is trivially assignable to cuda::complex<T>
-  static_assert(
-    !cuda::std::is_same_v<T, U> || cuda::std::is_trivially_assignable_v<cuda::complex<T>&, const cuda::complex<U>&>);
+  // 3. If T and U are the same type, test that cuda::complex<T> is trivially assignable from cuda::complex<U> if T is
+  // trivially assignable from U
+  static_assert(!cuda::std::is_same_v<T, U>
+                || (cuda::std::is_trivially_assignable_v<T&, const U&>
+                    == cuda::std::is_trivially_assignable_v<cuda::complex<T>&, const cuda::complex<U>&>) );
 
   const cuda::complex<U> u{U(1), U(2)};
   assert(u.real() == U(1));

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/assignment_operators/from_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/assignment_operators/from_complex.pass.cpp
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+template <class T, class U>
+__host__ __device__ constexpr void test_assignment_from_complex()
+{
+  // 1. Test that cuda::complex<U> is assignable to cuda::complex<T>
+  static_assert(cuda::std::is_assignable_v<cuda::complex<T>&, const cuda::complex<U>&>);
+
+  // 2. Test that the assignment is noexcept
+  static_assert(noexcept(cuda::std::declval<cuda::complex<T>&>() = cuda::std::declval<const cuda::complex<U>&>()));
+
+  // 3. If T and U are the same, cuda::complex<U> is trivially assignable to cuda::complex<T>
+  static_assert(
+    !cuda::std::is_same_v<T, U> || cuda::std::is_trivially_assignable_v<cuda::complex<T>&, const cuda::complex<U>&>);
+
+  const cuda::complex<U> u{U(1), U(2)};
+  assert(u.real() == U(1));
+  assert(u.imag() == U(2));
+
+  const cuda::complex<T> t{u};
+  assert(t.real() == T(1));
+  assert(t.imag() == T(2));
+}
+
+template <class T>
+__host__ __device__ constexpr void test()
+{
+  test_assignment_from_complex<T, float>();
+  test_assignment_from_complex<T, double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_assignment_from_complex<T, long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_assignment_from_complex<T, __float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_assignment_from_complex<T, signed char>();
+  test_assignment_from_complex<T, signed short>();
+  test_assignment_from_complex<T, signed int>();
+  test_assignment_from_complex<T, signed long>();
+  test_assignment_from_complex<T, signed long long>();
+#if _CCCL_HAS_INT128()
+  test_assignment_from_complex<T, __int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_assignment_from_complex<T, unsigned char>();
+  test_assignment_from_complex<T, unsigned short>();
+  test_assignment_from_complex<T, unsigned int>();
+  test_assignment_from_complex<T, unsigned long>();
+  test_assignment_from_complex<T, unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_assignment_from_complex<T, __uint128_t>();
+#endif // _CCCL_HAS_INT128()
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<float>();
+  test<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test<signed char>();
+  test<signed short>();
+  test<signed int>();
+  test<signed long>();
+  test<signed long long>();
+#if _CCCL_HAS_INT128()
+  test<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test<unsigned char>();
+  test<unsigned short>();
+  test<unsigned int>();
+  test<unsigned long>();
+  test<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/assignment_operators/from_value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/assignment_operators/from_value.pass.cpp
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+template <class T>
+__host__ __device__ constexpr void test_assignment_from_value()
+{
+  // 1. Test that T is assignable to cuda::complex<T>
+  static_assert(cuda::std::is_assignable_v<cuda::complex<T>&, const T&>);
+
+  // 2. Test that the assignment is noexcept
+  static_assert(noexcept(cuda::std::declval<cuda::complex<T>&>() = cuda::std::declval<const T&>()));
+
+  cuda::complex<T> v{T(1), T(2)};
+  assert(v.real() == T(1));
+  assert(v.imag() == T(2));
+
+  v = T(2);
+  assert(v.real() == T(2));
+  assert(v.imag() == T(0));
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_assignment_from_value<float>();
+  test_assignment_from_value<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_assignment_from_value<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_assignment_from_value<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_assignment_from_value<signed char>();
+  test_assignment_from_value<signed short>();
+  test_assignment_from_value<signed int>();
+  test_assignment_from_value<signed long>();
+  test_assignment_from_value<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_assignment_from_value<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_assignment_from_value<unsigned char>();
+  test_assignment_from_value<unsigned short>();
+  test_assignment_from_value<unsigned int>();
+  test_assignment_from_value<unsigned long>();
+  test_assignment_from_value<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_assignment_from_value<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/copy.pass.cpp
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+template <class T>
+__host__ __device__ constexpr void test_copy_constructor()
+{
+  using C = cuda::complex<T>;
+
+  // 1. Test that cuda::complex<T> is copy constructible
+  static_assert(cuda::std::is_copy_constructible_v<C>);
+
+  // 2. If T is trivially copy constructible, then cuda::complex<T> is also trivially copy constructible
+  static_assert(cuda::std::is_trivially_copy_constructible_v<C> == cuda::std::is_trivially_copy_constructible_v<T>);
+
+  // 3. Test that the copy constructor is noexcept
+  static_assert(noexcept(C{cuda::std::declval<const C&>()}));
+
+  // 4. Test that the constructor is implicit
+  static_assert(cuda::std::is_convertible_v<const C&, C>);
+
+  const C v1{T(1), T(2)};
+  assert(v1.real() == T(1));
+  assert(v1.imag() == T(2));
+
+  C v2{v1};
+  assert(v2.real() == T(1));
+  assert(v2.imag() == T(2));
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_copy_constructor<float>();
+  test_copy_constructor<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_copy_constructor<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_copy_constructor<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_copy_constructor<signed char>();
+  test_copy_constructor<signed short>();
+  test_copy_constructor<signed int>();
+  test_copy_constructor<signed long>();
+  test_copy_constructor<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_copy_constructor<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_copy_constructor<unsigned char>();
+  test_copy_constructor<unsigned short>();
+  test_copy_constructor<unsigned int>();
+  test_copy_constructor<unsigned long>();
+  test_copy_constructor<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_copy_constructor<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/default.pass.cpp
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+template <class T>
+__host__ __device__ constexpr void test_default_constructor()
+{
+  using C = cuda::complex<T>;
+
+  // 1. Test that cuda::complex<T> is default constructible
+  static_assert(cuda::std::is_default_constructible_v<C>);
+
+  // 2. If T is trivially default constructible, then cuda::complex<T> is also trivially default constructible
+  static_assert(
+    cuda::std::is_trivially_default_constructible_v<C> == cuda::std::is_trivially_default_constructible_v<T>);
+
+  // 3. Test that the constructor is noexcept
+  static_assert(noexcept(C{}));
+
+  C v{};
+  assert(v.real() == T{});
+  assert(v.imag() == T{});
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_default_constructor<float>();
+  test_default_constructor<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_default_constructor<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_default_constructor<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_default_constructor<signed char>();
+  test_default_constructor<signed short>();
+  test_default_constructor<signed int>();
+  test_default_constructor<signed long>();
+  test_default_constructor<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_default_constructor<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_default_constructor<unsigned char>();
+  test_default_constructor<unsigned short>();
+  test_default_constructor<unsigned int>();
+  test_default_constructor<unsigned long>();
+  test_default_constructor<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_default_constructor<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/from_complex.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/from_complex.pass.cpp
@@ -1,0 +1,150 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#if !_CCCL_COMPILER(NVRTC)
+#  include <complex>
+#endif // !_CCCL_COMPILER(NVRTC)
+
+template <class From, class To>
+__host__ __device__ constexpr bool is_implicit_conversion()
+{
+  if constexpr (cuda::std::__is_fp_v<From> && cuda::std::__is_fp_v<To>)
+  {
+    return cuda::std::__fp_is_implicit_conversion_v<From, To>;
+  }
+  else
+  {
+    return true;
+  }
+}
+
+template <class T, class C>
+__host__ __device__ constexpr void test_constructor_from_complex(const C& other)
+{
+  using U = typename C::value_type;
+
+  // 1. Test that cuda::complex<T> constructible from C
+  static_assert(cuda::std::is_constructible_v<cuda::complex<T>, const C&>);
+
+  // 2. Test that the constructor is noexcept
+  static_assert(noexcept(cuda::complex<T>{cuda::std::declval<const C&>()}));
+
+  // 3. Test that the constructor takes into account floating-point conversion rank order
+  static_assert(cuda::std::is_convertible_v<const C&, cuda::complex<T>> == is_implicit_conversion<U, T>());
+
+  const cuda::complex<T> v2{other};
+  assert(v2.real() == T(1));
+  assert(v2.imag() == T(2));
+}
+
+template <class T, class U>
+__host__ __device__ constexpr bool test_cccl_types()
+{
+  if constexpr (!cuda::std::is_same_v<T, U>)
+  {
+    test_constructor_from_complex<T>(cuda::complex<U>{U(1), U(2)});
+  }
+  test_constructor_from_complex<T>(cuda::std::complex<U>{U(1), U(2)});
+
+  return true;
+}
+
+template <class T, class U>
+__host__ __device__ void test_types()
+{
+  test_cccl_types<T, U>();
+  static_assert(test_cccl_types<T, U>());
+
+#if !_CCCL_COMPILER(NVRTC)
+  // std::complex is not required to support other than standard floating-point types
+  if constexpr (cuda::std::__is_std_fp_v<T>)
+  {
+    NV_IF_TARGET(NV_IS_HOST, (test_constructor_from_complex<T>(std::complex<U>{U(1), U(2)});))
+  }
+#endif // !_CCCL_COMPILER(NVRTC)
+}
+
+template <class T>
+__host__ __device__ void test()
+{
+  test_types<T, float>();
+  test_types<T, double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_types<T, long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_types<T, __float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_types<T, signed char>();
+  test_types<T, signed short>();
+  test_types<T, signed int>();
+  test_types<T, signed long>();
+  test_types<T, signed long long>();
+#if _CCCL_HAS_INT128()
+  test_types<T, __int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_types<T, unsigned char>();
+  test_types<T, unsigned short>();
+  test_types<T, unsigned int>();
+  test_types<T, unsigned long>();
+  test_types<T, unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_types<T, __uint128_t>();
+#endif // _CCCL_HAS_INT128()
+}
+
+__host__ __device__ void test()
+{
+  test<float>();
+  test<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test<signed char>();
+  test<signed short>();
+  test<signed int>();
+  test<signed long>();
+  test<signed long long>();
+#if _CCCL_HAS_INT128()
+  test<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test<unsigned char>();
+  test<unsigned short>();
+  test<unsigned int>();
+  test<unsigned long>();
+  test<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/from_tuple_like.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/from_tuple_like.pass.cpp
@@ -1,0 +1,258 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// UNSUPPORTED: c++17
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+
+#if !_CCCL_COMPILER(NVRTC)
+#  include <tuple>
+#endif // !_CCCL_COMPILER(NVRTC)
+
+// vvv MyPair & tuple protocol for MyPair vvv
+
+namespace my_namespace
+{
+template <class A, class B>
+struct MyPair
+{
+  A first;
+  B second;
+};
+
+template <cuda::std::size_t I, class A, class B>
+[[nodiscard]] __host__ __device__ constexpr auto& get(MyPair<A, B>& p)
+{
+  if constexpr (I == 0)
+  {
+    return p.first;
+  }
+  else
+  {
+    return p.second;
+  }
+}
+
+template <cuda::std::size_t I, class A, class B>
+[[nodiscard]] __host__ __device__ constexpr auto&& get(MyPair<A, B>&& p)
+{
+  if constexpr (I == 0)
+  {
+    return cuda::std::move(p.first);
+  }
+  else
+  {
+    return cuda::std::move(p.second);
+  }
+}
+
+template <cuda::std::size_t I, class A, class B>
+[[nodiscard]] __host__ __device__ constexpr const auto& get(const MyPair<A, B>& p)
+{
+  if constexpr (I == 0)
+  {
+    return p.first;
+  }
+  else
+  {
+    return p.second;
+  }
+}
+
+template <cuda::std::size_t I, class A, class B>
+[[nodiscard]] __host__ __device__ constexpr const auto&& get(const MyPair<A, B>&& p)
+{
+  if constexpr (I == 0)
+  {
+    return cuda::std::move(p.first);
+  }
+  else
+  {
+    return cuda::std::move(p.second);
+  }
+}
+} // namespace my_namespace
+
+template <class A, class B>
+struct cuda::std::tuple_size<my_namespace::MyPair<A, B>> : cuda::std::integral_constant<cuda::std::size_t, 2>
+{};
+
+template <class A, class B>
+struct cuda::std::tuple_element<0, my_namespace::MyPair<A, B>>
+{
+  using type = A;
+};
+
+template <class A, class B>
+struct cuda::std::tuple_element<1, my_namespace::MyPair<A, B>>
+{
+  using type = B;
+};
+
+// ^^^ MyPair & tuple protocol for MyPair ^^^
+
+template <class T, bool is_noexcept, class TupleLike>
+__host__ __device__ constexpr void test_constructor_from_tuple_like(const TupleLike& tuple_like)
+{
+  using C = cuda::complex<T>;
+
+  // 1. Test that cuda::complex<T> is constructible from TupleLike
+  static_assert(cuda::std::is_constructible_v<C, const TupleLike&>);
+
+  // 2. Test that the constructor is noexcept
+  static_assert(noexcept(C{tuple_like}) == is_noexcept);
+
+  // 3. Test that the constructor is explicit
+  static_assert(!cuda::std::is_convertible_v<const TupleLike&, C>);
+
+  const C v{tuple_like};
+  assert(v.real() == T(1));
+  assert(v.imag() == T(2));
+}
+
+template <class T>
+__host__ __device__ constexpr void test_constructor_from_tuple_like()
+{
+  T real_part(1);
+  T imag_part(2);
+
+  // 1. Test cuda::std::tuple
+  test_constructor_from_tuple_like<T, true>(cuda::std::tuple<T, T>{real_part, imag_part});
+  test_constructor_from_tuple_like<T, true>(cuda::std::tuple<const T&, const T>{real_part, imag_part});
+  test_constructor_from_tuple_like<T, true>(cuda::std::tuple<T&, T&&>{real_part, T{imag_part}});
+
+  // 2. Test cuda::std::pair
+  test_constructor_from_tuple_like<T, true>(cuda::std::pair<T, T>{real_part, imag_part});
+  test_constructor_from_tuple_like<T, true>(cuda::std::pair<const T&, const T>{real_part, imag_part});
+  test_constructor_from_tuple_like<T, true>(cuda::std::pair<T&, T&&>{real_part, T{imag_part}});
+
+  // 3. Test my_namespace::MyPair
+  test_constructor_from_tuple_like<T, false>(my_namespace::MyPair<T, T>{real_part, imag_part});
+  test_constructor_from_tuple_like<T, false>(my_namespace::MyPair<const T&, const T>{real_part, imag_part});
+  test_constructor_from_tuple_like<T, false>(my_namespace::MyPair<T&, T&&>{real_part, T{imag_part}});
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_constructor_from_tuple_like<float>();
+  test_constructor_from_tuple_like<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_constructor_from_tuple_like<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_constructor_from_tuple_like<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_constructor_from_tuple_like<signed char>();
+  test_constructor_from_tuple_like<signed short>();
+  test_constructor_from_tuple_like<signed int>();
+  test_constructor_from_tuple_like<signed long>();
+  test_constructor_from_tuple_like<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_constructor_from_tuple_like<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_constructor_from_tuple_like<unsigned char>();
+  test_constructor_from_tuple_like<unsigned short>();
+  test_constructor_from_tuple_like<unsigned int>();
+  test_constructor_from_tuple_like<unsigned long>();
+  test_constructor_from_tuple_like<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_constructor_from_tuple_like<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+#if !_CCCL_COMPILER(NVRTC)
+
+template <class... Args>
+struct cuda::std::tuple_size<std::tuple<Args...>> : cuda::std::integral_constant<cuda::std::size_t, sizeof...(Args)>
+{};
+
+template <std::size_t I, class... Args>
+struct cuda::std::tuple_element<I, std::tuple<Args...>> : std::tuple_element<I, cuda::std::tuple<Args...>>
+{};
+
+template <class A, class B>
+struct cuda::std::tuple_size<std::pair<A, B>> : cuda::std::integral_constant<cuda::std::size_t, 2>
+{};
+
+template <cuda::std::size_t I, class A, class B>
+struct cuda::std::tuple_element<I, std::pair<A, B>> : cuda::std::conditional<I == 0, A, B>
+{};
+
+template <class T>
+void test_constructor_from_host_tuple_like()
+{
+  T real_part(1);
+  T imag_part(2);
+
+  // 1. Test std::tuple
+  test_constructor_from_tuple_like<T, true>(std::tuple<T, T>{real_part, imag_part});
+  test_constructor_from_tuple_like<T, true>(std::tuple<const T&, const T>{real_part, imag_part});
+  test_constructor_from_tuple_like<T, true>(std::tuple<T&, T&&>(real_part, T{imag_part}));
+
+  // 2. Test std::pair
+  test_constructor_from_tuple_like<T, true>(std::pair<T, T>{real_part, imag_part});
+  test_constructor_from_tuple_like<T, true>(std::pair<const T&, const T>{real_part, imag_part});
+  test_constructor_from_tuple_like<T, true>(std::pair<T&, T&&>(real_part, T{imag_part}));
+}
+
+void test_host_types()
+{
+  test_constructor_from_host_tuple_like<float>();
+  test_constructor_from_host_tuple_like<double>();
+#  if _CCCL_HAS_LONG_DOUBLE()
+  test_constructor_from_host_tuple_like<long double>();
+#  endif // _CCCL_HAS_LONG_DOUBLE()
+#  if _CCCL_HAS_FLOAT128()
+  test_constructor_from_host_tuple_like<__float128>();
+#  endif // _CCCL_HAS_FLOAT128()
+
+  test_constructor_from_host_tuple_like<signed char>();
+  test_constructor_from_host_tuple_like<signed short>();
+  test_constructor_from_host_tuple_like<signed int>();
+  test_constructor_from_host_tuple_like<signed long>();
+  test_constructor_from_host_tuple_like<signed long long>();
+#  if _CCCL_HAS_INT128()
+  test_constructor_from_host_tuple_like<__int128_t>();
+#  endif // _CCCL_HAS_INT128()
+
+  test_constructor_from_host_tuple_like<unsigned char>();
+  test_constructor_from_host_tuple_like<unsigned short>();
+  test_constructor_from_host_tuple_like<unsigned int>();
+  test_constructor_from_host_tuple_like<unsigned long>();
+  test_constructor_from_host_tuple_like<unsigned long long>();
+#  if _CCCL_HAS_INT128()
+  test_constructor_from_host_tuple_like<__uint128_t>();
+#  endif // _CCCL_HAS_INT128()
+}
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+#if !_CCCL_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, (test_host_types();))
+#endif // !_CCCL_COMPILER(NVRTC)
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/from_values.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/from_values.pass.cpp
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+template <class T>
+__host__ __device__ constexpr void test_constructor_from_values()
+{
+  // 1. Test that cuda::complex<T> constructible from T and T T
+  static_assert(cuda::std::is_constructible_v<cuda::complex<T>, const T&>);
+  static_assert(cuda::std::is_constructible_v<cuda::complex<T>, const T&, const T&>);
+
+  // 2. Test that the constructor is noexcept
+  static_assert(noexcept(cuda::complex<T>{cuda::std::declval<const T&>()}));
+  static_assert(noexcept(cuda::complex<T>{cuda::std::declval<const T&>(), cuda::std::declval<const T&>()}));
+
+  const cuda::complex<T> v1{T(2)};
+  assert(v1.real() == T(2));
+  assert(v1.imag() == T(0));
+
+  const cuda::complex<T> v2{T(1), T(2)};
+  assert(v2.real() == T(1));
+  assert(v2.imag() == T(2));
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_constructor_from_values<float>();
+  test_constructor_from_values<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_constructor_from_values<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_constructor_from_values<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_constructor_from_values<signed char>();
+  test_constructor_from_values<signed short>();
+  test_constructor_from_values<signed int>();
+  test_constructor_from_values<signed long>();
+  test_constructor_from_values<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_constructor_from_values<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_constructor_from_values<unsigned char>();
+  test_constructor_from_values<unsigned short>();
+  test_constructor_from_values<unsigned int>();
+  test_constructor_from_values<unsigned long>();
+  test_constructor_from_values<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_constructor_from_values<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/real_imag.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/real_imag.pass.cpp
@@ -1,0 +1,164 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+template <class T>
+__host__ __device__ constexpr void test_real_and_imag()
+{
+  using C = cuda::complex<T>;
+
+  // 1. Test real() const signature
+  static_assert(cuda::std::is_same_v<T, decltype(cuda::std::declval<const C>().real())>);
+  static_assert(noexcept(cuda::std::declval<const C>().real()));
+
+  // 2. Test real(T) signature
+  static_assert(cuda::std::is_same_v<void, decltype(cuda::std::declval<C>().real(T{}))>);
+  static_assert(noexcept(cuda::std::declval<C>().real(T{})));
+
+  // 3. Test imag() const signature
+  static_assert(cuda::std::is_same_v<T, decltype(cuda::std::declval<const C>().imag())>);
+  static_assert(noexcept(cuda::std::declval<const C>().imag()));
+
+  // 4. Test imag(T) signature
+  static_assert(cuda::std::is_same_v<void, decltype(cuda::std::declval<C>().imag(T{}))>);
+  static_assert(noexcept(cuda::std::declval<C>().imag(T{})));
+
+  const C c1{};
+  assert(c1.real() == T{});
+  assert(c1.imag() == T{});
+
+  C c2{1};
+  assert(c2.real() == T{1});
+  assert(c2.imag() == T{});
+
+  c2.real(T(2));
+  assert(c2.real() == T(2));
+  assert(c2.imag() == T{});
+
+  c2.imag(T(4));
+  assert(c2.real() == T(2));
+  assert(c2.imag() == T(4));
+}
+
+template <class T>
+__host__ __device__ void test_real_and_imag_volatile()
+{
+  using C = cuda::complex<T>;
+
+  // 1. Test real() const volatile signature
+  static_assert(cuda::std::is_same_v<T, decltype(cuda::std::declval<const volatile C>().real())>);
+  static_assert(noexcept(cuda::std::declval<const volatile C>().real()));
+
+  // 2. Test real(T) volatile signature
+  static_assert(cuda::std::is_same_v<void, decltype(cuda::std::declval<volatile C>().real(T{}))>);
+  static_assert(noexcept(cuda::std::declval<volatile C>().real(T{})));
+
+  // 3. Test imag() const volatile signature
+  static_assert(cuda::std::is_same_v<T, decltype(cuda::std::declval<const volatile C>().imag())>);
+  static_assert(noexcept(cuda::std::declval<const volatile C>().imag()));
+
+  // 4. Test imag(T) volatile signature
+  static_assert(cuda::std::is_same_v<void, decltype(cuda::std::declval<volatile C>().imag(T{}))>);
+  static_assert(noexcept(cuda::std::declval<volatile C>().imag(T{})));
+
+  const volatile C c1{};
+  assert(c1.real() == T{});
+  assert(c1.imag() == T{});
+
+  volatile C c2{1};
+  assert(c2.real() == T{1});
+  assert(c2.imag() == T{});
+
+  c2.real(T(2));
+  assert(c2.real() == T(2));
+  assert(c2.imag() == T{});
+
+  c2.imag(T(4));
+  assert(c2.real() == T(2));
+  assert(c2.imag() == T(4));
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_real_and_imag<float>();
+  test_real_and_imag<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_real_and_imag<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_real_and_imag<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_real_and_imag<signed char>();
+  test_real_and_imag<signed short>();
+  test_real_and_imag<signed int>();
+  test_real_and_imag<signed long>();
+  test_real_and_imag<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_real_and_imag<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_real_and_imag<unsigned char>();
+  test_real_and_imag<unsigned short>();
+  test_real_and_imag<unsigned int>();
+  test_real_and_imag<unsigned long>();
+  test_real_and_imag<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_real_and_imag<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  return true;
+}
+
+__host__ __device__ void test_volatile()
+{
+  test_real_and_imag_volatile<float>();
+  test_real_and_imag_volatile<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_real_and_imag_volatile<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_real_and_imag_volatile<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_real_and_imag_volatile<signed char>();
+  test_real_and_imag_volatile<signed short>();
+  test_real_and_imag_volatile<signed int>();
+  test_real_and_imag_volatile<signed long>();
+  test_real_and_imag_volatile<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_real_and_imag_volatile<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_real_and_imag_volatile<unsigned char>();
+  test_real_and_imag_volatile<unsigned short>();
+  test_real_and_imag_volatile<unsigned int>();
+  test_real_and_imag_volatile<unsigned long>();
+  test_real_and_imag_volatile<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_real_and_imag_volatile<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+}
+
+int main(int, char**)
+{
+  test();
+  test_volatile();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex/abi.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex/abi.pass.cpp
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+
+template <class T>
+__host__ __device__ void test_abi()
+{
+  static_assert(sizeof(cuda::complex<T>) == (sizeof(T) * 2), "wrong size");
+  static_assert(alignof(cuda::complex<T>) == (alignof(T) * 2), "misaligned");
+}
+
+__host__ __device__ void test()
+{
+  test_abi<float>();
+  test_abi<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_abi<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_abi<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_abi<signed char>();
+  test_abi<signed short>();
+  test_abi<signed int>();
+  test_abi<signed long>();
+  test_abi<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_abi<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_abi<unsigned char>();
+  test_abi<unsigned short>();
+  test_abi<unsigned int>();
+  test_abi<unsigned long>();
+  test_abi<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_abi<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex/layout.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex/layout.pass.cpp
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/cassert>
+
+template <class T>
+__host__ __device__ void test_layout()
+{
+  cuda::complex<T> z{T(1), T(2)};
+  T* p = (T*) &z;
+  assert(T(1) == z.real());
+  assert(T(2) == z.imag());
+  assert(p[0] == z.real());
+  assert(p[1] == z.imag());
+  p[0] = T(2);
+  p[1] = T(4);
+  assert(p[0] == z.real());
+  assert(p[1] == z.imag());
+}
+
+__host__ __device__ void test()
+{
+  test_layout<float>();
+  test_layout<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_layout<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_layout<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_layout<signed char>();
+  test_layout<signed short>();
+  test_layout<signed int>();
+  test_layout<signed long>();
+  test_layout<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_layout<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_layout<unsigned char>();
+  test_layout<unsigned short>();
+  test_layout<unsigned int>();
+  test_layout<unsigned long>();
+  test_layout<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_layout<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex/types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex/types.pass.cpp
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/type_traits>
+
+template <class T>
+__host__ __device__ void test_types()
+{
+  static_assert(cuda::std::is_same_v<T, typename cuda::complex<T>::value_type>);
+}
+
+__host__ __device__ void test()
+{
+  test_types<float>();
+  test_types<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_types<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_types<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_types<signed char>();
+  test_types<signed short>();
+  test_types<signed int>();
+  test_types<signed long>();
+  test_types<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_types<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_types<unsigned char>();
+  test_types<unsigned short>();
+  test_types<unsigned int>();
+  test_types<unsigned long>();
+  test_types<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_types<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/deduction.pass.cpp
@@ -1,0 +1,114 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// ADDITIONAL_COMPILE_OPTIONS_HOST: -fext-numeric-literals
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_GCC_HAS_EXTENDED_NUMERIC_LITERALS
+
+// <cuda/complex>
+
+#include <cuda/__complex_>
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+
+#if !_CCCL_COMPILER(NVRTC)
+#  include <complex>
+#endif // !_CCCL_COMPILER(NVRTC)
+
+template <class T>
+__host__ __device__ void test_deduction()
+{
+  // 1. Test cuda::complex(T)
+  {
+    [[maybe_unused]] cuda::complex c{T{}};
+    static_assert(cuda::std::is_same_v<T, typename decltype(c)::value_type>);
+  }
+
+  // 2. Test cuda::complex(T, T)
+  {
+    [[maybe_unused]] cuda::complex c{T{}, T{}};
+    static_assert(cuda::std::is_same_v<T, typename decltype(c)::value_type>);
+  }
+
+  // 3. Test cuda::complex(cuda::complex)
+  {
+    [[maybe_unused]] cuda::complex c{cuda::complex<T>{}};
+    static_assert(cuda::std::is_same_v<T, typename decltype(c)::value_type>);
+  }
+
+  // 4. Test cuda::complex(cuda::std::complex)
+  {
+    [[maybe_unused]] cuda::complex c{cuda::std::complex<T>{}};
+    static_assert(cuda::std::is_same_v<T, typename decltype(c)::value_type>);
+  }
+
+  // 5. Test cuda::complex(std::complex)
+#if !_CCCL_COMPILER(NVRTC)
+  // std::complex is not required to support other than standard floating-point types
+  if constexpr (cuda::std::__is_std_fp_v<T>)
+  {
+    NV_IF_TARGET(NV_IS_HOST,
+                 ([[maybe_unused]] cuda::complex c{std::complex<T>{}}; //
+                  assert((cuda::std::is_same_v<T, typename decltype(c)::value_type>) );))
+  }
+#endif // !_CCCL_COMPILER(NVRTC)
+
+  // 6. Test cuda::complex(tuple-like)
+#if _CCCL_STD_VER >= 2020
+  {
+    T value{};
+
+    [[maybe_unused]] cuda::complex c1{cuda::std::tuple<T, T>{value, value}};
+    static_assert(cuda::std::is_same_v<T, typename decltype(c1)::value_type>);
+
+    [[maybe_unused]] cuda::complex c2{cuda::std::tuple<const T, T&>{value, value}};
+    static_assert(cuda::std::is_same_v<T, typename decltype(c2)::value_type>);
+
+    [[maybe_unused]] cuda::complex c3{cuda::std::tuple<const T&, T&&>{value, T{value}}};
+    static_assert(cuda::std::is_same_v<T, typename decltype(c3)::value_type>);
+  }
+#endif // _CCCL_STD_VER >= 2020
+}
+
+__host__ __device__ void test()
+{
+  test_deduction<float>();
+  test_deduction<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test_deduction<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if _CCCL_HAS_FLOAT128()
+  test_deduction<__float128>();
+#endif // _CCCL_HAS_FLOAT128()
+
+  test_deduction<signed char>();
+  test_deduction<signed short>();
+  test_deduction<signed int>();
+  test_deduction<signed long>();
+  test_deduction<signed long long>();
+#if _CCCL_HAS_INT128()
+  test_deduction<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+
+  test_deduction<unsigned char>();
+  test_deduction<unsigned short>();
+  test_deduction<unsigned int>();
+  test_deduction<unsigned long>();
+  test_deduction<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test_deduction<__uint128_t>();
+#endif // _CCCL_HAS_INT128()
+}
+
+int main(int, char**)
+{
+  test();
+  return 0;
+}


### PR DESCRIPTION
This PR implements `cuda::complex` that is similar to `cuda::std::complex` but has the benefit of being trivially default constructible. I've also added a constructor from tuple-like types.

This implementation also takes into account conversion ranks of floating point types as specified by C++23.

This is a first part of the implementation only containing constructors and member accessors.