### PR TITLE
Fix issues with compiling on 12.0 for memcpy_async on Ampere+

### DIFF
--- a/libcudacxx/include/cuda/__memcpy_async/cp_async_shared_global.h
+++ b/libcudacxx/include/cuda/__memcpy_async/cp_async_shared_global.h
@@ -116,7 +116,7 @@ inline _CCCL_DEVICE void __cp_async_shared_global<16>(char* __dest, const char* 
                   "n"(16) : "memory");),
     (::cuda::__cuda_ptx_cp_async_shared_global_is_not_supported_before_SM_80__();));
 }
-#  endif
+#  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
 
 template <size_t _Alignment, typename _Group>
 inline _CCCL_DEVICE void


### PR DESCRIPTION
## Description

Fixes issues found in recent CI updates. 

Works around a compiler bug by removing state space checks from the frontend.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
