### PR TITLE
fix issue in concepts macros where `noexcept(t)` became `{noexcept(t)} noexcept`

### DIFF
--- a/libcudacxx/include/cuda/std/__concepts/concept_macros.h
+++ b/libcudacxx/include/cuda/std/__concepts/concept_macros.h
@@ -202,7 +202,7 @@ namespace __cccl_unqualified_cuda_std = ::cuda::std; // NOLINT(misc-unused-alias
 // The following macros handle the various special forms of requirements:
 #  define _CCCL_CONCEPT_REQUIREMENT_CASE_DEFAULT(_REQ)  _REQ
 #  define _CCCL_CONCEPT_REQUIREMENT_CASE_REQUIRES(_REQ) requires _CCCL_CONCEPT_EAT_REQUIRES_(_REQ)
-#  define _CCCL_CONCEPT_REQUIREMENT_CASE_NOEXCEPT(_REQ) _CCCL_PP_EXPAND({ _REQ } noexcept)
+#  define _CCCL_CONCEPT_REQUIREMENT_CASE_NOEXCEPT(_REQ) _CCCL_PP_EXPAND({ _CCCL_CONCEPT_EAT_NOEXCEPT_(_REQ) } noexcept)
 #  define _CCCL_CONCEPT_REQUIREMENT_CASE_TYPENAME(_REQ) \
     _CCCL_CONCEPT_TRY_ADD_TYPENAME_(_CCCL_CONCEPT_EAT_TYPENAME_(_REQ))
 #  define _CCCL_CONCEPT_REQUIREMENT_CASE_SAME_AS(_REQ) \


### PR DESCRIPTION
## Description

#5817 tidied up the concept macros but also introduced a subtle bug. in c++20, the following:

```c++
template <class T>
_CCCL_CONCEPT Fooable = _CCCL_REQUIRES_EXPR((T), T t)( noexcept(t.foo()) );
```

erroneously expands to:

```c++
template <class T>
concept Fooable = requires { {noexcept(t.foo())} noexcept; };
```

whereas it should become:

```c++
template <class T>
concept Fooable = requires { {t.foo()} noexcept; };
```

this PR corrects the error.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
