### PR TITLE
fix completion signature computation of `starts_on`, work around gcc9 ICE

### DIFF
--- a/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
@@ -207,7 +207,7 @@ _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_MSVC(4913)
 
 #define _CUDAX_GET_COMPLSIGS(...) \
-  ::cuda::std::remove_reference_t<_Sndr>::template get_completion_signatures<__VA_ARGS__>()
+  ::cuda::std::remove_reference_t<_CCCL_PP_FIRST(__VA_ARGS__)>::template get_completion_signatures<__VA_ARGS__>()
 
 #define _CUDAX_CHECKED_COMPLSIGS(...) \
   (static_cast<void>(__VA_ARGS__), void(), execution::__checked_complsigs<decltype(__VA_ARGS__)>())
@@ -234,6 +234,9 @@ _CCCL_NODEBUG_API _CCCL_CONSTEVAL auto __checked_complsigs()
 }
 
 template <class _Sndr, class... _Env>
+using __get_complsigs_t = decltype(_CUDAX_GET_COMPLSIGS(_Sndr, _Env...));
+
+template <class _Sndr, class... _Env>
 inline constexpr bool __has_get_completion_signatures = false;
 
 // clang-format off
@@ -241,14 +244,14 @@ template <class _Sndr>
 inline constexpr bool __has_get_completion_signatures<_Sndr> =
   _CCCL_REQUIRES_EXPR((_Sndr))
   (
-    (_CUDAX_GET_COMPLSIGS(_Sndr))
+    typename(__get_complsigs_t<_Sndr>)
   );
 
 template <class _Sndr, class _Env>
 inline constexpr bool __has_get_completion_signatures<_Sndr, _Env> =
   _CCCL_REQUIRES_EXPR((_Sndr, _Env))
   (
-    (_CUDAX_GET_COMPLSIGS(_Sndr, _Env))
+    typename(__get_complsigs_t<_Sndr, _Env>)
   );
 // clang-format on
 

--- a/cudax/include/cuda/experimental/__execution/queries.cuh
+++ b/cudax/include/cuda/experimental/__execution/queries.cuh
@@ -195,7 +195,7 @@ private:
     _CCCL_EXEC_CHECK_DISABLE
     template <class _Self = __recurse_query_t, class _Sch, class... _Env>
     [[nodiscard]]
-    _CCCL_API constexpr auto operator()(_Sch __sch, const _Env&... __env) const noexcept
+    _CCCL_API constexpr auto operator()([[maybe_unused]] _Sch __sch, const _Env&... __env) const noexcept
     {
       // When determining where the scheduler's operations will complete, we query
       // for the completion scheduler of the value channel:

--- a/cudax/test/execution/test_starts_on.cu
+++ b/cudax/test/execution/test_starts_on.cu
@@ -248,7 +248,7 @@ C2H_TEST("starts_on has the right completion scheduler", "[adaptors][starts_on]"
     ex::thread_context thread;
     auto sch = thread.get_scheduler();
     auto snd = ex::starts_on(sch, ex::just());
-    CHECK(ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(snd)) == sch);
+    CHECK(ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(snd), ex::env{}) == sch);
   }
 
   SECTION("thread scheduler with a sender that completes on another thread")
@@ -256,7 +256,7 @@ C2H_TEST("starts_on has the right completion scheduler", "[adaptors][starts_on]"
     ex::thread_context thread1, thread2;
     auto sch1 = thread1.get_scheduler(), sch2 = thread2.get_scheduler();
     auto snd = ex::starts_on(sch1, ex::starts_on(sch2, ex::just()));
-    CHECK(ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(snd)) == sch2);
+    CHECK(ex::get_completion_scheduler<ex::set_value_t>(ex::get_env(snd), ex::env{}) == sch2);
   }
 
   SECTION("inline scheduler with inline sender completion with a given starting scheduler")


### PR DESCRIPTION
## Description

the cudax execution library is causing gcc9 to [ICE in nightly CI](https://github.com/NVIDIA/cccl/actions/runs/17313694494/job/49152675443#step:4:1199). some implementation details of `cudax::execution::get_completion_signatures` were tripping up gcc9. this pr simplifies the code enough for gcc9 to accept it.

investigating this let me to an issue in how the `starts_on` sender is computing its completion signatures. this pr addresses that problem as well, which was contributing to the ICE.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
