### PR TITLE
[STF] Implement token elision in cuda_kernel constructs

### DIFF
--- a/cudax/examples/stf/void_data_interface.cu
+++ b/cudax/examples/stf/void_data_interface.cu
@@ -19,6 +19,10 @@
 
 using namespace cuda::experimental::stf;
 
+__global__ void dummy_kernel()
+{
+}
+
 int main()
 {
   context ctx;
@@ -41,6 +45,10 @@ int main()
   // or actual underlying data.
   ctx.task(token3.rw(), token.read())->*[](cudaStream_t) {
 
+  };
+
+  ctx.cuda_kernel(token3.rw())->*[](){
+      return cuda_kernel_desc{dummy_kernel, 16, 128, 0};
   };
 
   ctx.finalize();

--- a/cudax/include/cuda/experimental/__stf/internal/cuda_kernel_scope.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/cuda_kernel_scope.cuh
@@ -446,7 +446,7 @@ public:
     // should be executed one after the other.
     if constexpr (chained)
     {
-      kernel_descs = ::std::apply(f, deps.instance(t));
+      kernel_descs = ::std::apply(f, deps.non_void_instance(t));
       assert(!kernel_descs.empty());
     }
     else
@@ -456,7 +456,7 @@ public:
       // descriptor, not a vector
       static_assert(!chained);
 
-      cuda_kernel_desc res = ::std::apply(f, deps.instance(t));
+      cuda_kernel_desc res = ::std::apply(f, deps.non_void_instance(t));
       kernel_descs.push_back(res);
     }
   }

--- a/cudax/include/cuda/experimental/__stf/internal/task_dep.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/task_dep.cuh
@@ -21,6 +21,8 @@
 #endif // no system header
 
 #include <cuda/experimental/__stf/internal/reduction_base.cuh>
+#include <cuda/experimental/__stf/internal/void_interface.cuh>
+#include <cuda/experimental/__stf/utility/core.cuh>
 
 namespace cuda::experimental::stf
 {
@@ -318,6 +320,26 @@ public:
   {
     return make_tuple_indexwise<sizeof...(Data)>([&](auto i) {
       return at<i>().instance(t);
+    });
+  }
+
+  using non_void_instance_t = reserved::remove_void_interface_from_pack_t<Data...>;
+
+  /**
+   * @brief Get all non void instances
+   */
+  non_void_instance_t non_void_instance(task& t)
+  {
+    // Note that make_tuple_indexwise will remove ::std::ignore entries
+    return make_tuple_indexwise<sizeof...(Data)>([&](auto i) {
+      if constexpr (::std::is_same_v<type_at<i>, void_interface>)
+      {
+        return ::std::ignore;
+      }
+      else
+      {
+        return at<i>().instance(t);
+      }
     });
   }
 


### PR DESCRIPTION
## Description

token (void_interface arguments) are removed from the prototype of the lambda function used in cuda_kernel constructs

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
