### PR TITLE
Fix template argument order of `cuda::transform_*_iterator`

### DIFF
--- a/libcudacxx/include/cuda/__iterator/transform_input_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_input_output_iterator.h
@@ -48,7 +48,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-template <class _Iter, class _InputFn, class _OutputFn>
+template <class _InputFn, class _OutputFn, class _Iter>
 class __transform_input_output_proxy
 {
 private:
@@ -150,7 +150,7 @@ public:
 //!
 //!  }
 //! @endcode
-template <class _Iter, class _InputFn, class _OutputFn>
+template <class _InputFn, class _OutputFn, class _Iter>
 class transform_input_output_iterator
 {
 public:
@@ -170,7 +170,7 @@ public:
   using difference_type   = ::cuda::std::iter_difference_t<_Iter>;
   using value_type        = ::cuda::std::invoke_result_t<_InputFn&, ::cuda::std::iter_reference_t<_Iter>>;
   using pointer           = void;
-  using reference         = __transform_input_output_proxy<_Iter, _InputFn, _OutputFn>;
+  using reference         = __transform_input_output_proxy<_InputFn, _OutputFn, _Iter>;
 
   static_assert(::cuda::std::is_object_v<_InputFn>,
                 "cuda::transform_input_output_iterator requires that _InputFn is a function object");
@@ -481,11 +481,11 @@ public:
 //! @param __input_fun The input functor used to transform the range when read
 //! @param __output_fun The output functor used to transform the range when written
 //! @relates transform_output_iterator
-template <class _Iter, class _InputFn, class _OutputFn>
+template <class _InputFn, class _OutputFn, class _Iter>
 [[nodiscard]] _CCCL_API constexpr auto
 make_transform_input_output_iterator(_Iter __iter, _InputFn __input_fun, _OutputFn __output_fun)
 {
-  return transform_input_output_iterator<_Iter, _InputFn, _OutputFn>{__iter, __input_fun, __output_fun};
+  return transform_input_output_iterator<_InputFn, _OutputFn, _Iter>{__iter, __input_fun, __output_fun};
 }
 
 //! @}

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -173,6 +173,11 @@ public:
     ::cuda::std::remove_cvref_t<::cuda::std::invoke_result_t<_Fn&, ::cuda::std::iter_reference_t<_Iter>>>;
   using difference_type = ::cuda::std::iter_difference_t<_Iter>;
 
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using pointer   = void;
+  using reference = value_type;
+
   //! @brief Default constructs a @c transform_iterator with a value initialized iterator and functor
 #if _CCCL_HAS_CONCEPTS()
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -54,8 +54,8 @@ template <class, class, class = void>
 struct __transform_iterator_category_base
 {};
 
-template <class _Iter, class _Fn>
-struct __transform_iterator_category_base<_Iter, _Fn, ::cuda::std::enable_if_t<::cuda::std::forward_iterator<_Iter>>>
+template <class _Fn, class _Iter>
+struct __transform_iterator_category_base<_Fn, _Iter, ::cuda::std::enable_if_t<::cuda::std::forward_iterator<_Iter>>>
 {
   using _Cat = typename ::cuda::std::iterator_traits<_Iter>::iterator_category;
 
@@ -148,8 +148,8 @@ inline constexpr bool __transform_iterator_nothrow_subscript<_Fn, _Iter, true> =
 //!   return 0;
 //! }
 //! @endcode
-template <class _Iter, class _Fn>
-class transform_iterator : public __transform_iterator_category_base<_Iter, _Fn>
+template <class _Fn, class _Iter>
+class transform_iterator : public __transform_iterator_category_base<_Fn, _Iter>
 {
   static_assert(::cuda::std::is_object_v<_Fn>, "cuda::transform_iterator requires that _Fn is a functor object");
   static_assert(::cuda::std::regular_invocable<_Fn&, ::cuda::std::iter_reference_t<_Iter>>,
@@ -480,10 +480,10 @@ public:
 //! @param __iter The iterator of the input range
 //! @param __fun The functor used to transform the input range
 //! @relates transform_iterator
-template <class _Iter, class _Fn>
+template <class _Fn, class _Iter>
 [[nodiscard]] _CCCL_API constexpr auto make_transform_iterator(_Iter __iter, _Fn __fun)
 {
-  return transform_iterator<_Iter, _Fn>{__iter, __fun};
+  return transform_iterator<_Fn, _Iter>{__iter, __fun};
 }
 
 //! @}

--- a/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
@@ -51,7 +51,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 //! @addtogroup iterators
 //! @{
 
-template <class _Iter, class _Fn>
+template <class _Fn, class _Iter>
 class __transform_output_proxy
 {
 private:
@@ -138,7 +138,7 @@ public:
 //!
 //! }
 //! @endcode
-template <class _Iter, class _Fn>
+template <class _Fn, class _Iter>
 class transform_output_iterator
 {
   static_assert(::cuda::std::is_object_v<_Fn>,
@@ -439,10 +439,10 @@ public:
 //! @param __iter The iterator of the input range
 //! @param __fun The output function
 //! @relates transform_output_iterator
-template <class _Iter, class _Fn>
+template <class _Fn, class _Iter>
 [[nodiscard]] _CCCL_API constexpr auto make_transform_output_iterator(_Iter __iter, _Fn __fun)
 {
-  return transform_output_iterator<_Iter, _Fn>{__iter, __fun};
+  return transform_output_iterator<_Fn, _Iter>{__iter, __fun};
 }
 
 //! @}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/compare.pass.cpp
@@ -46,7 +46,7 @@ __host__ __device__ constexpr bool test()
   assert(!(iter2 != iter2));
 
 #if TEST_HAS_SPACESHIP()
-  static_assert(cuda::std::three_way_comparable<cuda::transform_input_output_iterator<int>>);
+  static_assert(cuda::std::three_way_comparable<cuda::transform_input_output_iterator<PlusOne, PlusOne, int*>>);
   assert((iter1 <=> iter2) == cuda::std::strong_ordering::less);
   assert((iter1 <=> iter1) == cuda::std::strong_ordering::equal);
   assert((iter2 <=> iter1) == cuda::std::strong_ordering::greater);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/ctor.default.pass.cpp
@@ -20,22 +20,22 @@
 __host__ __device__ constexpr bool test()
 {
   {
-    cuda::transform_input_output_iterator<random_access_iterator<int*>, PlusOne, PlusOne> iter;
+    cuda::transform_input_output_iterator<PlusOne, PlusOne, random_access_iterator<int*>> iter;
     assert(iter.base() == random_access_iterator<int*>{});
   }
 
   {
-    const cuda::transform_input_output_iterator<random_access_iterator<int*>, PlusOne, PlusOne> iter;
+    const cuda::transform_input_output_iterator<PlusOne, PlusOne, random_access_iterator<int*>> iter;
     assert(iter.base() == random_access_iterator<int*>{});
   }
 
   {
     static_assert(
       !cuda::std::is_default_constructible_v<
-        cuda::transform_input_output_iterator<random_access_iterator<int*>, NotDefaultConstructiblePlusOne, PlusOne>>);
+        cuda::transform_input_output_iterator<NotDefaultConstructiblePlusOne, PlusOne, random_access_iterator<int*>>>);
     static_assert(
       !cuda::std::is_default_constructible_v<
-        cuda::transform_input_output_iterator<random_access_iterator<int*>, PlusOne, NotDefaultConstructiblePlusOne>>);
+        cuda::transform_input_output_iterator<PlusOne, NotDefaultConstructiblePlusOne, random_access_iterator<int*>>>);
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/ctor.value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/ctor.value.pass.cpp
@@ -40,7 +40,7 @@ __host__ __device__ constexpr bool test()
 #endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     static_assert(
       cuda::std::is_same_v<decltype(iter),
-                           cuda::transform_input_output_iterator<random_access_iterator<int*>, InputFn, OutputFn>>);
+                           cuda::transform_input_output_iterator<InputFn, OutputFn, random_access_iterator<int*>>>);
   }
 
   { // CTAD
@@ -52,11 +52,11 @@ __host__ __device__ constexpr bool test()
     buffer[2] = 2;
 
     static_assert(noexcept(cuda::transform_input_output_iterator{buffer + 2, input_func, output_func}));
-    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_input_output_iterator<int*, InputFn, OutputFn>>);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_input_output_iterator<InputFn, OutputFn, int*>>);
   }
 
   {
-    cuda::transform_input_output_iterator<random_access_iterator<int*>, InputFn, OutputFn> iter{
+    cuda::transform_input_output_iterator<InputFn, OutputFn, random_access_iterator<int*>> iter{
       random_access_iterator{buffer + 2}, input_func, output_func};
     assert(base(iter.base()) == buffer + 2);
     assert(*iter == input_func(buffer[2]));
@@ -66,20 +66,20 @@ __host__ __device__ constexpr bool test()
 
 #if !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     // The test iterators are not `is_nothrow_move_constructible`
-    static_assert(!noexcept(cuda::transform_input_output_iterator<random_access_iterator<int*>, InputFn, OutputFn>{
+    static_assert(!noexcept(cuda::transform_input_output_iterator<InputFn, OutputFn, random_access_iterator<int*>>{
       random_access_iterator{buffer + 2}, input_func, output_func}));
 #endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
   }
 
   {
-    cuda::transform_input_output_iterator<int*, InputFn, OutputFn> iter{buffer + 2, input_func, output_func};
+    cuda::transform_input_output_iterator<InputFn, OutputFn, int*> iter{buffer + 2, input_func, output_func};
     assert(iter.base() == buffer + 2);
     assert(*iter == input_func(buffer[2]));
     *iter = 3;
     assert(buffer[2] == output_func(3));
 
     static_assert(
-      noexcept(cuda::transform_input_output_iterator<int*, InputFn, OutputFn>{buffer + 2, input_func, output_func}));
+      noexcept(cuda::transform_input_output_iterator<InputFn, OutputFn, int*>{buffer + 2, input_func, output_func}));
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/iterator_traits.compile.pass.cpp
@@ -15,16 +15,16 @@
 
 __host__ __device__ void test()
 {
-  using IterTraits = cuda::std::iterator_traits<cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>>;
+  using IterTraits = cuda::std::iterator_traits<cuda::transform_input_output_iterator<PlusOne, TimesTwo, int*>>;
 
   static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::output_iterator_tag>);
   static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
   static_assert(cuda::std::same_as<IterTraits::value_type, int>);
   static_assert(cuda::std::same_as<IterTraits::pointer, void>);
   static_assert(
-    cuda::std::same_as<IterTraits::reference, cuda::__transform_input_output_proxy<int*, PlusOne, TimesTwo>>);
-  static_assert(cuda::std::input_or_output_iterator<cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>>);
-  static_assert(cuda::std::output_iterator<cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>, int>);
+    cuda::std::same_as<IterTraits::reference, cuda::__transform_input_output_proxy<PlusOne, TimesTwo, int*>>);
+  static_assert(cuda::std::input_or_output_iterator<cuda::transform_input_output_iterator<PlusOne, TimesTwo, int*>>);
+  static_assert(cuda::std::output_iterator<cuda::transform_input_output_iterator<PlusOne, TimesTwo, int*>, int>);
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/member_typedefs.compile.pass.cpp
@@ -21,24 +21,24 @@
 __host__ __device__ void test()
 {
   {
-    using Iter = cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>;
+    using Iter = cuda::transform_input_output_iterator<PlusOne, TimesTwo, int*>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
-    static_assert(cuda::std::same_as<Iter::reference, cuda::__transform_input_output_proxy<int*, PlusOne, TimesTwo>>);
+    static_assert(cuda::std::same_as<Iter::reference, cuda::__transform_input_output_proxy<PlusOne, TimesTwo, int*>>);
     static_assert(cuda::std::same_as<Iter::value_type, int>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::output_iterator<Iter, int>);
   }
 
   {
-    using Iter = cuda::transform_input_output_iterator<random_access_iterator<int*>, PlusOne, TimesTwo>;
+    using Iter = cuda::transform_input_output_iterator<PlusOne, TimesTwo, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
     static_assert(
       cuda::std::same_as<Iter::reference,
-                         cuda::__transform_input_output_proxy<random_access_iterator<int*>, PlusOne, TimesTwo>>);
+                         cuda::__transform_input_output_proxy<PlusOne, TimesTwo, random_access_iterator<int*>>>);
     static_assert(cuda::std::same_as<Iter::value_type, int>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::output_iterator<Iter, int>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/ctor.pass.cpp
@@ -92,10 +92,10 @@ __host__ __device__ constexpr void test(Fn fun)
 
   { // default initialization
     constexpr bool can_default_init = cuda::std::default_initializable<Iter> && cuda::std::default_initializable<Fn>;
-    static_assert(cuda::std::default_initializable<cuda::transform_iterator<Iter, Fn>> == can_default_init);
+    static_assert(cuda::std::default_initializable<cuda::transform_iterator<Fn, Iter>> == can_default_init);
     if constexpr (can_default_init)
     {
-      [[maybe_unused]] cuda::transform_iterator<Iter, Fn> iter{};
+      [[maybe_unused]] cuda::transform_iterator<Fn, Iter> iter{};
     }
   }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.pass.cpp
@@ -1,0 +1,127 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <class Iter, class Fn>
+_CCCL_CONCEPT HasIterCategory =
+  _CCCL_REQUIRES_EXPR((Iter, Fn))(typename(typename cuda::transform_iterator<Fn, Iter>::iterator_category));
+
+template <template <class...> class Traits>
+__host__ __device__ constexpr void test()
+{
+  {
+    using TIter      = cuda::transform_iterator<Increment, int*>;
+    using IterTraits = Traits<TIter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
+  }
+  {
+    // Member typedefs for random access iterator.
+    using TIter      = cuda::transform_iterator<Increment, random_access_iterator<int*>>;
+    using IterTraits = Traits<TIter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
+  }
+  {
+    // Member typedefs for random access iterator, LWG3798 rvalue reference.
+    using TIter      = cuda::transform_iterator<IncrementRvalueRef, random_access_iterator<int*>>;
+    using IterTraits = Traits<TIter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
+  }
+  {
+    // Member typedefs for random access iterator/not-lvalue-ref.
+    using TIter      = cuda::transform_iterator<PlusOneMutable, random_access_iterator<int*>>;
+    using IterTraits = Traits<TIter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
+  }
+  {
+    // Member typedefs for bidirectional iterator.
+    using TIter      = cuda::transform_iterator<Increment, bidirectional_iterator<int*>>;
+    using IterTraits = Traits<TIter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::bidirectional_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::bidirectional_iterator<TIter>);
+  }
+  {
+    // Member typedefs for forward iterator.
+    using TIter      = cuda::transform_iterator<Increment, forward_iterator<int*>>;
+    using IterTraits = Traits<TIter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::forward_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::forward_iterator<TIter>);
+  }
+  {
+    // Member typedefs for input iterator.
+    using TIter      = cuda::transform_iterator<Increment, cpp17_input_iterator<int*>>;
+    using IterTraits = Traits<TIter>;
+    static_assert(!HasIterCategory<cpp17_input_iterator<int*>, Increment>);
+  }
+
+  {
+    // Ensure we can work with other cuda iterators
+    using TIter      = cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>;
+    using IterTraits = Traits<TIter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
+  }
+
+  {
+    // Ensure we can work with other cuda iterators
+    using TIter      = cuda::std::reverse_iterator<cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>>;
+    using IterTraits = Traits<TIter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/make_transform_iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/make_transform_iterator.pass.cpp
@@ -25,7 +25,7 @@ __host__ __device__ constexpr void test()
 
   {
     auto iter = cuda::make_transform_iterator(Iter{buffer}, PlusOne{});
-    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_iterator<Iter, PlusOne>>);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_iterator<PlusOne, Iter>>);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class Iter, class Fn>
 _CCCL_CONCEPT HasIterCategory =
-  _CCCL_REQUIRES_EXPR((Iter, Fn))(typename(typename cuda::transform_iterator<Iter, Fn>::iterator_category));
+  _CCCL_REQUIRES_EXPR((Iter, Fn))(typename(typename cuda::transform_iterator<Fn, Iter>::iterator_category));
 
 __host__ __device__ constexpr bool test()
 {
@@ -29,7 +29,7 @@ __host__ __device__ constexpr bool test()
     static_assert(
       cuda::std::same_as<cuda::std::iterator_traits<int*>::iterator_category, cuda::std::random_access_iterator_tag>);
 
-    using TIter = cuda::transform_iterator<int*, Increment>;
+    using TIter = cuda::transform_iterator<Increment, int*>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -38,7 +38,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for random access iterator.
-    using TIter = cuda::transform_iterator<random_access_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -47,7 +47,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for random access iterator, LWG3798 rvalue reference.
-    using TIter = cuda::transform_iterator<random_access_iterator<int*>, IncrementRvalueRef>;
+    using TIter = cuda::transform_iterator<IncrementRvalueRef, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -56,7 +56,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for random access iterator/not-lvalue-ref.
-    using TIter = cuda::transform_iterator<random_access_iterator<int*>, PlusOneMutable>;
+    using TIter = cuda::transform_iterator<PlusOneMutable, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -65,7 +65,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for bidirectional iterator.
-    using TIter = cuda::transform_iterator<bidirectional_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, bidirectional_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -74,7 +74,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for forward iterator.
-    using TIter = cuda::transform_iterator<forward_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, forward_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -83,7 +83,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for input iterator.
-    using TIter = cuda::transform_iterator<cpp17_input_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, cpp17_input_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::input_iterator_tag>);
     static_assert(!HasIterCategory<cpp17_input_iterator<int*>, Increment>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -93,7 +93,7 @@ __host__ __device__ constexpr bool test()
 
   {
     // Ensure we can work with other cuda iterators
-    using TIter = cuda::transform_iterator<cuda::counting_iterator<int>, TimesTwo>;
+    using TIter = cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -103,7 +103,7 @@ __host__ __device__ constexpr bool test()
 
   {
     // Ensure we can work with other cuda iterators
-    using TIter = cuda::std::reverse_iterator<cuda::transform_iterator<cuda::counting_iterator<int>, TimesTwo>>;
+    using TIter = cuda::std::reverse_iterator<cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/plus_minus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/plus_minus.pass.cpp
@@ -42,8 +42,8 @@ __host__ __device__ constexpr void test()
   }
   else
   {
-    static_assert(!can_plus<cuda::transform_iterator<Iter, PlusOne>>);
-    static_assert(!can_minus<cuda::transform_iterator<Iter, PlusOne>>);
+    static_assert(!can_plus<cuda::transform_iterator<PlusOne, Iter>>);
+    static_assert(!can_minus<cuda::transform_iterator<PlusOne, Iter>>);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/compare.pass.cpp
@@ -46,7 +46,7 @@ __host__ __device__ constexpr bool test()
   assert(!(iter2 != iter2));
 
 #if TEST_HAS_SPACESHIP()
-  static_assert(cuda::std::three_way_comparable<cuda::transform_output_iterator<int>>);
+  static_assert(cuda::std::three_way_comparable<cuda::transform_output_iterator<PlusOne, int*>>);
   assert((iter1 <=> iter2) == cuda::std::strong_ordering::less);
   assert((iter1 <=> iter1) == cuda::std::strong_ordering::equal);
   assert((iter2 <=> iter1) == cuda::std::strong_ordering::greater);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.default.pass.cpp
@@ -20,18 +20,18 @@
 __host__ __device__ constexpr bool test()
 {
   {
-    cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne> iter;
+    cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>> iter;
     assert(iter.base() == random_access_iterator<int*>{});
   }
 
   {
-    const cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne> iter;
+    const cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>> iter;
     assert(iter.base() == random_access_iterator<int*>{});
   }
 
   {
     static_assert(!cuda::std::is_default_constructible_v<
-                  cuda::transform_output_iterator<random_access_iterator<int*>, NotDefaultConstructiblePlusOne>>);
+                  cuda::transform_output_iterator<NotDefaultConstructiblePlusOne, random_access_iterator<int*>>>);
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.value.pass.cpp
@@ -35,7 +35,7 @@ __host__ __device__ constexpr bool test()
     static_assert(!noexcept(cuda::transform_output_iterator{random_access_iterator{buffer + 2}, func}));
 #endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     static_assert(
-      cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<random_access_iterator<int*>, Fn>>);
+      cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<Fn, random_access_iterator<int*>>>);
   }
 
   { // CTAD
@@ -45,11 +45,11 @@ __host__ __device__ constexpr bool test()
     assert(buffer[2] == 3 + 1);
     buffer[2] = 2;
     static_assert(noexcept(cuda::transform_output_iterator{buffer + 2, func}));
-    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<int*, Fn>>);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<Fn, int*>>);
   }
 
   {
-    cuda::transform_output_iterator<random_access_iterator<int*>, Fn> iter{random_access_iterator{buffer + 2}, func};
+    cuda::transform_output_iterator<Fn, random_access_iterator<int*>> iter{random_access_iterator{buffer + 2}, func};
     assert(base(iter.base()) == buffer + 2);
     *iter = 3;
     assert(buffer[2] == 3 + 1);
@@ -57,17 +57,17 @@ __host__ __device__ constexpr bool test()
 #if !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     // The test iterators are not `is_nothrow_move_constructible`
     static_assert(!noexcept(
-      cuda::transform_output_iterator<random_access_iterator<int*>, Fn>{random_access_iterator{buffer + 2}, func}));
+      cuda::transform_output_iterator<Fn, random_access_iterator<int*>>{random_access_iterator{buffer + 2}, func}));
 #endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
   }
 
   {
-    cuda::transform_output_iterator<int*, Fn> iter{buffer + 2, func};
+    cuda::transform_output_iterator<Fn, int*> iter{buffer + 2, func};
     assert(iter.base() == buffer + 2);
     *iter = 3;
     assert(buffer[2] == 3 + 1);
     buffer[2] = 2;
-    static_assert(noexcept(cuda::transform_output_iterator<int*, Fn>{buffer + 2, func}));
+    static_assert(noexcept(cuda::transform_output_iterator<Fn, int*>{buffer + 2, func}));
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/iterator_traits.compile.pass.cpp
@@ -15,15 +15,15 @@
 
 __host__ __device__ void test()
 {
-  using IterTraits = cuda::std::iterator_traits<cuda::transform_output_iterator<int*, PlusOne>>;
+  using IterTraits = cuda::std::iterator_traits<cuda::transform_output_iterator<PlusOne, int*>>;
 
   static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::output_iterator_tag>);
   static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
   static_assert(cuda::std::same_as<IterTraits::value_type, void>);
   static_assert(cuda::std::same_as<IterTraits::pointer, void>);
   static_assert(cuda::std::same_as<IterTraits::reference, void>);
-  static_assert(cuda::std::input_or_output_iterator<cuda::transform_output_iterator<int*, PlusOne>>);
-  static_assert(cuda::std::output_iterator<cuda::transform_output_iterator<int*, PlusOne>, int>);
+  static_assert(cuda::std::input_or_output_iterator<cuda::transform_output_iterator<PlusOne, int*>>);
+  static_assert(cuda::std::output_iterator<cuda::transform_output_iterator<PlusOne, int*>, int>);
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/member_typedefs.compile.pass.cpp
@@ -21,7 +21,7 @@
 __host__ __device__ void test()
 {
   {
-    using Iter = cuda::transform_output_iterator<int*, PlusOne>;
+    using Iter = cuda::transform_output_iterator<PlusOne, int*>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
@@ -32,7 +32,7 @@ __host__ __device__ void test()
   }
 
   {
-    using Iter = cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne>;
+    using Iter = cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);

--- a/thrust/thrust/iterator/iterator_traits.h
+++ b/thrust/thrust/iterator/iterator_traits.h
@@ -283,25 +283,25 @@ struct iterator_traversal<::cuda::tabulate_output_iterator<Fn, Index>>
   using type = random_access_traversal_tag;
 };
 
-template <class Iter, class InputFn, class OutputFn>
-struct iterator_system<::cuda::transform_input_output_iterator<Iter, InputFn, OutputFn>> : iterator_system<Iter>
+template <class InputFn, class OutputFn, class Iter>
+struct iterator_system<::cuda::transform_input_output_iterator<InputFn, OutputFn, Iter>> : iterator_system<Iter>
 {};
-template <class Iter, class InputFn, class OutputFn>
-struct iterator_traversal<::cuda::transform_input_output_iterator<Iter, InputFn, OutputFn>> : iterator_traversal<Iter>
-{};
-
-template <class Iter, class Fn>
-struct iterator_system<::cuda::transform_output_iterator<Iter, Fn>> : iterator_system<Iter>
-{};
-template <class Iter, class Fn>
-struct iterator_traversal<::cuda::transform_output_iterator<Iter, Fn>> : iterator_traversal<Iter>
+template <class InputFn, class OutputFn, class Iter>
+struct iterator_traversal<::cuda::transform_input_output_iterator<InputFn, OutputFn, Iter>> : iterator_traversal<Iter>
 {};
 
-template <class Iter, class Fn>
-struct iterator_system<::cuda::transform_iterator<Iter, Fn>> : iterator_system<Iter>
+template <class Fn, class Iter>
+struct iterator_system<::cuda::transform_output_iterator<Fn, Iter>> : iterator_system<Iter>
 {};
-template <class Iter, class Fn>
-struct iterator_traversal<::cuda::transform_iterator<Iter, Fn>> : iterator_traversal<Iter>
+template <class Fn, class Iter>
+struct iterator_traversal<::cuda::transform_output_iterator<Fn, Iter>> : iterator_traversal<Iter>
+{};
+
+template <class Fn, class Iter>
+struct iterator_system<::cuda::transform_iterator<Fn, Iter>> : iterator_system<Iter>
+{};
+template <class Fn, class Iter>
+struct iterator_traversal<::cuda::transform_iterator<Fn, Iter>> : iterator_traversal<Iter>
 {};
 
 template <class... Iterators>


### PR DESCRIPTION
I swapped the order of the arguments, because that is the common order for standard algorithms.

However, that wil break our transition from `thrust::transform_iterator` becuase users would have to swap arguments actively and not simply change the namespace
