### PR TITLE
[CUDAX] Change async_buffer constructor and make_async_buffer to only optionally take an environment

### DIFF
--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -59,6 +59,10 @@
 namespace cuda::experimental
 {
 
+// Once we add support from options taken from the env we can list them here in addition to using is_same_v
+template <class _Env>
+inline constexpr bool __buffer_compatible_env = ::cuda::std::is_same_v<_Env, ::cuda::std::execution::env<>>;
+
 //! @rst
 //! .. _cudax-containers-async-vector:
 //!
@@ -193,7 +197,8 @@ public:
   //! @brief Constructs an empty async_buffer using an environment
   //! @param __env The environment providing the needed information
   //! @note No memory is allocated.
-  template <class _Env = ::cuda::std::execution::env<>>
+  _CCCL_TEMPLATE(class _Env = ::cuda::std::execution::env<>)
+  _CCCL_REQUIRES(__buffer_compatible_env<_Env>)
   _CCCL_HIDE_FROM_ABI
   async_buffer(::cuda::stream_ref __stream, __resource_t __resource, [[maybe_unused]] const _Env& __env = {})
       : __buf_(__resource, __stream, 0)
@@ -657,7 +662,8 @@ auto make_async_buffer(
 }
 
 // Empty buffer make function
-template <class _Tp, class... _Properties, class _Env = ::cuda::std::execution::env<>>
+_CCCL_TEMPLATE(class _Tp, class... _Properties, class _Env = ::cuda::std::execution::env<>)
+_CCCL_REQUIRES(__buffer_compatible_env<_Env>)
 async_buffer<_Tp, _Properties...>
 make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr, const _Env& __env = {})
 {
@@ -665,7 +671,8 @@ make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr, const 
 }
 
 _CCCL_TEMPLATE(class _Tp, class _Resource, class _Env = ::cuda::std::execution::env<>)
-_CCCL_REQUIRES(::cuda::mr::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
+_CCCL_REQUIRES(
+  ::cuda::mr::resource<_Resource> _CCCL_AND __has_default_queries<_Resource> _CCCL_AND __buffer_compatible_env<_Env>)
 auto make_async_buffer(stream_ref __stream, _Resource&& __mr, const _Env& __env = {})
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename ::cuda::std::decay_t<_Resource>::default_queries>;

--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -29,6 +29,7 @@
 #include <cuda/__memory_resource/properties.h>
 #include <cuda/__memory_resource/resource_ref.h>
 #include <cuda/__stream/get_stream.h>
+#include <cuda/std/__execution/env.h>
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__iterator/distance.h>
 #include <cuda/std/__iterator/reverse_iterator.h>
@@ -45,7 +46,8 @@
 
 #include <cuda/experimental/__container/heterogeneous_iterator.cuh>
 #include <cuda/experimental/__container/uninitialized_async_buffer.cuh>
-#include <cuda/experimental/__execution/env.cuh>
+#include <cuda/experimental/__detail/utility.cuh>
+#include <cuda/experimental/__execution/policy.cuh>
 #include <cuda/experimental/__launch/host_launch.cuh>
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
 #include <cuda/experimental/__memory_resource/properties.cuh>
@@ -92,8 +94,6 @@ public:
   using difference_type        = ::cuda::std::ptrdiff_t;
   using properties_list        = ::cuda::experimental::properties_list<_Properties...>;
 
-  using __env_t          = ::cuda::experimental::env_t<_Properties...>;
-  using __policy_t       = ::cuda::experimental::execution::any_execution_policy;
   using __buffer_t       = ::cuda::experimental::uninitialized_async_buffer<_Tp, _Properties...>;
   using __resource_t     = ::cuda::experimental::any_resource<_Properties...>;
   using __resource_ref_t = ::cuda::mr::resource_ref<_Properties...>;
@@ -193,8 +193,10 @@ public:
   //! @brief Constructs an empty async_buffer using an environment
   //! @param __env The environment providing the needed information
   //! @note No memory is allocated.
-  _CCCL_HIDE_FROM_ABI async_buffer(const __env_t& __env)
-      : async_buffer(__env, 0, ::cuda::experimental::no_init)
+  template <class _Env = ::cuda::std::execution::env<>>
+  _CCCL_HIDE_FROM_ABI
+  async_buffer(::cuda::stream_ref __stream, __resource_t __resource, [[maybe_unused]] const _Env& __env = {})
+      : __buf_(__resource, __stream, 0)
   {}
 
   //! @brief Constructs a async_buffer of size \p __size using a memory and leaves all elements uninitialized
@@ -203,9 +205,14 @@ public:
   //! @warning This constructor does *NOT* initialize any elements. It is the user's responsibility to ensure that the
   //! elements within `[vec.begin(), vec.end())` are properly initialized, e.g with `cuda::std::uninitialized_copy`.
   //! At the destruction of the \c async_buffer all elements in the range `[vec.begin(), vec.end())` will be destroyed.
+  template <class _Env = ::cuda::std::execution::env<>>
   _CCCL_HIDE_FROM_ABI explicit async_buffer(
-    const __env_t& __env, const size_type __size, ::cuda::experimental::no_init_t)
-      : __buf_(::cuda::mr::get_memory_resource(__env), ::cuda::get_stream(__env), __size)
+    ::cuda::stream_ref __stream,
+    __resource_t __resource,
+    const size_type __size,
+    ::cuda::experimental::no_init_t,
+    [[maybe_unused]] const _Env& __env = {})
+      : __buf_(__resource, __stream, __size)
   {}
 
   //! @brief Constructs a async_buffer using a memory resource and copy-constructs all elements from the forward range
@@ -214,11 +221,15 @@ public:
   //! @param __first The start of the input sequence.
   //! @param __last The end of the input sequence.
   //! @note If `__first == __last` then no memory is allocated
-  _CCCL_TEMPLATE(class _Iter)
+  _CCCL_TEMPLATE(class _Iter, class _Env = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES(::cuda::std::__is_cpp17_forward_iterator<_Iter>::value)
-  _CCCL_HIDE_FROM_ABI async_buffer(const __env_t& __env, _Iter __first, _Iter __last)
-      : async_buffer(
-          __env, static_cast<size_type>(::cuda::std::distance(__first, __last)), ::cuda::experimental::no_init)
+  _CCCL_HIDE_FROM_ABI async_buffer(
+    ::cuda::stream_ref __stream,
+    __resource_t __resource,
+    _Iter __first,
+    _Iter __last,
+    [[maybe_unused]] const _Env& __env = {})
+      : __buf_(__resource, __stream, static_cast<size_type>(::cuda::std::distance(__first, __last)))
   {
     this->__copy_cross<_Iter>(__first, __last, __unwrapped_begin(), __buf_.size());
   }
@@ -227,8 +238,13 @@ public:
   //! @param __env The environment used to query the memory resource.
   //! @param __ilist The initializer_list being copied into the async_buffer.
   //! @note If `__ilist.size() == 0` then no memory is allocated
-  _CCCL_HIDE_FROM_ABI async_buffer(const __env_t& __env, ::cuda::std::initializer_list<_Tp> __ilist)
-      : async_buffer(__env, __ilist.size(), ::cuda::experimental::no_init)
+  template <class _Env = ::cuda::std::execution::env<>>
+  _CCCL_HIDE_FROM_ABI async_buffer(
+    ::cuda::stream_ref __stream,
+    __resource_t __resource,
+    ::cuda::std::initializer_list<_Tp> __ilist,
+    [[maybe_unused]] const _Env& __env = {})
+      : __buf_(__resource, __stream, __ilist.size())
   {
     this->__copy_cross(__ilist.begin(), __ilist.end(), __unwrapped_begin(), __buf_.size());
   }
@@ -237,11 +253,12 @@ public:
   //! @param __env The environment used to query the memory resource.
   //! @param __range The input range to be moved into the async_buffer.
   //! @note If `__range.size() == 0` then no memory is allocated.
-  _CCCL_TEMPLATE(class _Range)
+  _CCCL_TEMPLATE(class _Range, class _Env = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES(__compatible_range<_Range> _CCCL_AND ::cuda::std::ranges::forward_range<_Range>
                    _CCCL_AND ::cuda::std::ranges::sized_range<_Range>)
-  _CCCL_HIDE_FROM_ABI async_buffer(const __env_t& __env, _Range&& __range)
-      : async_buffer(__env, static_cast<size_type>(::cuda::std::ranges::size(__range)), ::cuda::experimental::no_init)
+  _CCCL_HIDE_FROM_ABI async_buffer(
+    ::cuda::stream_ref __stream, __resource_t __resource, _Range&& __range, [[maybe_unused]] const _Env& __env = {})
+      : __buf_(__resource, __stream, static_cast<size_type>(::cuda::std::ranges::size(__range)))
   {
     using _Iter = ::cuda::std::ranges::iterator_t<_Range>;
     this->__copy_cross<_Iter>(
@@ -252,14 +269,16 @@ public:
   }
 
 #ifndef _CCCL_DOXYGEN_INVOKED // doxygen conflates the overloads
-  _CCCL_TEMPLATE(class _Range)
+  _CCCL_TEMPLATE(class _Range, class _Env = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES(__compatible_range<_Range> _CCCL_AND ::cuda::std::ranges::forward_range<_Range> _CCCL_AND(
     !::cuda::std::ranges::sized_range<_Range>))
-  _CCCL_HIDE_FROM_ABI async_buffer(const __env_t& __env, _Range&& __range)
-      : async_buffer(__env,
-                     static_cast<size_type>(::cuda::std::ranges::distance(
-                       ::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range))),
-                     ::cuda::experimental::no_init)
+  _CCCL_HIDE_FROM_ABI async_buffer(
+    ::cuda::stream_ref __stream, __resource_t __resource, _Range&& __range, [[maybe_unused]] const _Env& __env = {})
+      : __buf_(__resource,
+               __stream,
+               static_cast<size_type>(
+                 ::cuda::std::ranges::distance(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range))),
+               __env)
   {
     using _Iter = ::cuda::std::ranges::iterator_t<_Range>;
     this->__copy_cross<_Iter>(
@@ -610,25 +629,27 @@ __fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::std::size_t __count, c
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 
-template <class _Tp, class... _TargetProperties, class... _SourceProperties>
+template <class _Tp, class... _TargetProperties, class... _SourceProperties, class _Env = ::cuda::std::execution::env<>>
 async_buffer<_Tp, _TargetProperties...> make_async_buffer(
-  stream_ref __stream, any_resource<_TargetProperties...> __mr, const async_buffer<_Tp, _SourceProperties...>& __source)
+  stream_ref __stream,
+  any_resource<_TargetProperties...> __mr,
+  const async_buffer<_Tp, _SourceProperties...>& __source,
+  const _Env& __env = {})
 {
-  env_t<_TargetProperties...> __env{__mr, __stream};
-  async_buffer<_Tp, _TargetProperties...> __res{__env, __source.size(), no_init};
+  async_buffer<_Tp, _TargetProperties...> __res{__stream, __mr, __source.size(), no_init, __env};
 
   __copy_cross_buffers(__stream, __res, __source);
 
   return __res;
 }
 
-_CCCL_TEMPLATE(class _Tp, class _Resource, class... _SourceProperties)
+_CCCL_TEMPLATE(class _Tp, class _Resource, class... _SourceProperties, class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(::cuda::mr::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
-auto make_async_buffer(stream_ref __stream, _Resource&& __mr, const async_buffer<_Tp, _SourceProperties...>& __source)
+auto make_async_buffer(
+  stream_ref __stream, _Resource&& __mr, const async_buffer<_Tp, _SourceProperties...>& __source, const _Env& __env = {})
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename ::cuda::std::decay_t<_Resource>::default_queries>;
-  typename __buffer_type::__env_t __env{__mr, __stream};
-  auto __res = __buffer_type{__env, __source.size(), uninit};
+  auto __res          = __buffer_type{__stream, __mr, __source.size(), uninit, __env};
 
   __copy_cross_buffers(__stream, __res, __source);
 
@@ -636,44 +657,42 @@ auto make_async_buffer(stream_ref __stream, _Resource&& __mr, const async_buffer
 }
 
 // Empty buffer make function
-template <class _Tp, class... _Properties>
-async_buffer<_Tp, _Properties...> make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr)
+template <class _Tp, class... _Properties, class _Env = ::cuda::std::execution::env<>>
+async_buffer<_Tp, _Properties...>
+make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr, const _Env& __env = {})
 {
-  env_t<_Properties...> __env{__mr, __stream};
-  return async_buffer<_Tp, _Properties...>{__env};
+  return async_buffer<_Tp, _Properties...>{__stream, __mr, __env};
 }
 
-_CCCL_TEMPLATE(class _Tp, class _Resource)
+_CCCL_TEMPLATE(class _Tp, class _Resource, class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(::cuda::mr::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
-auto make_async_buffer(stream_ref __stream, _Resource&& __mr)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr, const _Env& __env = {})
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename ::cuda::std::decay_t<_Resource>::default_queries>;
-  typename __buffer_type::__env_t __env{__mr, __stream};
-  return __buffer_type{__env};
+  return __buffer_type{__stream, __mr, __env};
 }
 
 _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 
 // Size and value make function
-template <class _Tp, class... _Properties>
-async_buffer<_Tp, _Properties...>
-make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr, size_t __size, const _Tp& __value)
+template <class _Tp, class... _Properties, class _Env = ::cuda::std::execution::env<>>
+async_buffer<_Tp, _Properties...> make_async_buffer(
+  stream_ref __stream, any_resource<_Properties...> __mr, size_t __size, const _Tp& __value, const _Env& __env = {})
 {
-  env_t<_Properties...> __env{__mr, __stream};
-  auto __res = async_buffer<_Tp, _Properties...>{__env, __size, no_init};
+  auto __res = async_buffer<_Tp, _Properties...>{__stream, __mr, __size, no_init};
   __fill_n<_Tp, !::cuda::mr::__is_device_accessible<_Properties...>>(
     __stream, __res.__unwrapped_begin(), __size, __value);
   return __res;
 }
 
-_CCCL_TEMPLATE(class _Tp, class _Resource)
+_CCCL_TEMPLATE(class _Tp, class _Resource, class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(::cuda::mr::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
-auto make_async_buffer(stream_ref __stream, _Resource&& __mr, size_t __size, const _Tp& __value)
+auto make_async_buffer(
+  stream_ref __stream, _Resource&& __mr, size_t __size, const _Tp& __value, [[maybe_unused]] const _Env& __env = {})
 {
   using __default_queries = typename ::cuda::std::decay_t<_Resource>::default_queries;
   using __buffer_type     = __buffer_type_for_props<_Tp, __default_queries>;
-  typename __buffer_type::__env_t __env{__mr, __stream};
-  auto __res = __buffer_type{__env, __size, no_init};
+  auto __res              = __buffer_type{__stream, __mr, __size, no_init};
   __fill_n<_Tp, !__default_queries::has_property(::cuda::mr::device_accessible{})>(
     __stream, __res.__unwrapped_begin(), __size, __value);
   return __res;
@@ -682,79 +701,80 @@ auto make_async_buffer(stream_ref __stream, _Resource&& __mr, size_t __size, con
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT
 
 // Size with no initialization make function
-template <class _Tp, class... _Properties>
+template <class _Tp, class... _Properties, class _Env = ::cuda::std::execution::env<>>
 async_buffer<_Tp, _Properties...> make_async_buffer(
-  stream_ref __stream, any_resource<_Properties...> __mr, size_t __size, ::cuda::experimental::no_init_t)
+  stream_ref __stream,
+  any_resource<_Properties...> __mr,
+  size_t __size,
+  ::cuda::experimental::no_init_t,
+  const _Env& __env = {})
 {
-  env_t<_Properties...> __env{__mr, __stream};
-  return async_buffer<_Tp, _Properties...>{__env, __size, ::cuda::experimental::no_init};
+  return async_buffer<_Tp, _Properties...>{__stream, __mr, __size, ::cuda::experimental::no_init, __env};
 }
 
-_CCCL_TEMPLATE(class _Tp, class _Resource)
+_CCCL_TEMPLATE(class _Tp, class _Resource, class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(::cuda::mr::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
-auto make_async_buffer(stream_ref __stream, _Resource&& __mr, size_t __size, ::cuda::experimental::no_init_t)
+auto make_async_buffer(
+  stream_ref __stream, _Resource&& __mr, size_t __size, ::cuda::experimental::no_init_t, const _Env& __env = {})
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename ::cuda::std::decay_t<_Resource>::default_queries>;
-  typename __buffer_type::__env_t __env{__mr, __stream};
-  return __buffer_type{__env, __size, ::cuda::experimental::no_init};
+  return __buffer_type{__stream, __mr, __size, ::cuda::experimental::no_init, __env};
 }
 
 // Iterator range make function
-_CCCL_TEMPLATE(class _Tp, class... _Properties, class _Iter)
+_CCCL_TEMPLATE(class _Tp, class... _Properties, class _Iter, class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(::cuda::std::__is_cpp17_forward_iterator<_Iter>::value)
-async_buffer<_Tp, _Properties...>
-make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr, _Iter __first, _Iter __last)
+async_buffer<_Tp, _Properties...> make_async_buffer(
+  stream_ref __stream, any_resource<_Properties...> __mr, _Iter __first, _Iter __last, const _Env& __env = {})
 {
-  env_t<_Properties...> __env{__mr, __stream};
-  return async_buffer<_Tp, _Properties...>{__env, __first, __last};
+  return async_buffer<_Tp, _Properties...>{__stream, __mr, __first, __last, __env};
 }
 
-_CCCL_TEMPLATE(class _Tp, class _Resource, class _Iter)
+_CCCL_TEMPLATE(class _Tp, class _Resource, class _Iter, class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(::cuda::mr::resource<_Resource> _CCCL_AND
                  __has_default_queries<_Resource> _CCCL_AND ::cuda::std::__is_cpp17_forward_iterator<_Iter>::value)
-auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _Iter __first, _Iter __last)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _Iter __first, _Iter __last, const _Env& __env = {})
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename ::cuda::std::decay_t<_Resource>::default_queries>;
-  typename __buffer_type::__env_t __env{__mr, __stream};
-  return __buffer_type{__env, __first, __last};
+  return __buffer_type{__stream, __mr, __first, __last, __env};
 }
 
 // Initializer list make function
-template <class _Tp, class... _Properties>
-async_buffer<_Tp, _Properties...>
-make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr, ::cuda::std::initializer_list<_Tp> __ilist)
+template <class _Tp, class... _Properties, class _Env = ::cuda::std::execution::env<>>
+async_buffer<_Tp, _Properties...> make_async_buffer(
+  stream_ref __stream,
+  any_resource<_Properties...> __mr,
+  ::cuda::std::initializer_list<_Tp> __ilist,
+  const _Env& __env = {})
 {
-  env_t<_Properties...> __env{__mr, __stream};
-  return async_buffer<_Tp, _Properties...>{__env, __ilist};
+  return async_buffer<_Tp, _Properties...>{__stream, __mr, __ilist, __env};
 }
 
-_CCCL_TEMPLATE(class _Tp, class _Resource)
+_CCCL_TEMPLATE(class _Tp, class _Resource, class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(::cuda::mr::resource<_Resource> _CCCL_AND __has_default_queries<_Resource>)
-auto make_async_buffer(stream_ref __stream, _Resource&& __mr, ::cuda::std::initializer_list<_Tp> __ilist)
+auto make_async_buffer(
+  stream_ref __stream, _Resource&& __mr, ::cuda::std::initializer_list<_Tp> __ilist, const _Env& __env = {})
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename ::cuda::std::decay_t<_Resource>::default_queries>;
-  typename __buffer_type::__env_t __env{__mr, __stream};
-  return __buffer_type{__env, __ilist};
+  return __buffer_type{__stream, __mr, __ilist, __env};
 }
 
 // Range make function for ranges
-_CCCL_TEMPLATE(class _Tp, class... _Properties, class _Range)
+_CCCL_TEMPLATE(class _Tp, class... _Properties, class _Range, class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(::cuda::std::ranges::forward_range<_Range>)
 async_buffer<_Tp, _Properties...>
-make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr, _Range&& __range)
+make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr, _Range&& __range, const _Env& __env = {})
 {
-  env_t<_Properties...> __env{__mr, __stream};
-  return async_buffer<_Tp, _Properties...>{__env, ::cuda::std::forward<_Range>(__range)};
+  return async_buffer<_Tp, _Properties...>{__stream, __mr, ::cuda::std::forward<_Range>(__range), __env};
 }
 
-_CCCL_TEMPLATE(class _Tp, class _Resource, class _Range)
+_CCCL_TEMPLATE(class _Tp, class _Resource, class _Range, class _Env = ::cuda::std::execution::env<>)
 _CCCL_REQUIRES(::cuda::mr::resource<_Resource> _CCCL_AND
                  __has_default_queries<_Resource> _CCCL_AND ::cuda::std::ranges::forward_range<_Range>)
-auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _Range&& __range)
+auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _Range&& __range, const _Env& __env = {})
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename ::cuda::std::decay_t<_Resource>::default_queries>;
-  typename __buffer_type::__env_t __env{__mr, __stream};
-  return __buffer_type{__env, ::cuda::std::forward<_Range>(__range)};
+  return __buffer_type{__stream, __mr, ::cuda::std::forward<_Range>(__range), __env};
 }
 
 } // namespace cuda::experimental

--- a/cudax/test/containers/async_buffer/access.cu
+++ b/cudax/test/containers/async_buffer/access.cu
@@ -25,17 +25,16 @@
 #include "types.h"
 
 #if _CCCL_CUDACC_AT_LEAST(12, 6)
-using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
-                                  cuda::std::tuple<cuda::mr::device_accessible>,
-                                  cuda::std::tuple<cuda::mr::host_accessible, cuda::mr::device_accessible>>;
+using test_types = c2h::type_list<cuda::std::tuple<int, cuda::mr::host_accessible>,
+                                  cuda::std::tuple<unsigned long long, cuda::mr::device_accessible>,
+                                  cuda::std::tuple<int, cuda::mr::host_accessible, cuda::mr::device_accessible>>;
 #else
-using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
+using test_types = c2h::type_list<cuda::std::tuple<int, cuda::mr::device_accessible>>;
 #endif
 
 C2H_CCCLRT_TEST("cudax::async_buffer access and stream", "[container][async_buffer]", test_types)
 {
   using TestT           = c2h::get<0, TestType>;
-  using Env             = typename extract_properties<TestT>::env;
   using Resource        = typename extract_properties<TestT>::resource;
   using Buffer          = typename extract_properties<TestT>::async_buffer;
   using T               = typename Buffer::value_type;
@@ -45,7 +44,7 @@ C2H_CCCLRT_TEST("cudax::async_buffer access and stream", "[container][async_buff
   using const_pointer   = typename Buffer::const_pointer;
 
   cudax::stream stream{cuda::device_ref{0}};
-  Env env{Resource{}, stream};
+  Resource resource{};
 
   SECTION("cudax::async_buffer::get_unsynchronized")
   {
@@ -54,7 +53,7 @@ C2H_CCCLRT_TEST("cudax::async_buffer access and stream", "[container][async_buff
       cuda::std::is_same_v<decltype(cuda::std::declval<const Buffer&>().get_unsynchronized(1ull)), const_reference>);
 
     {
-      Buffer buf{env, {T(1), T(42), T(1337), T(0)}};
+      Buffer buf{stream, resource, {T(1), T(42), T(1337), T(0)}};
       buf.stream().sync();
       auto& res = buf.get_unsynchronized(2);
       CUDAX_CHECK(compare_value<Buffer>(res, T(1337)));
@@ -73,14 +72,14 @@ C2H_CCCLRT_TEST("cudax::async_buffer access and stream", "[container][async_buff
     static_assert(cuda::std::is_same_v<decltype(cuda::std::declval<const Buffer&>().data()), const_pointer>);
 
     { // Works without allocation
-      Buffer buf{env};
+      Buffer buf{stream, resource};
       buf.stream().sync();
       CUDAX_CHECK(buf.data() == nullptr);
       CUDAX_CHECK(cuda::std::as_const(buf).data() == nullptr);
     }
 
     { // Works with allocation
-      Buffer buf{env, {T(1), T(42), T(1337), T(0)}};
+      Buffer buf{stream, resource, {T(1), T(42), T(1337), T(0)}};
       buf.stream().sync();
       CUDAX_CHECK(buf.data() != nullptr);
       CUDAX_CHECK(cuda::std::as_const(buf).data() != nullptr);
@@ -90,7 +89,7 @@ C2H_CCCLRT_TEST("cudax::async_buffer access and stream", "[container][async_buff
 
   SECTION("cudax::async_buffer::stream")
   {
-    Buffer buf{env, {T(1), T(42), T(1337), T(0)}};
+    Buffer buf{stream, resource, {T(1), T(42), T(1337), T(0)}};
     CUDAX_CHECK(buf.stream() == stream);
 
     {

--- a/cudax/test/containers/async_buffer/capacity.cu
+++ b/cudax/test/containers/async_buffer/capacity.cu
@@ -23,24 +23,23 @@
 #include "types.h"
 
 #if _CCCL_CUDACC_AT_LEAST(12, 6)
-using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
-                                  cuda::std::tuple<cuda::mr::device_accessible>,
-                                  cuda::std::tuple<cuda::mr::host_accessible, cuda::mr::device_accessible>>;
+using test_types = c2h::type_list<cuda::std::tuple<int, cuda::mr::host_accessible>,
+                                  cuda::std::tuple<unsigned long long, cuda::mr::device_accessible>,
+                                  cuda::std::tuple<int, cuda::mr::host_accessible, cuda::mr::device_accessible>>;
 #else
-using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
+using test_types = c2h::type_list<cuda::std::tuple<int, cuda::mr::device_accessible>>;
 #endif
 
 C2H_CCCLRT_TEST("cudax::async_buffer capacity", "[container][async_buffer]", test_types)
 {
   using TestT     = c2h::get<0, TestType>;
-  using Env       = typename extract_properties<TestT>::env;
   using Resource  = typename extract_properties<TestT>::resource;
   using Buffer    = typename extract_properties<TestT>::async_buffer;
   using T         = typename Buffer::value_type;
   using size_type = typename Buffer::size_type;
 
   cudax::stream stream{cuda::device_ref{0}};
-  Env env{Resource{}, stream};
+  Resource resource{};
 
   SECTION("cudax::async_buffer::empty")
   {
@@ -50,7 +49,7 @@ C2H_CCCLRT_TEST("cudax::async_buffer capacity", "[container][async_buffer]", tes
     STATIC_REQUIRE(noexcept(cuda::std::declval<const Buffer&>().empty()));
 
     { // Works without allocation
-      Buffer buf{env, 0, cudax::no_init};
+      Buffer buf{stream, resource, 0, cudax::no_init, cudax::no_init};
       CUDAX_CHECK(buf.empty());
       CUDAX_CHECK(cuda::std::as_const(buf).empty());
     }
@@ -64,7 +63,7 @@ C2H_CCCLRT_TEST("cudax::async_buffer capacity", "[container][async_buffer]", tes
     STATIC_REQUIRE(noexcept(cuda::std::declval<const Buffer&>().size()));
 
     { // Works without allocation
-      Buffer buf{env, 0, cudax::no_init};
+      Buffer buf{stream, resource, 0, cudax::no_init, cudax::no_init};
       CUDAX_CHECK(buf.size() == 0);
       CUDAX_CHECK(cuda::std::as_const(buf).size() == 0);
     }

--- a/cudax/test/containers/async_buffer/conversion.cu
+++ b/cudax/test/containers/async_buffer/conversion.cu
@@ -23,41 +23,38 @@
 #include "types.h"
 
 #if _CCCL_CUDACC_AT_LEAST(12, 6)
-using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
-                                  cuda::std::tuple<cuda::mr::device_accessible>,
-                                  cuda::std::tuple<cuda::mr::host_accessible, cuda::mr::device_accessible>>;
+using test_types = c2h::type_list<cuda::std::tuple<int, cuda::mr::host_accessible>,
+                                  cuda::std::tuple<unsigned long long, cuda::mr::device_accessible>,
+                                  cuda::std::tuple<int, cuda::mr::host_accessible, cuda::mr::device_accessible>>;
 #else
-using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
+using test_types = c2h::type_list<cuda::std::tuple<int, cuda::mr::device_accessible>>;
 #endif
 
 C2H_CCCLRT_TEST("cudax::async_buffer conversion", "[container][async_buffer]", test_types)
 {
   using TestT    = c2h::get<0, TestType>;
-  using Env      = typename extract_properties<TestT>::env;
   using Resource = typename extract_properties<TestT>::resource;
   using Buffer   = typename extract_properties<TestT>::async_buffer;
   using T        = typename Buffer::value_type;
 
   cudax::stream stream{cuda::device_ref{0}};
   Resource resource{};
-  Env env{resource, stream};
 
   // Convert from a async_buffer that has more properties than the current one
   using MatchingBuffer   = typename extract_properties<TestT>::matching_vector;
   using MatchingResource = typename extract_properties<TestT>::matching_resource;
-  Env matching_env{MatchingResource{resource}, stream};
 
   SECTION("cudax::async_buffer construction with matching async_buffer")
   {
     { // can be copy constructed from empty input
-      const MatchingBuffer input{matching_env, 0, cudax::no_init};
+      const MatchingBuffer input{stream, resource, 0, cudax::no_init};
       Buffer buf(input);
       CUDAX_CHECK(buf.empty());
       CUDAX_CHECK(input.empty());
     }
 
     { // can be copy constructed from non-empty input
-      const MatchingBuffer input{matching_env, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+      const MatchingBuffer input{stream, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
       Buffer buf(input);
       CUDAX_CHECK(!buf.empty());
       CUDAX_CHECK(equal_range(buf));
@@ -65,14 +62,14 @@ C2H_CCCLRT_TEST("cudax::async_buffer conversion", "[container][async_buffer]", t
     }
 
     { // can be move constructed with empty input
-      MatchingBuffer input{matching_env, 0, cudax::no_init};
+      MatchingBuffer input{stream, resource, 0, cudax::no_init};
       Buffer buf(cuda::std::move(input));
       CUDAX_CHECK(buf.empty());
       CUDAX_CHECK(input.empty());
     }
 
     { // can be move constructed from non-empty input
-      MatchingBuffer input{matching_env, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
+      MatchingBuffer input{stream, resource, {T(1), T(42), T(1337), T(0), T(12), T(-1)}};
 
       // ensure that we steal the data
       const auto* allocation = input.data();

--- a/cudax/test/containers/async_buffer/properties.cu
+++ b/cudax/test/containers/async_buffer/properties.cu
@@ -22,11 +22,11 @@
 #include "types.h"
 
 #if _CCCL_CUDACC_AT_LEAST(12, 6)
-using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::host_accessible>,
-                                  cuda::std::tuple<cuda::mr::device_accessible>,
-                                  cuda::std::tuple<cuda::mr::host_accessible, cuda::mr::device_accessible>>;
+using test_types = c2h::type_list<cuda::std::tuple<int, cuda::mr::host_accessible>,
+                                  cuda::std::tuple<int, cuda::mr::device_accessible>,
+                                  cuda::std::tuple<int, cuda::mr::host_accessible, cuda::mr::device_accessible>>;
 #else
-using test_types = c2h::type_list<cuda::std::tuple<cuda::mr::device_accessible>>;
+using test_types = c2h::type_list<cuda::std::tuple<int, cuda::mr::device_accessible>>;
 #endif
 
 C2H_CCCLRT_TEST("cudax::async_buffer properties", "[container][async_buffer]", test_types)

--- a/cudax/test/containers/async_buffer/transform.cu
+++ b/cudax/test/containers/async_buffer/transform.cu
@@ -33,14 +33,14 @@ C2H_TEST("DeviceTransform::Transform cudax::async_device_buffer", "[device][devi
   const int num_items = 1 << 24;
 
   cudax::stream stream{cuda::device_ref{0}};
-  cudax::env_t<cuda::mr::device_accessible> env{cudax::device_memory_resource{cuda::device_ref{0}}, stream};
+  cudax::device_memory_resource resource{cuda::device_ref{0}};
 
-  cudax::async_device_buffer<type> a{env, num_items, cudax::no_init};
-  cudax::async_device_buffer<type> b{env, num_items, cudax::no_init};
+  cudax::async_device_buffer<type> a{stream, resource, num_items, cudax::no_init};
+  cudax::async_device_buffer<type> b{stream, resource, num_items, cudax::no_init};
   thrust::sequence(thrust::cuda::par_nosync.on(stream.get()), a.begin(), a.end());
   thrust::sequence(thrust::cuda::par_nosync.on(stream.get()), b.begin(), b.end());
 
-  cudax::async_device_buffer<type> result{env, num_items, cudax::no_init};
+  cudax::async_device_buffer<type> result{stream, resource, num_items, cudax::no_init};
 
   cub::DeviceTransform::Transform(
     ::cuda::std::make_tuple(a.begin(), b.begin()), result.begin(), num_items, ::cuda::std::plus<type>{});


### PR DESCRIPTION
Currently `async_buffer` constructor takes an environment, while `make_async_buffer` doesn't. This might not be the most future proof design, if we end up using something else from the environment and `make_async_buffer` would not support it. At the same time, the constructor is sometimes inconvenient to use. The idea that you would use a single env object across multiple buffer constructors does not work out even in simple examples we have in `cudax`, where you usually need different memory resources, not even getting into multiple streams.

We decided to align the usage of environments in `async_buffer` to be closer to how it's used in CUB, which is a bag of optional arguments. This PR unifies the constructor and `make_async_buffer` interface to take a stream, memory resource, some form of input and an optional environment. We do not use the environment for anything yet, but whenever we add some new functionality to `async_buffer` that requires some input, it will go there.
This also align with the overall goal to have all stream-ordered APIs to take a stream argument in the first position.

This change also adds support for multiple element types in `async_buffer` testing and adds testing for 8 byte types to more test cases.

Finally this PR contains a fly-by change to `async_buffer_add` example to use `tabulate` instead of `generate` to correctly generate a random sequence in the buffer