### PR TITLE
Drop `thrust::strided_iterator`

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/make_strided_iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/make_strided_iterator.pass.cpp
@@ -1,0 +1,70 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// constexpr make_strided_iterator(iter, stride = 0);
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+#include "types.h"
+
+template <class Stride>
+__host__ __device__ constexpr void test(Stride stride)
+{
+  int buffer[] = {1, 2, 3, 4, 5, 6, 7, 8};
+
+  { // make_strided_iterator(iter, stride);
+    cuda::strided_iterator iter = cuda::make_strided_iterator(buffer, stride);
+    assert(iter.stride() == stride);
+    assert(iter.base() == buffer);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::strided_iterator<int*, Stride>>);
+  }
+
+  { // explicit template arguments make_strided_iterator(iter, stride);
+    cuda::strided_iterator iter = cuda::make_strided_iterator<const int*, int>(buffer, static_cast<int>(stride));
+    assert(iter.stride() == stride);
+    assert(iter.base() == buffer);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::strided_iterator<const int*, int>>);
+  }
+
+  if constexpr (cuda::std::__integral_constant_like<Stride>)
+  {
+    { // make_strided_iterator(iter);
+      cuda::strided_iterator iter = cuda::make_strided_iterator<Stride>(buffer);
+      assert(iter.stride() == 2);
+      assert(iter.base() == buffer);
+      static_assert(cuda::std::is_same_v<decltype(iter), cuda::strided_iterator<int*, Stride>>);
+    }
+
+    { // explicit template arguments make_strided_iterator(iter);
+      cuda::strided_iterator iter = cuda::make_strided_iterator<Stride, const int*>(buffer);
+      assert(iter.stride() == 2);
+      assert(iter.base() == buffer);
+      static_assert(cuda::std::is_same_v<decltype(iter), cuda::strided_iterator<const int*, Stride>>);
+    }
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test(2);
+  test(Stride<2>{});
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/thrust/cmake/ThrustHeaderTesting.cmake
+++ b/thrust/cmake/ThrustHeaderTesting.cmake
@@ -5,7 +5,11 @@
 # entrypoints.
 
 # Add regexes matching deprecated headers here to disable warnings for them:
-set(deprecated_headers_regexes "thrust/iterator/tabulate_output_iterator\\.h")
+set(
+  deprecated_headers_regexes
+  "thrust/iterator/tabulate_output_iterator\\.h"
+  "thrust/iterator/strided_iterator\\.h"
+)
 
 cccl_get_cudatoolkit()
 

--- a/thrust/testing/strided_iterator.cu
+++ b/thrust/testing/strided_iterator.cu
@@ -1,3 +1,5 @@
+#define CCCL_IGNORE_DEPRECATED_API
+
 #include <cuda/__cccl_config>
 
 _CCCL_DIAG_PUSH

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -31,7 +31,6 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/iterator_adaptor.h>
 #include <thrust/iterator/iterator_traits.h>
-#include <thrust/iterator/strided_iterator.h>
 
 #include <cuda/__type_traits/is_floating_point.h>
 #include <cuda/std/__type_traits/conditional.h>
@@ -41,6 +40,18 @@
 #include <cuda/std/cstddef>
 
 THRUST_NAMESPACE_BEGIN
+
+template <typename T>
+struct __runtime_value
+{
+  T value;
+};
+
+template <auto Value>
+struct __compile_time_value
+{
+  static constexpr decltype(Value) value = Value;
+};
 
 template <typename Incrementable, typename System, typename Traversal, typename Difference, typename StrideHolder>
 class counting_iterator;
@@ -76,7 +87,7 @@ struct make_counting_iterator_base
                      difference>;
 };
 
-using unit_stride = compile_time_value<1>;
+using unit_stride = __compile_time_value<1>;
 } // namespace detail
 
 //! \addtogroup iterators
@@ -307,7 +318,7 @@ inline _CCCL_HOST_DEVICE counting_iterator<Incrementable> make_counting_iterator
 template <typename Incrementable, typename Stride>
 _CCCL_HOST_DEVICE auto make_counting_iterator(Incrementable x, Stride stride)
 {
-  return counting_iterator<Incrementable, use_default, random_access_traversal_tag, use_default, runtime_value<Stride>>(
+  return counting_iterator<Incrementable, use_default, random_access_traversal_tag, use_default, __runtime_value<Stride>>(
     x, {stride});
 }
 
@@ -319,7 +330,7 @@ _CCCL_HOST_DEVICE auto make_counting_iterator(Incrementable x)
                            use_default,
                            random_access_traversal_tag,
                            use_default,
-                           compile_time_value<Stride>>(x, {});
+                           __compile_time_value<Stride>>(x, {});
 }
 #endif // _CCCL_DOXYGEN_INVOKED
 

--- a/thrust/thrust/iterator/strided_iterator.h
+++ b/thrust/thrust/iterator/strided_iterator.h
@@ -51,13 +51,14 @@ template <auto Value>
 inline constexpr bool is_compile_time_value<compile_time_value<Value>> = true;
 } // namespace detail
 
-//! A \p strided_iterator wraps another iterator and moves it by a specified stride each time it is incremented or
+//! A @p strided_iterator wraps another iterator and moves it by a specified stride each time it is incremented or
 //! decremented.
 //!
-//! \param RandomAccessIterator A random access iterator
-//! \param StrideHolder Either a \ref runtime_value or a \ref compile_time_value specifying the stride
+//! @param RandomAccessIterator A random access iterator
+//! @param StrideHolder Either a @ref runtime_value or a @ref compile_time_value specifying the stride
+//! @deprecated Use @p cuda::strided_iterator instead
 template <typename RandomAccessIterator, typename StrideHolder>
-class _CCCL_DECLSPEC_EMPTY_BASES strided_iterator
+class _CCCL_DECLSPEC_EMPTY_BASES CCCL_DEPRECATED_BECAUSE("Use cuda::strided_iterator instead") strided_iterator
     : public iterator_adaptor<strided_iterator<RandomAccessIterator, StrideHolder>, RandomAccessIterator>
     , StrideHolder
 {
@@ -77,7 +78,7 @@ public:
 
   strided_iterator() = default;
 
-  //! Creates a strided_iterator from an existing iterator and a stride.
+  //! @brief Creates a strided_iterator from an existing iterator and a stride.
   _CCCL_HOST_DEVICE strided_iterator(RandomAccessIterator it, StrideHolder stride = {})
       : super_t(it)
       , StrideHolder(stride)
@@ -85,20 +86,20 @@ public:
 
   static constexpr bool has_static_stride = detail::is_compile_time_value<StrideHolder>;
 
-  //! Returns either the \ref runtime_value or the \ref compile_time_value holding the stride's value
+  //! @brief Returns either the @ref runtime_value or the @ref compile_time_value holding the stride's value
   _CCCL_HOST_DEVICE const auto& stride_holder() const
   {
     return static_cast<const StrideHolder&>(*this);
   }
 
-  //! Returns the stride's value
+  //! @brief Returns the stride's value
   _CCCL_HOST_DEVICE auto stride() const -> difference_type
   {
     return static_cast<detail::it_difference_t<RandomAccessIterator>>(stride_holder().value);
   }
 
 private:
-  //! \cond
+  //! @cond
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HOST_DEVICE void advance(difference_type n)
   {
@@ -129,19 +130,21 @@ private:
     _CCCL_ASSERT(dist % stride() == 0, "Underlying iterator difference must be divisible by the stride");
     return dist / stride();
   }
-  //! \endcond
+  //! @endcond
 };
 
-//! Constructs a strided_iterator with a runtime stride
+//! @brief Constructs a strided_iterator from an iterator @param it with a given @param stride
 template <typename Iterator, typename Stride>
-_CCCL_HOST_DEVICE auto make_strided_iterator(Iterator it, Stride stride)
+CCCL_DEPRECATED_BECAUSE("Use cuda::make_strided_iterator instead")
+_CCCL_API auto make_strided_iterator(Iterator it, Stride stride)
 {
   return strided_iterator<Iterator, runtime_value<Stride>>(it, {stride});
 }
 
-//! Constructs a strided_iterator with a compile-time stride
+//! @brief Constructs a strided_iterator from an iterator @param it with a value-initialized compile-time @tparam Stride
 template <auto Stride, typename Iterator>
-_CCCL_HOST_DEVICE auto make_strided_iterator(Iterator it)
+CCCL_DEPRECATED_BECAUSE("Use cuda::make_strided_iterator instead")
+_CCCL_API auto make_strided_iterator(Iterator it)
 {
   return strided_iterator<Iterator, compile_time_value<Stride>>(it, {});
 }

--- a/thrust/thrust/iterator/strided_iterator.h
+++ b/thrust/thrust/iterator/strided_iterator.h
@@ -135,16 +135,15 @@ private:
 
 //! @brief Constructs a strided_iterator from an iterator @param it with a given @param stride
 template <typename Iterator, typename Stride>
-CCCL_DEPRECATED_BECAUSE("Use cuda::make_strided_iterator instead")
-_CCCL_API auto make_strided_iterator(Iterator it, Stride stride)
+CCCL_DEPRECATED_BECAUSE("Use cuda::make_strided_iterator instead") _CCCL_API auto
+make_strided_iterator(Iterator it, Stride stride)
 {
   return strided_iterator<Iterator, runtime_value<Stride>>(it, {stride});
 }
 
 //! @brief Constructs a strided_iterator from an iterator @param it with a value-initialized compile-time @tparam Stride
 template <auto Stride, typename Iterator>
-CCCL_DEPRECATED_BECAUSE("Use cuda::make_strided_iterator instead")
-_CCCL_API auto make_strided_iterator(Iterator it)
+CCCL_DEPRECATED_BECAUSE("Use cuda::make_strided_iterator instead") _CCCL_API auto make_strided_iterator(Iterator it)
 {
   return strided_iterator<Iterator, compile_time_value<Stride>>(it, {});
 }


### PR DESCRIPTION
This drops `thrust::strided_iterator` in favor of `cuda::strided_iterator`

Both are quite similar but I opted to keep the old thrust implementation, because it provides us with a clearer deprecation message