### PR TITLE
[libcu++] Add SM_110 arch traits

### DIFF
--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -49,10 +49,12 @@ enum class id : int
   sm_90   = 90,
   sm_100  = 100,
   sm_103  = 103,
+  sm_110  = 110,
   sm_120  = 120,
   sm_90a  = 90 * __arch_specific_id_multiplier,
   sm_100a = 100 * __arch_specific_id_multiplier,
   sm_103a = 103 * __arch_specific_id_multiplier,
+  sm_110a = 110 * __arch_specific_id_multiplier,
   sm_120a = 120 * __arch_specific_id_multiplier,
 };
 
@@ -427,6 +429,23 @@ template <>
 };
 
 template <>
+[[nodiscard]] _CCCL_HOST_DEVICE inline constexpr traits_t traits<id::sm_110>()
+{
+  traits_t __traits                 = ::cuda::arch::traits<id::sm_100>();
+  __traits.arch_id                  = id::sm_110;
+  __traits.compute_capability_major = 11;
+  __traits.compute_capability_minor = 0;
+  __traits.compute_capability       = 110;
+  return __traits;
+};
+
+template <>
+[[nodiscard]] _CCCL_HOST_DEVICE inline constexpr traits_t traits<id::sm_110a>()
+{
+  return ::cuda::arch::traits<id::sm_110>();
+};
+
+template <>
 [[nodiscard]] _CCCL_HOST_DEVICE inline constexpr traits_t traits<id::sm_120>()
 {
   traits_t __traits{};
@@ -488,6 +507,10 @@ inline constexpr int __highest_known_arch = 120;
       return ::cuda::arch::traits<id::sm_103>();
     case id::sm_103a:
       return ::cuda::arch::traits<id::sm_103a>();
+    case id::sm_110:
+      return ::cuda::arch::traits<id::sm_110>();
+    case id::sm_110a:
+      return ::cuda::arch::traits<id::sm_110a>();
     case id::sm_120:
       return ::cuda::arch::traits<id::sm_120>();
     case id::sm_120a:
@@ -522,6 +545,8 @@ _CCCL_API inline constexpr id __special_id_for_compute_capability(int value)
       return id::sm_100a;
     case 103:
       return id::sm_103a;
+    case 110:
+      return id::sm_110a;
     case 120:
       return id::sm_120a;
     default:

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_traits.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_traits.c2h.cu
@@ -52,10 +52,12 @@ template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id:
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id::sm_90>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id::sm_100>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id::sm_103>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id::sm_110>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id::sm_120>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id::sm_90a>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id::sm_100a>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id::sm_103a>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id::sm_110a>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch::id::sm_120a>();
 
 template <unsigned int ComputeCapability>
@@ -115,6 +117,7 @@ C2H_CCCLRT_TEST("Traits", "[device]")
   compare_static_and_dynamic<90>();
   compare_static_and_dynamic<100>();
   compare_static_and_dynamic<103>();
+  compare_static_and_dynamic<110>();
   compare_static_and_dynamic<120>();
 
   // Compare arch traits with attributes


### PR DESCRIPTION
After the rename from `SM_101` we need traits for `SM_110` for our testing of all major compute capabilities