### PR TITLE
[cub/grid] fix documentation typo in `grid_even_share.cuh`

### DIFF
--- a/cub/cub/grid/grid_even_share.cuh
+++ b/cub/cub/grid/grid_even_share.cuh
@@ -116,7 +116,7 @@ public:
   {}
 
   /**
-   * @brief Dispatch initializer. To be called prior prior to kernel launch.
+   * @brief Dispatch initializer. To be called prior to kernel launch.
    *
    * @param num_items_
    *   Total number of input items


### PR DESCRIPTION
## Description

Fix duplicate "prior" in documentation for `DispatchInit`'s `@brief` section.

