### PR TITLE
Backport some MSVC test fixes to 3.0

### DIFF
--- a/libcudacxx/include/cuda/std/__iterator/concepts.h
+++ b/libcudacxx/include/cuda/std/__iterator/concepts.h
@@ -77,12 +77,11 @@ using iter_common_reference_t = common_reference_t<iter_reference_t<_Tp>, iter_v
 // [iterator.concept.writable]
 template <class _Out, class _Tp>
 concept indirectly_writable = requires(_Out&& __o, _Tp&& __t) {
-  *__o                            = _CUDA_VSTD::forward<_Tp>(__t); // not required to be equality-preserving
-  *_CUDA_VSTD::forward<_Out>(__o) = _CUDA_VSTD::forward<_Tp>(__t); // not required to be equality-preserving
-  const_cast<const iter_reference_t<_Out>&&>(*__o) = _CUDA_VSTD::forward<_Tp>(__t); // not required to be
-                                                                                    // equality-preserving
-  const_cast<const iter_reference_t<_Out>&&>(*_CUDA_VSTD::forward<_Out>(__o)) =
-    _CUDA_VSTD::forward<_Tp>(__t); // not required to be equality-preserving
+  *__o                                             = static_cast<_Tp&&>(__t); // not required to be equality-preserving
+  *static_cast<_Out&&>(__o)                        = static_cast<_Tp&&>(__t); // not required to be equality-preserving
+  const_cast<const iter_reference_t<_Out>&&>(*__o) = static_cast<_Tp&&>(__t); // not required to be equality-preserving
+  const_cast<const iter_reference_t<_Out>&&>(*static_cast<_Out&&>(__o)) =
+    static_cast<_Tp&&>(__t); // not required to be equality-preserving
 };
 
 // [iterator.concept.winc]
@@ -278,17 +277,11 @@ using iter_common_reference_t =
   enable_if_t<indirectly_readable<_Tp>, common_reference_t<iter_reference_t<_Tp>, iter_value_t<_Tp>&>>;
 // [iterator.concept.writable]
 template <class _Out, class _Tp>
-_CCCL_CONCEPT_FRAGMENT(
-  __indirectly_writable_,
-  requires(_Out&& __o, _Tp&& __t)(
-    typename(decltype(*__o = _CUDA_VSTD::forward<_Tp>(__t))),
-    typename(decltype(*_CUDA_VSTD::forward<_Out>(__o) = _CUDA_VSTD::forward<_Tp>(__t))),
-    typename(decltype(const_cast<const iter_reference_t<_Out>&&>(*__o) = _CUDA_VSTD::forward<_Tp>(__t))),
-    typename(decltype(const_cast<const iter_reference_t<_Out>&&>(*_CUDA_VSTD::forward<_Out>(__o)) =
-                        _CUDA_VSTD::forward<_Tp>(__t)))));
-
-template <class _Out, class _Tp>
-_CCCL_CONCEPT indirectly_writable = _CCCL_FRAGMENT(__indirectly_writable_, _Out, _Tp);
+_CCCL_CONCEPT indirectly_writable = _CCCL_REQUIRES_EXPR((_Out, _Tp), _Out&& __o, _Tp&& __t)(
+  (*__o = static_cast<_Tp&&>(__t)),
+  (*static_cast<_Out&&>(__o) = static_cast<_Tp&&>(__t)),
+  (const_cast<const iter_reference_t<_Out>&&>(*__o) = static_cast<_Tp&&>(__t)),
+  (const_cast<const iter_reference_t<_Out>&&>(*static_cast<_Out&&>(__o)) = static_cast<_Tp&&>(__t)));
 
 // [iterator.concept.winc]
 template <class _Tp>

--- a/libcudacxx/test/libcudacxx/cuda/cmath/ilog.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/ilog.pass.cpp
@@ -14,7 +14,6 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
-#include "cuda/std/__type_traits/is_constant_evaluated.h"
 #include "test_macros.h"
 
 template <class T>
@@ -24,10 +23,10 @@ __host__ __device__ constexpr void test_log2()
   for (T value = 1; value <= cuda::std::numeric_limits<T>::max() / 2; value *= 2)
   {
     assert(cuda::ilog2(value) == i);
-    if (i >= 1)
+    if (value > 1)
     {
       assert(cuda::ilog2(static_cast<T>(value - 1)) == i - 1);
-      assert(cuda::ilog2(static_cast<T>(value + 1)) == i); // not true if value == 1
+      assert(cuda::ilog2(static_cast<T>(value + 1)) == i);
     }
     i++;
   }
@@ -51,11 +50,13 @@ __host__ __device__ constexpr void test_log10()
     }
     i++;
   }
+#if !TEST_COMPILER(MSVC)
   if (!cuda::std::__cccl_default_is_constant_evaluated())
   {
     constexpr auto max_v = cuda::std::numeric_limits<T>::max();
     assert(cuda::ilog10(max_v) == static_cast<int>(cuda::std::floor(cuda::std::log10(max_v))));
   }
+#endif // !TEST_COMPILER(MSVC)
 }
 
 template <class T>
@@ -83,7 +84,7 @@ __host__ __device__ constexpr bool test()
   test<long long>();
   test<unsigned long long>();
 
-#if !defined(TEST_COMPILER_NVRTC)
+#if !TEST_COMPILER(NVRTC)
   // cstdint types:
   test<cuda::std::size_t>();
   test<cuda::std::ptrdiff_t>();
@@ -99,7 +100,7 @@ __host__ __device__ constexpr bool test()
   test<cuda::std::uint16_t>();
   test<cuda::std::uint32_t>();
   test<cuda::std::uint64_t>();
-#endif // !TEST_COMPILER_NVRTC
+#endif // !TEST_COMPILER(NVRTC)
 
 #if _CCCL_HAS_INT128()
   test<__int128_t>();

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable.compile.pass.cpp
@@ -35,7 +35,9 @@ static_assert(!cuda::std::indirectly_copyable<int*, const int*>, "");
 static_assert(!cuda::std::indirectly_copyable<const int*, const int*>, "");
 
 // Can copy from a pointer into an array but arrays aren't considered indirectly copyable-from.
+#if !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(cuda::std::indirectly_copyable<int*, int[2]>, "");
+#endif // !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(!cuda::std::indirectly_copyable<int[2], int*>, "");
 static_assert(!cuda::std::indirectly_copyable<int[2], int[2]>, "");
 static_assert(!cuda::std::indirectly_copyable<int (&)[2], int (&)[2]>, "");

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable_storable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.copy/indirectly_copyable_storable.compile.pass.cpp
@@ -37,7 +37,9 @@ static_assert(cuda::std::indirectly_copyable_storable<int*, int*>, "");
 static_assert(cuda::std::indirectly_copyable_storable<const int*, int*>, "");
 static_assert(!cuda::std::indirectly_copyable_storable<int*, const int*>, "");
 static_assert(!cuda::std::indirectly_copyable_storable<const int*, const int*>, "");
+#if !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(cuda::std::indirectly_copyable_storable<int*, int[2]>, "");
+#endif // !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(!cuda::std::indirectly_copyable_storable<int[2], int*>, "");
 static_assert(!cuda::std::indirectly_copyable_storable<MoveOnly*, MoveOnly*>, "");
 static_assert(!cuda::std::indirectly_copyable_storable<PointerTo<MoveOnly>, PointerTo<MoveOnly>>, "");

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable.compile.pass.cpp
@@ -22,7 +22,9 @@ static_assert(!cuda::std::indirectly_movable<int*, const int*>, "");
 static_assert(cuda::std::indirectly_movable<const int*, int*>, "");
 
 // Can move from a pointer into an array but arrays aren't considered indirectly movable-from.
+#if !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(cuda::std::indirectly_movable<int*, int[2]>, "");
+#endif // !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(!cuda::std::indirectly_movable<int[2], int*>, "");
 static_assert(!cuda::std::indirectly_movable<int[2], int[2]>, "");
 static_assert(!cuda::std::indirectly_movable<int (&)[2], int (&)[2]>, "");

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable_storable.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/alg.req.ind.move/indirectly_movable_storable.compile.pass.cpp
@@ -28,7 +28,9 @@ static_assert(cuda::std::indirectly_movable_storable<int*, int*>, "");
 static_assert(cuda::std::indirectly_movable_storable<const int*, int*>, "");
 static_assert(!cuda::std::indirectly_movable_storable<int*, const int*>, "");
 static_assert(!cuda::std::indirectly_movable_storable<const int*, const int*>, "");
+#if !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(cuda::std::indirectly_movable_storable<int*, int[2]>, "");
+#endif // !TEST_COMPILER(MSVC) || TEST_STD_VER != 2017
 static_assert(!cuda::std::indirectly_movable_storable<int[2], int*>, "");
 static_assert(cuda::std::indirectly_movable_storable<MoveOnly*, MoveOnly*>, "");
 static_assert(cuda::std::indirectly_movable_storable<PointerTo<MoveOnly>, PointerTo<MoveOnly>>, "");

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.swap/iter_swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.requirements/iterator.cust/iterator.cust.swap/iter_swap.pass.cpp
@@ -205,10 +205,11 @@ __host__ __device__ constexpr bool test()
     assert(g.value && h.value);
   }
 #if defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
-  {
+#  if !TEST_COMPILER(MSVC) && TEST_STD_VER == 2017
+  { // MSVC has different behavior here
     move_tracker arr[2];
     cuda::std::ranges::iter_swap(cuda::std::begin(arr), cuda::std::begin(arr) + 1);
-    if (__builtin_is_constant_evaluated())
+    if (cuda::std::is_constant_evaluated())
     {
       assert(arr[0].moves() == 1 && arr[1].moves() == 3);
     }
@@ -217,6 +218,7 @@ __host__ __device__ constexpr bool test()
       assert(arr[0].moves() == 1 && arr[1].moves() == 2);
     }
   }
+#  endif // !TEST_COMPILER(MSVC) && TEST_STD_VER == 2017
 #endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
   {
     int buff[2] = {1, 2};


### PR DESCRIPTION
We are getting QA bugs because of those failures, most are MSVC limitations that are popping up again.

There is one fix in the definition of `indirectly_writable` for an MSVC oddity
