### PR TITLE
Implement `__fp_is_explicit_conversion_v`

### DIFF
--- a/libcudacxx/include/cuda/std/__floating_point/cccl_fp.h
+++ b/libcudacxx/include/cuda/std/__floating_point/cccl_fp.h
@@ -54,7 +54,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES(__is_fp_v<_Tp> _CCCL_AND(!__fp_is_implicit_conversion_v<_Tp, __cccl_fp>))
+  _CCCL_REQUIRES(__is_fp_v<_Tp> _CCCL_AND __fp_is_explicit_conversion_v<_Tp, __cccl_fp>)
   _CCCL_API explicit constexpr __cccl_fp(const _Tp&) noexcept
       : __cccl_fp{}
   {
@@ -84,7 +84,7 @@ public:
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__is_fp_v<_Tp> _CCCL_AND(!__is_ext_cccl_fp_v<_Tp>)
-                   _CCCL_AND(!__fp_is_implicit_conversion_v<__cccl_fp, _Tp>))
+                   _CCCL_AND __fp_is_explicit_conversion_v<__cccl_fp, _Tp>)
   _CCCL_API explicit constexpr operator _Tp() const noexcept
   {
     // todo: implement conversion to a floating-point type using __fp_cast

--- a/libcudacxx/include/cuda/std/__floating_point/common_type.h
+++ b/libcudacxx/include/cuda/std/__floating_point/common_type.h
@@ -33,7 +33,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Lhs, class _Rhs>
 using __fp_common_type_t =
-  enable_if_t<__fp_conv_rank_order_v<_Lhs, _Rhs> != __fp_conv_rank_order::__unordered,
+  enable_if_t<__fp_conv_rank_order_v<_Lhs, _Rhs> != __fp_conv_rank_order::__unordered
+                && __fp_conv_rank_order_v<_Lhs, _Rhs> != __fp_conv_rank_order::__invalid,
               conditional_t<__fp_conv_rank_order_v<_Lhs, _Rhs> == __fp_conv_rank_order::__greater, _Lhs, _Rhs>>;
 
 template <class _Lhs, class _Rhs>

--- a/libcudacxx/include/cuda/std/__floating_point/conversion_rank_order.h
+++ b/libcudacxx/include/cuda/std/__floating_point/conversion_rank_order.h
@@ -33,6 +33,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 enum class __fp_conv_rank_order
 {
+  __invalid = -1,
   __unordered,
   __greater,
   __equal,
@@ -84,17 +85,17 @@ template <class _Lhs, class _Rhs>
   }
   else
   {
-    return __fp_conv_rank_order::__unordered;
+    return __fp_conv_rank_order::__invalid;
   }
 }
 
 //! @brief Returns the conversion rank order between two types. If any of the types is not a known floating point type,
-//!        returns __fp_conv_rank_order::__unordered.
+//!        returns __fp_conv_rank_order::__invalid.
 template <class _Lhs, class _Rhs>
 inline constexpr __fp_conv_rank_order __fp_conv_rank_order_v = ::cuda::std::__fp_conv_rank_order_v_impl<_Lhs, _Rhs>();
 
 //! @brief Returns the conversion rank order between two types. Integral types are treated as `double`. Other types are
-//!        treated as unknown and return __fp_conv_rank_order::__unordered.
+//!        treated as unknown and return __fp_conv_rank_order::__invalid.
 template <class _Lhs, class _Rhs>
 inline constexpr __fp_conv_rank_order __fp_conv_rank_order_int_ext_v =
   __fp_conv_rank_order_v<conditional_t<is_integral_v<_Lhs>, double, _Lhs>,
@@ -102,10 +103,19 @@ inline constexpr __fp_conv_rank_order __fp_conv_rank_order_int_ext_v =
 
 //! @brief True if _From can be implicitly converted to _To according to the floating point conversion rank rules.
 //! @warning User should ensure that the types are known floating point types.
+//! @note If you want to check for explicit conversions, use __fp_is_explicit_conversion_v instead.
 template <class _From, class _To>
 inline constexpr bool __fp_is_implicit_conversion_v =
   __fp_conv_rank_order_v<_From, _To> == __fp_conv_rank_order::__less
   || __fp_conv_rank_order_v<_From, _To> == __fp_conv_rank_order::__equal;
+
+//! @brief True if _From can be explicitly converted to _To according to the floating point conversion rank rules.
+//! @warning User should ensure that the types are known floating point types.
+//! @note If you want to check for implicit conversions, use __fp_is_implicit_conversion_v instead.
+template <class _From, class _To>
+inline constexpr bool __fp_is_explicit_conversion_v =
+  __fp_conv_rank_order_v<_From, _To> == __fp_conv_rank_order::__greater
+  || __fp_conv_rank_order_v<_From, _To> == __fp_conv_rank_order::__unordered;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/cccl_fp/constructors/floating_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/cccl_fp/constructors/floating_point.pass.cpp
@@ -26,6 +26,7 @@ __host__ __device__ constexpr void test_fp_constructor()
 
   // Construction from a floating point type is implicit if T has the greater or equal conversion rank
   static_assert(cuda::std::__fp_is_implicit_conversion_v<Fp, T> == cuda::std::is_convertible_v<Fp, T>);
+  static_assert(cuda::std::__fp_is_explicit_conversion_v<Fp, T> == !cuda::std::is_convertible_v<Fp, T>);
 
   // TODO: check construction from a floating point type
   [[maybe_unused]] T val{Fp{}};

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/cccl_fp/conversion_operators/floating_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/cccl_fp/conversion_operators/floating_point.pass.cpp
@@ -23,6 +23,7 @@ __host__ __device__ constexpr void test_fp_conversion_operator()
 
   // Conversion to a floating point type is implicit if Fp has the greater or equal conversion rank
   static_assert(cuda::std::__fp_is_implicit_conversion_v<T, Fp> == cuda::std::is_convertible_v<T, Fp>);
+  static_assert(cuda::std::__fp_is_explicit_conversion_v<T, Fp> == !cuda::std::is_convertible_v<T, Fp>);
 
   // TODO: check conversion to a floating point type
   [[maybe_unused]] Fp val(T{});

--- a/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/conversion_rank_order.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/numerics/floating.point/conversion_rank_order.pass.cpp
@@ -377,6 +377,14 @@ static_assert(fp_conv_rank_order_v<__nv_fp4_e2m1, __nv_fp4_e2m1> == fp_conv_rank
 #  endif // _CCCL_HAS_NVFP4_E2M1()
 #endif // _CCCL_HAS_NVFP4_E2M1()
 
+enum class NotFloatingPoint
+{
+};
+
+static_assert(fp_conv_rank_order_v<NotFloatingPoint, float> == fp_conv_rank_order::__invalid);
+static_assert(fp_conv_rank_order_v<float, NotFloatingPoint> == fp_conv_rank_order::__invalid);
+static_assert(fp_conv_rank_order_v<NotFloatingPoint, NotFloatingPoint> == fp_conv_rank_order::__invalid);
+
 int main(int, char**)
 {
   return 0;


### PR DESCRIPTION
This PR add `__fp_is_explicit_conversion_v` that should be use instead of the `!__fp_is_implicit_conversion_v<T>` trait.