### PR TITLE
Fix grammar in doc comment for TilePrefixCallbackOp

### DIFF
--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -1179,13 +1179,13 @@ struct ReduceByKeyScanTileState<ValueT, KeyT, true>
 #endif // _CCCL_DOXYGEN_INVOKED
 
 /******************************************************************************
- * Prefix call-back operator for coupling local block scan within a
+ * Prefix callback operator for coupling local block scan within a
  * block-cooperative scan
  ******************************************************************************/
 
 /**
- * Stateful block-scan prefix functor.  Provides the the running prefix for
- * the current tile by using the call-back warp to wait on on
+ * Stateful block-scan prefix functor.  Provides the running prefix for
+ * the current tile by using the callback warp to wait for
  * aggregates/prefixes from predecessor tiles to become available.
  *
  * @tparam DelayConstructorT


### PR DESCRIPTION
## Description

Fix grammar in doc comment for `cub::TilePrefixCallbackOp`.

<img width="1449" height="566" alt="image" src="https://github.com/user-attachments/assets/20c87bad-5cac-4260-8c77-a3bf33c253fa" />


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
