### PR TITLE
Fix `generate_version.sh` script to only consider tags beginning with `v`

### DIFF
--- a/ci/generate_version.sh
+++ b/ci/generate_version.sh
@@ -8,7 +8,7 @@
 CCCL_BRANCH="${CCCL_BRANCH:-dev}"
 PACKAGE_VERSION_PREFIX="${PACKAGE_VERSION_PREFIX:-}"
 
-GIT_DESCRIBE_TAG=$(git describe --tags --match "v[0-9]*")
+GIT_DESCRIBE_TAG=$(git describe --tags --match "v[0-9]*" --abbrev=0)
 GIT_DESCRIBE_NUMBER=$(git rev-list ${GIT_DESCRIBE_TAG}..HEAD --count)
 
 JSON_VERSION=$(jq -r .full /workspace/cccl-version.json)


### PR DESCRIPTION
## Description

https://github.com/NVIDIA/cccl/pull/5586 applied this change to `pyproject.toml`, but not to `generate_version.sh`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
