### PR TITLE
Port thrust::generate[_n] to cub::DeviceTransform::Fill

### DIFF
--- a/thrust/benchmarks/bench/generate/basic.cu
+++ b/thrust/benchmarks/bench/generate/basic.cu
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/generate.h>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+struct generator
+{
+  THRUST_DEVICE_FUNCTION auto operator()() const -> T
+  {
+    return 42;
+  }
+};
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> output(elements);
+
+  state.add_element_count(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc;
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               thrust::generate(policy(alloc, launch), output.begin(), output.end(), generator<T>{});
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/thrust/thrust/system/cuda/detail/generate.h
+++ b/thrust/thrust/system/cuda/detail/generate.h
@@ -23,21 +23,23 @@ THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class Derived, class OutputIt, class Size, class Generator>
 OutputIt _CCCL_HOST_DEVICE
 generate_n(execution_policy<Derived>& policy, OutputIt result, Size count, Generator generator)
 {
-  using Predicate = ::cub::detail::transform::always_true_predicate;
+  using Predicate = CUB_NS_QUALIFIER::detail::transform::always_true_predicate;
 
   cudaError_t status;
   THRUST_INDEX_TYPE_DISPATCH(
     status,
-    (::cub::detail::transform::dispatch_t<::cub::detail::transform::requires_stable_address::no,
-                                          decltype(count_fixed),
-                                          ::cuda::std::tuple<>,
-                                          OutputIt,
-                                          Predicate,
-                                          Generator>::dispatch),
+    (CUB_NS_QUALIFIER::detail::transform::dispatch_t<
+      CUB_NS_QUALIFIER::detail::transform::requires_stable_address::no,
+      decltype(count_fixed),
+      ::cuda::std::tuple<>,
+      OutputIt,
+      Predicate,
+      Generator>::dispatch),
     count,
     (::cuda::std::tuple<>{}, result, count_fixed, Predicate{}, generator, cuda_cub::stream(policy)));
   throw_on_error(status, "generate_n: failed inside CUB");

--- a/thrust/thrust/system/cuda/detail/generate.h
+++ b/thrust/thrust/system/cuda/detail/generate.h
@@ -1,29 +1,5 @@
-/******************************************************************************
- * Copyright (c) 2016, NVIDIA CORPORATION.  All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the NVIDIA CORPORATION nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
- * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
- * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
- * ARE DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- ******************************************************************************/
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
 #pragma once
 
 #include <thrust/detail/config.h>
@@ -37,43 +13,38 @@
 #endif // no system header
 
 #if _CCCL_HAS_CUDA_COMPILER()
-#  include <thrust/system/cuda/config.h>
+#  include <cub/device/device_transform.cuh>
 
-#  include <thrust/distance.h>
-#  include <thrust/system/cuda/detail/for_each.h>
+#  include <thrust/system/cuda/detail/dispatch.h>
+
+#  include <cuda/std/iterator>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
 
-// for_each functor
-template <class Generator>
-struct generate_f
-{
-  Generator generator;
-
-  THRUST_FUNCTION
-  generate_f(Generator generator_)
-      : generator(generator_)
-  {}
-
-  template <class T>
-  THRUST_DEVICE_FUNCTION void operator()(T const& value)
-  {
-    T& lvalue = const_cast<T&>(value);
-    lvalue    = generator();
-  }
-};
-
-// for_each_n
 template <class Derived, class OutputIt, class Size, class Generator>
 OutputIt _CCCL_HOST_DEVICE
 generate_n(execution_policy<Derived>& policy, OutputIt result, Size count, Generator generator)
 {
-  return cuda_cub::for_each_n(policy, result, count, generate_f<Generator>(generator));
+  using Predicate = ::cub::detail::transform::always_true_predicate;
+
+  cudaError_t status;
+  THRUST_INDEX_TYPE_DISPATCH(
+    status,
+    (::cub::detail::transform::dispatch_t<::cub::detail::transform::requires_stable_address::no,
+                                          decltype(count_fixed),
+                                          ::cuda::std::tuple<>,
+                                          OutputIt,
+                                          Predicate,
+                                          Generator>::dispatch),
+    count,
+    (::cuda::std::tuple<>{}, result, count_fixed, Predicate{}, generator, cuda_cub::stream(policy)));
+  throw_on_error(status, "generate_n: failed inside CUB");
+
+  return result + count;
 }
 
-// for_each
 template <class Derived, class OutputIt, class Generator>
 void _CCCL_HOST_DEVICE generate(execution_policy<Derived>& policy, OutputIt first, OutputIt last, Generator generator)
 {


### PR DESCRIPTION
Fixes: #5806

Benchmark on RTX 5090:
```
## [0] NVIDIA GeForce RTX 5090

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^16    |   6.923 us |       9.77% |   3.226 us |      19.49% |  -3.697 us | -53.40% |   FAST   |
|   I8    |    2^20    |   8.255 us |       7.04% |   4.143 us |     134.02% |  -4.112 us | -49.82% |   FAST   |
|   I8    |    2^24    |  22.812 us |       3.78% |   8.986 us |       9.98% | -13.826 us | -60.61% |   FAST   |
|   I8    |    2^28    | 250.103 us |       1.07% | 158.613 us |       0.91% | -91.490 us | -36.58% |   FAST   |
|   I16   |    2^16    |   7.738 us |      18.69% |   3.773 us |      29.71% |  -3.964 us | -51.23% |   FAST   |
|   I16   |    2^20    |   8.591 us |      10.14% |   5.557 us |     118.86% |  -3.034 us | -35.31% |   FAST   |
|   I16   |    2^24    |  23.209 us |       3.54% |  18.612 us |       9.11% |  -4.598 us | -19.81% |   FAST   |
|   I16   |    2^28    | 321.003 us |       0.94% | 319.540 us |       0.69% |  -1.463 us |  -0.46% |   SAME   |
|   I32   |    2^16    |   7.831 us |       6.62% |   3.698 us |      23.81% |  -4.133 us | -52.78% |   FAST   |
|   I32   |    2^20    |   8.831 us |       9.46% |   4.827 us |      21.75% |  -4.005 us | -45.34% |   FAST   |
|   I32   |    2^24    |  42.580 us |       2.34% |  39.146 us |       2.66% |  -3.434 us |  -8.07% |   FAST   |
|   I32   |    2^28    | 641.706 us |       0.52% | 638.532 us |       0.43% |  -3.174 us |  -0.49% |   FAST   |
|   I64   |    2^16    |   7.690 us |      22.11% |   3.438 us |      43.42% |  -4.252 us | -55.29% |   FAST   |
|   I64   |    2^20    |  10.755 us |      41.69% |   6.751 us |       7.16% |  -4.004 us | -37.23% |   FAST   |
|   I64   |    2^24    |  82.590 us |       1.59% |  79.150 us |       2.73% |  -3.440 us |  -4.16% |   FAST   |
|   I64   |    2^28    |   1.284 ms |       0.49% |   1.281 ms |       0.40% |  -2.948 us |  -0.23% |   SAME   |
|  I128   |    2^16    |   7.898 us |       4.65% |   3.751 us |      22.19% |  -4.147 us | -52.50% |   FAST   |
|  I128   |    2^20    |  13.012 us |       8.97% |   8.890 us |       7.96% |  -4.122 us | -31.68% |   FAST   |
|  I128   |    2^24    | 161.726 us |       1.50% | 157.722 us |       0.88% |  -4.003 us |  -2.48% |   FAST   |
|  I128   |    2^28    |   2.553 ms |       0.36% |   2.551 ms |       0.36% |  -1.580 us |  -0.06% |   SAME   |
|   F32   |    2^16    |   7.926 us |      10.05% |   3.597 us |      19.42% |  -4.329 us | -54.62% |   FAST   |
|   F32   |    2^20    |   8.686 us |      12.87% |   4.876 us |      20.92% |  -3.810 us | -43.86% |   FAST   |
|   F32   |    2^24    |  42.115 us |       1.97% |  38.874 us |      11.56% |  -3.241 us |  -7.70% |   FAST   |
|   F32   |    2^28    | 641.531 us |       0.63% | 638.469 us |       0.47% |  -3.062 us |  -0.48% |   FAST   |
|   F64   |    2^16    |   9.956 us |     123.02% |   4.291 us |      51.01% |  -5.666 us | -56.91% |   FAST   |
|   F64   |    2^20    |  10.003 us |      10.21% |   6.785 us |      14.00% |  -3.218 us | -32.17% |   FAST   |
|   F64   |    2^24    |  82.599 us |       1.52% |  78.766 us |       1.38% |  -3.833 us |  -4.64% |   FAST   |
|   F64   |    2^28    |   1.284 ms |       0.42% |   1.281 ms |       0.48% |  -3.050 us |  -0.24% |   SAME   |
```