### PR TITLE
[STF] Improve how we retrieve streams from async_resources_handle objects

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/async_resources_handle.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/async_resources_handle.cuh
@@ -394,7 +394,7 @@ private:
     mutable exec_affinity affinity;
   };
 
-  ::std::shared_ptr<impl> pimpl;
+  mutable ::std::shared_ptr<impl> pimpl;
 
 public:
   async_resources_handle()
@@ -408,7 +408,7 @@ public:
     return pimpl != nullptr;
   }
 
-  stream_pool& get_device_stream_pool(int dev_id, bool for_computation)
+  stream_pool& get_device_stream_pool(int dev_id, bool for_computation) const
   {
     assert(pimpl);
     return pimpl->get_device_stream_pool(dev_id, for_computation);

--- a/cudax/include/cuda/experimental/__stf/places/place_partition.cuh
+++ b/cudax/include/cuda/experimental/__stf/places/place_partition.cuh
@@ -195,7 +195,7 @@ private:
         // 8 SMs per green context is a granularity that should work on any arch.
         const char* env = getenv("CUDASTF_GREEN_CONTEXT_SIZE");
         int sm_cnt      = env ? atoi(env) : 8;
-        h               = ::std::make_shared<green_context_helper>(sm_cnt, dev_id);
+        h               = ::std::make_shared<green_context_helper>(sm_cnt, handle, dev_id);
       }
 
       // Get views of green context out of the helper to create execution places

--- a/cudax/test/stf/cpp/task_get_stream.cu
+++ b/cudax/test/stf/cpp/task_get_stream.cu
@@ -8,11 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 //! \file
 //!
 //! \brief Test the behavior of the get_stream() method of the tasks in the different backends
-
 
 #include <cuda/experimental/stf.cuh>
 
@@ -20,7 +18,8 @@ using namespace cuda::experimental::stf;
 
 __global__ void dummy() {}
 
-void test_stream() {
+void test_stream()
+{
   // stream context
   context ctx;
 
@@ -34,7 +33,8 @@ void test_stream() {
   ctx.finalize();
 }
 
-void test_graph() {
+void test_graph()
+{
   context ctx = graph_ctx();
 
   auto token = ctx.token();
@@ -45,7 +45,7 @@ void test_graph() {
   EXPECT(s == nullptr);
   t.end();
 
-  auto t2     = ctx.task(token.rw());
+  auto t2 = ctx.task(token.rw());
   t2.enable_capture();
   t2.start();
   cudaStream_t s2 = t2.get_stream();
@@ -56,9 +56,9 @@ void test_graph() {
   ctx.finalize();
 }
 
-int main() {
+int main()
+{
   test_stream();
   test_graph();
   return 0;
 }
-

--- a/cudax/test/stf/cpp/task_get_stream.cu
+++ b/cudax/test/stf/cpp/task_get_stream.cu
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDASTF in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2022-2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+
+//! \file
+//!
+//! \brief Test the behavior of the get_stream() method of the tasks in the different backends
+
+
+#include <cuda/experimental/stf.cuh>
+
+using namespace cuda::experimental::stf;
+
+__global__ void dummy() {}
+
+void test_stream() {
+  // stream context
+  context ctx;
+
+  auto token = ctx.token();
+  auto t     = ctx.task(token.write());
+  t.start();
+  cudaStream_t s = t.get_stream();
+  EXPECT(s != nullptr);
+  dummy<<<1, 1, 0, s>>>();
+  t.end();
+  ctx.finalize();
+}
+
+void test_graph() {
+  context ctx = graph_ctx();
+
+  auto token = ctx.token();
+  auto t     = ctx.task(token.write());
+  t.start();
+  cudaStream_t s = t.get_stream();
+  // We are not capturing so there is no stream associated
+  EXPECT(s == nullptr);
+  t.end();
+
+  auto t2     = ctx.task(token.rw());
+  t2.enable_capture();
+  t2.start();
+  cudaStream_t s2 = t2.get_stream();
+  // We are capturing so the stream used for capture is associated to the task
+  EXPECT(s2 != nullptr);
+  t2.end();
+
+  ctx.finalize();
+}
+
+int main() {
+  test_stream();
+  test_graph();
+  return 0;
+}
+

--- a/cudax/test/stf/cpp/test_pick_stream.cu
+++ b/cudax/test/stf/cpp/test_pick_stream.cu
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDASTF in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+//! \file
+//! \brief Test the stream picking functionality using execution place abstraction
+
+#include <cuda/experimental/stf.cuh>
+
+using namespace cuda::experimental::stf;
+
+int main()
+{
+  // Get the number of available devices
+  int device_count;
+  cuda_safe_call(cudaGetDeviceCount(&device_count));
+  
+  // Create async_resources for stream pool management
+  async_resources_handle resources;
+  
+  // Get current device for comparison
+  int current_device;
+  cuda_safe_call(cudaGetDevice(&current_device));
+  
+  // Test picking streams from execution places
+  exec_place current_dev_place = exec_place::current_device();
+  
+  // Test getting decorated stream from current device execution place
+  decorated_stream dstream1 = current_dev_place.getStream(resources, true);
+  EXPECT(dstream1.stream != nullptr);
+  EXPECT(dstream1.dev_id == current_device);
+  EXPECT(get_device_from_stream(dstream1.stream) == current_device);
+  
+  // Test with different computation vs transfer flag
+  decorated_stream dstream2 = current_dev_place.getStream(resources, false);
+  EXPECT(dstream2.stream != nullptr);
+  EXPECT(dstream2.dev_id == current_device);
+  EXPECT(get_device_from_stream(dstream2.stream) == current_device);
+  
+  // Test with multiple devices if available
+  if (device_count > 1)
+  {
+    // Test picking streams from different device execution places
+    for (int test_device = 0; test_device < ::std::min(device_count, 2); ++test_device)
+    {
+      exec_place dev_place = exec_place::device(test_device);
+      
+      decorated_stream dstream_dev = dev_place.getStream(resources, true);
+      EXPECT(dstream_dev.stream != nullptr);
+      EXPECT(dstream_dev.dev_id == test_device);
+      EXPECT(get_device_from_stream(dstream_dev.stream) == test_device);
+      
+      // Test different computation flag
+      decorated_stream dstream_transfer = dev_place.getStream(resources, false);
+      EXPECT(dstream_transfer.stream != nullptr);
+      EXPECT(dstream_transfer.dev_id == test_device);
+      EXPECT(get_device_from_stream(dstream_transfer.stream) == test_device);
+    }
+  }
+  
+  // Test context stream picking - contexts now respect execution place abstraction
+  {
+    context ctx;
+    // Context pick_stream now uses default_exec_place().getStream() internally
+    cudaStream_t stream3 = ctx.pick_stream();
+    EXPECT(stream3 != nullptr);
+    EXPECT(get_device_from_stream(stream3) == current_device);
+    ctx.finalize();
+  }
+  
+  // Test with graph context - now also uses execution place abstraction
+  {
+    graph_ctx gctx;
+    // Graph context get_stream() now uses default_exec_place().getStream() internally
+    cudaStream_t stream4 = gctx.pick_stream();
+    EXPECT(stream4 != nullptr);
+    EXPECT(get_device_from_stream(stream4) == current_device);
+    gctx.finalize();
+  }
+  
+  // Test context with execution affinity - demonstrates execution place abstraction
+  {
+    context ctx;
+    
+    // Set affinity to a specific device execution place
+    if (device_count > 1)
+    {
+      exec_place dev1_place = exec_place::device(1);
+      ctx.set_affinity({::std::make_shared<exec_place>(dev1_place)});
+      
+      // Stream should now come from device 1's pool
+      cudaStream_t affinity_stream = ctx.pick_stream();
+      EXPECT(affinity_stream != nullptr);
+      EXPECT(get_device_from_stream(affinity_stream) == 1);
+    }
+    
+    ctx.finalize();
+  }
+}

--- a/cudax/test/stf/cpp/test_pick_stream.cu
+++ b/cudax/test/stf/cpp/test_pick_stream.cu
@@ -20,29 +20,29 @@ int main()
   // Get the number of available devices
   int device_count;
   cuda_safe_call(cudaGetDeviceCount(&device_count));
-  
+
   // Create async_resources for stream pool management
   async_resources_handle resources;
-  
+
   // Get current device for comparison
   int current_device;
   cuda_safe_call(cudaGetDevice(&current_device));
-  
+
   // Test picking streams from execution places
   exec_place current_dev_place = exec_place::current_device();
-  
+
   // Test getting decorated stream from current device execution place
   decorated_stream dstream1 = current_dev_place.getStream(resources, true);
   EXPECT(dstream1.stream != nullptr);
   EXPECT(dstream1.dev_id == current_device);
   EXPECT(get_device_from_stream(dstream1.stream) == current_device);
-  
+
   // Test with different computation vs transfer flag
   decorated_stream dstream2 = current_dev_place.getStream(resources, false);
   EXPECT(dstream2.stream != nullptr);
   EXPECT(dstream2.dev_id == current_device);
   EXPECT(get_device_from_stream(dstream2.stream) == current_device);
-  
+
   // Test with multiple devices if available
   if (device_count > 1)
   {
@@ -50,12 +50,12 @@ int main()
     for (int test_device = 0; test_device < ::std::min(device_count, 2); ++test_device)
     {
       exec_place dev_place = exec_place::device(test_device);
-      
+
       decorated_stream dstream_dev = dev_place.getStream(resources, true);
       EXPECT(dstream_dev.stream != nullptr);
       EXPECT(dstream_dev.dev_id == test_device);
       EXPECT(get_device_from_stream(dstream_dev.stream) == test_device);
-      
+
       // Test different computation flag
       decorated_stream dstream_transfer = dev_place.getStream(resources, false);
       EXPECT(dstream_transfer.stream != nullptr);
@@ -63,7 +63,7 @@ int main()
       EXPECT(get_device_from_stream(dstream_transfer.stream) == test_device);
     }
   }
-  
+
   // Test context stream picking - contexts now respect execution place abstraction
   {
     context ctx;
@@ -73,7 +73,7 @@ int main()
     EXPECT(get_device_from_stream(stream3) == current_device);
     ctx.finalize();
   }
-  
+
   // Test with graph context - now also uses execution place abstraction
   {
     graph_ctx gctx;
@@ -83,23 +83,23 @@ int main()
     EXPECT(get_device_from_stream(stream4) == current_device);
     gctx.finalize();
   }
-  
+
   // Test context with execution affinity - demonstrates execution place abstraction
   {
     context ctx;
-    
+
     // Set affinity to a specific device execution place
     if (device_count > 1)
     {
       exec_place dev1_place = exec_place::device(1);
       ctx.set_affinity({::std::make_shared<exec_place>(dev1_place)});
-      
+
       // Stream should now come from device 1's pool
       cudaStream_t affinity_stream = ctx.pick_stream();
       EXPECT(affinity_stream != nullptr);
       EXPECT(get_device_from_stream(affinity_stream) == 1);
     }
-    
+
     ctx.finalize();
   }
 }

--- a/cudax/test/stf/cpp/test_pick_stream_green_context.cu
+++ b/cudax/test/stf/cpp/test_pick_stream_green_context.cu
@@ -1,0 +1,162 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDASTF in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2022-2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+//! \file
+//! \brief Test the pick_stream functionality with green contexts
+
+#include <cuda/experimental/__stf/places/exec/green_context.cuh>
+#include <cuda/experimental/stf.cuh>
+
+using namespace cuda::experimental::stf;
+
+// Green contexts are only supported since CUDA 12.4
+#if _CCCL_CTK_AT_LEAST(12, 4)
+
+//! \brief Verify that a stream belongs to the expected green context
+void verify_stream_green_context(cudaStream_t stream, CUgreenCtx expected_g_ctx)
+{
+  // Get the green context associated to that CUDA stream
+  CUgreenCtx stream_cugc;
+  cuda_safe_call(cuStreamGetGreenCtx(CUstream(stream), &stream_cugc));
+  EXPECT(stream_cugc != nullptr);
+
+  CUcontext stream_green_primary;
+  CUcontext expected_green_primary;
+
+  unsigned long long stream_ctxId;
+  unsigned long long expected_ctxId;
+
+  // Convert green contexts to primary contexts and get their ID
+  cuda_safe_call(cuCtxFromGreenCtx(&stream_green_primary, stream_cugc));
+  cuda_safe_call(cuCtxGetId(stream_green_primary, &stream_ctxId));
+
+  cuda_safe_call(cuCtxFromGreenCtx(&expected_green_primary, expected_g_ctx));
+  cuda_safe_call(cuCtxGetId(expected_green_primary, &expected_ctxId));
+
+  // Make sure the stream belongs to the same green context as expected
+  EXPECT(stream_ctxId == expected_ctxId);
+}
+
+#endif // _CCCL_CTK_AT_LEAST(12, 4)
+
+int main()
+{
+#if _CCCL_CTK_BELOW(12, 4)
+  // Green contexts are not supported, skip the test
+  return 0;
+#else // ^^^ _CCCL_CTK_BELOW(12, 4) ^^^ / vvv _CCCL_CTK_AT_LEAST(12, 4) vvv
+
+  // Get current device
+  int current_device;
+  cuda_safe_call(cudaGetDevice(&current_device));
+  
+  // Create green context helper with 8 SMs per context
+  const int num_sms = 8;
+  green_context_helper gc(num_sms, current_device);
+  
+  // Test execution place abstraction with different place types
+  async_resources_handle resources;
+  
+  // Compare regular device execution place vs green context execution places
+  exec_place regular_device_place = exec_place::current_device();
+  decorated_stream device_stream = regular_device_place.getStream(resources, true);
+  EXPECT(device_stream.stream != nullptr);
+  EXPECT(device_stream.dev_id == current_device);
+  
+  // Test green context execution places - each has isolated stream pools
+  auto cnt = gc.get_count();
+  if (cnt > 0)
+  {
+    // Test first green context view - demonstrates place-specific stream pools
+    auto view0 = gc.get_view(0);
+    exec_place gc_place0 = exec_place::green_ctx(view0);
+    
+    // Green context execution place uses its dedicated stream pool (not shared device pool)
+    decorated_stream gc_stream = gc_place0.getStream(resources, true);
+    EXPECT(gc_stream.stream != nullptr);
+    EXPECT(gc_stream.dev_id == current_device);
+    EXPECT(get_device_from_stream(gc_stream.stream) == current_device);
+    
+    // Verify the stream belongs to the correct green context
+    verify_stream_green_context(gc_stream.stream, view0.g_ctx);
+    
+    // Test with multiple views - demonstrates isolation between green contexts
+    if (cnt > 1)
+    {
+      auto view1 = gc.get_view(1);
+      exec_place gc_place1 = exec_place::green_ctx(view1);
+      
+      decorated_stream gc_stream1 = gc_place1.getStream(resources, true);
+      EXPECT(gc_stream1.stream != nullptr);
+      EXPECT(gc_stream1.dev_id == current_device);
+      EXPECT(get_device_from_stream(gc_stream1.stream) == current_device);
+      
+      // Each green context has its own isolated stream pool
+      verify_stream_green_context(gc_stream1.stream, view1.g_ctx);
+      
+      // Streams from different green context places are isolated
+      EXPECT(gc_stream.stream != gc_stream1.stream);
+    }
+  }
+  
+  // Test context with green context affinity - demonstrates execution place abstraction
+  {
+    stream_ctx ctx;
+    
+    if (cnt > 0)
+    {
+      // Set affinity to green context execution place  
+      auto view = gc.get_view(0);
+      exec_place gc_place = exec_place::green_ctx(view);
+      
+      ctx.set_affinity({::std::make_shared<exec_place>(gc_place)});
+      
+      // Context pick_stream() uses default_exec_place().getStream() internally
+      // This respects the green context affinity we just set
+      cudaStream_t stream = ctx.pick_stream();
+      EXPECT(stream != nullptr);
+      EXPECT(get_device_from_stream(stream) == current_device);
+      
+      // Verify stream belongs to the green context we set as affinity
+      // This proves the execution place abstraction is working correctly
+      verify_stream_green_context(stream, view.g_ctx);
+    }
+    
+    ctx.finalize();
+  }
+  
+  // Test graph context with green context affinity
+  {
+    graph_ctx gctx;
+    
+    if (cnt > 0)
+    {
+      // Set green context affinity for graph context
+      auto view = gc.get_view(0);
+      exec_place gc_place = exec_place::green_ctx(view);
+      
+      gctx.set_affinity({::std::make_shared<exec_place>(gc_place)});
+      
+      // Graph context also uses default_exec_place().getStream() internally
+      // This demonstrates that both context types use the same execution place abstraction
+      cudaStream_t graph_stream = gctx.pick_stream();
+      EXPECT(graph_stream != nullptr);
+      EXPECT(get_device_from_stream(graph_stream) == current_device);
+      
+      // Verify graph submission stream also respects green context affinity
+      verify_stream_green_context(graph_stream, view.g_ctx);
+    }
+    
+    gctx.finalize();
+  }
+  
+  return 0;
+#endif // ^^^ _CCCL_CTK_AT_LEAST(12, 4) ^^^
+}

--- a/cudax/test/stf/cpp/test_pick_stream_green_context.cu
+++ b/cudax/test/stf/cpp/test_pick_stream_green_context.cu
@@ -56,107 +56,107 @@ int main()
   // Get current device
   int current_device;
   cuda_safe_call(cudaGetDevice(&current_device));
-  
+
   // Create green context helper with 8 SMs per context
   const int num_sms = 8;
   green_context_helper gc(num_sms, current_device);
-  
+
   // Test execution place abstraction with different place types
   async_resources_handle resources;
-  
+
   // Compare regular device execution place vs green context execution places
   exec_place regular_device_place = exec_place::current_device();
-  decorated_stream device_stream = regular_device_place.getStream(resources, true);
+  decorated_stream device_stream  = regular_device_place.getStream(resources, true);
   EXPECT(device_stream.stream != nullptr);
   EXPECT(device_stream.dev_id == current_device);
-  
+
   // Test green context execution places - each has isolated stream pools
   auto cnt = gc.get_count();
   if (cnt > 0)
   {
     // Test first green context view - demonstrates place-specific stream pools
-    auto view0 = gc.get_view(0);
+    auto view0           = gc.get_view(0);
     exec_place gc_place0 = exec_place::green_ctx(view0);
-    
+
     // Green context execution place uses its dedicated stream pool (not shared device pool)
     decorated_stream gc_stream = gc_place0.getStream(resources, true);
     EXPECT(gc_stream.stream != nullptr);
     EXPECT(gc_stream.dev_id == current_device);
     EXPECT(get_device_from_stream(gc_stream.stream) == current_device);
-    
+
     // Verify the stream belongs to the correct green context
     verify_stream_green_context(gc_stream.stream, view0.g_ctx);
-    
+
     // Test with multiple views - demonstrates isolation between green contexts
     if (cnt > 1)
     {
-      auto view1 = gc.get_view(1);
+      auto view1           = gc.get_view(1);
       exec_place gc_place1 = exec_place::green_ctx(view1);
-      
+
       decorated_stream gc_stream1 = gc_place1.getStream(resources, true);
       EXPECT(gc_stream1.stream != nullptr);
       EXPECT(gc_stream1.dev_id == current_device);
       EXPECT(get_device_from_stream(gc_stream1.stream) == current_device);
-      
+
       // Each green context has its own isolated stream pool
       verify_stream_green_context(gc_stream1.stream, view1.g_ctx);
-      
+
       // Streams from different green context places are isolated
       EXPECT(gc_stream.stream != gc_stream1.stream);
     }
   }
-  
+
   // Test context with green context affinity - demonstrates execution place abstraction
   {
     stream_ctx ctx;
-    
+
     if (cnt > 0)
     {
-      // Set affinity to green context execution place  
-      auto view = gc.get_view(0);
+      // Set affinity to green context execution place
+      auto view           = gc.get_view(0);
       exec_place gc_place = exec_place::green_ctx(view);
-      
+
       ctx.set_affinity({::std::make_shared<exec_place>(gc_place)});
-      
+
       // Context pick_stream() uses default_exec_place().getStream() internally
       // This respects the green context affinity we just set
       cudaStream_t stream = ctx.pick_stream();
       EXPECT(stream != nullptr);
       EXPECT(get_device_from_stream(stream) == current_device);
-      
+
       // Verify stream belongs to the green context we set as affinity
       // This proves the execution place abstraction is working correctly
       verify_stream_green_context(stream, view.g_ctx);
     }
-    
+
     ctx.finalize();
   }
-  
+
   // Test graph context with green context affinity
   {
     graph_ctx gctx;
-    
+
     if (cnt > 0)
     {
       // Set green context affinity for graph context
-      auto view = gc.get_view(0);
+      auto view           = gc.get_view(0);
       exec_place gc_place = exec_place::green_ctx(view);
-      
+
       gctx.set_affinity({::std::make_shared<exec_place>(gc_place)});
-      
+
       // Graph context also uses default_exec_place().getStream() internally
       // This demonstrates that both context types use the same execution place abstraction
       cudaStream_t graph_stream = gctx.pick_stream();
       EXPECT(graph_stream != nullptr);
       EXPECT(get_device_from_stream(graph_stream) == current_device);
-      
+
       // Verify graph submission stream also respects green context affinity
       verify_stream_green_context(graph_stream, view.g_ctx);
     }
-    
+
     gctx.finalize();
   }
-  
+
   return 0;
 #endif // ^^^ _CCCL_CTK_AT_LEAST(12, 4) ^^^
 }

--- a/cudax/test/stf/graph/freeze_nested_graphs_allocator.cu
+++ b/cudax/test/stf/graph/freeze_nested_graphs_allocator.cu
@@ -71,7 +71,7 @@ int main()
 
   // The child graph depends on the events to get the frozen data
   ::std::vector<cudaGraphNode_t> fX_ready_nodes = reserved::join_with_graph_nodes(ctx, fX_get_events, ctx.stage());
-  
+
   // Add the child graph as a node that depends on the frozen data being ready
   cudaGraphNode_t child_graph_node;
   cuda_safe_call(cudaGraphAddChildGraphNode(
@@ -81,7 +81,7 @@ int main()
   event_list child_graph_event;
   reserved::fork_from_graph_node(
     ctx, child_graph_node, ctx.get_graph(), ctx.stage(), child_graph_event, "child graph done");
-  
+
   // Unfreeze the data after the child graph completes
   fX.unfreeze(child_graph_event);
 

--- a/cudax/test/stf/graph/freeze_nested_graphs_allocator.cu
+++ b/cudax/test/stf/graph/freeze_nested_graphs_allocator.cu
@@ -71,7 +71,7 @@ int main()
 
   // The child graph depends on the events to get the frozen data
   ::std::vector<cudaGraphNode_t> fX_ready_nodes = reserved::join_with_graph_nodes(ctx, fX_get_events, ctx.stage());
-
+  
   // Add the child graph as a node that depends on the frozen data being ready
   cudaGraphNode_t child_graph_node;
   cuda_safe_call(cudaGraphAddChildGraphNode(
@@ -81,7 +81,7 @@ int main()
   event_list child_graph_event;
   reserved::fork_from_graph_node(
     ctx, child_graph_node, ctx.get_graph(), ctx.stage(), child_graph_event, "child graph done");
-
+  
   // Unfreeze the data after the child graph completes
   fX.unfreeze(child_graph_event);
 

--- a/cudax/test/stf/green_context/axpy_gc.cu
+++ b/cudax/test/stf/green_context/axpy_gc.cu
@@ -83,7 +83,7 @@ int main()
   std::vector<green_context_helper> gc(ndevs);
   for (int devid = 0; devid < ndevs; devid++)
   {
-    gc[devid] = green_context_helper(num_sms, devid);
+    gc[devid] = green_context_helper(num_sms, ctx.async_resources(), devid);
   }
 
   for (int iter = 0; iter < NITER; iter++)

--- a/cudax/test/stf/green_context/cuda_graph.cu
+++ b/cudax/test/stf/green_context/cuda_graph.cu
@@ -56,7 +56,7 @@ int main()
   auto handle_Y = ctx.logical_data(make_slice(&Y[0], n));
 
   // The green_context_helper class automates the creation of green context views
-  green_context_helper gc(num_sms);
+  green_context_helper gc(num_sms, ctx.async_resources());
 
   for (int iter = 0; iter < NITER; iter++)
   {

--- a/cudax/test/stf/green_context/gc_grid.cu
+++ b/cudax/test/stf/green_context/gc_grid.cu
@@ -85,7 +85,7 @@ int main()
   std::vector<green_context_helper> gc(ndevs);
   for (int devid = 0; devid < ndevs; devid++)
   {
-    gc[devid] = green_context_helper(num_sms, devid);
+    gc[devid] = green_context_helper(num_sms, ctx.async_resources(), devid);
 
     auto& g_ctx = gc[devid];
     auto cnt    = g_ctx.get_count();


### PR DESCRIPTION
## Description

This improves how we can get a stream from a pool associated to a specific execution place, and removes some pitfall in the green context abstraction where we could end up with inconsistent async_resource_handles in the context and in the green context helper

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
