### PR TITLE
Document UB in warp_match_all

### DIFF
--- a/docs/libcudacxx/extended_api/warp/warp_match_all.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_match_all.rst
@@ -31,6 +31,7 @@ The function allows bitwise comparison of any data size, including raw arrays, p
 
 - The functionality is only supported on ``SM >= 70``.
 - ``lane_mask`` must be non-zero.
+- ``T`` shall have no padding bits, that is, ``T``'s value representation shall be identical to its object representation.
 
 **Undefined Behavior**
 
@@ -57,14 +58,14 @@ Example
     #include <cuda/warp>
 
     struct MyStruct {
-        double x;
-        int    y;
-    };
+        double x; // 8 bytes
+        int    y; // 4 bytes
+    };            // 4 bytes of padding
 
     __global__ void warp_match_kernel() {
         assert(cuda::device::warp_match_all(2));
         assert(cuda::device::warp_match_all(2, cuda::device::lane_mask::all()));
-        assert(cuda::device::warp_match_all(MyStruct{1.0, 3}));
+        assert(cuda::device::warp_match_all(MyStruct{1.0, 3})); // Undefined Behavior
         assert(!cuda::device::warp_match_all(threadIdx.x));
     }
 

--- a/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
@@ -125,7 +125,7 @@ The functions allow to exchange data of any data size, including raw arrays, poi
 **Constrains**
 
 - ``Width`` must be a power of two in the range [1, 32]
-- ``T``: only ``void`` pointers are allowed to avoid bug-prone code
+- ``T``: all ``T`` are allowed except if ``T`` is a pointer, in which case it must be a ``void`` pointer to avoid buggy programs.
 
 **Preconditions**
 

--- a/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
@@ -125,7 +125,7 @@ The functions allow to exchange data of any data size, including raw arrays, poi
 **Constrains**
 
 - ``Width`` must be a power of two in the range [1, 32]
-- ``T``: all ``T`` are allowed except if ``T`` is a pointer, in which case it must be a ``void`` pointer to avoid buggy programs.
+- ``T``: all ``T`` are allowed except if ``T`` is a pointer, in which case it must be a ``void`` pointer to avoid bug-prone code.
 
 **Preconditions**
 

--- a/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
+++ b/docs/libcudacxx/extended_api/warp/warp_shuffle.rst
@@ -125,7 +125,7 @@ The functions allow to exchange data of any data size, including raw arrays, poi
 **Constrains**
 
 - ``Width`` must be a power of two in the range [1, 32]
-- ``T``: all ``T`` are allowed except if ``T`` is a pointer, in which case it must be a ``void`` pointer to avoid bug-prone code.
+- ``T``: all ``T`` are allowed except if ``T`` is a pointer, in which case it must be a ``void`` pointer to avoid bug-prone code
 
 **Preconditions**
 


### PR DESCRIPTION
## Description

See https://github.com/NVIDIA/cccl/pull/4746/files#r2299323767 .

Shuffling padding bytes around seems fine, so the `warp_shuffle` APIs are ok.