### PR TITLE
Properly guard ptx includes for when we are in cuda mode

### DIFF
--- a/libcudacxx/cmake/LibcudacxxPublicHeaderTestingHost.cmake
+++ b/libcudacxx/cmake/LibcudacxxPublicHeaderTestingHost.cmake
@@ -13,6 +13,17 @@ file(GLOB public_headers_host_only
   RELATIVE "${libcudacxx_SOURCE_DIR}/include"
   CONFIGURE_DEPENDS
   "${libcudacxx_SOURCE_DIR}/include/cuda/std/*"
+  # Add some files we expect to work in host only compilation
+  "${libcudacxx_SOURCE_DIR}/include/cuda/bit"
+  "${libcudacxx_SOURCE_DIR}/include/cuda/cmath"
+  "${libcudacxx_SOURCE_DIR}/include/cuda/functional"
+  "${libcudacxx_SOURCE_DIR}/include/cuda/iterator"
+  "${libcudacxx_SOURCE_DIR}/include/cuda/mdspan"
+  "${libcudacxx_SOURCE_DIR}/include/cuda/memory"
+  "${libcudacxx_SOURCE_DIR}/include/cuda/numeric"
+  "${libcudacxx_SOURCE_DIR}/include/cuda/type_traits"
+  "${libcudacxx_SOURCE_DIR}/include/cuda/utility"
+  "${libcudacxx_SOURCE_DIR}/include/cuda/version"
 )
 
 function(libcudacxx_create_public_header_test_host header_name, headertest_src)

--- a/libcudacxx/include/cuda/__bit/bitmask.h
+++ b/libcudacxx/include/cuda/__bit/bitmask.h
@@ -21,9 +21,11 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__ptx/instructions/bmsk.h>
-#include <cuda/__ptx/instructions/shl.h>
-#include <cuda/__ptx/instructions/shr.h>
+#if _CCCL_CUDA_COMPILATION()
+#  include <cuda/__ptx/instructions/bmsk.h>
+#  include <cuda/__ptx/instructions/shl.h>
+#  include <cuda/__ptx/instructions/shr.h>
+#endif // _CCCL_CUDA_COMPILATION()
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/__type_traits/is_unsigned_integer.h>

--- a/libcudacxx/include/cuda/__warp/warp_shuffle.h
+++ b/libcudacxx/include/cuda/__warp/warp_shuffle.h
@@ -21,22 +21,23 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__cmath/ceil_div.h>
-#include <cuda/__ptx/instructions/get_sreg.h>
-#include <cuda/__ptx/instructions/shfl_sync.h>
-#include <cuda/std/__bit/has_single_bit.h>
-#include <cuda/std/__concepts/concept_macros.h>
-#include <cuda/std/__memory/addressof.h>
-#include <cuda/std/__type_traits/enable_if.h>
-#include <cuda/std/__type_traits/integral_constant.h>
-#include <cuda/std/__type_traits/is_pointer.h>
-#include <cuda/std/__type_traits/is_void.h>
-#include <cuda/std/__type_traits/remove_cvref.h>
-#include <cuda/std/cstdint>
+#if _CCCL_CUDA_COMPILATION()
+#  if __cccl_ptx_isa >= 600
 
-#if __cccl_ptx_isa >= 600
+#    include <cuda/__cmath/ceil_div.h>
+#    include <cuda/__ptx/instructions/get_sreg.h>
+#    include <cuda/__ptx/instructions/shfl_sync.h>
+#    include <cuda/std/__bit/has_single_bit.h>
+#    include <cuda/std/__concepts/concept_macros.h>
+#    include <cuda/std/__memory/addressof.h>
+#    include <cuda/std/__type_traits/enable_if.h>
+#    include <cuda/std/__type_traits/integral_constant.h>
+#    include <cuda/std/__type_traits/is_pointer.h>
+#    include <cuda/std/__type_traits/is_void.h>
+#    include <cuda/std/__type_traits/remove_cvref.h>
+#    include <cuda/std/cstdint>
 
-#  include <cuda/std/__cccl/prologue.h>
+#    include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 
@@ -243,7 +244,8 @@ warp_shuffle_xor(const _Tp& __data, int __src_lane, ::cuda::std::integral_consta
 
 _CCCL_END_NAMESPACE_CUDA_DEVICE
 
-#  include <cuda/std/__cccl/epilogue.h>
+#    include <cuda/std/__cccl/epilogue.h>
 
-#endif // __cccl_ptx_isa >= 600
+#  endif // __cccl_ptx_isa >= 600
+#endif // _CCCL_CUDA_COMPILATION()
 #endif // _CUDA___WARP_WARP_SHUFFLE_H

--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -21,7 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__ptx/instructions/prmt.h>
+#if _CCCL_CUDA_COMPILATION()
+#  include <cuda/__ptx/instructions/prmt.h>
+#endif // _CCCL_CUDA_COMPILATION()
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/__type_traits/is_integral.h>

--- a/libcudacxx/include/cuda/std/__bit/integral.h
+++ b/libcudacxx/include/cuda/std/__bit/integral.h
@@ -21,9 +21,11 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__ptx/instructions/bfind.h>
-#include <cuda/__ptx/instructions/shl.h>
-#include <cuda/__ptx/instructions/shr.h>
+#if _CCCL_CUDA_COMPILATION()
+#  include <cuda/__ptx/instructions/bfind.h>
+#  include <cuda/__ptx/instructions/shl.h>
+#  include <cuda/__ptx/instructions/shr.h>
+#endif // _CCCL_CUDA_COMPILATION()
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__bit/countl.h>
 #include <cuda/std/__concepts/concept_macros.h>

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -109,10 +109,14 @@ private:
   [[maybe_unused]] const char* __api                  = nullptr,
   [[maybe_unused]] ::cuda::std::source_location __loc = ::cuda::std::source_location::current())
 {
+#  if _CCCL_CUDA_COMPILATION()
   NV_IF_ELSE_TARGET(NV_IS_HOST,
                     (::cudaGetLastError(); // clear CUDA error state
                      throw ::cuda::cuda_error(__status, __msg, __api, __loc);), //
                     (::cuda::std::terminate();))
+#  else // ^^^ _CCCL_CUDA_COMPILATION() ^^^ / vvv !_CCCL_CUDA_COMPILATION() vvv
+  throw ::cuda::cuda_error(__status, __msg, __api, __loc);
+#  endif // !_CCCL_CUDA_COMPILATION()
 }
 #else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
 class cuda_error

--- a/libcudacxx/include/cuda/std/ctime
+++ b/libcudacxx/include/cuda/std/ctime
@@ -21,7 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__ptx/instructions/get_sreg.h>
+#if _CCCL_CUDA_COMPILATION()
+#  include <cuda/__ptx/instructions/get_sreg.h>
+#endif // _CCCL_CUDA_COMPILATION()
 
 #if !_CCCL_COMPILER(NVRTC)
 #  include <time.h>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
@@ -839,7 +839,9 @@ constexpr chrono::year                                  operator ""y(unsigned lo
 #  endif // _CCCL_COMPILER(NVRTC)
 #endif // __cuda_std__
 
-#include <cuda/__ptx/instructions/get_sreg.h>
+#if _CCCL_CUDA_COMPILATION()
+#  include <cuda/__ptx/instructions/get_sreg.h>
+#endif // _CCCL_CUDA_COMPILATION()
 #include <cuda/std/__type_traits/common_type.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>


### PR DESCRIPTION
I have expanded our host-only header tests to also include those headers from `cuda/` that we expect to also work with a host compiler

Fixes #5747
