### PR TITLE
[Backport 3.1]: Work around `submdspan` compiler issue on MSVC (#5885)

### DIFF
--- a/libcudacxx/include/cuda/std/__mdspan/concepts.h
+++ b/libcudacxx/include/cuda/std/__mdspan/concepts.h
@@ -118,6 +118,12 @@ _CCCL_CONCEPT __all_convertible_to_index_type =
   (_CCCL_TRAIT(is_convertible, _Indices, _IndexType) && ... && true)
   && (_CCCL_TRAIT(is_nothrow_constructible, _IndexType, _Indices) && ... && true);
 
+template <class _Extent, size_t _Size>
+static constexpr bool __matches_dynamic_rank = (_Size == _Extent::rank_dynamic());
+
+template <class _Extent, size_t _Size>
+static constexpr bool __matches_static_rank = (_Size == _Extent::rank()) && (_Size != _Extent::rank_dynamic());
+
 } // namespace __mdspan_detail
 
 template <class _Tp, class _IndexType>

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -141,16 +141,10 @@ public:
   _CCCL_HIDE_FROM_ABI constexpr mdspan(const mdspan&) = default;
   _CCCL_HIDE_FROM_ABI constexpr mdspan(mdspan&&)      = default;
 
-  template <size_t _Size>
-  static constexpr bool __matches_dynamic_rank = (_Size == extents_type::rank_dynamic());
-
-  template <size_t _Size>
-  static constexpr bool __matches_static_rank =
-    (_Size == extents_type::rank()) && (_Size != extents_type::rank_dynamic());
-
   template <class... _OtherIndexTypes>
   static constexpr bool __can_construct_from_handle_and_variadic =
-    (__matches_dynamic_rank<sizeof...(_OtherIndexTypes)> || __matches_static_rank<sizeof...(_OtherIndexTypes)>)
+    (__mdspan_detail::__matches_dynamic_rank<extents_type, sizeof...(_OtherIndexTypes)>
+     || __mdspan_detail::__matches_static_rank<extents_type, sizeof...(_OtherIndexTypes)>)
     && __mdspan_detail::__all_convertible_to_index_type<index_type, _OtherIndexTypes...>
     && _CCCL_TRAIT(is_constructible, mapping_type, extents_type)
     && _CCCL_TRAIT(is_default_constructible, accessor_type);
@@ -169,25 +163,29 @@ public:
     && _CCCL_TRAIT(is_default_constructible, accessor_type);
 
   _CCCL_TEMPLATE(class _OtherIndexType, size_t _Size)
-  _CCCL_REQUIRES(__matches_dynamic_rank<_Size> _CCCL_AND __is_constructible_from_index_type<_OtherIndexType>)
+  _CCCL_REQUIRES(__mdspan_detail::__matches_dynamic_rank<extents_type, _Size> _CCCL_AND
+                   __is_constructible_from_index_type<_OtherIndexType>)
   _CCCL_API constexpr mdspan(data_handle_type __p, const array<_OtherIndexType, _Size>& __exts)
       : __base(_CUDA_VSTD::move(__p), extents_type{__exts})
   {}
 
   _CCCL_TEMPLATE(class _OtherIndexType, size_t _Size)
-  _CCCL_REQUIRES(__matches_static_rank<_Size> _CCCL_AND __is_constructible_from_index_type<_OtherIndexType>)
+  _CCCL_REQUIRES(__mdspan_detail::__matches_static_rank<extents_type, _Size> _CCCL_AND
+                   __is_constructible_from_index_type<_OtherIndexType>)
   _CCCL_API explicit constexpr mdspan(data_handle_type __p, const array<_OtherIndexType, _Size>& __exts)
       : __base(_CUDA_VSTD::move(__p), extents_type{__exts})
   {}
 
   _CCCL_TEMPLATE(class _OtherIndexType, size_t _Size)
-  _CCCL_REQUIRES(__matches_dynamic_rank<_Size> _CCCL_AND __is_constructible_from_index_type<_OtherIndexType>)
+  _CCCL_REQUIRES(__mdspan_detail::__matches_dynamic_rank<extents_type, _Size> _CCCL_AND
+                   __is_constructible_from_index_type<_OtherIndexType>)
   _CCCL_API constexpr mdspan(data_handle_type __p, span<_OtherIndexType, _Size> __exts)
       : __base(_CUDA_VSTD::move(__p), extents_type{__exts})
   {}
 
   _CCCL_TEMPLATE(class _OtherIndexType, size_t _Size)
-  _CCCL_REQUIRES(__matches_static_rank<_Size> _CCCL_AND __is_constructible_from_index_type<_OtherIndexType>)
+  _CCCL_REQUIRES(__mdspan_detail::__matches_static_rank<extents_type, _Size> _CCCL_AND
+                   __is_constructible_from_index_type<_OtherIndexType>)
   _CCCL_API explicit constexpr mdspan(data_handle_type __p, span<_OtherIndexType, _Size> __exts)
       : __base(_CUDA_VSTD::move(__p), extents_type{__exts})
   {}

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.submdspan.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/default_accessor/accessor.submdspan.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// nvbug5272086
-// UNSUPPORTED: nvcc-12.9 && msvc
-
 #include <cuda/mdspan>
 #include <cuda/std/type_traits>
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/deduction.pass.cpp
@@ -47,9 +47,6 @@
 //      -> mdspan<typename AccessorType::element_type, typename MappingType::extents_type,
 //                typename MappingType::layout_type, AccessorType>;
 
-// nvbug5272086
-// UNSUPPORTED: nvcc-12.9 && msvc
-
 #include <cuda/std/cassert>
 #include <cuda/std/concepts>
 #include <cuda/std/mdspan>

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_left.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_left.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// nvbug5272086
-// UNSUPPORTED: nvcc-12.9 && msvc
-
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_right.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/layout_right.pass.cpp
@@ -7,9 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// nvbug5272086
-// UNSUPPORTED: nvcc-12.9 && msvc
-
 // <mdspan>
 
 // constexpr mdspan& operator=(const mdspan& rhs) = default;


### PR DESCRIPTION
We were experiencing segfaults with `submdspan` on MSVC

Thanks to some friendly help of the compiler team we have a workaround for those crashes
