### PR TITLE
Fix `thrust::malloc` for `void`

### DIFF
--- a/thrust/thrust/system/detail/generic/memory.inl
+++ b/thrust/thrust/system/detail/generic/memory.inl
@@ -31,6 +31,8 @@
 #include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/system/detail/adl/malloc_and_free.h>
 
+#include <cuda/std/__type_traits/is_void.h>
+
 THRUST_NAMESPACE_BEGIN
 namespace system
 {
@@ -48,9 +50,16 @@ _CCCL_HOST_DEVICE void malloc(thrust::execution_policy<DerivedPolicy>&, Size)
 template <typename T, typename DerivedPolicy>
 _CCCL_HOST_DEVICE thrust::pointer<T, DerivedPolicy> malloc(thrust::execution_policy<DerivedPolicy>& exec, std::size_t n)
 {
-  thrust::pointer<void, DerivedPolicy> void_ptr = thrust::malloc(exec, sizeof(T) * n);
+  if constexpr (::cuda::std::is_void_v<T>)
+  {
+    // We cannot determine sizeof(void), but if void is the target type we are allocating bytes anyway
+    return pointer<void, DerivedPolicy>(thrust::malloc(exec, n).get());
+  }
+  else
+  {
+    return pointer<T, DerivedPolicy>(static_cast<T*>(thrust::malloc(exec, sizeof(T) * n).get()));
+  }
 
-  return pointer<T, DerivedPolicy>(static_cast<T*>(void_ptr.get()));
 } // end malloc()
 
 template <typename DerivedPolicy, typename Pointer>


### PR DESCRIPTION
We cannot use `sizeof(void)` as that is an incomplete type.

Instead if someone calls malloc with `void` we already know that they want to allocate bytes, so just do that instead.

Fixes nvbug5457333
