### PR TITLE
Inherit `thrust::transform_iterator` traversal from base iterator traversal

### DIFF
--- a/thrust/testing/catch2_test_iterator_traits.cu
+++ b/thrust/testing/catch2_test_iterator_traits.cu
@@ -99,6 +99,10 @@ struct thrust_make_zip_iterator
   }
 };
 
+template <typename Iterator>
+inline constexpr bool has_random_access_traversal =
+  cuda::std::is_same_v<thrust::iterator_traversal_t<Iterator>, thrust::random_access_traversal_tag>;
+
 using cuda::std::__type_cartesian_product;
 using cuda::std::__type_list;
 
@@ -106,7 +110,7 @@ using make_counting_t  = __type_list<cuda_make_counting_iterator, thrust_make_co
 using make_transform_t = __type_list<cuda_make_transform_iterator, thrust_make_transform_iterator>;
 using make_zip_t       = __type_list<cuda_make_zip_iterator, thrust_make_zip_iterator>;
 using make_it_t        = __type_cartesian_product<make_counting_t, make_transform_t, make_zip_t>;
-TEMPLATE_LIST_TEST_CASE("iterator system propagation - any system", "[iterators]", make_it_t)
+TEMPLATE_LIST_TEST_CASE("iterator system and traversal propagation - any system", "[iterators]", make_it_t)
 {
   using namespace cuda::std;
   __type_at_c<0, TestType> make_counting_iterator;
@@ -115,12 +119,15 @@ TEMPLATE_LIST_TEST_CASE("iterator system propagation - any system", "[iterators]
 
   auto counting_it = make_counting_iterator(0);
   STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(counting_it)>, thrust::any_system_tag>);
+  STATIC_REQUIRE(has_random_access_traversal<decltype(counting_it)>);
 
   auto transform_it = make_transform_iterator(counting_it, thrust::square<>{});
   STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(transform_it)>, thrust::any_system_tag>);
+  STATIC_REQUIRE(has_random_access_traversal<decltype(transform_it)>);
 
   [[maybe_unused]] auto zip_it = make_zip_iterator(counting_it, transform_it);
   STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(zip_it)>, thrust::any_system_tag>);
+  STATIC_REQUIRE(has_random_access_traversal<decltype(zip_it)>);
 }
 
 auto expected_tag(thrust::device_vector<int>) -> thrust::device_system_tag;
@@ -129,7 +136,7 @@ auto expected_tag(std::vector<int>) -> thrust::host_system_tag;
 
 using vectors           = __type_list<thrust::device_vector<int>, thrust::host_vector<int>, std::vector<int>>;
 using make_vec_and_it_t = __type_cartesian_product<vectors, make_transform_t, make_zip_t>;
-TEMPLATE_LIST_TEST_CASE("iterator system propagation - vectors", "[iterators]", make_vec_and_it_t)
+TEMPLATE_LIST_TEST_CASE("iterator system and traversal propagation - vectors", "[iterators]", make_vec_and_it_t)
 {
   using namespace cuda::std;
   __type_at_c<0, TestType> vec{};
@@ -140,17 +147,21 @@ TEMPLATE_LIST_TEST_CASE("iterator system propagation - vectors", "[iterators]", 
 
   auto vec_it = vec.begin();
   STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(vec_it)>, tag>);
+  STATIC_REQUIRE(has_random_access_traversal<decltype(vec_it)>);
 
   using thrust::placeholders::_1;
   auto transform_it = make_transform_iterator(vec_it, _1 + 1);
   STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(transform_it)>, tag>);
+  STATIC_REQUIRE(has_random_access_traversal<decltype(transform_it)>);
 
   [[maybe_unused]] auto zip_it = make_zip_iterator(vec_it, transform_it);
   STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(zip_it)>, tag>);
+  STATIC_REQUIRE(has_random_access_traversal<decltype(zip_it)>);
 }
 
 using make_vec_count_zip_it_t = __type_cartesian_product<vectors, make_counting_t, make_zip_t>;
-TEMPLATE_LIST_TEST_CASE("iterator system propagation - vectors and any system", "[iterators]", make_vec_count_zip_it_t)
+TEMPLATE_LIST_TEST_CASE(
+  "iterator system and traversal propagation - vectors and any system", "[iterators]", make_vec_count_zip_it_t)
 {
   using namespace cuda::std;
   __type_at_c<0, TestType> vec{};
@@ -161,10 +172,13 @@ TEMPLATE_LIST_TEST_CASE("iterator system propagation - vectors and any system", 
 
   auto vec_it = vec.begin();
   STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(vec_it)>, vec_tag>);
+  STATIC_REQUIRE(has_random_access_traversal<decltype(vec_it)>);
 
   auto counting_it = make_counting_iterator(0);
   STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(counting_it)>, thrust::any_system_tag>);
+  STATIC_REQUIRE(has_random_access_traversal<decltype(counting_it)>);
 
   [[maybe_unused]] auto zip_it = make_zip_iterator(vec_it, counting_it);
   STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(zip_it)>, vec_tag>);
+  STATIC_REQUIRE(has_random_access_traversal<decltype(zip_it)>);
 }

--- a/thrust/testing/catch2_test_iterator_traits.cu
+++ b/thrust/testing/catch2_test_iterator_traits.cu
@@ -4,6 +4,8 @@
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
 
+#include <vector>
+
 #include "catch2_test_helper.h"
 
 template <typename Cat, typename Tag>
@@ -43,53 +45,126 @@ TEST_CASE("iterator_category_to_traversal", "[iterators]")
   STATIC_REQUIRE(traversal_is<thrust::random_access_host_iterator_tag, thrust::random_access_traversal_tag>);
 }
 
-TEST_CASE("iterator system propagation - any system", "[iterators]")
+struct cuda_make_counting_iterator
 {
-  [[maybe_unused]] auto counting_it = thrust::make_counting_iterator(0);
+  template <typename... Args>
+  auto operator()(Args&&... args) const
+  {
+    return cuda::make_counting_iterator(cuda::std::forward<Args>(args)...);
+  }
+};
+
+struct cuda_make_transform_iterator
+{
+  template <typename... Args>
+  auto operator()(Args&&... args) const
+  {
+    return cuda::make_transform_iterator(cuda::std::forward<Args>(args)...);
+  }
+};
+
+struct cuda_make_zip_iterator
+{
+  template <typename... Args>
+  auto operator()(Args&&... args) const
+  {
+    return cuda::make_zip_iterator(cuda::std::forward<Args>(args)...);
+  }
+};
+
+struct thrust_make_counting_iterator
+{
+  template <typename... Args>
+  auto operator()(Args&&... args) const
+  {
+    return thrust::make_counting_iterator(cuda::std::forward<Args>(args)...);
+  }
+};
+
+struct thrust_make_transform_iterator
+{
+  template <typename... Args>
+  auto operator()(Args&&... args) const
+  {
+    return thrust::make_transform_iterator(cuda::std::forward<Args>(args)...);
+  }
+};
+
+struct thrust_make_zip_iterator
+{
+  template <typename... Args>
+  auto operator()(Args&&... args) const
+  {
+    return thrust::make_zip_iterator(cuda::std::forward<Args>(args)...);
+  }
+};
+
+using cuda::std::__type_cartesian_product;
+using cuda::std::__type_list;
+
+using make_counting_t  = __type_list<cuda_make_counting_iterator, thrust_make_counting_iterator>;
+using make_transform_t = __type_list<cuda_make_transform_iterator, thrust_make_transform_iterator>;
+using make_zip_t       = __type_list<cuda_make_zip_iterator, thrust_make_zip_iterator>;
+using make_it_t        = __type_cartesian_product<make_counting_t, make_transform_t, make_zip_t>;
+TEMPLATE_LIST_TEST_CASE("iterator system propagation - any system", "[iterators]", make_it_t)
+{
+  using namespace cuda::std;
+  __type_at_c<0, TestType> make_counting_iterator;
+  __type_at_c<1, TestType> make_transform_iterator;
+  __type_at_c<2, TestType> make_zip_iterator;
+
+  auto counting_it = make_counting_iterator(0);
+  STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(counting_it)>, thrust::any_system_tag>);
+
+  auto transform_it = make_transform_iterator(counting_it, thrust::square<>{});
+  STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(transform_it)>, thrust::any_system_tag>);
+
+  [[maybe_unused]] auto zip_it = make_zip_iterator(counting_it, transform_it);
+  STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(zip_it)>, thrust::any_system_tag>);
+}
+
+auto expected_tag(thrust::device_vector<int>) -> thrust::device_system_tag;
+auto expected_tag(thrust::host_vector<int>) -> thrust::host_system_tag;
+auto expected_tag(std::vector<int>) -> thrust::host_system_tag;
+
+using vectors           = __type_list<thrust::device_vector<int>, thrust::host_vector<int>, std::vector<int>>;
+using make_vec_and_it_t = __type_cartesian_product<vectors, make_transform_t, make_zip_t>;
+TEMPLATE_LIST_TEST_CASE("iterator system propagation - vectors", "[iterators]", make_vec_and_it_t)
+{
+  using namespace cuda::std;
+  __type_at_c<0, TestType> vec{};
+  __type_at_c<1, TestType> make_transform_iterator;
+  __type_at_c<2, TestType> make_zip_iterator;
+
+  using tag = decltype(expected_tag(vec));
+
+  auto vec_it = vec.begin();
+  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(vec_it)>, tag>);
+
+  using thrust::placeholders::_1;
+  auto transform_it = make_transform_iterator(vec_it, _1 + 1);
+  STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(transform_it)>, tag>);
+
+  [[maybe_unused]] auto zip_it = make_zip_iterator(vec_it, transform_it);
+  STATIC_REQUIRE(is_same_v<thrust::iterator_system_t<decltype(zip_it)>, tag>);
+}
+
+using make_vec_count_zip_it_t = __type_cartesian_product<vectors, make_counting_t, make_zip_t>;
+TEMPLATE_LIST_TEST_CASE("iterator system propagation - vectors and any system", "[iterators]", make_vec_count_zip_it_t)
+{
+  using namespace cuda::std;
+  __type_at_c<0, TestType> vec{};
+  __type_at_c<1, TestType> make_counting_iterator;
+  __type_at_c<2, TestType> make_zip_iterator;
+
+  using vec_tag = decltype(expected_tag(vec));
+
+  auto vec_it = vec.begin();
+  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(vec_it)>, vec_tag>);
+
+  auto counting_it = make_counting_iterator(0);
   STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(counting_it)>, thrust::any_system_tag>);
 
-  [[maybe_unused]] auto transform_it = thrust::make_transform_iterator(counting_it, thrust::square<>{});
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(transform_it)>, thrust::any_system_tag>);
-
-  [[maybe_unused]] auto zip_it = thrust::make_zip_iterator(counting_it, transform_it);
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(zip_it)>, thrust::any_system_tag>);
-}
-
-TEST_CASE("iterator system propagation - host system", "[iterators]")
-{
-  [[maybe_unused]] auto h_vec    = thrust::host_vector<int>{};
-  [[maybe_unused]] auto h_vec_it = h_vec.begin();
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(h_vec_it)>, thrust::host_system_tag>);
-
-  [[maybe_unused]] auto transform_it = thrust::make_transform_iterator(h_vec_it, thrust::square<>{});
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(transform_it)>, thrust::host_system_tag>);
-
-  [[maybe_unused]] auto zip_it = thrust::make_zip_iterator(h_vec_it, transform_it);
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(zip_it)>, thrust::host_system_tag>);
-}
-
-TEST_CASE("iterator system propagation - device system", "[iterators]")
-{
-  [[maybe_unused]] auto d_vec    = thrust::device_vector<int>{};
-  [[maybe_unused]] auto d_vec_it = d_vec.begin();
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(d_vec_it)>, thrust::device_system_tag>);
-
-  [[maybe_unused]] auto transform_it = thrust::make_transform_iterator(d_vec_it, thrust::square<>{});
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(transform_it)>, thrust::device_system_tag>);
-
-  [[maybe_unused]] auto zip_it = thrust::make_zip_iterator(d_vec_it, transform_it);
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(zip_it)>, thrust::device_system_tag>);
-}
-
-TEST_CASE("iterator system propagation - any and device system", "[iterators]")
-{
-  [[maybe_unused]] auto d_vec    = thrust::device_vector<int>{};
-  [[maybe_unused]] auto d_vec_it = d_vec.begin();
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(d_vec_it)>, thrust::device_system_tag>);
-
-  [[maybe_unused]] auto counting_it = thrust::make_counting_iterator(0);
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(counting_it)>, thrust::any_system_tag>);
-
-  [[maybe_unused]] auto zip_it = thrust::make_zip_iterator(d_vec_it, counting_it);
-  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(zip_it)>, thrust::device_system_tag>);
+  [[maybe_unused]] auto zip_it = make_zip_iterator(vec_it, counting_it);
+  STATIC_REQUIRE(cuda::std::is_same_v<thrust::iterator_system_t<decltype(zip_it)>, vec_tag>);
 }

--- a/thrust/thrust/iterator/transform_iterator.h
+++ b/thrust/thrust/iterator/transform_iterator.h
@@ -93,8 +93,8 @@ public:
     iterator_adaptor<transform_iterator<UnaryFunc, Iterator, Reference, Value>,
                      Iterator,
                      value_type,
-                     use_default,
-                     typename ::cuda::std::iterator_traits<Iterator>::iterator_category,
+                     use_default, // pick system from Iterator
+                     use_default, // pick traversal from Iterator
                      reference>;
 };
 


### PR DESCRIPTION
Instead of from the base iterator's iterator category.

- [x] Merge before: #5880

Fixes: #5860