### PR TITLE
Make sure that `cuda::` iterators are `random_access_iterator` when possible

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/member_typedefs.compile.pass.cpp
@@ -25,6 +25,7 @@ __host__ __device__ void test()
   static_assert(cuda::std::same_as<Iter::value_type, int>);
   static_assert(cuda::std::is_signed_v<Iter::difference_type>);
   static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
+  static_assert(cuda::std::random_access_iterator<Iter>);
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/counting_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/counting_iterator/member_typedefs.compile.pass.cpp
@@ -115,6 +115,7 @@ __host__ __device__ void test()
     static_assert(sizeof(Iter::difference_type) > sizeof(char));
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, int>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
   {
     using Iter = cuda::counting_iterator<short>;
@@ -124,6 +125,7 @@ __host__ __device__ void test()
     static_assert(sizeof(Iter::difference_type) > sizeof(short));
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, int>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
   {
     using Iter = cuda::counting_iterator<int>;
@@ -139,6 +141,7 @@ __host__ __device__ void test()
 #else
     static_assert(cuda::std::same_as<Iter::difference_type, long>);
 #endif
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
   {
     using Iter = cuda::counting_iterator<long>;
@@ -149,6 +152,7 @@ __host__ __device__ void test()
     static_assert(sizeof(Iter::difference_type) >= sizeof(long));
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, long long>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
   {
     using Iter = cuda::counting_iterator<long long>;
@@ -160,6 +164,7 @@ __host__ __device__ void test()
     static_assert(sizeof(Iter::difference_type) >= sizeof(long long));
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, long long>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
   {
     using Iter = cuda::counting_iterator<Decrementable>;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/member_typedefs.compile.pass.cpp
@@ -26,6 +26,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::same_as<Iter::value_type, int>);
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
 
   {
@@ -35,6 +36,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::same_as<Iter::value_type, int>);
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.pass.cpp
@@ -34,6 +34,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
   }
   {
     // Member typedefs for random access iterator.
@@ -42,6 +43,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
   }
   {
     // Member typedefs for random access iterator, LWG3798 rvalue reference.
@@ -50,6 +52,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
   }
   {
     // Member typedefs for random access iterator/not-lvalue-ref.
@@ -58,6 +61,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
   }
   {
     // Member typedefs for bidirectional iterator.
@@ -66,6 +70,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::bidirectional_iterator<TIter>);
   }
   {
     // Member typedefs for forward iterator.
@@ -74,6 +79,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::forward_iterator<TIter>);
   }
   {
     // Member typedefs for input iterator.
@@ -82,6 +88,7 @@ __host__ __device__ constexpr bool test()
     static_assert(!HasIterCategory<cpp17_input_iterator<int*>, Increment>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::input_iterator<TIter>);
   }
 
   return true;
@@ -90,7 +97,7 @@ __host__ __device__ constexpr bool test()
 int main(int, char**)
 {
   test();
-  static_assert(test(), "");
+  static_assert(test());
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/member_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/member_types.compile.pass.cpp
@@ -55,6 +55,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int>>);
     static_assert(HasIterCategory<Iter>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
 
   { // Two iterator should have pair value type
@@ -64,6 +65,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::pair<int, Foo>>);
     static_assert(HasIterCategory<Iter>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
 
   { // !=2 views should have tuple value_type
@@ -73,6 +75,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int, Foo, int>>);
     static_assert(HasIterCategory<Iter>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
 
   { // If one iterator is not random access then the whole zip_iterator is not random access
@@ -82,6 +85,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int, Foo, int>>);
     static_assert(HasIterCategory<Iter>);
+    static_assert(cuda::std::bidirectional_iterator<Iter>);
   }
 
   { // If one iterator is not bidirectional_iterator then the whole zip_iterator is not bidirectional_iterator
@@ -91,6 +95,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int, Foo, int>>);
     static_assert(HasIterCategory<Iter>);
+    static_assert(cuda::std::forward_iterator<Iter>);
   }
 
   { // If one iterator is not forward_iterator then the whole zip_iterator is not forward_iterator
@@ -99,6 +104,7 @@ __host__ __device__ void test()
     static_assert(!HasIterCategory<Iter>);
     static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int, Foo, int>>);
+    static_assert(cuda::std::input_iterator<Iter>);
   }
 
   { // nested iterator has the right value type
@@ -108,6 +114,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::pair<int, cuda::std::pair<Foo, int>>>);
     static_assert(HasIterCategory<Iter>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
 
   { // Takes the difference type from the base iterator


### PR DESCRIPTION
There was an issue with `cuda::transform_iterator::operator*() const` which prevented it to satisfy `cuda::std::input_iterator`

In a nutshell, we need to do some UB to `const_cast` the functor so that it works even with a `const transform_iterator`