### PR TITLE
[cudax] Implement `kernel_argument` concept

### DIFF
--- a/cudax/include/cuda/experimental/__kernel/concepts.cuh
+++ b/cudax/include/cuda/experimental/__kernel/concepts.cuh
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX___KERNEL_CONCEPTS
+#define _CUDAX___KERNEL_CONCEPTS
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__type_traits/is_trivially_copyable.h>
+#include <cuda/std/__type_traits/is_trivially_destructible.h>
+
+namespace cuda::experimental
+{
+
+//! @brief Concept that checks if a type is a valid kernel argument type.
+//!
+//! @details A valid kernel argument type is one that is trivially copyable and trivially destructible. For more details
+//!          see https://docs.nvidia.com/cuda/cuda-c-programming-guide/#global-function-argument-processing.
+//!
+/// @tparam _Tp The type to check.
+template <class _Tp>
+_CCCL_CONCEPT kernel_argument =
+  ::cuda::std::is_trivially_copyable_v<_Tp> && ::cuda::std::is_trivially_destructible_v<_Tp>;
+
+} // namespace cuda::experimental
+
+#endif // _CUDAX___KERNEL_CONCEPTS

--- a/cudax/include/cuda/experimental/__kernel/kernel_ref.cuh
+++ b/cudax/include/cuda/experimental/__kernel/kernel_ref.cuh
@@ -25,22 +25,20 @@
 #include <cuda/__driver/driver_api.h>
 #include <cuda/__memory/address_space.h>
 #include <cuda/std/__type_traits/always_false.h>
-#include <cuda/std/__type_traits/is_trivially_copyable.h>
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/string_view>
 
-#include <string>
+#include <cuda/experimental/__kernel/concepts.cuh>
+#include <cuda/experimental/__kernel/traits.cuh>
 
 #include <cuda.h>
 
 namespace cuda::experimental
 {
 
-//! @brief A non-owning representation of a CUDA kernel
+//! @brief A non-owning representation of a CUDA kernel.
 //!
-//! @tparam _Signature The signature of the kernel
-//!
-//! @note The return type of the kernel must be `void`
+//! @tparam _Signature The signature of the kernel in the form `void(Args...)` where `Args...` are the argument types.
 template <class _Signature>
 class kernel_ref
 {
@@ -51,8 +49,8 @@ class kernel_ref
 template <class... _Args>
 class kernel_ref<void(_Args...)>
 {
-  static_assert((true && ... && ::cuda::std::is_trivially_copyable_v<_Args>),
-                "All kernel_ref argument types must be trivially copyable.");
+  static_assert((true && ... && (kernel_argument<_Args> || proclaim_kernel_argument_v<_Args>) ),
+                "All kernel_ref argument types must be valid kernel arguments.");
 
 public:
 #if _CCCL_CTK_BELOW(12, 1)

--- a/cudax/include/cuda/experimental/__kernel/traits.cuh
+++ b/cudax/include/cuda/experimental/__kernel/traits.cuh
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX___KERNEL_TRAITS
+#define _CUDAX___KERNEL_TRAITS
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+namespace cuda::experimental
+{
+
+//! @brief A variable that can be specialized to `true` for types that don't satisfy the `kernel_argument` concept
+//!        but should be treated as valid kernel argument types anyway.
+//!
+//! @warning This violates the standard C++ model and can lead to undefined behaviour and hard-to-resolve bugs.
+//!
+//! @tparam _Tp The type to proclaim.
+template <class _Tp>
+inline constexpr bool proclaim_kernel_argument_v = false;
+
+} // namespace cuda::experimental
+
+#endif // _CUDAX___KERNEL_TRAITS

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -36,7 +36,9 @@
 #include <cuda/experimental/__graph/concepts.cuh>
 #include <cuda/experimental/__graph/graph_node_ref.cuh>
 #include <cuda/experimental/__graph/path_builder.cuh>
+#include <cuda/experimental/__kernel/concepts.cuh>
 #include <cuda/experimental/__kernel/kernel_ref.cuh>
+#include <cuda/experimental/__kernel/traits.cuh>
 #include <cuda/experimental/__launch/configuration.cuh>
 #include <cuda/experimental/__stream/device_transform.cuh>
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
@@ -119,8 +121,12 @@ _CCCL_HOST_API void inline __do_launch(
 template <typename... _ExpTypes, typename _Dst, typename _Config>
 _CCCL_HOST_API auto __launch_impl(_Dst&& __dst, _Config __conf, ::CUfunction __kernel, _ExpTypes... __args)
 {
+  static_assert((true && ... && (kernel_argument<_ExpTypes> || proclaim_kernel_argument_v<_ExpTypes>) ),
+                "All launch argument types must be valid kernel arguments.");
+
   static_assert(!::cuda::std::is_same_v<decltype(__conf.dims), no_init_t>,
                 "Can't launch a configuration without hierarchy dimensions");
+
   ::CUlaunchConfig __config{};
   constexpr bool __has_cluster_level        = has_level<cluster_level, decltype(__conf.dims)>;
   constexpr unsigned int __num_attrs_needed = __detail::kernel_config_count_attr_space(__conf) + __has_cluster_level;

--- a/cudax/include/cuda/experimental/kernel.cuh
+++ b/cudax/include/cuda/experimental/kernel.cuh
@@ -12,6 +12,8 @@
 #define __CUDAX_KERNEL__
 
 #include <cuda/experimental/__kernel/attributes.cuh>
+#include <cuda/experimental/__kernel/concepts.cuh>
 #include <cuda/experimental/__kernel/kernel_ref.cuh>
+#include <cuda/experimental/__kernel/traits.cuh>
 
 #endif // __CUDAX_KERNEL__


### PR DESCRIPTION
This PR introduces the `kernel_argument` concept that checks if a type is a valid kernel argument - trivially copyable + trivially destructible as the CUDA programming guide says.

The checks are applied in `kernel_ref` and `launch` and can be overriden by specializing the `proclaim_kernel_argument_v` template variable.