### PR TITLE
Fix local builds

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -93,7 +93,7 @@ set -u
 readonly PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
 
 if [ -z ${CCCL_BUILD_INFIX+x} ]; then
-    CCCL_BUILD_INFIX=""
+    CCCL_BUILD_INFIX="local"
 fi
 
 mkdir -p ../build


### PR DESCRIPTION
Our build scripts get confused if `CCCL_BUILD_INFIX` is empty, so give it something to chew on
