### PR TITLE
Fix problematic clang attribute namespace

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -140,8 +140,8 @@
 
 // _CCCL_NO_SPECIALIZATIONS
 
-#if _CCCL_HAS_CPP_ATTRIBUTE(_Clang::__no_specializations__)
-#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)   [[_Clang::__no_specializations__(_MSG)]]
+#if _CCCL_HAS_CPP_ATTRIBUTE(clang::__no_specializations__)
+#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)   [[clang::__no_specializations__(_MSG)]]
 #  define _CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS() 1
 #elif _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
 #  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)   [[msvc::no_specializations(_MSG)]]

--- a/libcudacxx/include/cuda/std/__cccl/epilogue.h
+++ b/libcudacxx/include/cuda/std/__cccl/epilogue.h
@@ -331,4 +331,14 @@ _CCCL_DIAG_POP
 #  undef _CCCL_POP_MACRO___valid
 #endif
 
+// other macros
+
+#if defined(clang)
+#  error \
+    "cccl internal error: macro `clang` was redefined between <cuda/std/__cccl/prologue.h> and <cuda/std/__cccl/epilogue.h>"
+#elif defined(_CCCL_POP_MACRO_clang)
+#  pragma pop_macro("clang")
+#  undef _CCCL_POP_MACRO_clang
+#endif
+
 // NO include guards here (this file is included multiple times)

--- a/libcudacxx/include/cuda/std/__cccl/prologue.h
+++ b/libcudacxx/include/cuda/std/__cccl/prologue.h
@@ -253,6 +253,14 @@
 #  define _CCCL_POP_MACRO___valid
 #endif // defined(__valid)
 
+// other macros
+
+#if defined(clang)
+#  pragma push_macro("clang")
+#  undef clang
+#  define _CCCL_POP_MACRO_clang
+#endif // defined(clang)
+
 _CCCL_DIAG_PUSH
 
 // disable some msvc warnings


### PR DESCRIPTION
Fixes nvbug 5498112.

nvcc doesn't recognize `_Clang::` as a known attribute namespace. So let's use `clang::` instead and add `clang` to pushed/poped macros.
