### PR TITLE
Fix uninitialized read in uninitialized_copy_n

### DIFF
--- a/thrust/thrust/system/cuda/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_copy.h
@@ -86,10 +86,13 @@ OutputIt _CCCL_HOST_DEVICE
 uninitialized_copy_n(execution_policy<Derived>& policy, InputIt first, Size count, OutputIt result)
 {
   // if the output type is trivially constructible from the input, it has no side effect, and we can skip placement new
-  // and calling a constructor. So we can delegate to copy_n.
-  using ctor_arg_t = thrust::detail::raw_reference_t<::cuda::std::iter_reference_t<InputIt>>;
-  using output_t   = thrust::detail::it_value_t<OutputIt>;
-  if constexpr (::cuda::std::is_trivially_constructible_v<output_t, ctor_arg_t>)
+  // and calling a constructor. Furthermore, if assigning an input to an output element is also trivial, there is no
+  // copy constructor which could have a side effect and we can delegate to copy_n.
+  using input_ref_t  = thrust::detail::raw_reference_t<::cuda::std::iter_reference_t<InputIt>>;
+  using output_ref_t = thrust::detail::raw_reference_t<::cuda::std::iter_reference_t<OutputIt>>;
+  using output_t     = thrust::detail::it_value_t<OutputIt>;
+  if constexpr (::cuda::std::is_trivially_constructible_v<output_t, input_ref_t>
+                && ::cuda::std::is_trivially_assignable_v<output_ref_t, input_ref_t>)
   {
     cuda_cub::copy_n(policy, first, count, result);
   }


### PR DESCRIPTION
We need to tighten the check to use copy_n only when the copy ctor also has no side effect.

Fixes: #5809