### PR TITLE
Work around `submdspan` compiler issue on MSVC

### DIFF
--- a/libcudacxx/include/cuda/std/__mdspan/concepts.h
+++ b/libcudacxx/include/cuda/std/__mdspan/concepts.h
@@ -118,6 +118,12 @@ _CCCL_CONCEPT __all_convertible_to_index_type =
   (is_convertible_v<_Indices, _IndexType> && ... && true)
   && (is_nothrow_constructible_v<_IndexType, _Indices> && ... && true);
 
+template <class _Extent, size_t _Size>
+static constexpr bool __matches_dynamic_rank = (_Size == _Extent::rank_dynamic());
+
+template <class _Extent, size_t _Size>
+static constexpr bool __matches_static_rank = (_Size == _Extent::rank()) && (_Size != _Extent::rank_dynamic());
+
 } // namespace __mdspan_detail
 
 template <class _Tp, class _IndexType>

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -96,8 +96,8 @@ public:
   using data_handle_type = typename accessor_type::data_handle_type;
   using reference        = typename accessor_type::reference;
   using __base           = __mdspan_ebco<typename accessor_type::data_handle_type,
-                                         typename _LayoutPolicy::template mapping<_Extents>,
-                                         _AccessorPolicy>;
+                               typename _LayoutPolicy::template mapping<_Extents>,
+                               _AccessorPolicy>;
 
   [[nodiscard]] _CCCL_API static constexpr rank_type rank() noexcept
   {
@@ -136,17 +136,11 @@ public:
   _CCCL_HIDE_FROM_ABI constexpr mdspan(const mdspan&) = default;
   _CCCL_HIDE_FROM_ABI constexpr mdspan(mdspan&&)      = default;
 
-  template <size_t _Size>
-  static constexpr bool __matches_dynamic_rank = (_Size == extents_type::rank_dynamic());
-
-  template <size_t _Size>
-  static constexpr bool __matches_static_rank =
-    (_Size == extents_type::rank()) && (_Size != extents_type::rank_dynamic());
-
   template <class... _OtherIndexTypes>
   static constexpr bool __can_construct_from_handle_and_variadic =
-    (__matches_dynamic_rank<sizeof...(_OtherIndexTypes)> || __matches_static_rank<sizeof...(_OtherIndexTypes)>)
-    && __mdspan_detail::__all_convertible_to_index_type<index_type, _OtherIndexTypes...>
+    (__mdspan_detail::__matches_dynamic_rank<extents_type, sizeof...(_OtherIndexTypes)>
+     || __mdspan_detail::__matches_static_rank<extents_type, sizeof...(_OtherIndexTypes)>) &&__mdspan_detail::
+      __all_convertible_to_index_type<index_type, _OtherIndexTypes...>
     && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>;
 
   _CCCL_TEMPLATE(class... _OtherIndexTypes)
@@ -162,25 +156,29 @@ public:
     && is_default_constructible_v<accessor_type>;
 
   _CCCL_TEMPLATE(class _OtherIndexType, size_t _Size)
-  _CCCL_REQUIRES(__matches_dynamic_rank<_Size> _CCCL_AND __is_constructible_from_index_type<_OtherIndexType>)
+  _CCCL_REQUIRES(__mdspan_detail::__matches_dynamic_rank<extents_type, _Size> _CCCL_AND
+                   __is_constructible_from_index_type<_OtherIndexType>)
   _CCCL_API constexpr mdspan(data_handle_type __p, const array<_OtherIndexType, _Size>& __exts)
       : __base(::cuda::std::move(__p), extents_type{__exts})
   {}
 
   _CCCL_TEMPLATE(class _OtherIndexType, size_t _Size)
-  _CCCL_REQUIRES(__matches_static_rank<_Size> _CCCL_AND __is_constructible_from_index_type<_OtherIndexType>)
+  _CCCL_REQUIRES(__mdspan_detail::__matches_static_rank<extents_type, _Size> _CCCL_AND
+                   __is_constructible_from_index_type<_OtherIndexType>)
   _CCCL_API explicit constexpr mdspan(data_handle_type __p, const array<_OtherIndexType, _Size>& __exts)
       : __base(::cuda::std::move(__p), extents_type{__exts})
   {}
 
   _CCCL_TEMPLATE(class _OtherIndexType, size_t _Size)
-  _CCCL_REQUIRES(__matches_dynamic_rank<_Size> _CCCL_AND __is_constructible_from_index_type<_OtherIndexType>)
+  _CCCL_REQUIRES(__mdspan_detail::__matches_dynamic_rank<extents_type, _Size> _CCCL_AND
+                   __is_constructible_from_index_type<_OtherIndexType>)
   _CCCL_API constexpr mdspan(data_handle_type __p, span<_OtherIndexType, _Size> __exts)
       : __base(::cuda::std::move(__p), extents_type{__exts})
   {}
 
   _CCCL_TEMPLATE(class _OtherIndexType, size_t _Size)
-  _CCCL_REQUIRES(__matches_static_rank<_Size> _CCCL_AND __is_constructible_from_index_type<_OtherIndexType>)
+  _CCCL_REQUIRES(__mdspan_detail::__matches_static_rank<extents_type, _Size> _CCCL_AND
+                   __is_constructible_from_index_type<_OtherIndexType>)
   _CCCL_API explicit constexpr mdspan(data_handle_type __p, span<_OtherIndexType, _Size> __exts)
       : __base(::cuda::std::move(__p), extents_type{__exts})
   {}

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -96,8 +96,8 @@ public:
   using data_handle_type = typename accessor_type::data_handle_type;
   using reference        = typename accessor_type::reference;
   using __base           = __mdspan_ebco<typename accessor_type::data_handle_type,
-                               typename _LayoutPolicy::template mapping<_Extents>,
-                               _AccessorPolicy>;
+                                         typename _LayoutPolicy::template mapping<_Extents>,
+                                         _AccessorPolicy>;
 
   [[nodiscard]] _CCCL_API static constexpr rank_type rank() noexcept
   {
@@ -139,8 +139,8 @@ public:
   template <class... _OtherIndexTypes>
   static constexpr bool __can_construct_from_handle_and_variadic =
     (__mdspan_detail::__matches_dynamic_rank<extents_type, sizeof...(_OtherIndexTypes)>
-     || __mdspan_detail::__matches_static_rank<extents_type, sizeof...(_OtherIndexTypes)>) &&__mdspan_detail::
-      __all_convertible_to_index_type<index_type, _OtherIndexTypes...>
+     || __mdspan_detail::__matches_static_rank<extents_type, sizeof...(_OtherIndexTypes)>)
+    && __mdspan_detail::__all_convertible_to_index_type<index_type, _OtherIndexTypes...>
     && is_constructible_v<mapping_type, extents_type> && is_default_constructible_v<accessor_type>;
 
   _CCCL_TEMPLATE(class... _OtherIndexTypes)

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.submdspan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.submdspan.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// nvbug5272086
-// UNSUPPORTED: msvc
-
 #include <cuda/mdspan>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/deduction.pass.cpp
@@ -47,9 +47,6 @@
 //      -> mdspan<typename AccessorType::element_type, typename MappingType::extents_type,
 //                typename MappingType::layout_type, AccessorType>;
 
-// nvbug5272086
-// UNSUPPORTED: msvc
-
 #include <cuda/std/cassert>
 #include <cuda/std/concepts>
 #include <cuda/std/mdspan>

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_left.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_left.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// nvbug5272086
-// UNSUPPORTED: msvc
-
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_right.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_right.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// nvbug5272086
-// UNSUPPORTED: msvc
-
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;


### PR DESCRIPTION
We were experiencing segfaults with `submdspan` on MSVC

Thanks to some friendly help of the compiler team we have a workaround for those crashes
