### PR TITLE
Allow C++ code for operators in c.parallel

### DIFF
--- a/c/parallel/include/cccl/c/for.h
+++ b/c/parallel/include/cccl/c/for.h
@@ -42,6 +42,19 @@ CCCL_C_API CUresult cccl_device_for_build(
   const char* libcudacxx_path,
   const char* ctk_path);
 
+// Extended version with build configuration
+CCCL_C_API CUresult cccl_device_for_build_ex(
+  cccl_device_for_build_result_t* build,
+  cccl_iterator_t d_data,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
 CCCL_C_API CUresult cccl_device_for(
   cccl_device_for_build_result_t build, cccl_iterator_t d_data, uint64_t num_items, cccl_op_t op, CUstream stream);
 

--- a/c/parallel/include/cccl/c/histogram.h
+++ b/c/parallel/include/cccl/c/histogram.h
@@ -53,6 +53,26 @@ CCCL_C_API CUresult cccl_device_histogram_build(
   const char* libcudacxx_path,
   const char* ctk_path);
 
+// Extended version with build configuration
+CCCL_C_API CUresult cccl_device_histogram_build_ex(
+  cccl_device_histogram_build_result_t* build,
+  int num_channels,
+  int num_active_channels,
+  cccl_iterator_t d_samples,
+  int num_output_levels_val,
+  cccl_iterator_t d_output_histograms,
+  cccl_value_t lower_level,
+  int64_t num_rows,
+  int64_t row_stride_samples,
+  bool is_evenly_segmented,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
 CCCL_C_API CUresult cccl_device_histogram_even(
   cccl_device_histogram_build_result_t build,
   void* d_temp_storage,

--- a/c/parallel/include/cccl/c/merge_sort.h
+++ b/c/parallel/include/cccl/c/merge_sort.h
@@ -49,6 +49,22 @@ CCCL_C_API CUresult cccl_device_merge_sort_build(
   const char* libcudacxx_path,
   const char* ctk_path);
 
+// Extended version with build configuration
+CCCL_C_API CUresult cccl_device_merge_sort_build_ex(
+  cccl_device_merge_sort_build_result_t* build,
+  cccl_iterator_t d_in_keys,
+  cccl_iterator_t d_in_items,
+  cccl_iterator_t d_out_keys,
+  cccl_iterator_t d_out_items,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
 CCCL_C_API CUresult cccl_device_merge_sort(
   cccl_device_merge_sort_build_result_t build,
   void* d_temp_storage,

--- a/c/parallel/include/cccl/c/radix_sort.h
+++ b/c/parallel/include/cccl/c/radix_sort.h
@@ -57,6 +57,22 @@ CCCL_C_API CUresult cccl_device_radix_sort_build(
   const char* libcudacxx_path,
   const char* ctk_path);
 
+// Extended version with build configuration
+CCCL_C_API CUresult cccl_device_radix_sort_build_ex(
+  cccl_device_radix_sort_build_result_t* build,
+  cccl_sort_order_t sort_order,
+  cccl_iterator_t input_keys_it,
+  cccl_iterator_t input_values_it,
+  cccl_op_t decomposer,
+  const char* decomposer_return_type,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
 CCCL_C_API CUresult cccl_device_radix_sort(
   cccl_device_radix_sort_build_result_t build,
   void* d_temp_storage,

--- a/c/parallel/include/cccl/c/reduce.h
+++ b/c/parallel/include/cccl/c/reduce.h
@@ -49,6 +49,21 @@ CCCL_C_API CUresult cccl_device_reduce_build(
   const char* libcudacxx_path,
   const char* ctk_path);
 
+// Extended version with build configuration
+CCCL_C_API CUresult cccl_device_reduce_build_ex(
+  cccl_device_reduce_build_result_t* build,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  cccl_value_t init,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
 CCCL_C_API CUresult cccl_device_reduce(
   cccl_device_reduce_build_result_t build,
   void* d_temp_storage,

--- a/c/parallel/include/cccl/c/scan.h
+++ b/c/parallel/include/cccl/c/scan.h
@@ -51,6 +51,22 @@ CCCL_C_API CUresult cccl_device_scan_build(
   const char* libcudacxx_path,
   const char* ctk_path);
 
+// Extended version with build configuration
+CCCL_C_API CUresult cccl_device_scan_build_ex(
+  cccl_device_scan_build_result_t* build_ptr,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  cccl_value_t init,
+  bool force_inclusive,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
 CCCL_C_API CUresult cccl_device_exclusive_scan(
   cccl_device_scan_build_result_t build,
   void* d_temp_storage,

--- a/c/parallel/include/cccl/c/segmented_reduce.h
+++ b/c/parallel/include/cccl/c/segmented_reduce.h
@@ -49,6 +49,23 @@ CCCL_C_API CUresult cccl_device_segmented_reduce_build(
   const char* libcudacxx_path,
   const char* ctk_path);
 
+// Extended version with build configuration
+CCCL_C_API CUresult cccl_device_segmented_reduce_build_ex(
+  cccl_device_segmented_reduce_build_result_t* build,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_iterator_t begin_offset_in,
+  cccl_iterator_t end_offset_in,
+  cccl_op_t op,
+  cccl_value_t init,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
 CCCL_C_API CUresult cccl_device_segmented_reduce(
   cccl_device_segmented_reduce_build_result_t build,
   void* d_temp_storage,

--- a/c/parallel/include/cccl/c/transform.h
+++ b/c/parallel/include/cccl/c/transform.h
@@ -44,6 +44,20 @@ CCCL_C_API CUresult cccl_device_unary_transform_build(
   const char* libcudacxx_path,
   const char* ctk_path);
 
+// Extended version with build configuration
+CCCL_C_API CUresult cccl_device_unary_transform_build_ex(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
 CCCL_C_API CUresult cccl_device_unary_transform(
   cccl_device_transform_build_result_t build,
   cccl_iterator_t d_in,
@@ -64,6 +78,21 @@ CCCL_C_API CUresult cccl_device_binary_transform_build(
   const char* thrust_path,
   const char* libcudacxx_path,
   const char* ctk_path);
+
+// Extended version with build configuration
+CCCL_C_API CUresult cccl_device_binary_transform_build_ex(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t d_in1,
+  cccl_iterator_t d_in2,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
 
 CCCL_C_API CUresult cccl_device_binary_transform(
   cccl_device_transform_build_result_t build,

--- a/c/parallel/include/cccl/c/types.h
+++ b/c/parallel/include/cccl/c/types.h
@@ -85,16 +85,31 @@ typedef enum cccl_op_kind_t
   CCCL_MAXIMUM       = 23,
 } cccl_op_kind_t;
 
+typedef enum cccl_op_code_type
+{
+  CCCL_OP_LTOIR      = 0, // Pre-compiled LTO-IR (default for backward compatibility)
+  CCCL_OP_CPP_SOURCE = 1 // C++ source code
+} cccl_op_code_type;
+
 typedef struct cccl_op_t
 {
   cccl_op_kind_t type;
   const char* name;
-  const char* ltoir;
-  size_t ltoir_size;
+  const char* code; // Renamed from 'ltoir' - can be either LTO-IR or C++ source
+  size_t code_size; // Renamed from 'ltoir_size'
+  cccl_op_code_type code_type; // New field to distinguish content type
   size_t size;
   size_t alignment;
   void* state;
 } cccl_op_t;
+
+typedef struct cccl_build_config
+{
+  const char** extra_compile_flags; // e.g., {"-DENABLE_FAST_MATH", "-O3"}
+  size_t num_extra_compile_flags;
+  const char** extra_include_dirs; // e.g., {"/path/to/my/headers"}
+  size_t num_extra_include_dirs;
+} cccl_build_config;
 
 typedef enum cccl_iterator_kind_t
 {

--- a/c/parallel/include/cccl/c/unique_by_key.h
+++ b/c/parallel/include/cccl/c/unique_by_key.h
@@ -49,6 +49,23 @@ CCCL_C_API CUresult cccl_device_unique_by_key_build(
   const char* libcudacxx_path,
   const char* ctk_path);
 
+// Extended version with build configuration
+CCCL_C_API CUresult cccl_device_unique_by_key_build_ex(
+  cccl_device_unique_by_key_build_result_t* build,
+  cccl_iterator_t d_keys_in,
+  cccl_iterator_t d_values_in,
+  cccl_iterator_t d_keys_out,
+  cccl_iterator_t d_values_out,
+  cccl_iterator_t d_num_selected_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path,
+  cccl_build_config* config);
+
 CCCL_C_API CUresult cccl_device_unique_by_key(
   cccl_device_unique_by_key_build_result_t build,
   void* d_temp_storage,

--- a/c/parallel/src/for.cu
+++ b/c/parallel/src/for.cu
@@ -14,11 +14,14 @@
 
 #include <format>
 #include <type_traits>
+#include <vector>
 
 #include <cccl/c/for.h>
 #include <cccl/c/types.h>
 #include <for/for_op_helper.h>
 #include <nvrtc/command_list.h>
+#include <nvrtc/ltoir_list_appender.h>
+#include <util/build_utils.h>
 #include <util/context.h>
 #include <util/errors.h>
 #include <util/types.h>
@@ -65,7 +68,7 @@ static std::string get_device_for_kernel_name()
   return std::format("cub::detail::for_each::static_kernel<device_for_policy, {0}, {1}>", offset_t, function_op_t);
 }
 
-CUresult cccl_device_for_build(
+CUresult cccl_device_for_build_ex(
   cccl_device_for_build_result_t* build_ptr,
   cccl_iterator_t d_data,
   cccl_op_t op,
@@ -74,7 +77,8 @@ CUresult cccl_device_for_build(
   const char* cub_path,
   const char* thrust_path,
   const char* libcudacxx_path,
-  const char* ctk_path)
+  const char* ctk_path,
+  cccl_build_config* config)
 {
   CUresult error = CUDA_SUCCESS;
 
@@ -94,36 +98,39 @@ CUresult cccl_device_for_build(
 
     const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
 
-    constexpr size_t num_args  = 8;
-    const char* args[num_args] = {
+    std::vector<const char*> args = {
       arch.c_str(), cub_path, thrust_path, libcudacxx_path, ctk_path, "-rdc=true", "-dlto", "-DCUB_DISABLE_CDP"};
+
+    cccl::detail::extend_args_with_build_config(args, config);
 
     constexpr size_t num_lto_args   = 2;
     const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
 
     std::string lowered_name;
 
-    auto cl =
+    // Collect all LTO-IRs to be linked
+    nvrtc_linkable_list linkable_list;
+    nvrtc_linkable_list_appender appender{linkable_list};
+
+    // Add operation if it's LTO-IR (C++ source not yet supported in for)
+    appender.append_operation(op);
+
+    // Add iterator definitions if present
+    if (cccl_iterator_kind_t::CCCL_ITERATOR == d_data.type)
+    {
+      appender.append_operation(d_data.advance);
+      appender.append_operation(d_data.dereference);
+    }
+
+    nvrtc_link_result result =
       begin_linking_nvrtc_program(num_lto_args, lopts)
         ->add_program(nvrtc_translation_unit{device_for_kernel, name})
         ->add_expression({for_kernel_name})
-        ->compile_program({args, num_args})
+        ->compile_program({args.data(), args.size()})
         ->get_name({for_kernel_name, lowered_name})
         ->link_program()
-        ->add_link({op.ltoir, op.ltoir_size});
-
-    nvrtc_link_result result{};
-
-    if (cccl_iterator_kind_t::CCCL_ITERATOR == d_data.type)
-    {
-      result = cl->add_link({d_data.advance.ltoir, d_data.advance.ltoir_size})
-                 ->add_link({d_data.dereference.ltoir, d_data.dereference.ltoir_size})
-                 ->finalize_program();
-    }
-    else
-    {
-      result = cl->finalize_program();
-    }
+        ->add_link_list(linkable_list)
+        ->finalize_program();
 
     cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
     check(cuLibraryGetKernel(&build_ptr->static_kernel, build_ptr->library, lowered_name.c_str()));
@@ -163,6 +170,21 @@ CUresult cccl_device_for(
   }
 
   return error;
+}
+
+CUresult cccl_device_for_build(
+  cccl_device_for_build_result_t* build,
+  cccl_iterator_t d_data,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path)
+{
+  return cccl_device_for_build_ex(
+    build, d_data, op, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path, nullptr);
 }
 
 CUresult cccl_device_for_cleanup(cccl_device_for_build_result_t* build_ptr)

--- a/c/parallel/src/nvrtc/command_list.h
+++ b/c/parallel/src/nvrtc/command_list.h
@@ -66,8 +66,8 @@ struct nvrtc_get_name
 };
 struct nvrtc_compile
 {
-  const char** args;
-  size_t num_args;
+  const char** args = nullptr;
+  size_t num_args   = 0;
 };
 struct nvrtc_get_ptx
 {
@@ -75,10 +75,16 @@ struct nvrtc_get_ptx
 };
 struct nvrtc_ltoir
 {
-  const char* ltoir;
-  size_t ltsz;
+  const char* ltoir = nullptr;
+  size_t size       = 0;
 };
-using nvrtc_ltoir_list = std::vector<nvrtc_ltoir>;
+struct nvrtc_code
+{
+  const char* code = nullptr;
+  size_t size      = 0;
+};
+using nvrtc_linkable      = std::variant<nvrtc_ltoir, nvrtc_code>;
+using nvrtc_linkable_list = std::vector<nvrtc_linkable>;
 struct nvrtc_jitlink_cleanup
 {
   nvrtc_link_result& link_result_ref;
@@ -86,6 +92,8 @@ struct nvrtc_jitlink_cleanup
 struct nvrtc_jitlink
 {
   nvJitLinkHandle handle{};
+  uint32_t numOpts{};
+  const char** opts{};
 
   nvrtc_jitlink()                     = delete;
   nvrtc_jitlink(const nvrtc_jitlink&) = delete;
@@ -97,6 +105,8 @@ struct nvrtc_jitlink
 
   nvrtc_jitlink(uint32_t numOpts, const char** opts)
       : handle(nullptr)
+      , numOpts(numOpts)
+      , opts(opts)
   {
     if (opts)
     {
@@ -122,6 +132,7 @@ struct nvrtc2_lto_context
 {
   nvrtc_jitlink jit;
   nvrtcProgram program{};
+  nvrtc_compile compile_args{};
   std::string_view program_name = "test";
 };
 
@@ -129,6 +140,13 @@ using nvrtc2_top_level_nl   = node_list<nvrtc2_lto_context, nvrtc2_top_level>;
 using nvrtc2_pre_build_nl   = node_list<nvrtc2_lto_context, nvrtc2_pre_build>;
 using nvrtc2_link_result_nl = node_list<nvrtc2_lto_context, nvrtc2_link_result>;
 using nvrtc2_post_build_nl  = node_list<nvrtc2_lto_context, nvrtc2_post_build>;
+
+inline nvrtc2_top_level_nl begin_linking_nvrtc_program(uint32_t numLtoOpts, const char** ltoOpts)
+{
+  nvrtc2_lto_context context{nvrtc_jitlink(numLtoOpts, ltoOpts)};
+
+  return {std::move(context)};
+}
 
 struct nvrtc2_post_build
 {
@@ -156,19 +174,32 @@ struct nvrtc2_post_build
     return ret;
   }
 
+  inline std::pair<std::size_t, std::unique_ptr<char[]>> get_program_ltoir()
+  {
+    auto ltoir = get_ltoir();
+    cleanup_program();
+    return ltoir;
+  }
+
   inline nvrtc2_top_level_nl link_program()
+  {
+    auto [ltoir_size, ltoir] = get_ltoir();
+    check(nvJitLinkAddData(
+      context.jit.handle, NVJITLINK_INPUT_LTOIR, ltoir.get(), ltoir_size, context.program_name.data()));
+    return cleanup_program();
+  }
+
+private:
+  inline std::pair<std::size_t, std::unique_ptr<char[]>> get_ltoir()
   {
     std::size_t ltoir_size{};
     check(nvrtcGetLTOIRSize(context.program, &ltoir_size));
     std::unique_ptr<char[]> ltoir{new char[ltoir_size]};
     check(nvrtcGetLTOIR(context.program, ltoir.get()));
-    check(nvJitLinkAddData(
-      context.jit.handle, NVJITLINK_INPUT_LTOIR, ltoir.get(), ltoir_size, context.program_name.data()));
 
-    return cleanup_program();
+    return {ltoir_size, std::move(ltoir)};
   }
 
-private:
   inline nvrtc2_top_level_nl cleanup_program()
   {
     nvrtcDestroyProgram(&context.program);
@@ -209,6 +240,8 @@ struct nvrtc2_pre_build
     }
     check(result);
 
+    context.compile_args = {compile_args.args, n_actual_args};
+
     return {std::move(context)};
   }
 };
@@ -231,18 +264,60 @@ struct nvrtc2_top_level
   inline nvrtc2_top_level_nl add_link(nvrtc_ltoir arg)
   {
     check(nvJitLinkAddData(
-      context.jit.handle, NVJITLINK_INPUT_LTOIR, (const void*) arg.ltoir, arg.ltsz, context.program_name.data()));
+      context.jit.handle, NVJITLINK_INPUT_LTOIR, (const void*) arg.ltoir, arg.size, context.program_name.data()));
     return {std::move(context)};
   }
 
   // Add linkable units to whole program
-  inline nvrtc2_top_level_nl add_link_list(nvrtc_ltoir_list list)
+  inline nvrtc2_top_level_nl add_link_list(nvrtc_linkable_list list)
   {
-    for (const auto& lto : list)
+    // Partition: move all LTO-IR items to the front
+    auto ltoir_end = std::partition(list.begin(), list.end(), [](const auto& linkable) {
+      return std::holds_alternative<nvrtc_ltoir>(linkable);
+    });
+
+    // Collect all code items
+    std::string user_program;
+    for (auto it = ltoir_end; it != list.end(); ++it)
     {
-      check(nvJitLinkAddData(
-        context.jit.handle, NVJITLINK_INPUT_LTOIR, (const void*) lto.ltoir, lto.ltsz, context.program_name.data()));
+      const auto& code = std::get<nvrtc_code>(*it);
+      user_program.append(code.code, code.size);
     }
+
+    // Compile accumulated code if any
+    std::pair<std::size_t, std::unique_ptr<char[]>> user_program_ltoir;
+
+    if (!user_program.empty())
+    {
+      user_program_ltoir =
+        begin_linking_nvrtc_program(context.jit.numOpts, context.jit.opts)
+          ->add_program(nvrtc_translation_unit{user_program.c_str(), "user_tu"})
+          ->compile_program({context.compile_args.args, context.compile_args.num_args})
+          ->get_program_ltoir();
+
+      if (user_program_ltoir.first)
+      {
+        // Replace the first code item with the compiled LTO-IR
+        *ltoir_end = nvrtc_ltoir{user_program_ltoir.second.get(), user_program_ltoir.first};
+        ++ltoir_end;
+      }
+    }
+
+    // Add all LTO-IR items to the linker
+    for (auto it = list.begin(); it != ltoir_end; ++it)
+    {
+      const auto& ltoir = std::get<nvrtc_ltoir>(*it);
+      if (ltoir.size)
+      {
+        check(nvJitLinkAddData(
+          context.jit.handle,
+          NVJITLINK_INPUT_LTOIR,
+          (const void*) ltoir.ltoir,
+          ltoir.size,
+          context.program_name.data()));
+      }
+    }
+
     return {std::move(context)};
   }
 
@@ -285,10 +360,3 @@ struct nvrtc2_top_level
     return link_result;
   }
 };
-
-inline nvrtc2_top_level_nl begin_linking_nvrtc_program(uint32_t numLtoOpts, const char** ltoOpts)
-{
-  nvrtc2_lto_context context{nvrtc_jitlink(numLtoOpts, ltoOpts)};
-
-  return {std::move(context)};
-}

--- a/c/parallel/src/reduce.cu
+++ b/c/parallel/src/reduce.cu
@@ -21,6 +21,7 @@
 
 #include <format>
 #include <memory>
+#include <vector>
 
 #include "jit_templates/templates/input_iterator.h"
 #include "jit_templates/templates/operation.h"
@@ -34,6 +35,7 @@
 #include <cccl/c/reduce.h>
 #include <nvrtc/command_list.h>
 #include <nvrtc/ltoir_list_appender.h>
+#include <util/build_utils.h>
 
 struct device_reduce_policy;
 using TransformOpT = ::cuda::std::identity;
@@ -158,7 +160,7 @@ struct reduce_kernel_source
 struct reduce_iterator_tag;
 struct reduction_operation_tag;
 
-CUresult cccl_device_reduce_build(
+CUresult cccl_device_reduce_build_ex(
   cccl_device_reduce_build_result_t* build,
   cccl_iterator_t input_it,
   cccl_iterator_t output_it,
@@ -169,7 +171,8 @@ CUresult cccl_device_reduce_build(
   const char* cub_path,
   const char* thrust_path,
   const char* libcudacxx_path,
-  const char* ctk_path)
+  const char* ctk_path,
+  cccl_build_config* config)
 {
   CUresult error = CUDA_SUCCESS;
 
@@ -256,8 +259,8 @@ struct __align__({1}) storage_t {{
 
     const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
 
-    constexpr size_t num_args  = 9;
-    const char* args[num_args] = {
+    // Build compilation arguments
+    std::vector<const char*> args = {
       arch.c_str(),
       cub_path,
       thrust_path,
@@ -268,14 +271,17 @@ struct __align__({1}) storage_t {{
       "-DCUB_DISABLE_CDP",
       "-std=c++20"};
 
+    // Add user's extra flags if config is provided
+    cccl::detail::extend_args_with_build_config(args, config);
+
     constexpr size_t num_lto_args   = 2;
     const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
 
     // Collect all LTO-IRs to be linked.
-    nvrtc_ltoir_list ltoir_list;
-    nvrtc_ltoir_list_appender appender{ltoir_list};
+    nvrtc_linkable_list linkable_list;
+    nvrtc_linkable_list_appender appender{linkable_list};
 
-    appender.append({op.ltoir, op.ltoir_size});
+    appender.append_operation(op);
     appender.add_iterator_definition(input_it);
     appender.add_iterator_definition(output_it);
 
@@ -285,12 +291,12 @@ struct __align__({1}) storage_t {{
         ->add_expression({single_tile_kernel_name})
         ->add_expression({single_tile_second_kernel_name})
         ->add_expression({reduction_kernel_name})
-        ->compile_program({args, num_args})
+        ->compile_program({args.data(), args.size()})
         ->get_name({single_tile_kernel_name, single_tile_kernel_lowered_name})
         ->get_name({single_tile_second_kernel_name, single_tile_second_kernel_lowered_name})
         ->get_name({reduction_kernel_name, reduction_kernel_lowered_name})
         ->link_program()
-        ->add_link_list(ltoir_list)
+        ->add_link_list(linkable_list)
         ->finalize_program();
 
     cuLibraryLoadData(&build->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
@@ -402,4 +408,22 @@ CUresult cccl_device_reduce_cleanup(cccl_device_reduce_build_result_t* build_ptr
   }
 
   return CUDA_SUCCESS;
+}
+
+// Backward compatibility wrapper
+CUresult cccl_device_reduce_build(
+  cccl_device_reduce_build_result_t* build,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  cccl_value_t init,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path)
+{
+  return cccl_device_reduce_build_ex(
+    build, d_in, d_out, op, init, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path, nullptr);
 }

--- a/c/parallel/src/segmented_reduce.cu
+++ b/c/parallel/src/segmented_reduce.cu
@@ -14,10 +14,11 @@
 #include <cub/thread/thread_load.cuh> // cub::LoadModifier
 
 #include <exception> // std::exception
-#include <format> // std::format
+#include <format>
 #include <string> // std::string
 #include <string_view> // std::string_view
 #include <type_traits> // std::is_same_v
+#include <vector> // std::format
 
 #include <stdio.h> // printf
 
@@ -25,15 +26,16 @@
 #include "jit_templates/templates/operation.h"
 #include "jit_templates/templates/output_iterator.h"
 #include "jit_templates/traits.h"
-#include "util/context.h"
-#include "util/errors.h"
-#include "util/indirect_arg.h"
-#include "util/runtime_policy.h"
-#include "util/types.h"
 #include <cccl/c/segmented_reduce.h>
 #include <cccl/c/types.h> // cccl_type_info
 #include <nvrtc/command_list.h>
 #include <nvrtc/ltoir_list_appender.h>
+#include <util/build_utils.h>
+#include <util/context.h>
+#include <util/errors.h>
+#include <util/indirect_arg.h>
+#include <util/runtime_policy.h>
+#include <util/types.h>
 
 struct device_segmented_reduce_policy;
 using OffsetT = unsigned long long;
@@ -134,7 +136,7 @@ struct segmented_reduce_start_offset_iterator_tag;
 struct segmented_reduce_end_offset_iterator_tag;
 struct segmented_reduce_operation_tag;
 
-CUresult cccl_device_segmented_reduce_build(
+CUresult cccl_device_segmented_reduce_build_ex(
   cccl_device_segmented_reduce_build_result_t* build_ptr,
   cccl_iterator_t input_it,
   cccl_iterator_t output_it,
@@ -147,7 +149,8 @@ CUresult cccl_device_segmented_reduce_build(
   const char* cub_path,
   const char* thrust_path,
   const char* libcudacxx_path,
-  const char* ctk_path)
+  const char* ctk_path,
+  cccl_build_config* config)
 {
   CUresult error = CUDA_SUCCESS;
 
@@ -260,8 +263,7 @@ struct device_segmented_reduce_policy {{
 
     const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
 
-    constexpr size_t num_args  = 9;
-    const char* args[num_args] = {
+    std::vector<const char*> args = {
       arch.c_str(),
       cub_path,
       thrust_path,
@@ -272,15 +274,17 @@ struct device_segmented_reduce_policy {{
       "-DCUB_DISABLE_CDP",
       "-std=c++20"};
 
+    cccl::detail::extend_args_with_build_config(args, config);
+
     constexpr size_t num_lto_args   = 2;
     const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
 
     // Collect all LTO-IRs to be linked.
-    nvrtc_ltoir_list ltoir_list;
-    nvrtc_ltoir_list_appender appender{ltoir_list};
+    nvrtc_linkable_list linkable_list;
+    nvrtc_linkable_list_appender appender{linkable_list};
 
     // add definition of binary operation op
-    appender.append({op.ltoir, op.ltoir_size});
+    appender.append_operation(op);
     // add iterator definitions
     appender.add_iterator_definition(input_it);
     appender.add_iterator_definition(output_it);
@@ -291,10 +295,10 @@ struct device_segmented_reduce_policy {{
       begin_linking_nvrtc_program(num_lto_args, lopts)
         ->add_program(nvrtc_translation_unit{final_src.c_str(), name})
         ->add_expression({segmented_reduce_kernel_name})
-        ->compile_program({args, num_args})
+        ->compile_program({args.data(), args.size()})
         ->get_name({segmented_reduce_kernel_name, segmented_reduce_kernel_lowered_name})
         ->link_program()
-        ->add_link_list(ltoir_list)
+        ->add_link_list(linkable_list)
         ->finalize_program();
 
     // populate build struct members
@@ -385,6 +389,38 @@ CUresult cccl_device_segmented_reduce(
   }
 
   return error;
+}
+
+CUresult cccl_device_segmented_reduce_build(
+  cccl_device_segmented_reduce_build_result_t* build,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_iterator_t begin_offset_in,
+  cccl_iterator_t end_offset_in,
+  cccl_op_t op,
+  cccl_value_t init,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path)
+{
+  return cccl_device_segmented_reduce_build_ex(
+    build,
+    d_in,
+    d_out,
+    begin_offset_in,
+    end_offset_in,
+    op,
+    init,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    nullptr);
 }
 
 CUresult cccl_device_segmented_reduce_cleanup(cccl_device_segmented_reduce_build_result_t* build_ptr)

--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -18,20 +18,22 @@
 #include <format>
 #include <string>
 #include <type_traits>
+#include <vector>
 
 #include <stdio.h> // printf
 
-#include "kernels/iterators.h"
-#include "kernels/operators.h"
-#include "util/context.h"
-#include "util/errors.h"
-#include "util/indirect_arg.h"
-#include "util/runtime_policy.h"
-#include "util/types.h"
 #include <cccl/c/transform.h>
 #include <cccl/c/types.h> // cccl_type_info
+#include <kernels/iterators.h>
+#include <kernels/operators.h>
 #include <nvrtc/command_list.h>
 #include <nvrtc/ltoir_list_appender.h>
+#include <util/build_utils.h>
+#include <util/context.h>
+#include <util/errors.h>
+#include <util/indirect_arg.h>
+#include <util/runtime_policy.h>
+#include <util/types.h>
 
 struct op_wrapper;
 struct device_transform_policy;
@@ -211,7 +213,7 @@ struct transform_kernel_source
 
 } // namespace transform
 
-CUresult cccl_device_unary_transform_build(
+CUresult cccl_device_unary_transform_build_ex(
   cccl_device_transform_build_result_t* build_ptr,
   cccl_iterator_t input_it,
   cccl_iterator_t output_it,
@@ -221,7 +223,8 @@ CUresult cccl_device_unary_transform_build(
   const char* cub_path,
   const char* thrust_path,
   const char* libcudacxx_path,
-  const char* ctk_path)
+  const char* ctk_path,
+  cccl_build_config* config)
 {
   CUresult error = CUDA_SUCCESS;
 
@@ -326,8 +329,7 @@ struct device_transform_policy {{
     // Note: `-default-device` is needed because of the use of lambdas
     // in the transform kernel code. Qualifying those explicitly with
     // `__device__` seems not to be supported by NVRTC.
-    constexpr size_t num_args  = 9;
-    const char* args[num_args] = {
+    std::vector<const char*> args = {
       arch.c_str(),
       cub_path,
       thrust_path,
@@ -338,14 +340,16 @@ struct device_transform_policy {{
       "-default-device",
       "-DCUB_DISABLE_CDP"};
 
+    cccl::detail::extend_args_with_build_config(args, config);
+
     constexpr size_t num_lto_args   = 2;
     const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
 
     // Collect all LTO-IRs to be linked.
-    nvrtc_ltoir_list ltoir_list;
-    nvrtc_ltoir_list_appender appender{ltoir_list};
+    nvrtc_linkable_list linkable_list;
+    nvrtc_linkable_list_appender appender{linkable_list};
 
-    appender.append({op.ltoir, op.ltoir_size});
+    appender.append_operation(op);
     appender.add_iterator_definition(input_it);
     appender.add_iterator_definition(output_it);
 
@@ -353,10 +357,10 @@ struct device_transform_policy {{
       begin_linking_nvrtc_program(num_lto_args, lopts)
         ->add_program(nvrtc_translation_unit{final_src.c_str(), name})
         ->add_expression({kernel_name})
-        ->compile_program({args, num_args})
+        ->compile_program({args.data(), args.size()})
         ->get_name({kernel_name, kernel_lowered_name})
         ->link_program()
-        ->add_link_list(ltoir_list)
+        ->add_link_list(linkable_list)
         ->finalize_program();
 
     cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
@@ -434,7 +438,7 @@ CUresult cccl_device_unary_transform(
   return error;
 }
 
-CUresult cccl_device_binary_transform_build(
+CUresult cccl_device_binary_transform_build_ex(
   cccl_device_transform_build_result_t* build_ptr,
   cccl_iterator_t input1_it,
   cccl_iterator_t input2_it,
@@ -445,7 +449,8 @@ CUresult cccl_device_binary_transform_build(
   const char* cub_path,
   const char* thrust_path,
   const char* libcudacxx_path,
-  const char* ctk_path)
+  const char* ctk_path,
+  cccl_build_config* config)
 {
   CUresult error = CUDA_SUCCESS;
 
@@ -562,8 +567,7 @@ struct device_transform_policy {{
 
     const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
 
-    constexpr size_t num_args  = 9;
-    const char* args[num_args] = {
+    std::vector<const char*> args = {
       arch.c_str(),
       cub_path,
       thrust_path,
@@ -574,14 +578,16 @@ struct device_transform_policy {{
       "-default-device",
       "-DCUB_DISABLE_CDP"};
 
+    cccl::detail::extend_args_with_build_config(args, config);
+
     constexpr size_t num_lto_args   = 2;
     const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
 
     // Collect all LTO-IRs to be linked.
-    nvrtc_ltoir_list ltoir_list;
-    nvrtc_ltoir_list_appender appender{ltoir_list};
+    nvrtc_linkable_list linkable_list;
+    nvrtc_linkable_list_appender appender{linkable_list};
 
-    appender.append({op.ltoir, op.ltoir_size});
+    appender.append_operation(op);
     appender.add_iterator_definition(input1_it);
     appender.add_iterator_definition(input2_it);
     appender.add_iterator_definition(output_it);
@@ -590,10 +596,10 @@ struct device_transform_policy {{
       begin_linking_nvrtc_program(num_lto_args, lopts)
         ->add_program(nvrtc_translation_unit{final_src.c_str(), name})
         ->add_expression({kernel_name})
-        ->compile_program({args, num_args})
+        ->compile_program({args.data(), args.size()})
         ->get_name({kernel_name, kernel_lowered_name})
         ->link_program()
-        ->add_link_list(ltoir_list)
+        ->add_link_list(linkable_list)
         ->finalize_program();
 
     cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
@@ -674,6 +680,39 @@ CUresult cccl_device_binary_transform(
     cuCtxPopCurrent(&cu_context);
   }
   return error;
+}
+
+CUresult cccl_device_unary_transform_build(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t d_in,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path)
+{
+  return cccl_device_unary_transform_build_ex(
+    build_ptr, d_in, d_out, op, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path, nullptr);
+}
+
+CUresult cccl_device_binary_transform_build(
+  cccl_device_transform_build_result_t* build_ptr,
+  cccl_iterator_t d_in1,
+  cccl_iterator_t d_in2,
+  cccl_iterator_t d_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path)
+{
+  return cccl_device_binary_transform_build_ex(
+    build_ptr, d_in1, d_in2, d_out, op, cc_major, cc_minor, cub_path, thrust_path, libcudacxx_path, ctk_path, nullptr);
 }
 
 CUresult cccl_device_transform_cleanup(cccl_device_transform_build_result_t* build_ptr)

--- a/c/parallel/src/unique_by_key.cu
+++ b/c/parallel/src/unique_by_key.cu
@@ -8,23 +8,25 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cub/block/block_scan.cuh>
 #include <cub/detail/choose_offset.cuh>
 #include <cub/detail/launcher/cuda_driver.cuh>
 #include <cub/device/device_select.cuh>
 
 #include <format>
+#include <vector>
 
-#include "cub/block/block_scan.cuh"
-#include "kernels/iterators.h"
-#include "kernels/operators.h"
-#include "util/context.h"
-#include "util/indirect_arg.h"
-#include "util/scan_tile_state.h"
-#include "util/tuning.h"
-#include "util/types.h"
 #include <cccl/c/unique_by_key.h>
+#include <kernels/iterators.h>
+#include <kernels/operators.h>
 #include <nvrtc/command_list.h>
 #include <nvrtc/ltoir_list_appender.h>
+#include <util/build_utils.h>
+#include <util/context.h>
+#include <util/indirect_arg.h>
+#include <util/scan_tile_state.h>
+#include <util/tuning.h>
+#include <util/types.h>
 
 struct op_wrapper;
 struct device_unique_by_key_policy;
@@ -218,7 +220,7 @@ struct dynamic_vsmem_helper_t
 
 } // namespace unique_by_key
 
-CUresult cccl_device_unique_by_key_build(
+CUresult cccl_device_unique_by_key_build_ex(
   cccl_device_unique_by_key_build_result_t* build_ptr,
   cccl_iterator_t input_keys_it,
   cccl_iterator_t input_values_it,
@@ -231,7 +233,8 @@ CUresult cccl_device_unique_by_key_build(
   const char* cub_path,
   const char* thrust_path,
   const char* libcudacxx_path,
-  const char* ctk_path)
+  const char* ctk_path,
+  cccl_build_config* config)
 {
   CUresult error = CUDA_SUCCESS;
 
@@ -363,18 +366,19 @@ struct device_unique_by_key_vsmem_helper {{
 
     const std::string arch = std::format("-arch=sm_{0}{1}", cc_major, cc_minor);
 
-    constexpr size_t num_args  = 8;
-    const char* args[num_args] = {
+    std::vector<const char*> args = {
       arch.c_str(), cub_path, thrust_path, libcudacxx_path, ctk_path, "-rdc=true", "-dlto", "-DCUB_DISABLE_CDP"};
+
+    cccl::detail::extend_args_with_build_config(args, config);
 
     constexpr size_t num_lto_args   = 2;
     const char* lopts[num_lto_args] = {"-lto", arch.c_str()};
 
     // Collect all LTO-IRs to be linked.
-    nvrtc_ltoir_list ltoir_list;
-    nvrtc_ltoir_list_appender appender{ltoir_list};
+    nvrtc_linkable_list linkable_list;
+    nvrtc_linkable_list_appender appender{linkable_list};
 
-    appender.append({op.ltoir, op.ltoir_size});
+    appender.append_operation(op);
     appender.add_iterator_definition(input_keys_it);
     appender.add_iterator_definition(input_values_it);
     appender.add_iterator_definition(output_keys_it);
@@ -386,11 +390,11 @@ struct device_unique_by_key_vsmem_helper {{
         ->add_program(nvrtc_translation_unit{src.c_str(), name})
         ->add_expression({compact_init_kernel_name})
         ->add_expression({sweep_kernel_name})
-        ->compile_program({args, num_args})
+        ->compile_program({args.data(), args.size()})
         ->get_name({compact_init_kernel_name, compact_init_kernel_lowered_name})
         ->get_name({sweep_kernel_name, sweep_kernel_lowered_name})
         ->link_program()
-        ->add_link_list(ltoir_list)
+        ->add_link_list(linkable_list)
         ->finalize_program();
 
     cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
@@ -399,7 +403,7 @@ struct device_unique_by_key_vsmem_helper {{
     check(cuLibraryGetKernel(&build_ptr->sweep_kernel, build_ptr->library, sweep_kernel_lowered_name.c_str()));
 
     auto [description_bytes_per_tile,
-          payload_bytes_per_tile] = get_tile_state_bytes_per_tile(offset_t, offset_cpp, args, num_args, arch);
+          payload_bytes_per_tile] = get_tile_state_bytes_per_tile(offset_t, offset_cpp, args.data(), args.size(), arch);
 
     build_ptr->cc                         = cc;
     build_ptr->cubin                      = (void*) result.data.release();
@@ -484,6 +488,38 @@ CUresult cccl_device_unique_by_key(
   }
 
   return error;
+}
+
+CUresult cccl_device_unique_by_key_build(
+  cccl_device_unique_by_key_build_result_t* build,
+  cccl_iterator_t d_keys_in,
+  cccl_iterator_t d_values_in,
+  cccl_iterator_t d_keys_out,
+  cccl_iterator_t d_values_out,
+  cccl_iterator_t d_num_selected_out,
+  cccl_op_t op,
+  int cc_major,
+  int cc_minor,
+  const char* cub_path,
+  const char* thrust_path,
+  const char* libcudacxx_path,
+  const char* ctk_path)
+{
+  return cccl_device_unique_by_key_build_ex(
+    build,
+    d_keys_in,
+    d_values_in,
+    d_keys_out,
+    d_values_out,
+    d_num_selected_out,
+    op,
+    cc_major,
+    cc_minor,
+    cub_path,
+    thrust_path,
+    libcudacxx_path,
+    ctk_path,
+    nullptr);
 }
 
 CUresult cccl_device_unique_by_key_cleanup(cccl_device_unique_by_key_build_result_t* build_ptr)

--- a/c/parallel/src/util/build_utils.h
+++ b/c/parallel/src/util/build_utils.h
@@ -1,0 +1,47 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA Core Compute Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <vector>
+
+#include <cccl/c/types.h>
+
+namespace cccl
+{
+namespace detail
+{
+
+/**
+ * @brief Extends a vector of compilation arguments with extra flags and include directories from a build config
+ *
+ * @param args The vector of arguments to extend
+ * @param config The build configuration containing extra flags and include directories (can be nullptr)
+ */
+inline void extend_args_with_build_config(std::vector<const char*>& args, const cccl_build_config* config)
+{
+  if (config)
+  {
+    // Add extra compile flags
+    for (size_t i = 0; i < config->num_extra_compile_flags; ++i)
+    {
+      args.push_back(config->extra_compile_flags[i]);
+    }
+    // Add include directories
+    for (size_t i = 0; i < config->num_extra_include_dirs; ++i)
+    {
+      args.push_back("-I");
+      args.push_back(config->extra_include_dirs[i]);
+    }
+  }
+}
+
+} // namespace detail
+} // namespace cccl

--- a/c/parallel/test/CMakeLists.txt
+++ b/c/parallel/test/CMakeLists.txt
@@ -16,11 +16,14 @@ function(cccl_c_parallel_add_test target_name_var source)
     cccl.compiler_interface_cpp20
   )
 
+  # Get the first CUDA include directory only
+  list(GET CUDAToolkit_INCLUDE_DIRS 0 CUDA_FIRST_INCLUDE_DIR)
   target_compile_definitions(${target_name} PRIVATE
     TEST_CUB_PATH="-I${CCCL_SOURCE_DIR}/cub"
     TEST_THRUST_PATH="-I${CCCL_SOURCE_DIR}/thrust"
     TEST_LIBCUDACXX_PATH="-I${CCCL_SOURCE_DIR}/libcudacxx/include"
-    TEST_CTK_PATH="-I${CUDAToolkit_INCLUDE_DIRS}"
+    TEST_CTK_PATH="-I${CUDA_FIRST_INCLUDE_DIR}"
+    TEST_INCLUDE_PATH="${CMAKE_CURRENT_SOURCE_DIR}"
   )
 
   add_test(NAME ${target_name} COMMAND ${target_name})

--- a/c/parallel/test/test_for.cpp
+++ b/c/parallel/test/test_for.cpp
@@ -207,6 +207,103 @@ extern "C" __device__ void op(void* state_ptr, void* a_ptr) {
   REQUIRE(invocation_count == num_items);
 }
 
+C2H_TEST("for works with C++ source operations", "[for]")
+{
+  using T = int32_t;
+
+  const uint64_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source instead of LTO-IR
+  std::string cpp_source = R"(
+    extern "C" __device__ void op(void* a) {
+      int* ia = (int*)a;
+      *ia = *ia + 1;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  std::vector<T> input(num_items, T(1));
+  pointer_t<T> input_ptr(input);
+
+  // Test key including flag that this uses C++ source
+  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
+
+  auto& cache = fixture<for_each_build_cache_t, DeviceFor_Pointer_Fixture_Tag>::get_or_create().get_value();
+  std::optional<for_each_build_cache_t> cache_opt = cache;
+  for_each(input_ptr, num_items, op, cache_opt, test_key);
+
+  // Copy input array back to host
+  input = input_ptr;
+
+  REQUIRE(std::all_of(input.begin(), input.end(), [](auto&& v) {
+    return v == T{2};
+  }));
+}
+
+C2H_TEST("For works with C++ source operations using custom headers", "[for]")
+{
+  using T = int32_t;
+
+  const uint64_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source that uses the identity function from header
+  std::string cpp_source = R"(
+    #include "test_identity.h"
+    extern "C" __device__ void op(void* a) {
+      int* ia = (int*)a;
+      int val = test_identity(*ia);
+      *ia = val + 1;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  std::vector<T> input(num_items, T(1));
+  pointer_t<T> input_ptr(input);
+
+  // Test _ex version with custom build configuration
+  cccl_build_config config;
+  const char* extra_flags[]      = {"-DTEST_IDENTITY_ENABLED"};
+  const char* extra_dirs[]       = {TEST_INCLUDE_PATH};
+  config.extra_compile_flags     = extra_flags;
+  config.num_extra_compile_flags = 1;
+  config.extra_include_dirs      = extra_dirs;
+  config.num_extra_include_dirs  = 1;
+
+  // Build with _ex version
+  cccl_device_for_build_result_t build;
+  const auto& build_info = BuildInformation<>::init();
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_for_build_ex(
+      &build,
+      input_ptr,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      &config));
+
+  // Execute the for_each
+  REQUIRE(CUDA_SUCCESS == cccl_device_for(build, input_ptr, num_items, op, CU_STREAM_LEGACY));
+
+  // Verify results
+  std::vector<T> output(num_items);
+  cudaMemcpy(output.data(), static_cast<void*>(input_ptr.ptr), sizeof(T) * num_items, cudaMemcpyDeviceToHost);
+  std::vector<T> expected = input;
+  std::transform(expected.begin(), expected.end(), expected.begin(), [](T x) {
+    return x * 2;
+  });
+  REQUIRE(output == expected);
+
+  // Cleanup
+  REQUIRE(CUDA_SUCCESS == cccl_device_for_cleanup(&build));
+}
+
 // TODO:
 /*
 C2H_TEST("for works with iterators", "[for]")

--- a/c/parallel/test/test_identity.h
+++ b/c/parallel/test/test_identity.h
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#ifdef TEST_IDENTITY_ENABLED
+template <typename T>
+__device__ T test_identity(T value)
+{
+  return value;
+}
+#endif

--- a/c/parallel/test/test_merge_sort.cpp
+++ b/c/parallel/test/test_merge_sort.cpp
@@ -493,6 +493,151 @@ struct large_key_pair
   char c[100];
 };
 
+C2H_TEST("MergeSort works with C++ source operations", "[merge_sort]")
+{
+  using key_t = int32_t;
+
+  const std::size_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source instead of LTO-IR
+  std::string cpp_source = R"(
+    extern "C" __device__ void op(void* lhs, void* rhs, void* result) {
+      int* ilhs = (int*)lhs;
+      int* irhs = (int*)rhs;
+      bool* bresult = (bool*)result;
+      *bresult = *ilhs < *irhs;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  std::vector<key_t> input_keys = make_shuffled_sequence<key_t>(num_items);
+  pointer_t<key_t> input_keys_ptr(input_keys);
+  pointer_t<key_t> output_keys_ptr(num_items);
+
+  // Use int for items but won't actually use them
+  pointer_t<int> input_items_ptr;
+  pointer_t<int> output_items_ptr;
+
+  // Test key including flag that this uses C++ source
+  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(key_t).name());
+
+  auto& cache = fixture<merge_sort_build_cache_t, DeviceMergeSort_SortKeys_Fixture_Tag>::get_or_create().get_value();
+  std::optional<merge_sort_build_cache_t> cache_opt = cache;
+
+  merge_sort(input_keys_ptr, input_items_ptr, output_keys_ptr, output_items_ptr, num_items, op, cache_opt, test_key);
+
+  const std::vector<key_t> output = output_keys_ptr;
+  std::vector<key_t> expected     = input_keys;
+  std::sort(expected.begin(), expected.end());
+  REQUIRE(output == expected);
+}
+
+C2H_TEST("MergeSort works with C++ source operations using custom headers", "[merge_sort]")
+{
+  using key_t = int32_t;
+
+  const std::size_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source that uses the identity function from header
+  std::string cpp_source = R"(
+    #include "test_identity.h"
+    extern "C" __device__ void op(void* lhs, void* rhs, void* result) {
+      int* ilhs = (int*)lhs;
+      int* irhs = (int*)rhs;
+      bool* bresult = (bool*)result;
+      int val_lhs = test_identity(*ilhs);
+      int val_rhs = test_identity(*irhs);
+      *bresult = val_lhs < val_rhs;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  std::vector<key_t> input_keys = make_shuffled_sequence<key_t>(num_items);
+  pointer_t<key_t> input_keys_ptr(input_keys);
+  pointer_t<key_t> output_keys_ptr(num_items);
+
+  // Use int for items but won't actually use them
+  pointer_t<int> input_items_ptr;
+  pointer_t<int> output_items_ptr;
+
+  // Test _ex version with custom build configuration
+  cccl_build_config config;
+  const char* extra_flags[]      = {"-DTEST_IDENTITY_ENABLED"};
+  const char* extra_dirs[]       = {TEST_INCLUDE_PATH};
+  config.extra_compile_flags     = extra_flags;
+  config.num_extra_compile_flags = 1;
+  config.extra_include_dirs      = extra_dirs;
+  config.num_extra_include_dirs  = 1;
+
+  // Build with _ex version
+  cccl_device_merge_sort_build_result_t build;
+  const auto& build_info = BuildInformation<>::init();
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_merge_sort_build_ex(
+      &build,
+      input_keys_ptr,
+      input_items_ptr,
+      output_keys_ptr,
+      output_items_ptr,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      &config));
+
+  // Execute the merge sort
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_merge_sort(
+      build,
+      d_temp_storage,
+      &temp_storage_bytes,
+      input_keys_ptr,
+      input_items_ptr,
+      output_keys_ptr,
+      output_items_ptr,
+      num_items,
+      op,
+      CU_STREAM_LEGACY));
+  pointer_t<char> temp_storage(temp_storage_bytes);
+  d_temp_storage = static_cast<void*>(temp_storage.ptr);
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_merge_sort(
+      build,
+      d_temp_storage,
+      &temp_storage_bytes,
+      input_keys_ptr,
+      input_items_ptr,
+      output_keys_ptr,
+      output_items_ptr,
+      num_items,
+      op,
+      CU_STREAM_LEGACY));
+
+  // Verify results
+  std::vector<key_t> output_keys(num_items);
+  cudaMemcpy(
+    output_keys.data(), static_cast<void*>(output_keys_ptr.ptr), sizeof(key_t) * num_items, cudaMemcpyDeviceToHost);
+  std::vector<key_t> expected_keys(num_items);
+  cudaMemcpy(
+    expected_keys.data(), static_cast<void*>(input_keys_ptr.ptr), sizeof(key_t) * num_items, cudaMemcpyDeviceToHost);
+  std::sort(expected_keys.begin(), expected_keys.end());
+  std::sort(expected_keys.begin(), expected_keys.end());
+  REQUIRE(output_keys == expected_keys);
+
+  // Cleanup
+  REQUIRE(CUDA_SUCCESS == cccl_device_merge_sort_cleanup(&build));
+}
+
 // TODO: We no longer fail to build for large types due to no vsmem. Instead, the build passes,
 // but we get a ptxas error about the kernel using too much shared memory.
 /* C2H_TEST("DeviceMergeSort:SortPairsCopy fails to build for large types due to no vsmem", "[merge_sort]")

--- a/c/parallel/test/test_reduce.cpp
+++ b/c/parallel/test/test_reduce.cpp
@@ -60,6 +60,44 @@ struct reduce_build
   }
 };
 
+struct reduce_build_ex
+{
+  cccl_build_config config;
+
+  reduce_build_ex(const char** extra_compile_flags, size_t num_flags, const char** extra_include_dirs, size_t num_dirs)
+      : config{extra_compile_flags, num_flags, extra_include_dirs, num_dirs}
+  {}
+
+  CUresult operator()(
+    BuildResultT* build_ptr,
+    cccl_iterator_t input,
+    cccl_iterator_t output,
+    uint64_t,
+    cccl_op_t op,
+    cccl_value_t init,
+    int cc_major,
+    int cc_minor,
+    const char* cub_path,
+    const char* thrust_path,
+    const char* libcudacxx_path,
+    const char* ctk_path) const noexcept
+  {
+    return cccl_device_reduce_build_ex(
+      build_ptr,
+      input,
+      output,
+      op,
+      init,
+      cc_major,
+      cc_minor,
+      cub_path,
+      thrust_path,
+      libcudacxx_path,
+      ctk_path,
+      const_cast<cccl_build_config*>(&config));
+  }
+};
+
 struct reduce_run
 {
   template <typename... Ts>
@@ -361,4 +399,112 @@ C2H_TEST("Reduce works with stateful operators", "[reduce]")
   const int output   = output_ptr[0];
   const int expected = std::accumulate(input.begin(), input.end(), init.value);
   REQUIRE(output == expected);
+}
+
+C2H_TEST("Reduce works with C++ source operations", "[reduce]")
+{
+  using T = int32_t;
+
+  const std::size_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source instead of LTO-IR
+  std::string cpp_source = R"(
+    extern "C" __device__ void op(void* a, void* b, void* out) {
+      int* ia = (int*)a;
+      int* ib = (int*)b;
+      int* iout = (int*)out;
+      *iout = *ia + *ib;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  const std::vector<T> input = generate<T>(num_items);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(1);
+  value_t<T> init{T{0}};
+
+  // Test key including flag that this uses C++ source
+  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
+
+  auto& cache                                   = get_cache<Reduce_IntegralTypes_Fixture_Tag>();
+  std::optional<reduce_build_cache_t> cache_opt = cache;
+  reduce(input_ptr, output_ptr, num_items, op, init, cache_opt, test_key);
+
+  const T output   = output_ptr[0];
+  const T expected = std::accumulate(input.begin(), input.end(), init.value);
+  REQUIRE(output == expected);
+}
+
+struct Reduce_CppSourceWithEx_Fixture_Tag;
+C2H_TEST("Reduce works with C++ source operations using _ex build", "[reduce]")
+{
+  using T = int32_t;
+
+  const std::size_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source that uses the identity function from header
+  std::string cpp_source = R"(
+    #include "test_identity.h"
+    extern "C" __device__ void op(void* a, void* b, void* out) {
+      int* ia = (int*)a;
+      int* ib = (int*)b;
+      int* iout = (int*)out;
+      int val_a = test_identity(*ia);
+      int val_b = test_identity(*ib);
+      *iout = val_a + val_b;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  const std::vector<T> input = generate<T>(num_items);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(1);
+  value_t<T> init{T{0}};
+
+  // Prepare extra compile flags and include paths
+  const char* extra_flags[]    = {"-DTEST_IDENTITY_ENABLED"};
+  const char* extra_includes[] = {TEST_INCLUDE_PATH};
+
+  // Use extended AlgorithmExecute with custom build configuration
+  constexpr int device_id = 0;
+  const auto& build_info  = BuildInformation<device_id>::init();
+
+  BuildResultT build;
+  reduce_build_ex builder(extra_flags, 1, extra_includes, 1);
+
+  REQUIRE(
+    CUDA_SUCCESS
+    == builder(
+      &build,
+      input_ptr,
+      output_ptr,
+      num_items,
+      op,
+      init,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path()));
+
+  CUstream null_stream      = 0;
+  size_t temp_storage_bytes = 0;
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_reduce(
+            build, nullptr, &temp_storage_bytes, input_ptr, output_ptr, num_items, op, init, null_stream));
+
+  pointer_t<uint8_t> temp_storage(temp_storage_bytes);
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_reduce(
+            build, temp_storage.ptr, &temp_storage_bytes, input_ptr, output_ptr, num_items, op, init, null_stream));
+
+  const T output   = output_ptr[0];
+  const T expected = std::accumulate(input.begin(), input.end(), init.value);
+  REQUIRE(output == expected);
+
+  // Cleanup
+  REQUIRE(CUDA_SUCCESS == cccl_device_reduce_cleanup(&build));
 }

--- a/c/parallel/test/test_scan.cpp
+++ b/c/parallel/test/test_scan.cpp
@@ -426,3 +426,118 @@ C2H_TEST("Scan works with input and output iterators", "[scan]")
     REQUIRE(expected == std::vector<int>(inner_output_it));
   }
 }
+
+C2H_TEST("Scan works with C++ source operations", "[scan]")
+{
+  using T = int32_t;
+
+  const std::size_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source instead of LTO-IR
+  std::string cpp_source = R"(
+    extern "C" __device__ void op(void* a, void* b, void* out) {
+      int* ia = (int*)a;
+      int* ib = (int*)b;
+      int* iout = (int*)out;
+      *iout = *ia + *ib;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  const std::vector<T> input = generate<T>(num_items);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(num_items);
+  value_t<T> init{T{42}};
+
+  // Test key including flag that this uses C++ source
+  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
+
+  auto& cache                                 = get_cache<integral_types>();
+  std::optional<scan_build_cache_t> cache_opt = cache;
+  scan(input_ptr, output_ptr, num_items, op, init, false, cache_opt, test_key);
+
+  const std::vector<T> output = output_ptr;
+  std::vector<T> expected(num_items);
+  std::exclusive_scan(input.begin(), input.end(), expected.begin(), init.value);
+  REQUIRE(output == expected);
+}
+
+C2H_TEST("Scan works with C++ source operations using custom headers", "[scan]")
+{
+  using T = int32_t;
+
+  const std::size_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source that uses the identity function from header
+  std::string cpp_source = R"(
+    #include "test_identity.h"
+    extern "C" __device__ void op(void* a, void* b, void* out) {
+      int* ia = (int*)a;
+      int* ib = (int*)b;
+      int* iout = (int*)out;
+      int val_a = test_identity(*ia);
+      int val_b = test_identity(*ib);
+      *iout = val_a + val_b;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  const std::vector<T> input = generate<T>(num_items);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(num_items);
+  value_t<T> init{T{42}};
+
+  // Test _ex version with custom build configuration
+  cccl_build_config config;
+  const char* extra_flags[]      = {"-DTEST_IDENTITY_ENABLED"};
+  const char* extra_dirs[]       = {TEST_INCLUDE_PATH};
+  config.extra_compile_flags     = extra_flags;
+  config.num_extra_compile_flags = 1;
+  config.extra_include_dirs      = extra_dirs;
+  config.num_extra_include_dirs  = 1;
+
+  // Build with _ex version
+  cccl_device_scan_build_result_t build;
+  const auto& build_info = BuildInformation<>::init();
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_scan_build_ex(
+      &build,
+      input_ptr,
+      output_ptr,
+      op,
+      init,
+      true,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      &config));
+
+  // Execute the scan
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_inclusive_scan(
+            build, d_temp_storage, &temp_storage_bytes, input_ptr, output_ptr, num_items, op, init, CU_STREAM_LEGACY));
+  pointer_t<char> temp_storage(temp_storage_bytes);
+  d_temp_storage = static_cast<void*>(temp_storage.ptr);
+  REQUIRE(CUDA_SUCCESS
+          == cccl_device_inclusive_scan(
+            build, d_temp_storage, &temp_storage_bytes, input_ptr, output_ptr, num_items, op, init, CU_STREAM_LEGACY));
+
+  // Verify results
+  std::vector<T> expected(num_items, 0);
+  std::inclusive_scan(input.begin(), input.end(), expected.begin(), std::plus<>{}, init.value);
+  if (num_items > 0)
+  {
+    REQUIRE(expected == std::vector<T>(output_ptr));
+  }
+
+  // Cleanup
+  REQUIRE(CUDA_SUCCESS == cccl_device_scan_cleanup(&build));
+}

--- a/c/parallel/test/test_transform.cpp
+++ b/c/parallel/test/test_transform.cpp
@@ -521,3 +521,106 @@ C2H_TEST("Binary transform with one iterator", "[transform]")
     REQUIRE(expected == std::vector<int>(output_ptr));
   }
 }
+
+C2H_TEST("Transform works with C++ source operations", "[transform]")
+{
+  using T = int32_t;
+
+  const std::size_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source instead of LTO-IR
+  std::string cpp_source = R"(
+    extern "C" __device__ void op(void* input, void* output) {
+      int* in = (int*)input;
+      int* out = (int*)output;
+      *out = *in * 2;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  const std::vector<T> input = generate<T>(num_items);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(num_items);
+
+  // Test key including flag that this uses C++ source
+  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(T).name());
+
+  auto& cache = fixture<transform_build_cache_t, Transform_IntegralTypes_Fixture_Tag>::get_or_create().get_value();
+  std::optional<transform_build_cache_t> cache_opt = cache;
+
+  unary_transform(input_ptr, output_ptr, num_items, op, cache_opt, test_key);
+
+  const std::vector<T> output = output_ptr;
+  std::vector<T> expected     = input;
+  std::transform(expected.begin(), expected.end(), expected.begin(), [](T x) {
+    return x * 2;
+  });
+  REQUIRE(output == expected);
+}
+
+C2H_TEST("Transform works with C++ source operations using custom headers", "[transform]")
+{
+  using T = int32_t;
+
+  const std::size_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source that uses the identity function from header
+  std::string cpp_source = R"(
+    #include "test_identity.h"
+    extern "C" __device__ void op(void* input, void* output) {
+      int* in = (int*)input;
+      int* out = (int*)output;
+      int val = test_identity(*in);
+      *out = val * 2;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  const std::vector<T> input = generate<T>(num_items);
+  pointer_t<T> input_ptr(input);
+  pointer_t<T> output_ptr(num_items);
+
+  // Test _ex version with custom build configuration
+  cccl_build_config config;
+  const char* extra_flags[]      = {"-DTEST_IDENTITY_ENABLED"};
+  const char* extra_dirs[]       = {TEST_INCLUDE_PATH};
+  config.extra_compile_flags     = extra_flags;
+  config.num_extra_compile_flags = 1;
+  config.extra_include_dirs      = extra_dirs;
+  config.num_extra_include_dirs  = 1;
+
+  // Build with _ex version
+  cccl_device_transform_build_result_t build;
+  const auto& build_info = BuildInformation<>::init();
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unary_transform_build_ex(
+      &build,
+      input_ptr,
+      output_ptr,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      &config));
+
+  // Execute the transform
+  REQUIRE(CUDA_SUCCESS == cccl_device_unary_transform(build, input_ptr, output_ptr, num_items, op, CU_STREAM_LEGACY));
+
+  // Verify results
+  std::vector<T> output(num_items);
+  cudaMemcpy(output.data(), static_cast<void*>(output_ptr.ptr), sizeof(T) * num_items, cudaMemcpyDeviceToHost);
+  std::vector<T> expected = input;
+  std::transform(expected.begin(), expected.end(), expected.begin(), [](T x) {
+    return x * 2;
+  });
+  REQUIRE(output == expected);
+
+  // Cleanup
+  REQUIRE(CUDA_SUCCESS == cccl_device_transform_cleanup(&build));
+}

--- a/c/parallel/test/test_unique_by_key.cpp
+++ b/c/parallel/test/test_unique_by_key.cpp
@@ -629,3 +629,196 @@ C2H_TEST("DeviceSelect::UniqueByKey fails to build for large types due to no vsm
       libcudacxx_path,
       ctk_path));
 }
+
+C2H_TEST("UniqueByKey works with C++ source operations", "[unique_by_key]")
+{
+  using key_t   = int32_t;
+  using value_t = int32_t;
+
+  const std::size_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source instead of LTO-IR
+  std::string cpp_source = R"(
+    extern "C" __device__ void op(void* lhs, void* rhs, void* result) {
+      int* ilhs = (int*)lhs;
+      int* irhs = (int*)rhs;
+      bool* bresult = (bool*)result;
+      *bresult = *ilhs == *irhs;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  // Generate input with some duplicates
+  std::vector<key_t> input_keys(num_items);
+  std::vector<value_t> input_values(num_items);
+  for (std::size_t i = 0; i < num_items; ++i)
+  {
+    input_keys[i]   = static_cast<key_t>(i % (num_items / 10 + 1)); // Create duplicates
+    input_values[i] = static_cast<value_t>(i);
+  }
+
+  pointer_t<key_t> input_keys_ptr(input_keys);
+  pointer_t<value_t> input_values_ptr(input_values);
+  pointer_t<key_t> output_keys_ptr(num_items);
+  pointer_t<value_t> output_values_ptr(num_items);
+  pointer_t<std::size_t> output_num_selected_ptr(1);
+
+  // Test key including flag that this uses C++ source
+  std::optional<std::string> test_key = std::format("cpp_source_test_{}_{}", num_items, typeid(key_t).name());
+
+  auto& cache =
+    fixture<unique_by_key_build_cache_t, UniqueByKey_AllPointerInputs_Fixture_Tag>::get_or_create().get_value();
+  std::optional<unique_by_key_build_cache_t> cache_opt = cache;
+
+  unique_by_key(
+    input_keys_ptr,
+    input_values_ptr,
+    output_keys_ptr,
+    output_values_ptr,
+    output_num_selected_ptr,
+    op,
+    num_items,
+    cache_opt,
+    test_key);
+
+  const std::size_t num_selected = output_num_selected_ptr[0];
+
+  // Compute expected result
+  std::vector<key_t> expected_keys;
+  std::vector<value_t> expected_values;
+  if (num_items > 0)
+  {
+    expected_keys.push_back(input_keys[0]);
+    expected_values.push_back(input_values[0]);
+    for (std::size_t i = 1; i < num_items; ++i)
+    {
+      if (input_keys[i] != input_keys[i - 1])
+      {
+        expected_keys.push_back(input_keys[i]);
+        expected_values.push_back(input_values[i]);
+      }
+    }
+  }
+
+  REQUIRE(num_selected == expected_keys.size());
+
+  std::vector<key_t> output_keys(num_selected);
+  std::vector<value_t> output_values(num_selected);
+  cudaMemcpy(output_keys.data(), output_keys_ptr.ptr, num_selected * sizeof(key_t), cudaMemcpyDeviceToHost);
+  cudaMemcpy(output_values.data(), output_values_ptr.ptr, num_selected * sizeof(value_t), cudaMemcpyDeviceToHost);
+
+  REQUIRE(output_keys == expected_keys);
+  REQUIRE(output_values == expected_values);
+}
+
+C2H_TEST("UniqueByKey works with C++ source operations using custom headers", "[unique_by_key]")
+{
+  using key_t   = int32_t;
+  using value_t = int32_t;
+
+  const std::size_t num_items = GENERATE(42, 1337, 42000);
+
+  // Create operation from C++ source that uses the identity function from header
+  std::string cpp_source = R"(
+    #include "test_identity.h"
+    extern "C" __device__ void op(void* lhs, void* rhs, void* result) {
+      int* ilhs = (int*)lhs;
+      int* irhs = (int*)rhs;
+      bool* bresult = (bool*)result;
+      int val_lhs = test_identity(*ilhs);
+      int val_rhs = test_identity(*irhs);
+      *bresult = val_lhs == val_rhs;
+    }
+  )";
+
+  operation_t op = make_cpp_operation("op", cpp_source);
+
+  // Generate input with some duplicates
+  std::vector<key_t> input_keys(num_items);
+  std::vector<value_t> input_values(num_items);
+  for (std::size_t i = 0; i < num_items; ++i)
+  {
+    input_keys[i]   = static_cast<key_t>(i % (num_items / 10 + 1)); // Create duplicates
+    input_values[i] = static_cast<value_t>(i);
+  }
+
+  pointer_t<key_t> input_keys_ptr(input_keys);
+  pointer_t<value_t> input_values_ptr(input_values);
+  pointer_t<key_t> output_keys_ptr(num_items);
+  pointer_t<value_t> output_values_ptr(num_items);
+  pointer_t<std::size_t> output_num_selected_ptr(1);
+
+  // Test _ex version with custom build configuration
+  cccl_build_config config;
+  const char* extra_flags[]      = {"-DTEST_IDENTITY_ENABLED"};
+  const char* extra_dirs[]       = {TEST_INCLUDE_PATH};
+  config.extra_compile_flags     = extra_flags;
+  config.num_extra_compile_flags = 1;
+  config.extra_include_dirs      = extra_dirs;
+  config.num_extra_include_dirs  = 1;
+
+  // Build with _ex version
+  cccl_device_unique_by_key_build_result_t build;
+  const auto& build_info = BuildInformation<>::init();
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unique_by_key_build_ex(
+      &build,
+      input_keys_ptr,
+      input_values_ptr,
+      output_keys_ptr,
+      output_values_ptr,
+      output_num_selected_ptr,
+      op,
+      build_info.get_cc_major(),
+      build_info.get_cc_minor(),
+      build_info.get_cub_path(),
+      build_info.get_thrust_path(),
+      build_info.get_libcudacxx_path(),
+      build_info.get_ctk_path(),
+      &config));
+
+  // Execute unique_by_key
+  void* d_temp_storage      = nullptr;
+  size_t temp_storage_bytes = 0;
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unique_by_key(
+      build,
+      d_temp_storage,
+      &temp_storage_bytes,
+      input_keys_ptr,
+      input_values_ptr,
+      output_keys_ptr,
+      output_values_ptr,
+      output_num_selected_ptr,
+      op,
+      num_items,
+      CU_STREAM_LEGACY));
+  pointer_t<char> temp_storage(temp_storage_bytes);
+  d_temp_storage = static_cast<void*>(temp_storage.ptr);
+  REQUIRE(
+    CUDA_SUCCESS
+    == cccl_device_unique_by_key(
+      build,
+      d_temp_storage,
+      &temp_storage_bytes,
+      input_keys_ptr,
+      input_values_ptr,
+      output_keys_ptr,
+      output_values_ptr,
+      output_num_selected_ptr,
+      op,
+      num_items,
+      CU_STREAM_LEGACY));
+
+  // Verify results
+  size_t num_selected;
+  cudaMemcpy(&num_selected, static_cast<void*>(output_num_selected_ptr.ptr), sizeof(size_t), cudaMemcpyDeviceToHost);
+  REQUIRE(num_selected > 0);
+  REQUIRE(num_selected <= num_items);
+
+  // Cleanup
+  REQUIRE(CUDA_SUCCESS == cccl_device_unique_by_key_cleanup(&build));
+}


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
This PR allows any operation (iterators, operators, etc.) provided to c.parallel to be a C++ code.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
