### PR TITLE
Fix bug in reduce tuning

### DIFF
--- a/cub/benchmarks/bench/reduce/base.cuh
+++ b/cub/benchmarks/bench/reduce/base.cuh
@@ -80,8 +80,10 @@ void reduce(nvbench::state& state, nvbench::type_list<T, OffsetT>)
      accum_t
 #if !TUNE_BASE
     ,
+    ::cuda::std::identity, // pass the default TransformOpT which due to policy_hub_t instantiation is not deduced
+                           // automatically
     policy_hub_t<accum_t, offset_t>
-#endif // TUNE_BASE
+#endif // !TUNE_BASE
     >;
 
   // Retrieve axis parameters


### PR DESCRIPTION
Back in the day [we changed the order](https://github.com/NVIDIA/cccl/pull/3740/files) of the template arguments in `DispatchReduce`. Until then `TransformOpT` was deduced with its default value so we didn't need to pass it explicitly in the `cub::Reduce` benchmark (`base.cuh`). Now that it's before `PolicyHub` we need to specify it explicitly so when compiling variants (`#if !TUNE_BASE`) it doesn't fail.

old code:


```c++
template <...
typename PolicyHub    = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
typename TransformOpT = ::cuda::std::__identity,
...> DispatchReduce{};
```

changed code:

```c++
template <...
typename TransformOpT = ::cuda::std::__identity,
typename PolicyHub    = detail::reduce::policy_hub<AccumT, OffsetT, ReductionOpT>,
...> DispatchReduce{};
```
