### PR TITLE
Fix added ::std

### DIFF
--- a/libcudacxx/include/cuda/std/__cmath/fpclassify.h
+++ b/libcudacxx/include/cuda/std/__cmath/fpclassify.h
@@ -112,7 +112,7 @@ template <class _Tp>
 #else // ^^^ _CCCL_BUILTIN_FPCLASSIFY ^^^ / vvv !_CCCL_BUILTIN_FPCLASSIFY vvv
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    NV_IF_TARGET(NV_IS_HOST, (return ::fpclassify(__x);))
+    NV_IF_TARGET(NV_IS_HOST, (return ::std::fpclassify(__x);))
   }
   return ::cuda::std::__fpclassify_impl(__x);
 #endif // !_CCCL_BUILTIN_FPCLASSIFY
@@ -125,7 +125,7 @@ template <class _Tp>
 #else // ^^^ _CCCL_BUILTIN_FPCLASSIFY ^^^ / vvv !_CCCL_BUILTIN_FPCLASSIFY vvv
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    NV_IF_TARGET(NV_IS_HOST, (return ::fpclassify(__x);))
+    NV_IF_TARGET(NV_IS_HOST, (return ::std::fpclassify(__x);))
   }
   return ::cuda::std::__fpclassify_impl(__x);
 #endif // !_CCCL_BUILTIN_FPCLASSIFY
@@ -139,7 +139,7 @@ template <class _Tp>
 #  else // ^^^ _CCCL_BUILTIN_FPCLASSIFY ^^^ / vvv !_CCCL_BUILTIN_FPCLASSIFY vvv
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    NV_IF_TARGET(NV_IS_HOST, (return ::fpclassify(__x);))
+    NV_IF_TARGET(NV_IS_HOST, (return ::std::fpclassify(__x);))
   }
   return ::cuda::std::__fpclassify_impl(__x);
 #  endif // !_CCCL_BUILTIN_FPCLASSIFY

--- a/libcudacxx/include/cuda/std/__cmath/isfinite.h
+++ b/libcudacxx/include/cuda/std/__cmath/isfinite.h
@@ -47,7 +47,7 @@ template <class _Tp>
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    return ::isfinite(__x);
+    return ::std::isfinite(__x);
   }
   return !::cuda::std::isnan(__x) && !::cuda::std::isinf(__x);
 }
@@ -59,7 +59,7 @@ template <class _Tp>
 #else // ^^^ _CCCL_BUILTIN_ISFINITE ^^^ / vvv !_CCCL_BUILTIN_ISFINITE vvv
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    return ::isfinite(__x);
+    return ::std::isfinite(__x);
   }
 #  if _CCCL_HAS_CONSTEXPR_BIT_CAST()
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mask_of_v<float>) != __fp_exp_mask_of_v<float>;
@@ -76,7 +76,7 @@ template <class _Tp>
 #else // ^^^ _CCCL_BUILTIN_ISFINITE ^^^ / vvv !_CCCL_BUILTIN_ISFINITE vvv
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    return ::isfinite(__x);
+    return ::std::isfinite(__x);
   }
 #  if _CCCL_HAS_CONSTEXPR_BIT_CAST()
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mask_of_v<double>) != __fp_exp_mask_of_v<double>;

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -48,7 +48,7 @@ template <class _Tp>
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    return ::isinf(__x);
+    return ::std::isinf(__x);
   }
   if (::cuda::std::isnan(__x))
   {
@@ -71,7 +71,7 @@ template <class _Tp>
 #elif _CCCL_HAS_CONSTEXPR_BIT_CAST()
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    return ::isinf(__x);
+    return ::std::isinf(__x);
   }
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<float>) == __fp_exp_mask_of_v<float>;
 #else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
@@ -93,7 +93,7 @@ template <class _Tp>
 #elif _CCCL_HAS_CONSTEXPR_BIT_CAST()
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    return ::isinf(__x);
+    return ::std::isinf(__x);
   }
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<double>) == __fp_exp_mask_of_v<double>;
 #else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv

--- a/libcudacxx/include/cuda/std/__cmath/isnan.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnan.h
@@ -46,7 +46,7 @@ template <class _Tp>
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    return ::isnan(__x);
+    return ::std::isnan(__x);
   }
   return __x != __x;
 }


### PR DESCRIPTION
```
C:/gcc1520/x86_64-w64-mingw32/include/cuda/std/__cmath/isinf.h:51:14: error: '::isinf' has not been declared; did you mean 'std::isinf'? [-Wtemplate-body]
   51 |     return ::isinf(__x);
      |              ^~~~~
      |              std::isinf
In file included from C:/gcc1520/x86_64-w64-mingw32/include/cudart/crt/common_functions.h:303,
                 from C:/gcc1520/x86_64-w64-mingw32/include/cudart/cuda_runtime.h:117,
                 from <command-line>:
C:/gcc1520/x86_64-w64-mingw32/include/cudart/crt/math_functions.h:4717:61: note: 'std::isinf' declared here
 4717 | __DEVICE_FUNCTIONS_DECL__ __cudart_builtin__ constexpr bool isinf(long double x);
      |                                                             ^~~~~
```