### PR TITLE
Skip ptx-json tests for clang-cuda

### DIFF
--- a/cub/cub/detail/ptx-json/json.h
+++ b/cub/cub/detail/ptx-json/json.h
@@ -47,9 +47,10 @@ struct tagged_json<T, cuda::std::index_sequence<Is...>>
   template <typename V, typename = cuda::std::enable_if_t<is_object<V>::value || is_array<V>::value>>
   __noinline__ __device__ void operator=(V)
   {
-    asm volatile("cccl.ptx_json.begin(%0)\n\n" ::"C"(storage_helper<T.str[Is]...>::value) : "memory");
+    static constexpr char str[]{T.str[Is]...};
+    asm volatile("cccl.ptx_json.begin(%0)\n\n" ::"C"(str) : "memory");
     V::emit();
-    asm volatile("\ncccl.ptx_json.end(%0)" ::"C"(storage_helper<T.str[Is]...>::value) : "memory");
+    asm volatile("\ncccl.ptx_json.end(%0)" ::"C"(str) : "memory");
   }
 };
 

--- a/cub/cub/detail/ptx-json/string.h
+++ b/cub/cub/detail/ptx-json/string.h
@@ -50,22 +50,4 @@ __forceinline__ __device__ void comma()
 {
   asm volatile("," ::: "memory");
 }
-
-#pragma nv_diag_suppress 177
-template <char... Cs>
-struct storage_helper
-{
-  // This, and the dance to invoke this through value_traits elsewhere, is necessary because the "C" inline assembly
-  // constraint supported by NVCC requires that its argument is a pointer to a constant array of type char; NVCC also
-  // doesn't allow passing raw character literals as pointer template arguments; and *also* it seems to look at the type
-  // of a containing object, not a subobject it is given, when passed in a pointer to an array inside a literal type.
-  // All of this means that we can't just pass strings, and *also* we can't just use the string<N>::array member above
-  // as the string literal; therefore, using the fact that the length of the string is a core constant expression in the
-  // definition of value_traits, we can generate a variadic pack that allows us to expand the contents of
-  // string<N>::array into a comma separated list of N chars. We can then plug that in as template arguments to
-  // storage_helper, which then can, as below, turn that into its own char array that NVCC accepts as an argument for a
-  // "C" inline assembly constraint.
-  static const constexpr char value[] = {Cs...};
-};
-#pragma nv_diag_default 177
 } // namespace ptx_json

--- a/cub/cub/detail/ptx-json/value.h
+++ b/cub/cub/detail/ptx-json/value.h
@@ -86,8 +86,8 @@ struct value<V, cuda::std::index_sequence<Is...>>
 #pragma nv_diag_default 842
   __forceinline__ __device__ static void emit()
   {
-    // See the definition of storage_helper for why laundering the string through it is necessary.
-    asm volatile("\"%0\"" ::"C"(storage_helper<V.str[Is]...>::value) : "memory");
+    static constexpr char str[]{V.str[Is]...};
+    asm volatile("\"%0\"" ::"C"(str) : "memory");
   }
 };
 }; // namespace ptx_json

--- a/cub/test/ptx-json/CMakeLists.txt
+++ b/cub/test/ptx-json/CMakeLists.txt
@@ -3,6 +3,11 @@ if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   return()
 endif()
 
+if ("${CMAKE_CUDA_COMPILER_ID}" STREQUAL "Clang")
+  message(STATUS "Skipping ptx-json tests for clang-cuda.")
+  return()
+endif()
+
 set(is_20_available FALSE)
 foreach(cub_target IN LISTS CUB_TARGETS)
   cub_get_target_property(dialect ${cub_target} DIALECT)


### PR DESCRIPTION
This PR skips the ptx-json tests for `clang-cuda`.

`clang-cuda` doesn't implement the `"C"` inline PTX constraint and it causes clang 20 to fail the compilation. Even `nvcc` and `nvrtc` support it only since 12.5.

On top of that I remove the need `storage_helper` type which is not needed.