### PR TITLE
Allow single-target build/test jobs in CI override for faster turn-around times, reduced runner usage.

### DIFF
--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -428,6 +428,11 @@ def generate_dispatch_job_name(matrix_job, job_type):
     cmake_options = (
         (" " + matrix_job["cmake_options"]) if "cmake_options" in matrix_job else ""
     )
+    extra_args = (
+        (" " + matrix_job["args"])
+        if "args" in matrix_job and matrix_job["args"]
+        else ""
+    )
 
     ctk = matrix_job["ctk"]
     host_compiler = get_host_compiler(matrix_job["cxx"])
@@ -441,8 +446,8 @@ def generate_dispatch_job_name(matrix_job, job_type):
     )
 
     extra_info = (
-        f":{cuda_compile_arch}{cmake_options}"
-        if cuda_compile_arch or cmake_options
+        f":{cuda_compile_arch}{cmake_options}{extra_args}"
+        if cuda_compile_arch or cmake_options or extra_args
         else ""
     )
 
@@ -510,6 +515,7 @@ def generate_dispatch_job_command(matrix_job, job_type):
     cmake_options = matrix_job["cmake_options"] if "cmake_options" in matrix_job else ""
 
     py_version = matrix_job["py_version"] if "py_version" in matrix_job else ""
+    extra_args = matrix_job["args"] if "args" in matrix_job else ""
 
     command = f'"{script_name}"'
     if job_args:
@@ -524,6 +530,8 @@ def generate_dispatch_job_command(matrix_job, job_type):
         command += f' -cmake-options "{cmake_options}"'
     if py_version:
         command += f' -py-version "{py_version}"'
+    if extra_args:
+        command += f" {extra_args}"
 
     return command
 
@@ -561,6 +569,9 @@ def generate_dispatch_job_origin(matrix_job, job_type):
 
         origin_job["cudacxx"] = device_compiler["id"] + device_compiler["version"]
         origin_job["cudacxx_family"] = device_compiler["name"]
+
+    if "args" in origin_job and not origin_job["args"]:
+        del origin_job["args"]
 
     origin["matrix_job"] = origin_job
 

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -5,7 +5,20 @@ workflows:
   #
   # Example:
   # override:
-  #   - {jobs: ['test'], project: 'thrust', std: 17, ctk: '12.X', cxx: ['gcc12', 'clang16']}
+  #   # Full project build: slow, expensive
+  #   - { jobs: ['test'], project: 'thrust', std: 17, ctk: '12.X', cxx: ['gcc12', 'clang16'] }
+  #
+  #   # Build / run targeted tests: faster turnaround, less runner usage.
+  #   # Use project 'target'.
+  #   # args are passed to ci/util/build_and_test_targets.sh. See that script for available options.
+  #   - { jobs: ['run_cpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang', 'msvc'],
+  #       args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator"' }
+  #   - { jobs: ['run_gpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang'], gpu: 'rtxa6000',
+  #       args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator" --ctest-targets "cub.cpp20.test.iterator"' }
+  #   - { jobs: ['run_cpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang', 'msvc'],
+  #       args: '--preset libcudacxx-cpp20 --lit-precompile-tests "cuda/utility/basic_any.pass.cpp"' }
+  #   - { jobs: ['run_gpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang'], gpu: 'rtx2080',
+  #       args: '--preset libcudacxx-cpp20 --lit-tests "cuda/utility/basic_any.pass.cpp"' }
   #
   override:
 
@@ -396,6 +409,10 @@ jobs:
   test_py_par:      { name: "Test cuda.cccl.parallel",     gpu: true,  needs: 'build_py_wheel', force_producer_ctk: "pybuild", invoke: { prefix: 'test_cuda_cccl_parallel'} }
   test_py_examples: { name: "Test cuda.cccl.examples",     gpu: true,  needs: 'build_py_wheel', force_producer_ctk: "pybuild", invoke: { prefix: 'test_cuda_cccl_examples'} }
 
+  # Run jobs for 'target' project (ci/util/build_and_test_targets.sh):
+  run_cpu: { gpu: false }
+  run_gpu: { gpu: true  }
+
   # Only used for generating devcontainers. No scripts actually exist for these:
   dc:     { gpu: false }
   dc_ext: { gpu: false, cuda_ext: true }
@@ -451,6 +468,16 @@ projects:
   cccl_c_parallel:
     name: 'CCCL C Parallel'
     stds: [20]
+
+  # Run specific build_and_test_targets.sh invocations across the CI matrix.
+  # Use the override workflow and supply arguments via the `args` tag.
+  # Example:
+  #   override:
+  #     - { jobs: ['run'], project: 'target', ctk: ['12.X', '13.X'], cxx: 'gcc', gpu: 'rtx2080',
+  #         args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator" --ctest-targets "cub.cpp20.test.iterator"' }
+  target:
+    name: 'Target'
+    stds: [17, 20]
 
 # testing -> Runner with GPU is in a nv-gh-runners testing pool
 gpus:
@@ -508,3 +535,7 @@ tags:
   # Additional CMake options to pass to the build.
   # If set, passed to script with `-cmake_options "<cmake_options>"`.
   cmake_options: { required: false }
+  # Additional arguments appended to the generated command.
+  # Typically used with the `target` project to forward options to
+  # ci/util/build_and_test_targets.sh, but works with all CI jobs.
+  args: { required: false, default: "" }

--- a/ci/run_cpu_target.sh
+++ b/ci/run_cpu_target.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# CI wrapper for the `target` project build job.
+# Forwards all arguments to ci/util/build_and_test_targets.sh to configure
+# and build selected targets on a CPU runner.
+
+set -euo pipefail
+
+ci_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_dir=$(cd "${ci_dir}/.." && pwd)
+
+user_args=("$@")
+set --
+source "${ci_dir}/build_common.sh"
+set -- "${user_args[@]}"
+
+cd "${repo_dir}"
+cmd=("${ci_dir}/util/build_and_test_targets.sh" "$@")
+printf '\033[34m%s\033[0m\n' "${cmd[*]}"
+"${cmd[@]}"

--- a/ci/run_gpu_target.sh
+++ b/ci/run_gpu_target.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# CI wrapper for the `target` project test job.
+# Invokes ci/util/build_and_test_targets.sh with the provided arguments to
+# build and test selected targets on a GPU runner.
+
+set -euo pipefail
+
+ci_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+repo_dir=$(cd "${ci_dir}/.." && pwd)
+
+user_args=("$@")
+set --
+source "${ci_dir}/build_common.sh"
+set -- "${user_args[@]}"
+
+cd "${repo_dir}"
+cmd=("${ci_dir}/util/build_and_test_targets.sh" "$@")
+printf '\033[34m%s\033[0m\n' "${cmd[*]}"
+"${cmd[@]}"


### PR DESCRIPTION
## Sample Run

Example run here: https://github.com/NVIDIA/cccl/actions/runs/17489351367/attempts/2#summary-49696400693

10 minutes turnaround! 😎

### Matrix Setup

```yaml
  override:
    - { jobs: ['run_cpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang', 'msvc'],
        args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator"' }
    - { jobs: ['run_gpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang'], gpu: 'rtxa6000',
        args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator" --ctest-targets "cub.cpp20.test.iterator"' }
    - { jobs: ['run_cpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang', 'msvc'],
        args: '--preset libcudacxx-cpp20 --lit-precompile-tests "cuda/utility/basic_any.pass.cpp"' }
    - { jobs: ['run_gpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang'], gpu: 'rtx2080',
        args: '--preset libcudacxx-cpp20 --lit-tests "cuda/utility/basic_any.pass.cpp"' }
```

### Jobs Created:

<img width="1751" height="1019" alt="image" src="https://github.com/user-attachments/assets/eadc1498-ce72-45db-92bc-fa526219e761" />

### Results Summary:

<img width="1145" height="339" alt="image" src="https://github.com/user-attachments/assets/742dc87b-9bc6-4548-bb71-3dd76d3f3b88" />

## PR Summary
- Introduces a lightweight “target” project to the CI matrix for narrowly scoped CI builds/tests.

**Motivation**
- Developers often need to build or run a small subset of Ninja/CTest/lit targets without exercising full project matrices or reserving GPUs.
- This can be done locally, but only scales to a few configurations.
- The new `target` project allows the new `ci/util/build_and_test_targets.sh` script to be run from any CI environment available.
- This drastically lowers CI turnaround time for iterative development/testing of targeted fixes while reducing our runner usage.

**How To Use**
- Add entries under `override` in `ci/matrix.yaml` to limit PR CI to specific targets:

```yaml
 override:
   # Build / run targeted tests: faster turnaround, less runner usage.
   # Use project 'target'.
   # args are passed to ci/util/build_and_test_targets.sh. See that script for available options.
    - { jobs: ['run_cpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang', 'msvc'],
        args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator"' }
    - { jobs: ['run_gpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang'], gpu: 'rtxa6000',
        args: '--preset cub-cpp20 --build-targets "cub.cpp20.test.iterator" --ctest-targets "cub.cpp20.test.iterator"' }
    - { jobs: ['run_cpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang', 'msvc'],
        args: '--preset libcudacxx-cpp20 --lit-precompile-tests "cuda/utility/basic_any.pass.cpp"' }
    - { jobs: ['run_gpu'], project: 'target', ctk: ['12.X', '13.X'], cxx: ['gcc', 'clang'], gpu: 'rtx2080',
        args: '--preset libcudacxx-cpp20 --lit-tests "cuda/utility/basic_any.pass.cpp"' }
  ```

**Benefits**
- Faster iteration: skip full matrices when targeting a few tests.
- Resource efficiency: CPU runners handle build-only workflows; GPUs used only when needed.
- Clearer CI output: job names now surface `args` context for traceability.
- Can be used to teach agents to generate drafts with fast, narrowly scoped initial CI checks.

**What Changed**
- `ci/matrix.yaml`:
  - Adds `project: 'target'` with `run_cpu` and `run_gpu` jobs
  - Adds `override` examples showing how to build or test specific targets via `args`.
  - Adds an `args` tag to forward arbitrary options.
- `.github/actions/workflow-build/build-workflow.py`:
  - Includes `args` in generated job names for transparency.
  - Appends `args` to the final command invocation; omits empty `args` from origin JSON.
- New wrappers:
  - `ci/run_cpu_target.sh`: CPU-only builds for “target” jobs.
  - `ci/run_gpu_target.sh`: GPU compile+test for “target” jobs.

**Compatibility**
- Default PR workflows are unchanged unless `override` is populated.
- `args` is optional; existing jobs behave as before.

**Notes**
- This is CI-only; no library or API changes.