### PR TITLE
Add a missing variant header in c/parallel

### DIFF
--- a/c/parallel/src/nvrtc/command_list.h
+++ b/c/parallel/src/nvrtc/command_list.h
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <memory>
 #include <string_view>
+#include <variant>
 
 #include <nvrtc.h>
 


### PR DESCRIPTION
## Description

This fixes this compilation error I have with g++15 on my local machine
```
      In file included from /home/caugonnet/git/caugonnet_cccl/c/parallel/src/util/runtime_policy.cpp:17:
      /home/caugonnet/git/caugonnet_cccl/c/parallel/src/util/../nvrtc/command_list.h:86:34: error: 'variant' in namespace 'std' does not name a template type
         86 | using nvrtc_linkable      = std::variant<nvrtc_ltoir, nvrtc_code>;
            |                                  ^~~~~~~
      /home/caugonnet/git/caugonnet_cccl/c/parallel/src/util/../nvrtc/command_list.h:25:1: note: 'std::variant' is defined in header '<variant>'; this is probably fixable by adding '#include <variant>'
         24 | #include <util/errors.h>
        +++ |+#include <variant>
```

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
