### PR TITLE
Add a system traversal tag to the `cuda` iterators that cannot deduce it from a base iterator

### DIFF
--- a/libcudacxx/include/cuda/__iterator/any_system_tag.h
+++ b/libcudacxx/include/cuda/__iterator/any_system_tag.h
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___ITERATOR_ANY_SYSTEM_TAG_H
+#define _CUDA___ITERATOR_ANY_SYSTEM_TAG_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+struct __cccl_any_system_tag
+{};
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___ITERATOR_ANY_SYSTEM_TAG_H

--- a/libcudacxx/include/cuda/__iterator/constant_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/constant_iterator.h
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__iterator/any_system_tag.h>
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__ranges/movable_box.h>
@@ -33,7 +34,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA
 
 //! @brief The \c constant_iterator class represents an iterator in a sequence of repeated values.
-template <class _Tp, class _Index = ::cuda::std::ptrdiff_t>
+template <class _Tp, class _Index = ::cuda::std::ptrdiff_t, class _System = __cccl_any_system_tag>
 class constant_iterator
 {
 private:
@@ -47,6 +48,7 @@ public:
   using iterator_category = ::cuda::std::random_access_iterator_tag;
   using value_type        = _Tp;
   using difference_type   = ::cuda::std::ptrdiff_t;
+  using __system          = _System;
 
 #if _CCCL_HAS_CONCEPTS()
   _CCCL_HIDE_FROM_ABI constant_iterator()

--- a/libcudacxx/include/cuda/__iterator/counting_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/counting_iterator.h
@@ -23,6 +23,7 @@
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 #  include <cuda/std/__compare/three_way_comparable.h>
 #endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+#include <cuda/__iterator/any_system_tag.h>
 #include <cuda/std/__concepts/arithmetic.h>
 #include <cuda/std/__concepts/constructible.h>
 #include <cuda/std/__concepts/convertible_to.h>
@@ -176,10 +177,11 @@ struct __counting_iterator_category<_Tp, ::cuda::std::enable_if_t<::cuda::std::i
 //! }
 //! @endcode
 #if _CCCL_HAS_CONCEPTS()
-template <::cuda::std::weakly_incrementable _Start>
+template <::cuda::std::weakly_incrementable _Start, class _System = __cccl_any_system_tag>
   requires ::cuda::std::copyable<_Start>
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Start,
+          class _System                                                            = __cccl_any_system_tag,
           ::cuda::std::enable_if_t<::cuda::std::weakly_incrementable<_Start>, int> = 0,
           ::cuda::std::enable_if_t<::cuda::std::copyable<_Start>, int>             = 0>
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
@@ -196,6 +198,7 @@ struct counting_iterator : public __counting_iterator_category<_Start>
 
   using value_type      = _Start;
   using difference_type = _IotaDiffT<_Start>;
+  using __system        = _System;
 
   _Start __value_ = _Start();
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/ctor.default.pass.cpp
@@ -19,10 +19,10 @@ __host__ __device__ constexpr bool test()
 {
   [[maybe_unused]] cuda::discard_iterator iter{};
 
-  static_assert(cuda::std::is_copy_constructible_v<cuda::discard_iterator>);
-  static_assert(cuda::std::is_move_constructible_v<cuda::discard_iterator>);
-  static_assert(cuda::std::is_copy_assignable_v<cuda::discard_iterator>);
-  static_assert(cuda::std::is_move_assignable_v<cuda::discard_iterator>);
+  static_assert(cuda::std::is_copy_constructible_v<cuda::discard_iterator<>>);
+  static_assert(cuda::std::is_move_constructible_v<cuda::discard_iterator<>>);
+  static_assert(cuda::std::is_copy_assignable_v<cuda::discard_iterator<>>);
+  static_assert(cuda::std::is_move_assignable_v<cuda::discard_iterator<>>);
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/decrement.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/decrement.pass.cpp
@@ -22,8 +22,8 @@ __host__ __device__ constexpr bool test()
   assert(iter-- == cuda::discard_iterator(index + 0));
   assert(--iter == cuda::discard_iterator(index - 2));
 
-  static_assert(cuda::std::is_same_v<decltype(iter--), cuda::discard_iterator>);
-  static_assert(cuda::std::is_same_v<decltype(--iter), cuda::discard_iterator&>);
+  static_assert(cuda::std::is_same_v<decltype(iter--), cuda::discard_iterator<>>);
+  static_assert(cuda::std::is_same_v<decltype(--iter), cuda::discard_iterator<>&>);
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/increment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/increment.pass.cpp
@@ -23,8 +23,8 @@ __host__ __device__ constexpr bool test()
   assert(iter++ == cuda::discard_iterator(index + 0));
   assert(++iter == cuda::discard_iterator(index + 2));
 
-  static_assert(cuda::std::is_same_v<decltype(iter++), cuda::discard_iterator>);
-  static_assert(cuda::std::is_same_v<decltype(++iter), cuda::discard_iterator&>);
+  static_assert(cuda::std::is_same_v<decltype(iter++), cuda::discard_iterator<>>);
+  static_assert(cuda::std::is_same_v<decltype(++iter), cuda::discard_iterator<>&>);
 
   return true;
 }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/iterator_traits.compile.pass.cpp
@@ -18,15 +18,15 @@ void print() = delete;
 
 __host__ __device__ void test()
 {
-  using IterTraits = cuda::std::iterator_traits<cuda::discard_iterator>;
+  using IterTraits = cuda::std::iterator_traits<cuda::discard_iterator<>>;
 
   static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
   static_assert(cuda::std::same_as<IterTraits::value_type, void>);
   static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
   static_assert(cuda::std::same_as<IterTraits::pointer, void>);
   static_assert(cuda::std::same_as<IterTraits::reference, void>);
-  static_assert(cuda::std::input_or_output_iterator<cuda::discard_iterator>);
-  static_assert(cuda::std::output_iterator<cuda::discard_iterator, float>);
+  static_assert(cuda::std::input_or_output_iterator<cuda::discard_iterator<>>);
+  static_assert(cuda::std::output_iterator<cuda::discard_iterator<>, float>);
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/make_discard_iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/make_discard_iterator.pass.cpp
@@ -21,13 +21,13 @@ __host__ __device__ constexpr bool test()
 {
   {
     auto iter = cuda::make_discard_iterator();
-    static_assert(cuda::std::is_same_v<decltype(iter), cuda::discard_iterator>);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::discard_iterator<>>);
     *iter = 42;
   }
 
   {
     auto iter = cuda::make_discard_iterator(static_cast<short>(42));
-    static_assert(cuda::std::is_same_v<decltype(iter), cuda::discard_iterator>);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::discard_iterator<>>);
     *iter = 42;
   }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/member_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/member_types.compile.pass.cpp
@@ -17,7 +17,7 @@
 
 __host__ __device__ void test()
 {
-  using Iter = cuda::discard_iterator;
+  using Iter = cuda::discard_iterator<>;
   static_assert(cuda::std::same_as<Iter::value_type, void>);
   static_assert(cuda::std::same_as<Iter::pointer, void>);
   static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/minus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/minus.pass.cpp
@@ -32,7 +32,7 @@ __host__ __device__ constexpr bool test()
       assert(iter - diff == cuda::discard_iterator(index - diff));
       assert(iter - 0 == cuda::discard_iterator(index));
 
-      static_assert(cuda::std::is_same_v<decltype(iter - 2), cuda::discard_iterator>);
+      static_assert(cuda::std::is_same_v<decltype(iter - 2), cuda::discard_iterator<>>);
     }
 
     {
@@ -42,7 +42,7 @@ __host__ __device__ constexpr bool test()
       assert(iter - diff == cuda::discard_iterator(index - diff));
       assert(iter - 0 == cuda::discard_iterator(index));
 
-      static_assert(cuda::std::is_same_v<decltype(iter - 2), cuda::discard_iterator>);
+      static_assert(cuda::std::is_same_v<decltype(iter - 2), cuda::discard_iterator<>>);
     }
   }
 
@@ -77,7 +77,7 @@ __host__ __device__ constexpr bool test()
     assert((iter -= diff) == cuda::discard_iterator(1));
     assert((iter -= 0) == cuda::discard_iterator(1));
 
-    static_assert(cuda::std::is_same_v<decltype(iter -= 2), cuda::discard_iterator&>);
+    static_assert(cuda::std::is_same_v<decltype(iter -= 2), cuda::discard_iterator<>&>);
   }
 
   { // operator-(const discard_iterator& x, default_sentinel_t)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/plus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/plus.pass.cpp
@@ -27,7 +27,7 @@ __host__ __device__ constexpr bool test()
       assert(iter + diff == cuda::discard_iterator(index + diff));
       assert(iter + 0 == cuda::discard_iterator(index));
 
-      static_assert(cuda::std::is_same_v<decltype(iter + 2), cuda::discard_iterator>);
+      static_assert(cuda::std::is_same_v<decltype(iter + 2), cuda::discard_iterator<>>);
     }
 
     {
@@ -37,7 +37,7 @@ __host__ __device__ constexpr bool test()
       assert(iter + diff == cuda::discard_iterator(index + diff));
       assert(iter + 0 == cuda::discard_iterator(index));
 
-      static_assert(cuda::std::is_same_v<decltype(iter + 2), cuda::discard_iterator>);
+      static_assert(cuda::std::is_same_v<decltype(iter + 2), cuda::discard_iterator<>>);
     }
   }
 
@@ -49,7 +49,7 @@ __host__ __device__ constexpr bool test()
       assert(diff + iter == cuda::discard_iterator(index + diff));
       assert(0 + iter == cuda::discard_iterator(index));
 
-      static_assert(cuda::std::is_same_v<decltype(2 + iter), cuda::discard_iterator>);
+      static_assert(cuda::std::is_same_v<decltype(2 + iter), cuda::discard_iterator<>>);
     }
   }
 
@@ -61,7 +61,7 @@ __host__ __device__ constexpr bool test()
       assert((iter += 0) == cuda::discard_iterator(index));
       assert((iter += diff) == cuda::discard_iterator(index + diff));
 
-      static_assert(cuda::std::is_same_v<decltype(iter += 2), cuda::discard_iterator&>);
+      static_assert(cuda::std::is_same_v<decltype(iter += 2), cuda::discard_iterator<>&>);
     }
   }
 

--- a/thrust/thrust/detail/internal_functional.h
+++ b/thrust/thrust/detail/internal_functional.h
@@ -94,7 +94,7 @@ struct tuple_binary_predicate
 
 // We need to mark proxy iterators as such
 template <>
-inline constexpr bool is_proxy_reference_v<::cuda::discard_iterator::__discard_proxy> = true;
+inline constexpr bool is_proxy_reference_v<::cuda::__discard_proxy> = true;
 
 template <class Fn, class Index>
 inline constexpr bool is_proxy_reference_v<::cuda::__tabulate_proxy<Fn, Index>> = true;

--- a/thrust/thrust/iterator/iterator_traits.h
+++ b/thrust/thrust/iterator/iterator_traits.h
@@ -194,35 +194,39 @@ template <typename Iterator>
 using iterator_system_t = typename iterator_system<Iterator>::type;
 
 // specialize the respective cuda iterators
-template <>
-struct iterator_system<::cuda::discard_iterator>
+template <class System>
+using __cccl_translate_system =
+  ::cuda::std::conditional<::cuda::std::is_same_v<System, ::cuda::__cccl_any_system_tag>, any_system_tag, System>;
+
+template <class System>
+struct iterator_system<::cuda::discard_iterator<System>>
 {
-  using type = any_system_tag;
+  using type = __cccl_translate_system<System>;
 };
-template <>
-struct iterator_traversal<::cuda::discard_iterator>
+template <class System>
+struct iterator_traversal<::cuda::discard_iterator<System>>
 {
   using type = random_access_traversal_tag;
 };
 
-template <class T, class Index>
-struct iterator_system<::cuda::constant_iterator<T, Index>>
+template <class T, class Index, class System>
+struct iterator_system<::cuda::constant_iterator<T, Index, System>>
 {
-  using type = any_system_tag;
+  using type = __cccl_translate_system<System>;
 };
-template <class T, class Index>
-struct iterator_traversal<::cuda::constant_iterator<T, Index>>
+template <class T, class Index, class System>
+struct iterator_traversal<::cuda::constant_iterator<T, Index, System>>
 {
   using type = random_access_traversal_tag;
 };
 
-template <class Start>
-struct iterator_system<::cuda::counting_iterator<Start>>
+template <class Start, class System>
+struct iterator_system<::cuda::counting_iterator<Start, System>>
 {
-  using type = any_system_tag;
+  using type = __cccl_translate_system<System>;
 };
-template <class Start>
-struct iterator_traversal<::cuda::counting_iterator<Start>>
+template <class Start, class System>
+struct iterator_traversal<::cuda::counting_iterator<Start, System>>
 {
   using type = random_access_traversal_tag;
 };


### PR DESCRIPTION
We rely on this heavily in thrust to determine the execution space for algoriths.

E.g counting_iterator is used heavily as a sole argument to some thrust algorithms
