### PR TITLE
Remove problematic new build symlink

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -93,7 +93,7 @@ set -u
 readonly PARALLEL_LEVEL=${PARALLEL_LEVEL:=$(nproc)}
 
 if [ -z ${CCCL_BUILD_INFIX+x} ]; then
-    CCCL_BUILD_INFIX="local"
+    CCCL_BUILD_INFIX=""
 fi
 
 mkdir -p ../build
@@ -109,13 +109,10 @@ rm -f $BUILD_ROOT/latest
 ln -sf $BUILD_DIR $BUILD_ROOT/latest
 
 # The more recent preset build dir will always be symlinked to:
-# cccl/build/latest/latest
 # cccl/preset-latest
 function symlink_latest_preset {
     local PRESET=$1
     mkdir -p "$BUILD_DIR/$PRESET"
-    rm -f "$BUILD_ROOT/latest/latest"
-    ln -sf "$BUILD_DIR/$PRESET" "$BUILD_ROOT/latest/latest"
     rm -f "$BUILD_ROOT/preset-latest"
     ln -sf "$BUILD_DIR/$PRESET" "$BUILD_ROOT/preset-latest"
 }

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -349,10 +349,6 @@ host_compilers:
 #   - E.g. "force_producer_ctk: '12.0'" on a test step will force the generated build step to use CTK 12.0.
 
 jobs:
-  # Only used for generating devcontainers. No scripts actually exist for these:
-  dc:     { gpu: false }
-  dc_ext: { gpu: false, cuda_ext: true }
-
   # General:
   build:        { gpu: false }
   test:         { gpu: true, needs: 'build' }


### PR DESCRIPTION
The addition of 'local' to our build infix when using will break workflows that are directly configuring presets outside of a container by moving the build directory.

We can restore the previous behavior by removing the symlink that gets recursive when CCCL_BUILD_INFIX is unset.

Now builds outside of devcontainers will build to the same location whether using presets or scripts.