### PR TITLE
Try to find alternative for NV target macros v2

### DIFF
--- a/libcudacxx/include/cuda/__annotated_ptr/annotated_ptr.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/annotated_ptr.h
@@ -103,9 +103,16 @@ public:
     static_assert(__is_global_access_property_v<_RuntimeProperty>,
                   "This method requires RuntimeProperty=global|normal|streaming|persisting|access_property");
     _CCCL_ASSERT(__p != nullptr, "__p must not be null");
-    NV_IF_TARGET(NV_IS_DEVICE,
-                 (_CCCL_ASSERT(::cuda::device::is_address_from(__p, ::cuda::device::address_space::global),
-                               "__p must be global");))
+
+    // clang-format off
+
+    _CCCL_IF_TARGET(is_device)
+    (
+      _CCCL_ASSERT(::cuda::device::is_address_from(__p, ::cuda::device::address_space::global), "__p must be global");
+    )
+    (endif)
+
+    // clang-format on
   }
 
   // cannot be constexpr because of get()

--- a/libcudacxx/include/cuda/__cccl_config
+++ b/libcudacxx/include/cuda/__cccl_config
@@ -29,6 +29,7 @@
 #include <cuda/std/__cccl/rtti.h> // IWYU pragma: export
 #include <cuda/std/__cccl/sequence_access.h> // IWYU pragma: export
 #include <cuda/std/__cccl/system_header.h> // IWYU pragma: export
+#include <cuda/std/__cccl/target.h> // IWYU pragma: export
 #include <cuda/std/__cccl/unreachable.h> // IWYU pragma: export
 #include <cuda/std/__cccl/version.h> // IWYU pragma: export
 #include <cuda/std/__cccl/visibility.h> // IWYU pragma: export

--- a/libcudacxx/include/cuda/std/__atomic/wait/notify_wait.h
+++ b/libcudacxx/include/cuda/std/__atomic/wait/notify_wait.h
@@ -36,9 +36,22 @@ template <typename _Tp, typename _Sco>
 _CCCL_API inline void
 __atomic_try_wait_slow(_Tp const volatile* __a, __atomic_underlying_remove_cv_t<_Tp> __val, memory_order __order, _Sco)
 {
-  NV_DISPATCH_TARGET(NV_PROVIDES_SM_70, __atomic_try_wait_slow_fallback(__a, __val, __order, _Sco{});
-                     , NV_IS_HOST, __atomic_try_wait_slow_fallback(__a, __val, __order, _Sco{});
-                     , NV_ANY_TARGET, __atomic_try_wait_unsupported_before_SM_70__(););
+  // clang-format off
+
+  _CCCL_IF_TARGET(provides(70))
+  (
+    __atomic_try_wait_slow_fallback(__a, __val, __order, _Sco{});
+  )
+  (elif, is_host)
+  (
+    __atomic_try_wait_slow_fallback(__a, __val, __order, _Sco{});
+  )
+  (else)
+  (
+    __atomic_try_wait_unsupported_before_SM_70__();
+  )
+
+  // clang-format on
 }
 
 template <typename _Tp, typename _Sco>

--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -128,10 +128,20 @@ template <class _Tp>
 #else // ^^^ _CCCL_BUILTIN_BSWAP32 ^^^ / vvv !_CCCL_BUILTIN_BSWAP32 vvv
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
+    // clang-format off
+
+    _CCCL_IF_TARGET(is_host)
+    (
 #  if _CCCL_COMPILER(MSVC)
-    NV_IF_TARGET(NV_IS_HOST, return ::_byteswap_ulong(__val);)
+      return ::_byteswap_ulong(__val);
 #  endif // _CCCL_COMPILER(MSVC)
-    NV_IF_TARGET(NV_IS_DEVICE, return ::cuda::std::__byteswap_impl_device(__val);)
+    )
+    (else)
+    (
+      return ::cuda::ptx::prmt(__val, uint32_t{0}, uint32_t{0x0123});
+    )
+
+    // clang-format on
   }
   return ::cuda::std::__byteswap_impl_recursive(__val);
 #endif // !_CCCL_BUILTIN_BSWAP32

--- a/libcudacxx/include/cuda/std/__cccl/target.h
+++ b/libcudacxx/include/cuda/std/__cccl/target.h
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CCCL_TARGET_H
+#define __CCCL_TARGET_H
+
+#include <cuda/std/__cccl/compiler.h>
+#include <cuda/std/__cccl/system_header.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_CUDA_COMPILATION() && _CCCL_CUDA_COMPILER(NVHPC)
+#  define _CCCL_TARGET_is_device           ::nv::target::is_device
+#  define _CCCL_TARGET_is_host             ::nv::target::is_host
+#  define _CCCL_TARGET_any_target          ::nv::target::any_target
+#  define _CCCL_TARGET_no_target           ::nv::target::no_target
+#  define _CCCL_TARGET_is_exactly(_SM_VER) ::nv::target::is_exactly(::nv::target::sm_##_SM_VER)
+#  define _CCCL_TARGET_provides(_SM_VER)   ::nv::target::provides(::nv::target::sm_##_SM_VER)
+
+#  define _CCCL_TARGET_CONTINUE(_OP, ...)             _CCCL_##_OP##_TARGET(__VA_ARGS__)
+#  define _CCCL_TARGET_EXPAND_BLOCK(...)              {__VA_ARGS__}
+#  define _CCCL_TARGET_EXPAND_BLOCK_AND_CONTINUE(...) {__VA_ARGS__} _CCCL_TARGET_CONTINUE
+
+#  define _CCCL_IF_TARGET(_COND)     \
+    if target (_CCCL_TARGET_##_COND) \
+    _CCCL_TARGET_EXPAND_BLOCK_AND_CONTINUE
+#  define _CCCL_elif_TARGET(_COND) else if target (_CCCL_TARGET_##_COND) _CCCL_TARGET_EXPAND_BLOCK_AND_CONTINUE
+#  define _CCCL_else_TARGET()      else _CCCL_TARGET_EXPAND_BLOCK
+#  define _CCCL_endif_TARGET()
+#else
+#  if defined(__CUDA_ARCH__)
+#    define _CCCL_TARGET_is_device           1
+#    define _CCCL_TARGET_is_host             0
+#    define _CCCL_TARGET_is_exactly(_SM_VER) // todo
+#    define _CCCL_TARGET_provides(_SM_VER)   // todo
+#  else
+#    define _CCCL_TARGET_is_device           0
+#    define _CCCL_TARGET_is_host             1
+#    define _CCCL_TARGET_is_exactly(_SM_VER) 0
+#    define _CCCL_TARGET_provides(_SM_VER)   0
+#  endif
+#  define _CCCL_TARGET_any_target 1
+#  define _CCCL_TARGET_no_target  0
+
+#  define _CCCL_TARGET_CONTINUE(_CAN_EXPAND, _OP, ...) _OP(_CAN_EXPAND, __VA_ARGS__)
+
+#  define _CCCL_TARGET_CONTINUE_0(_OP, ...) _CCCL_TARGET_CONTINUE(0, _CCCL_##_OP##_TARGET, __VA_ARGS__)
+#  define _CCCL_TARGET_CONTINUE_1(_OP, ...) _CCCL_TARGET_CONTINUE(1, _CCCL_##_OP##_TARGET, __VA_ARGS__)
+
+// bitfield: 1. can expand, 2. condition, 3. should continue expansion
+#  define _CCCL_TARGET_EXPAND_IF_0_0_0(...)
+#  define _CCCL_TARGET_EXPAND_IF_0_1_0(...)
+#  define _CCCL_TARGET_EXPAND_IF_1_0_0(...)
+#  define _CCCL_TARGET_EXPAND_IF_1_1_0(...) {__VA_ARGS__}
+#  define _CCCL_TARGET_EXPAND_IF_0_0_1(...) _CCCL_TARGET_CONTINUE_0
+#  define _CCCL_TARGET_EXPAND_IF_0_1_1(...) _CCCL_TARGET_CONTINUE_0
+#  define _CCCL_TARGET_EXPAND_IF_1_0_1(...) _CCCL_TARGET_CONTINUE_1
+#  define _CCCL_TARGET_EXPAND_IF_1_1_1(...) {__VA_ARGS__} _CCCL_TARGET_CONTINUE_0
+
+#  define _CCCL_TARGET_EVAL_IMPL(_CAN_EXPAND, _COND, _CONTINUE) \
+    _CCCL_TARGET_EXPAND_IF_##_CAN_EXPAND##_##_COND##_##_CONTINUE
+#  define _CCCL_TARGET_EVAL(_CAN_EXPAND, _COND, _CONTINUE) _CCCL_TARGET_EVAL_IMPL(_CAN_EXPAND, _COND, _CONTINUE)
+
+#  define _CCCL_IF_TARGET(_COND)                _CCCL_TARGET_EVAL(1, _CCCL_TARGET_##_COND, 1)
+#  define _CCCL_elif_TARGET(_CAN_EXPAND, _COND) _CCCL_TARGET_EVAL(_CAN_EXPAND, _CCCL_TARGET_##_COND, 1)
+#  define _CCCL_else_TARGET(_CAN_EXPAND, _COND) _CCCL_TARGET_EVAL(_CAN_EXPAND, 1, 0)
+#  define _CCCL_endif_TARGET(_CAN_EXPAND, _COND)
+#endif
+
+#endif // __CCCL_TARGET_H


### PR DESCRIPTION
This attempt addresses the feedback I got in #5750

This time the preprocessor is used to remove the target code that is currently not being compiled (with exception of nvc++ CUDA compilation).

But that means that the code got much more ugly and clang-format hates me. The implementation is quite simple.

Any ideas how to improve as well as any feedback this are welcomed :)