### PR TITLE
[STF] Replace task dep's as_read_mode by a more general as_mode

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/hooks.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/hooks.cuh
@@ -133,7 +133,7 @@ static ::std::vector<::std::function<void()>> get_dump_hooks(ctxt_t* ctx, const 
       auto dep_ld = dep.get_data();
       if (dep.get_access_mode() != access_mode::read && dep_ld.get_auto_dump())
       {
-        const auto ro_dep = dep.as_read_mode();
+        const auto ro_dep = dep.as_mode(access_mode::read);
 
         /* We either make sure the directory exists or lazily create it if
          * we need to add content when dumping data */

--- a/cudax/include/cuda/experimental/__stf/internal/task_dep.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/task_dep.cuh
@@ -80,11 +80,11 @@ public:
   }
 
   /* Returns the same untyped task dependency with a read-only access mode */
-  task_dep_untyped as_read_mode_untyped() const
+  task_dep_untyped as_mode(access_mode another) const
   {
-    task_dep_untyped res(*this);
-    res.m = access_mode::read;
-    return res;
+    auto result = *this;
+    result.m    = another;
+    return result;
   }
 
   // We should only assign it once
@@ -215,9 +215,9 @@ public:
   }
 
   /* Returns the same task dependency with a read-only access mode */
-  task_dep<T> as_read_mode() const
+  task_dep<T> as_mode(access_mode another) const
   {
-    return task_dep<T>(as_read_mode_untyped());
+    return task_dep<T>(task_dep_untyped::as_mode(another));
   }
 
   /**


### PR DESCRIPTION
## Description

Make an as_mode method for task_dep in replacement of as_read_mode

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
