### PR TITLE
Fix `cudax::launch` for kernels with no parameters

### DIFF
--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -151,7 +151,7 @@ _CCCL_HOST_API auto __launch_impl(_Dst&& __dst, _Config __conf, ::CUfunction __k
     __config.attrs[__config.numAttrs++]    = __cluster_dims_attr;
   }
 
-  const void* __pArgs[] = {::cuda::std::addressof(__args)...};
+  const void* __pArgs[(sizeof...(__args) > 0) ? sizeof...(__args) : 1]{::cuda::std::addressof(__args)...};
   return __do_launch(::cuda::std::forward<_Dst>(__dst), __config, __kernel, const_cast<void**>(__pArgs));
 }
 

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -61,6 +61,11 @@ struct functor_taking_config
   }
 };
 
+__global__ void kernel_no_arguments()
+{
+  kernel_run_proof = true;
+}
+
 __global__ void kernel_int_argument(int dummy)
 {
   kernel_run_proof = true;
@@ -167,6 +172,9 @@ void launch_smoke_test(StreamOrPathBuilder& dst)
 
     // Not taking dims
     {
+      cudax::launch(dst, config, kernel_no_arguments);
+      check_kernel_run(dst);
+
       const int dummy = 1;
       cudax::launch(dst, config, kernel_int_argument, dummy);
       check_kernel_run(dst);
@@ -307,9 +315,9 @@ C2H_TEST("Launch smoke path builder", "[launch]")
 
   // In CUDA 12.0 we don't test kernel_ref launches, so the node count is lower
 #if _CCCL_CTK_BELOW(12, 1)
-  CUDAX_REQUIRE(g.node_count() == 46);
+  CUDAX_REQUIRE(g.node_count() == 48);
 #else // ^^^ _CCCL_CTK_BELOW(12, 1) ^^^ / vvv _CCCL_CTK_AT_LEAST(12, 1) vvv
-  CUDAX_REQUIRE(g.node_count() == 62);
+  CUDAX_REQUIRE(g.node_count() == 64);
 #endif // _CCCL_CTK_BELOW(12, 1)
 
   auto exec = g.instantiate();


### PR DESCRIPTION
If no arguments were passed, there was a problem with zero size array
