### PR TITLE
[BACKPORT 3.1]: Fix problematic clang attribute namespace (#5748)

### DIFF
--- a/libcudacxx/include/cuda/__bit/bitmask.h
+++ b/libcudacxx/include/cuda/__bit/bitmask.h
@@ -21,9 +21,11 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__ptx/instructions/bmsk.h>
-#include <cuda/__ptx/instructions/shl.h>
-#include <cuda/__ptx/instructions/shr.h>
+#if _CCCL_CUDA_COMPILATION()
+#  include <cuda/__ptx/instructions/bmsk.h>
+#  include <cuda/__ptx/instructions/shl.h>
+#  include <cuda/__ptx/instructions/shr.h>
+#endif // _CCCL_CUDA_COMPILATION()
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/__type_traits/is_unsigned_integer.h>

--- a/libcudacxx/include/cuda/__warp/warp_shuffle.h
+++ b/libcudacxx/include/cuda/__warp/warp_shuffle.h
@@ -21,22 +21,23 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__cmath/ceil_div.h>
-#include <cuda/__ptx/instructions/get_sreg.h>
-#include <cuda/__ptx/instructions/shfl_sync.h>
-#include <cuda/std/__bit/has_single_bit.h>
-#include <cuda/std/__concepts/concept_macros.h>
-#include <cuda/std/__memory/addressof.h>
-#include <cuda/std/__type_traits/enable_if.h>
-#include <cuda/std/__type_traits/integral_constant.h>
-#include <cuda/std/__type_traits/is_pointer.h>
-#include <cuda/std/__type_traits/is_void.h>
-#include <cuda/std/__type_traits/remove_cvref.h>
-#include <cuda/std/cstdint>
+#if _CCCL_CUDA_COMPILATION()
+#  if __cccl_ptx_isa >= 600
 
-#if __cccl_ptx_isa >= 600
+#    include <cuda/__cmath/ceil_div.h>
+#    include <cuda/__ptx/instructions/get_sreg.h>
+#    include <cuda/__ptx/instructions/shfl_sync.h>
+#    include <cuda/std/__bit/has_single_bit.h>
+#    include <cuda/std/__concepts/concept_macros.h>
+#    include <cuda/std/__memory/addressof.h>
+#    include <cuda/std/__type_traits/enable_if.h>
+#    include <cuda/std/__type_traits/integral_constant.h>
+#    include <cuda/std/__type_traits/is_pointer.h>
+#    include <cuda/std/__type_traits/is_void.h>
+#    include <cuda/std/__type_traits/remove_cvref.h>
+#    include <cuda/std/cstdint>
 
-#  include <cuda/std/__cccl/prologue.h>
+#    include <cuda/std/__cccl/prologue.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA_DEVICE
 
@@ -243,7 +244,8 @@ warp_shuffle_xor(const _Tp& __data, int __src_lane, _CUDA_VSTD::integral_constan
 
 _LIBCUDACXX_END_NAMESPACE_CUDA_DEVICE
 
-#  include <cuda/std/__cccl/epilogue.h>
+#    include <cuda/std/__cccl/epilogue.h>
 
-#endif // __cccl_ptx_isa >= 600
+#  endif // __cccl_ptx_isa >= 600
+#endif // _CCCL_CUDA_COMPILATION()
 #endif // _CUDA___WARP_WARP_SHUFFLE_H

--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -21,7 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__ptx/instructions/prmt.h>
+#if _CCCL_CUDA_COMPILATION()
+#  include <cuda/__ptx/instructions/prmt.h>
+#endif // _CCCL_CUDA_COMPILATION()
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/__type_traits/is_integral.h>

--- a/libcudacxx/include/cuda/std/__bit/integral.h
+++ b/libcudacxx/include/cuda/std/__bit/integral.h
@@ -21,9 +21,11 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__ptx/instructions/bfind.h>
-#include <cuda/__ptx/instructions/shl.h>
-#include <cuda/__ptx/instructions/shr.h>
+#if _CCCL_CUDA_COMPILATION()
+#  include <cuda/__ptx/instructions/bfind.h>
+#  include <cuda/__ptx/instructions/shl.h>
+#  include <cuda/__ptx/instructions/shr.h>
+#endif // _CCCL_CUDA_COMPILATION()
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__bit/countl.h>
 #include <cuda/std/__concepts/concept_macros.h>

--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -141,8 +141,8 @@
 
 // _CCCL_NO_SPECIALIZATIONS
 
-#if _CCCL_HAS_CPP_ATTRIBUTE(_Clang::__no_specializations__)
-#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)   [[_Clang::__no_specializations__(_MSG)]]
+#if _CCCL_HAS_CPP_ATTRIBUTE(clang::__no_specializations__)
+#  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)   [[clang::__no_specializations__(_MSG)]]
 #  define _CCCL_HAS_ATTRIBUTE_NO_SPECIALIZATIONS() 1
 #elif _CCCL_HAS_CPP_ATTRIBUTE(msvc::no_specializations)
 #  define _CCCL_NO_SPECIALIZATIONS_BECAUSE(_MSG)   [[msvc::no_specializations(_MSG)]]

--- a/libcudacxx/include/cuda/std/__cccl/epilogue.h
+++ b/libcudacxx/include/cuda/std/__cccl/epilogue.h
@@ -323,4 +323,22 @@ _CCCL_DIAG_POP
 #  undef _CCCL_POP_MACRO_interface
 #endif
 
+#if defined(__valid)
+#  error \
+    "cccl internal error: macro `__valid` was redefined between <cuda/std/__cccl/prologue.h> and <cuda/std/__cccl/epilogue.h>"
+#elif defined(_CCCL_POP_MACRO___valid)
+#  pragma pop_macro("__valid")
+#  undef _CCCL_POP_MACRO___valid
+#endif
+
+// other macros
+
+#if defined(clang)
+#  error \
+    "cccl internal error: macro `clang` was redefined between <cuda/std/__cccl/prologue.h> and <cuda/std/__cccl/epilogue.h>"
+#elif defined(_CCCL_POP_MACRO_clang)
+#  pragma pop_macro("clang")
+#  undef _CCCL_POP_MACRO_clang
+#endif
+
 // NO include guards here (this file is included multiple times)

--- a/libcudacxx/include/cuda/std/__cccl/prologue.h
+++ b/libcudacxx/include/cuda/std/__cccl/prologue.h
@@ -247,6 +247,20 @@
 #  define _CCCL_POP_MACRO_interface
 #endif // defined(interface)
 
+#if defined(__valid)
+#  pragma push_macro("__valid")
+#  undef __valid
+#  define _CCCL_POP_MACRO___valid
+#endif // defined(__valid)
+
+// other macros
+
+#if defined(clang)
+#  pragma push_macro("clang")
+#  undef clang
+#  define _CCCL_POP_MACRO_clang
+#endif // defined(clang)
+
 _CCCL_DIAG_PUSH
 
 // disable some msvc warnings

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -109,10 +109,14 @@ private:
   [[maybe_unused]] const char* __api                 = nullptr,
   [[maybe_unused]] _CUDA_VSTD::source_location __loc = _CUDA_VSTD::source_location::current())
 {
+#  if _CCCL_CUDA_COMPILATION()
   NV_IF_ELSE_TARGET(NV_IS_HOST,
                     (::cudaGetLastError(); // clear CUDA error state
                      throw ::cuda::cuda_error(__status, __msg, __api, __loc);), //
-                    (_CUDA_VSTD_NOVERSION::terminate();))
+                    (::cuda::std::terminate();))
+#  else // ^^^ _CCCL_CUDA_COMPILATION() ^^^ / vvv !_CCCL_CUDA_COMPILATION() vvv
+  throw ::cuda::cuda_error(__status, __msg, __api, __loc);
+#  endif // !_CCCL_CUDA_COMPILATION()
 }
 #else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
 class cuda_error

--- a/libcudacxx/include/cuda/std/ctime
+++ b/libcudacxx/include/cuda/std/ctime
@@ -21,7 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__ptx/instructions/get_sreg.h>
+#if _CCCL_CUDA_COMPILATION()
+#  include <cuda/__ptx/instructions/get_sreg.h>
+#endif // _CCCL_CUDA_COMPILATION()
 
 #if !_CCCL_COMPILER(NVRTC)
 #  include <time.h>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
@@ -839,7 +839,9 @@ constexpr chrono::year                                  operator ""y(unsigned lo
 #  endif // _CCCL_COMPILER(NVRTC)
 #endif // __cuda_std__
 
-#include <cuda/__ptx/instructions/get_sreg.h>
+#if _CCCL_CUDA_COMPILATION()
+#  include <cuda/__ptx/instructions/get_sreg.h>
+#endif // _CCCL_CUDA_COMPILATION()
 #include <cuda/std/__type_traits/common_type.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>


### PR DESCRIPTION
NVCC does not like `_Clang` as the attribute