### PR TITLE
[CUDAX] Lower copy_bytes to the batched memcpy starting with CUDA 13

### DIFF
--- a/libcudacxx/include/cuda/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/__algorithm/copy.h
@@ -45,7 +45,7 @@ enum class source_access_order
   any = cudaMemcpySrcAccessOrderAny,
 #  else
   any = 0x3,
-#  endif // _CCCL_CTK_AT_LEAST(13, 0)
+#  endif // _CCCL_CTK_BELOW(13, 0)
 };
 
 //! @brief Configuration for copy_bytes
@@ -93,7 +93,7 @@ _CCCL_HOST_API void __copy_bytes_impl(
     __dst.data(), __src.data(), __src.size_bytes(), __stream.get(), __attributes);
 #  else
   ::cuda::__driver::__memcpyAsync(__dst.data(), __src.data(), __src.size_bytes(), __stream.get());
-#  endif // _CCCL_CTK_AT_LEAST(13, 0)
+#  endif // _CCCL_CTK_BELOW(13, 0)
 }
 
 template <typename _SrcElem,

--- a/libcudacxx/include/cuda/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/__algorithm/copy.h
@@ -33,11 +33,40 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
+//! @brief Source access order for copy_bytes
+enum class source_access_order
+{
+#  if _CCCL_CTK_AT_LEAST(13, 0)
+  //! @brief Access source in stream order
+  stream = cudaMemcpySrcAccessOrderStream,
+  //! @brief Access source during the copy call, source can be destroyed after the API returns
+  during_api_call = cudaMemcpySrcAccessOrderDuringApiCall,
+  //! @brief Access source in any order, the order can change across CUDA releases
+  any = cudaMemcpySrcAccessOrderAny,
+#  else
+  any = 0x3,
+#  endif // _CCCL_CTK_AT_LEAST(13, 0)
+};
+
+//! @brief Configuration for copy_bytes
+struct copy_configuration
+{
+  //! @brief Source memory location hint for copy_bytes, used only for managed memory
+  memory_location src_location_hint = {};
+  //! @brief Destination memory location hint for copy_bytes, used only for managed memory
+  memory_location dst_location_hint = {};
+  //! @brief Source access order for copy_bytes
+  source_access_order src_access_order = source_access_order::any;
+};
+
 namespace __detail
 {
 template <typename _SrcTy, typename _DstTy>
-_CCCL_HOST_API void
-__copy_bytes_impl(stream_ref __stream, ::cuda::std::span<_SrcTy> __src, ::cuda::std::span<_DstTy> __dst)
+_CCCL_HOST_API void __copy_bytes_impl(
+  stream_ref __stream,
+  ::cuda::std::span<_SrcTy> __src,
+  ::cuda::std::span<_DstTy> __dst,
+  [[maybe_unused]] copy_configuration __config)
 {
   static_assert(!::cuda::std::is_const_v<_DstTy>, "Copy destination can't be const");
   static_assert(::cuda::std::is_trivially_copyable_v<_SrcTy> && ::cuda::std::is_trivially_copyable_v<_DstTy>);
@@ -46,8 +75,25 @@ __copy_bytes_impl(stream_ref __stream, ::cuda::std::span<_SrcTy> __src, ::cuda::
   {
     ::cuda::std::__throw_invalid_argument("Copy destination is too small to fit the source data");
   }
+  if (__src.size_bytes() == 0)
+  {
+    return;
+  }
 
+#  if _CCCL_CTK_AT_LEAST(13, 0)
+  CUmemcpyAttributes __attributes = {};
+  __attributes.srcAccessOrder     = static_cast<::CUmemcpySrcAccessOrder>(__config.src_access_order);
+  __attributes.srcLocHint.id      = __config.src_location_hint.id;
+  __attributes.srcLocHint.type    = static_cast<::CUmemLocationType>(__config.src_location_hint.type);
+  __attributes.dstLocHint.id      = __config.dst_location_hint.id;
+  __attributes.dstLocHint.type    = static_cast<::CUmemLocationType>(__config.dst_location_hint.type);
+
+  ::cuda::__ensure_current_context guard(__stream);
+  _CUDA_DRIVER::__memcpyAsyncWithAttributes(
+    __dst.data(), __src.data(), __src.size_bytes(), __stream.get(), __attributes);
+#  else
   ::cuda::__driver::__memcpyAsync(__dst.data(), __src.data(), __src.size_bytes(), __stream.get());
+#  endif // _CCCL_CTK_AT_LEAST(13, 0)
 }
 
 template <typename _SrcElem,
@@ -58,9 +104,11 @@ template <typename _SrcElem,
           typename _DstExtents,
           typename _DstLayout,
           typename _DstAccessor>
-_CCCL_HOST_API void __copy_bytes_impl(stream_ref __stream,
-                                      ::cuda::std::mdspan<_SrcElem, _SrcExtents, _SrcLayout, _SrcAccessor> __src,
-                                      ::cuda::std::mdspan<_DstElem, _DstExtents, _DstLayout, _DstAccessor> __dst)
+_CCCL_HOST_API void __copy_bytes_impl(
+  stream_ref __stream,
+  ::cuda::std::mdspan<_SrcElem, _SrcExtents, _SrcLayout, _SrcAccessor> __src,
+  ::cuda::std::mdspan<_DstElem, _DstExtents, _DstLayout, _DstAccessor> __dst,
+  copy_configuration __config)
 {
   static_assert(::cuda::std::is_constructible_v<_DstExtents, _SrcExtents>,
                 "Multidimensional copy requires both source and destination extents to be compatible");
@@ -81,7 +129,8 @@ _CCCL_HOST_API void __copy_bytes_impl(stream_ref __stream,
   ::cuda::__detail::__copy_bytes_impl(
     __stream,
     ::cuda::std::span(__src.data_handle(), __src.mapping().required_span_size()),
-    ::cuda::std::span(__dst.data_handle(), __dst.mapping().required_span_size()));
+    ::cuda::std::span(__dst.data_handle(), __dst.mapping().required_span_size()),
+    __config);
 }
 } // namespace __detail
 
@@ -98,14 +147,16 @@ _CCCL_HOST_API void __copy_bytes_impl(stream_ref __stream,
 //! @param __stream Stream that the copy should be inserted into
 //! @param __src Source to copy from
 //! @param __dst Destination to copy into
+//! @param __config Configuration for the copy
 _CCCL_TEMPLATE(typename _SrcTy, typename _DstTy)
 _CCCL_REQUIRES(__spannable<_SrcTy> _CCCL_AND __spannable<_DstTy>)
-_CCCL_HOST_API void copy_bytes(stream_ref __stream, _SrcTy&& __src, _DstTy&& __dst)
+_CCCL_HOST_API void copy_bytes(stream_ref __stream, _SrcTy&& __src, _DstTy&& __dst, copy_configuration __config = {})
 {
   ::cuda::__detail::__copy_bytes_impl(
     __stream,
     ::cuda::std::span(::cuda::std::forward<_SrcTy>(__src)),
-    ::cuda::std::span(::cuda::std::forward<_DstTy>(__dst)));
+    ::cuda::std::span(::cuda::std::forward<_DstTy>(__dst)),
+    __config);
 }
 
 //! @brief Launches a bytewise memory copy from source to destination into the provided
@@ -124,14 +175,16 @@ _CCCL_HOST_API void copy_bytes(stream_ref __stream, _SrcTy&& __src, _DstTy&& __d
 //! @param __stream Stream that the copy should be inserted into
 //! @param __src Source to copy from
 //! @param __dst Destination to copy into
+//! @param __config Configuration for the copy
 _CCCL_TEMPLATE(typename _SrcTy, typename _DstTy)
 _CCCL_REQUIRES(__mdspannable<_SrcTy> _CCCL_AND __mdspannable<_DstTy>)
-_CCCL_HOST_API void copy_bytes(stream_ref __stream, _SrcTy&& __src, _DstTy&& __dst)
+_CCCL_HOST_API void copy_bytes(stream_ref __stream, _SrcTy&& __src, _DstTy&& __dst, copy_configuration __config = {})
 {
   ::cuda::__detail::__copy_bytes_impl(
     __stream,
     ::cuda::__as_mdspan(::cuda::std::forward<_SrcTy>(__src)),
-    ::cuda::__as_mdspan(::cuda::std::forward<_DstTy>(__dst)));
+    ::cuda::__as_mdspan(::cuda::std::forward<_DstTy>(__dst)),
+    __config);
 }
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__device/device_ref.h
+++ b/libcudacxx/include/cuda/__device/device_ref.h
@@ -23,6 +23,7 @@
 
 #if _CCCL_HAS_CTK() && !_CCCL_COMPILER(NVRTC)
 #  include <cuda/__driver/driver_api.h>
+#  include <cuda/__runtime/types.h>
 #  include <cuda/std/__cuda/api_wrapper.h>
 
 #  include <string>
@@ -111,6 +112,14 @@ public:
   [[nodiscard]] auto attribute() const
   {
     return attribute(__detail::__dev_attr<_Attr>());
+  }
+
+  //! @brief Retrieve the memory location of this device
+  //!
+  //! @return The memory location of this device
+  [[nodiscard]] operator memory_location() const noexcept
+  {
+    return memory_location{::cudaMemLocationTypeDevice, get()};
   }
 
   //! @brief Retrieve string with the name of this device.

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -175,6 +175,26 @@ _CCCL_HOST_API inline void __memcpyAsync(void* __dst, const void* __src, size_t 
     __stream);
 }
 
+#  if _CCCL_CTK_AT_LEAST(13, 0)
+_CCCL_HOST_API inline void __memcpyAsyncWithAttributes(
+  void* __dst, const void* __src, size_t __count, ::CUstream __stream, ::CUmemcpyAttributes __attributes)
+{
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuMemcpyBatchAsync, cuMemcpyBatchAsync, 13, 0);
+  size_t __zero           = 0;
+  _CUDA_DRIVER::__call_driver_fn(
+    __driver_fn,
+    "Failed to perform a memcpy with attributes",
+    reinterpret_cast<::CUdeviceptr*>(&__dst),
+    reinterpret_cast<::CUdeviceptr*>(&__src),
+    &__count,
+    1,
+    &__attributes,
+    &__zero,
+    1,
+    __stream);
+}
+#  endif // _CCCL_CTK_AT_LEAST(13, 0)
+
 template <typename _Tp>
 _CCCL_HOST_API void __memsetAsync(void* __dst, _Tp __value, size_t __count, ::CUstream __stream)
 {

--- a/libcudacxx/include/cuda/__runtime/types.h
+++ b/libcudacxx/include/cuda/__runtime/types.h
@@ -28,8 +28,9 @@
 _CCCL_BEGIN_NAMESPACE_CUDA
 
 using memory_location = ::cudaMemLocation;
-
+#  if _CCCL_CTK_AT_LEAST(12, 2)
 inline constexpr memory_location host_memory_location = {cudaMemLocationTypeHost, 0};
+#  endif // _CCCL_CTK_AT_LEAST(12, 2)
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__runtime/types.h
+++ b/libcudacxx/include/cuda/__runtime/types.h
@@ -11,7 +11,7 @@
 #ifndef _CUDA___RUNTIME_TYPES_H
 #define _CUDA___RUNTIME_TYPES_H
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/__runtime/types.h
+++ b/libcudacxx/include/cuda/__runtime/types.h
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___RUNTIME_TYPES_H
+#define _CUDA___RUNTIME_TYPES_H
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_CTK() && !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+using memory_location = ::cudaMemLocation;
+
+inline constexpr memory_location host_memory_location = {cudaMemLocationTypeHost, 0};
+
+_CCCL_END_NAMESPACE_CUDA
+
+#endif // _CCCL_HAS_CTK() && !_CCCL_COMPILER(NVRTC)
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // __CUDA___RUNTIME_TYPES_H

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
@@ -328,3 +328,14 @@ C2H_CCCLRT_TEST("global devices vector", "[device]")
   }
 #endif // _CCCL_HAS_EXCEPTIONS()
 }
+
+C2H_CCCLRT_TEST("memory location", "[device]")
+{
+  cuda::memory_location loc = cuda::devices[0];
+  CCCLRT_REQUIRE(loc.type == ::cudaMemLocationTypeDevice);
+  CCCLRT_REQUIRE(loc.id == 0);
+
+  loc = cuda::device_ref{1};
+  CCCLRT_REQUIRE(loc.type == ::cudaMemLocationTypeDevice);
+  CCCLRT_REQUIRE(loc.id == 1);
+}


### PR DESCRIPTION
`cuMemcpyBatchAsync` is a new CUDA memcpy API that exposes configuration options like source access order or managed memory location hints. We should lower `copy_bytes` to this new API. It was introduced in CUDA 12.8, but for simplicity we should lower to it starting with CUDA 13.0 so driver version check is not needed. CUDA 12.X will continue to lower to `cuMemcpyAsync`. There could be some edge case difference in behavior between the two when it comes to performance or source access order, but those things are not guaranteed to be consistent across releases. This is another reason to split the different lowering across major versions, so the behavior is consistent within the major version.
In order to control the copy configuration options this change introduces `copy_configuration` structure. Technically we could just reuse the old runtime structure here, but it uses invalid access order as the default, where I think we should just default it to any order instead, which requires a new structure.

Because we can only use the copy configuration in CUDA 13.0+, any access order enum option is introduced for CUDA 12.X and its the only valid option there, the hints are fine to ignore since they are just hints.

This change also introduces `memory_location` alias for `cudaMemoryLocation` that is used in `copy_configuration` for location hints. To make it easier to use this PR introduces implicit conversion from `physical_device` and `device_ref` to `memory_location` so it can be used to populate the hints. We could also consider using it for memory pool access controls.

It seems that the new batched memcpy does not work without a context set current, a workaround was added to push/pop a context. Long term it might be possible to make the API work without a current context and remove the workaround.