### PR TITLE
[skip-ci] Clarify GPU architecture support in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,15 +268,21 @@ But we will not invest significant time in triaging or fixing issues for older c
 
 In the spirit of "You only support what you test", see our [CI Overview](https://github.com/NVIDIA/cccl/blob/main/ci-overview.md) for more information on exactly what we test.
 
+### GPU Architectures
+
+While some features may be specific to certain architectures, CCCL generally supports all GPU architectures that are [supported by the *current* major CUDA Toolkit (CTK)](https://developer.nvidia.com/cuda-gpus).
+
+To be clear, while CCCL supports compilation with [two CTK major versions](#CUDA-toolkit-(CTK)-compatibility), this does *not* mean we continue to support all architectures from the older CTK.
+
+For example, CCCL 3.0 supports compiling with CTK 12.x and 13.x where
+- CUDA Toolkit 13.x supports `>=sm_75`
+- CUDA Toolkit 12.x supports `>=sm_50`
+
+So even when compiling CCCL 3.0 with CTK 12.x, only the architectures supported by the current CTK (13.x) are available (`sm_75`+).
+
 ### C++ Dialects
 - C++17
 - C++20
-
-### GPU Architectures
-
-Unless otherwise specified, CCCL supports all the same GPU architectures/Compute Capabilities as the CUDA Toolkit, which are documented here: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#compute-capability
-
-Note that some features may only support certain architectures/Compute Capabilities.
 
 ### Testing Strategy
 


### PR DESCRIPTION
Our support policy around GPU architectures while supporting 2 CTK major versions is nuanced and ripe for confusion. 

This PR adds some more clarity and details around how our architecture support is informed by the latest CTK major version (similar to host compiler support). 
