### PR TITLE
fix: Add missing pages:write permission to PR cleanup workflow

### DIFF
--- a/.github/workflows/pr-preview-cleanup.yml
+++ b/.github/workflows/pr-preview-cleanup.yml
@@ -11,6 +11,7 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  pages: write
 
 jobs:
   cleanup-preview:


### PR DESCRIPTION
## Problem

The PR documentation preview cleanup workflow was failing with permission errors when trying to clean up GitHub Pages deployments.

**Error:**
> The workflow is requesting 'pages: write', but is only allowed 'pages: none'

## Root Cause

The  workflow calls the  reusable workflow, which requires  permission for GitHub Pages deployment operations. However, the cleanup workflow was only granting  and  permissions.

## Solution

Added the missing `pages: write` permission to the cleanup workflow's permissions block.

## Testing

This should resolve cleanup workflow failures like: https://github.com/NVIDIA/cccl/actions/runs/17416614789

## Changes

- Added `pages: write` permission to `.github/workflows/pr-preview-cleanup.yml`

Small fix to complement the recently merged PR documentation preview system (#5559).