### PR TITLE
Redacted some comments in util_type CUDA header file for clarity

### DIFF
--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -150,10 +150,8 @@ struct Log2<N, 0, COUNT>
 {
   enum
   {
-    VALUE = (1 << (COUNT - 1) < N) ? // Base case
-              COUNT
-                                   : COUNT - 1
-  };
+    VALUE = (1 << (COUNT - 1) < N) ? COUNT : COUNT - 1
+  }; // Base case
 };
 
 #  endif // _CCCL_DOXYGEN_INVOKED

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -414,19 +414,19 @@ struct UnitWord
       (sizeof(T) % sizeof(Unit) == 0) && (int(ALIGN_BYTES) % int(UNIT_ALIGN_BYTES) == 0);
   };
 
-  /// Biggest shuffle word that T is a whole multiple of and is not larger than the alignment of T
+  /// Largest shuffle word such that sizeof(T) % sizeof(W) == 0 and alignof(W) <= alignof(T)
   using ShuffleWord =
     ::cuda::std::_If<IsMultiple<int>::IS_MULTIPLE,
                      unsigned int,
                      ::cuda::std::_If<IsMultiple<short>::IS_MULTIPLE, unsigned short, unsigned char>>;
 
-  /// Biggest volatile word that T is a whole multiple of and is not larger than the alignment of T
+  /// Largest volatile word such that sizeof(T) % sizeof(W) == 0 and alignof(W) <= alignof(T)
   using VolatileWord = ::cuda::std::_If<IsMultiple<long long>::IS_MULTIPLE, unsigned long long, ShuffleWord>;
 
-  /// Biggest memory-access word that T is a whole multiple of and is not larger than the alignment of T
+  /// Largest memory-access word such that sizeof(T) % sizeof(W) == 0 and alignof(W) <= alignof(T)
   using DeviceWord = ::cuda::std::_If<IsMultiple<longlong2>::IS_MULTIPLE, ulonglong2, VolatileWord>;
 
-  /// Biggest texture reference word that T is a whole multiple of and is not larger than the alignment of T
+  /// Biggest texture reference word such that sizeof(T) % sizeof(W) == 0 and alignof(W) <= alignof(T)
   using TextureWord = ::cuda::std::
     _If<IsMultiple<int4>::IS_MULTIPLE, uint4, ::cuda::std::_If<IsMultiple<int2>::IS_MULTIPLE, uint2, ShuffleWord>>;
 };
@@ -668,7 +668,7 @@ CUB_DEFINE_VECTOR_TYPE(bool,               uchar)
 template <typename T>
 struct Uninitialized
 {
-  /// Biggest memory-access word that T is a whole multiple of and is not larger than the alignment of T
+  /// Largest memory-access word such that sizeof(T) % sizeof(W) == 0 and alignof(W) <= alignof(T)
   using DeviceWord = typename UnitWord<T>::DeviceWord;
 
   static constexpr ::cuda::std::size_t DATA_SIZE = sizeof(T);


### PR DESCRIPTION
## Description

Improved some comments in `util_type.cuh` for future code readers:

1. Unpacked description for typenames of different kinds of words defined by `UnitWord<T>` struct.
2. Move comment stating that a specialziation of `Log2` is the base case of recursive definition to allow for nice formatting of enum value defined in that specialization.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
