### PR TITLE
Fix `cuda::shuffle_iterator` not properly working with thrust algorithms

### DIFF
--- a/thrust/thrust/iterator/iterator_traits.h
+++ b/thrust/thrust/iterator/iterator_traits.h
@@ -245,6 +245,17 @@ template <class Iter>
 struct iterator_traversal<::cuda::std::reverse_iterator<Iter>> : iterator_traversal<Iter>
 {};
 
+template <class IndexType, class Bijection>
+struct iterator_system<::cuda::shuffle_iterator<IndexType, Bijection>>
+{
+  using type = any_system_tag;
+};
+template <class IndexType, class Bijection>
+struct iterator_traversal<::cuda::shuffle_iterator<IndexType, Bijection>>
+{
+  using type = random_access_traversal_tag;
+};
+
 template <class Iter, class Stride>
 struct iterator_system<::cuda::strided_iterator<Iter, Stride>> : iterator_system<Iter>
 {};


### PR DESCRIPTION
Someone forgot to add support for that to our thrust machinery. We will never know who.
