### PR TITLE
Improve interoperability of `cuda` iterators with thrust and std

### DIFF
--- a/libcudacxx/include/cuda/__iterator/constant_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/constant_iterator.h
@@ -73,6 +73,11 @@ public:
   using value_type        = _Tp;
   using difference_type   = ::cuda::std::ptrdiff_t;
 
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using reference = _Tp;
+  using pointer   = void;
+
 #if _CCCL_HAS_CONCEPTS()
   _CCCL_HIDE_FROM_ABI constant_iterator()
     requires ::cuda::std::default_initializable<_Tp>

--- a/libcudacxx/include/cuda/__iterator/counting_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/counting_iterator.h
@@ -178,6 +178,11 @@ public:
   using value_type      = _Start;
   using difference_type = _IotaDiffT<_Start>;
 
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using reference = _Start;
+  using pointer   = void;
+
 #if _CCCL_HAS_CONCEPTS()
   _CCCL_HIDE_FROM_ABI counting_iterator()
     requires ::cuda::std::default_initializable<_Start>

--- a/libcudacxx/include/cuda/__iterator/permutation_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/permutation_iterator.h
@@ -132,11 +132,11 @@ public:
                 "cuda::permutation_iterator: _Indexs value type must be convertible to iter_difference<Iter>");
 
   //! To actually use operator+ we need the index iterator to be random access
-  static_assert(::cuda::std::random_access_iterator<_Index>,
+  static_assert(::cuda::std::__is_cpp17_random_access_iterator<_Index>,
                 "cuda::permutation_iterator: _Index must be a random access iterator!");
 
   //! To actually use operator+ we need the base iterator to be random access
-  static_assert(::cuda::std::random_access_iterator<_Iter>,
+  static_assert(::cuda::std::__is_cpp17_random_access_iterator<_Iter>,
                 "cuda::permutation_iterator: _Iter must be a random access iterator!");
 
   //! @brief Default constructs an @c permutation_iterator with a value initialized iterator and index
@@ -429,7 +429,8 @@ public:
 };
 
 _CCCL_TEMPLATE(class _Iter, class _Index)
-_CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter> _CCCL_AND ::cuda::std::random_access_iterator<_Index>)
+_CCCL_REQUIRES(
+  ::cuda::std::__is_cpp17_random_access_iterator<_Iter> _CCCL_AND ::cuda::std::__is_cpp17_random_access_iterator<_Index>)
 _CCCL_HOST_DEVICE permutation_iterator(_Iter, _Index) -> permutation_iterator<_Iter, _Index>;
 
 //! @brief Creates an @c permutation_iterator from a base iterator and an iterator to an integral index
@@ -437,7 +438,8 @@ _CCCL_HOST_DEVICE permutation_iterator(_Iter, _Index) -> permutation_iterator<_I
 //! @param __index The iterator to an integral index
 //! @relates permutation_iterator
 _CCCL_TEMPLATE(class _Iter, class _Index)
-_CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter> _CCCL_AND ::cuda::std::random_access_iterator<_Index>)
+_CCCL_REQUIRES(
+  ::cuda::std::__is_cpp17_random_access_iterator<_Iter> _CCCL_AND ::cuda::std::__is_cpp17_random_access_iterator<_Index>)
 [[nodiscard]] _CCCL_API constexpr permutation_iterator<_Iter, _Index>
 make_permutation_iterator(_Iter __iter, _Index __index) noexcept(
   ::cuda::std::is_nothrow_copy_constructible_v<_Iter> && ::cuda::std::is_nothrow_copy_constructible_v<_Index>)

--- a/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
@@ -100,6 +100,11 @@ public:
   using value_type        = _IndexType;
   using difference_type   = ::cuda::std::make_signed_t<value_type>;
 
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using reference = _IndexType;
+  using pointer   = void;
+
   _CCCL_HIDE_FROM_ABI constexpr shuffle_iterator() noexcept = default;
 
   //! @brief Constructs a @c shuffle_iterator from a given bijection and an optional start position

--- a/libcudacxx/include/cuda/__iterator/strided_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/strided_iterator.h
@@ -52,7 +52,7 @@ template <class _Iter, class _Stride = ::cuda::std::iter_difference_t<_Iter>>
 class strided_iterator
 {
 private:
-  static_assert(::cuda::std::random_access_iterator<_Iter>,
+  static_assert(::cuda::std::__is_cpp17_random_access_iterator<_Iter>,
                 "The iterator underlying a strided_iterator must be a random access iterator.");
   static_assert(::cuda::std::__integer_like<_Stride> || ::cuda::std::__integral_constant_like<_Stride>,
                 "The stride of a strided_iterator must either be an integer-like or integral-constant-like.");

--- a/libcudacxx/include/cuda/__iterator/strided_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/strided_iterator.h
@@ -69,6 +69,11 @@ public:
   using value_type        = ::cuda::std::iter_value_t<_Iter>;
   using difference_type   = ::cuda::std::iter_difference_t<_Iter>;
 
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using reference = value_type;
+  using pointer   = void;
+
   //! @brief value-initializes both the base iterator and stride
   //! @note _Iter must be default initializable because it is a random_access_iterator and thereby semiregular
   //!       _Stride must be integer-like or integral_constant_like which requires default constructability

--- a/libcudacxx/include/cuda/__iterator/transform_input_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_input_output_iterator.h
@@ -48,7 +48,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-template <class _Iter, class _InputFn, class _OutputFn>
+template <class _InputFn, class _OutputFn, class _Iter>
 class __transform_input_output_proxy
 {
 private:
@@ -150,7 +150,7 @@ public:
 //!
 //!  }
 //! @endcode
-template <class _Iter, class _InputFn, class _OutputFn>
+template <class _InputFn, class _OutputFn, class _Iter>
 class transform_input_output_iterator
 {
 public:
@@ -170,7 +170,7 @@ public:
   using difference_type   = ::cuda::std::iter_difference_t<_Iter>;
   using value_type        = ::cuda::std::invoke_result_t<_InputFn&, ::cuda::std::iter_reference_t<_Iter>>;
   using pointer           = void;
-  using reference         = __transform_input_output_proxy<_Iter, _InputFn, _OutputFn>;
+  using reference         = __transform_input_output_proxy<_InputFn, _OutputFn, _Iter>;
 
   static_assert(::cuda::std::is_object_v<_InputFn>,
                 "cuda::transform_input_output_iterator requires that _InputFn is a function object");
@@ -231,7 +231,8 @@ public:
   //! @brief Dereferences the @c transform_input_output_iterator. Returns a proxy that transforms values read from the
   //! stored iterator via the stored input functor and transforms assigned values via the output functor
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API constexpr auto operator*() const noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Iter>)
+  [[nodiscard]] _CCCL_API constexpr reference operator*() const
+    noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Iter>)
   {
     return __transform_input_output_proxy{
       __current_, const_cast<_InputFn&>(*__input_func_), const_cast<_OutputFn&>(*__output_func_)};
@@ -240,7 +241,7 @@ public:
   //! @brief Dereferences the @c transform_input_output_iterator. Returns a proxy that transforms values read from the
   //! stored iterator via the stored input functor and transforms assigned values via the output functor
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API constexpr auto operator*() noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Iter>)
+  [[nodiscard]] _CCCL_API constexpr reference operator*() noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Iter>)
   {
     return __transform_input_output_proxy{__current_, *__input_func_, *__output_func_};
   }
@@ -252,7 +253,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2>)
-  [[nodiscard]] _CCCL_API constexpr auto operator[](difference_type __n) const
+  [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type __n) const
     noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Iter2> && noexcept(__current_ + __n))
   {
     return __transform_input_output_proxy{
@@ -266,7 +267,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2>)
-  [[nodiscard]] _CCCL_API constexpr auto operator[](difference_type __n) noexcept(
+  [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type __n) noexcept(
     ::cuda::std::is_nothrow_copy_constructible_v<_Iter2> && noexcept(__current_ + __n))
   {
     return __transform_input_output_proxy{__current_ + __n, *__input_func_, *__output_func_};
@@ -481,11 +482,11 @@ public:
 //! @param __input_fun The input functor used to transform the range when read
 //! @param __output_fun The output functor used to transform the range when written
 //! @relates transform_output_iterator
-template <class _Iter, class _InputFn, class _OutputFn>
+template <class _InputFn, class _OutputFn, class _Iter>
 [[nodiscard]] _CCCL_API constexpr auto
 make_transform_input_output_iterator(_Iter __iter, _InputFn __input_fun, _OutputFn __output_fun)
 {
-  return transform_input_output_iterator<_Iter, _InputFn, _OutputFn>{__iter, __input_fun, __output_fun};
+  return transform_input_output_iterator<_InputFn, _OutputFn, _Iter>{__iter, __input_fun, __output_fun};
 }
 
 //! @}

--- a/libcudacxx/include/cuda/__iterator/transform_input_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_input_output_iterator.h
@@ -176,7 +176,7 @@ public:
                 "cuda::transform_input_output_iterator requires that _InputFn is a function object");
   static_assert(::cuda::std::is_object_v<_OutputFn>,
                 "cuda::transform_input_output_iterator requires that _OutputFn is a function object");
-  static_assert(::cuda::std::forward_iterator<_Iter> || ::cuda::std::output_iterator<_Iter, value_type>,
+  static_assert(::cuda::std::__is_cpp17_forward_iterator<_Iter> || ::cuda::std::output_iterator<_Iter, value_type>,
                 "cuda::transform_input_output_iterator requires that _Iter models forward_iterator or output_iterator");
   static_assert(::cuda::std::is_invocable_v<_InputFn&, ::cuda::std::iter_reference_t<_Iter>>,
                 "cuda::transform_input_output_iterator requires that _InputFn is invocable on the result of "
@@ -252,7 +252,7 @@ public:
   //! @param __n The number of elements to advance
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type __n) const
     noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Iter2> && noexcept(__current_ + __n))
   {
@@ -266,7 +266,7 @@ public:
   //! @param __n The number of elements to advance
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type __n) noexcept(
     ::cuda::std::is_nothrow_copy_constructible_v<_Iter2> && noexcept(__current_ + __n))
   {
@@ -296,7 +296,7 @@ public:
   //! @brief Decrements the stored iterator
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::bidirectional_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_bidirectional_iterator<_Iter2>)
   _CCCL_API constexpr transform_input_output_iterator& operator--() noexcept(noexcept(--__current_))
   {
     --__current_;
@@ -306,7 +306,7 @@ public:
   //! @brief Decrements the stored iterator
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::bidirectional_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_bidirectional_iterator<_Iter2>)
   _CCCL_API constexpr transform_input_output_iterator
   operator--(int) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Iter> && noexcept(--__current_))
   {
@@ -319,7 +319,7 @@ public:
   //! @param __n The number of elements to advance
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   _CCCL_API constexpr transform_input_output_iterator&
   operator+=(difference_type __n) noexcept(noexcept(__current_ += __n))
   {
@@ -336,7 +336,7 @@ public:
   operator+(const transform_input_output_iterator& __iter, difference_type __n) //
     noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Iter>
              && noexcept(::cuda::std::declval<const _Iter2&>() + difference_type{}))
-      _CCCL_TRAILING_REQUIRES(transform_input_output_iterator)(::cuda::std::random_access_iterator<_Iter2>)
+      _CCCL_TRAILING_REQUIRES(transform_input_output_iterator)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return transform_input_output_iterator{__iter.__current_ + __n, *__iter.__input_func_, *__iter.__output_func_};
   }
@@ -350,7 +350,7 @@ public:
   operator+(difference_type __n, const transform_input_output_iterator& __iter) noexcept(
     ::cuda::std::is_nothrow_copy_constructible_v<_Iter>
     && noexcept(::cuda::std::declval<const _Iter2&>() + difference_type{}))
-    _CCCL_TRAILING_REQUIRES(transform_input_output_iterator)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(transform_input_output_iterator)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return transform_input_output_iterator{__iter.__current_ + __n, *__iter.__input_func_, *__iter.__output_func_};
   }
@@ -359,7 +359,7 @@ public:
   //! @param __n The number of elements to decrement
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   _CCCL_API constexpr transform_input_output_iterator&
   operator-=(difference_type __n) noexcept(noexcept(__current_ -= __n))
   {
@@ -376,7 +376,7 @@ public:
   operator-(const transform_input_output_iterator& __iter, difference_type __n) //
     noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Iter>
              && noexcept(::cuda::std::declval<const _Iter2&>() - difference_type{}))
-      _CCCL_TRAILING_REQUIRES(transform_input_output_iterator)(::cuda::std::random_access_iterator<_Iter2>)
+      _CCCL_TRAILING_REQUIRES(transform_input_output_iterator)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return transform_input_output_iterator{__iter.__current_ - __n, *__iter.__input_func_, *__iter.__output_func_};
   }
@@ -422,7 +422,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator<(const transform_input_output_iterator& __lhs, const transform_input_output_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ < __rhs.__current_;
   }
@@ -433,7 +433,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator>(const transform_input_output_iterator& __lhs, const transform_input_output_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ > __rhs.__current_;
   }
@@ -444,7 +444,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator<=(const transform_input_output_iterator& __lhs, const transform_input_output_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ <= __rhs.__current_;
   }
@@ -455,7 +455,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator>=(const transform_input_output_iterator& __lhs, const transform_input_output_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ >= __rhs.__current_;
   }
@@ -469,7 +469,7 @@ public:
   operator<=>(const transform_input_output_iterator& __lhs, const transform_input_output_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() <=> ::cuda::std::declval<const _Iter2&>()))
     _CCCL_TRAILING_REQUIRES(bool)(
-      ::cuda::std::random_access_iterator<_Iter2>&& ::cuda::std::three_way_comparable<_Iter2>)
+      ::cuda::std::__is_cpp17_random_access_iterator<_Iter2>&& ::cuda::std::three_way_comparable<_Iter2>)
   {
     return __lhs.__current_ <=> __rhs.__current_;
   }

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -55,7 +55,9 @@ struct __transform_iterator_category_base
 {};
 
 template <class _Fn, class _Iter>
-struct __transform_iterator_category_base<_Fn, _Iter, ::cuda::std::enable_if_t<::cuda::std::forward_iterator<_Iter>>>
+struct __transform_iterator_category_base<_Fn,
+                                          _Iter,
+                                          ::cuda::std::enable_if_t<::cuda::std::__is_cpp17_forward_iterator<_Iter>>>
 {
   using _Cat = typename ::cuda::std::iterator_traits<_Iter>::iterator_category;
 
@@ -67,7 +69,7 @@ struct __transform_iterator_category_base<_Fn, _Iter, ::cuda::std::enable_if_t<:
     ::cuda::std::input_iterator_tag>;
 };
 
-template <class _Fn, class _Iter, bool = (::cuda::std::random_access_iterator<_Iter>)>
+template <class _Fn, class _Iter, bool = (::cuda::std::__is_cpp17_random_access_iterator<_Iter>)>
 inline constexpr bool __transform_iterator_nothrow_subscript = false;
 
 template <class _Fn, class _Iter>
@@ -252,7 +254,7 @@ public:
   //! @param __n The number of elements to advance by
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2>
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>
                    _CCCL_AND ::cuda::std::regular_invocable<const _Fn&, ::cuda::std::iter_reference_t<const _Iter2>>)
   [[nodiscard]] _CCCL_API constexpr decltype(auto) operator[](difference_type __n) const
     noexcept(__transform_iterator_nothrow_subscript<const _Fn, _Iter2>)
@@ -267,7 +269,7 @@ public:
   //! forgotten to const qualify the call operator
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2> _CCCL_AND(
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2> _CCCL_AND(
     !::cuda::std::regular_invocable<const _Fn&, ::cuda::std::iter_reference_t<const _Iter2>>))
   [[nodiscard]] _CCCL_API constexpr decltype(auto) operator[](difference_type __n) const
     noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
@@ -280,7 +282,7 @@ public:
   //! @param __n The number of elements to advance by
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   [[nodiscard]] _CCCL_API constexpr decltype(auto)
   operator[](difference_type __n) noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
   {
@@ -299,7 +301,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr auto operator++(int) noexcept(noexcept(++__current_))
   {
-    if constexpr (::cuda::std::forward_iterator<_Iter>)
+    if constexpr (::cuda::std::__is_cpp17_forward_iterator<_Iter>)
     {
       auto __tmp = *this;
       ++*this;
@@ -314,7 +316,7 @@ public:
   //! @brief Decrements the stored iterator
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::bidirectional_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_bidirectional_iterator<_Iter2>)
   _CCCL_API constexpr transform_iterator& operator--() noexcept(noexcept(--__current_))
   {
     --__current_;
@@ -324,7 +326,7 @@ public:
   //! @brief Decrements the stored iterator
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::bidirectional_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_bidirectional_iterator<_Iter2>)
   _CCCL_API constexpr transform_iterator
   operator--(int) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Iter> && noexcept(--__current_))
   {
@@ -337,7 +339,7 @@ public:
   //! @param __n The number of elements to increment
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   _CCCL_API constexpr transform_iterator& operator+=(difference_type __n) noexcept(noexcept(__current_ += __n))
   {
     __current_ += __n;
@@ -350,7 +352,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto operator+(const transform_iterator& __iter, difference_type __n)
-    _CCCL_TRAILING_REQUIRES(transform_iterator)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(transform_iterator)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return transform_iterator{__iter.__current_ + __n, *__iter.__func_};
   }
@@ -361,7 +363,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto operator+(difference_type __n, const transform_iterator& __iter)
-    _CCCL_TRAILING_REQUIRES(transform_iterator)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(transform_iterator)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return transform_iterator{__iter.__current_ + __n, *__iter.__func_};
   }
@@ -370,7 +372,7 @@ public:
   //! @param __n The number of elements to decrement
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(::cuda::std::random_access_iterator<_Iter2>)
+  _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   _CCCL_API constexpr transform_iterator& operator-=(difference_type __n) noexcept(noexcept(__current_ -= __n))
   {
     __current_ -= __n;
@@ -383,7 +385,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto operator-(const transform_iterator& __iter, difference_type __n)
-    _CCCL_TRAILING_REQUIRES(transform_iterator)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(transform_iterator)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return transform_iterator{__iter.__current_ - __n, *__iter.__func_};
   }
@@ -430,7 +432,7 @@ public:
   operator<=>(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() <=> ::cuda::std::declval<const _Iter2&>()))
     _CCCL_TRAILING_REQUIRES(bool)(
-      ::cuda::std::random_access_iterator<_Iter2>&& ::cuda::std::three_way_comparable<_Iter2>)
+      ::cuda::std::__is_cpp17_random_access_iterator<_Iter2>&& ::cuda::std::three_way_comparable<_Iter2>)
   {
     return __lhs.__current_ <=> __rhs.__current_;
   }
@@ -441,7 +443,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator<(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ < __rhs.__current_;
   }
@@ -452,7 +454,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator>(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ > __rhs.__current_;
   }
@@ -463,7 +465,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator<=(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ <= __rhs.__current_;
   }
@@ -474,7 +476,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator>=(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ >= __rhs.__current_;
   }

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -54,8 +54,8 @@ template <class, class, class = void>
 struct __transform_iterator_category_base
 {};
 
-template <class _Iter, class _Fn>
-struct __transform_iterator_category_base<_Iter, _Fn, ::cuda::std::enable_if_t<::cuda::std::forward_iterator<_Iter>>>
+template <class _Fn, class _Iter>
+struct __transform_iterator_category_base<_Fn, _Iter, ::cuda::std::enable_if_t<::cuda::std::forward_iterator<_Iter>>>
 {
   using _Cat = typename ::cuda::std::iterator_traits<_Iter>::iterator_category;
 
@@ -148,8 +148,8 @@ inline constexpr bool __transform_iterator_nothrow_subscript<_Fn, _Iter, true> =
 //!   return 0;
 //! }
 //! @endcode
-template <class _Iter, class _Fn>
-class transform_iterator : public __transform_iterator_category_base<_Iter, _Fn>
+template <class _Fn, class _Iter>
+class transform_iterator : public __transform_iterator_category_base<_Fn, _Iter>
 {
   static_assert(::cuda::std::is_object_v<_Fn>, "cuda::transform_iterator requires that _Fn is a functor object");
   static_assert(::cuda::std::regular_invocable<_Fn&, ::cuda::std::iter_reference_t<_Iter>>,
@@ -485,10 +485,10 @@ public:
 //! @param __iter The iterator of the input range
 //! @param __fun The functor used to transform the input range
 //! @relates transform_iterator
-template <class _Iter, class _Fn>
+template <class _Fn, class _Iter>
 [[nodiscard]] _CCCL_API constexpr auto make_transform_iterator(_Iter __iter, _Fn __fun)
 {
-  return transform_iterator<_Iter, _Fn>{__iter, __fun};
+  return transform_iterator<_Fn, _Iter>{__iter, __fun};
 }
 
 //! @}

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -173,6 +173,11 @@ public:
     ::cuda::std::remove_cvref_t<::cuda::std::invoke_result_t<_Fn&, ::cuda::std::iter_reference_t<_Iter>>>;
   using difference_type = ::cuda::std::iter_difference_t<_Iter>;
 
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using reference = value_type;
+  using pointer   = void;
+
   //! @brief Default constructs a @c transform_iterator with a value initialized iterator and functor
 #if _CCCL_HAS_CONCEPTS()
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
@@ -148,7 +148,14 @@ public:
   _Iter __current_{};
   ::cuda::std::ranges::__movable_box<_Fn> __func_{};
 
-  using iterator_concept  = ::cuda::std::output_iterator_tag;
+  using iterator_concept = ::cuda::std::conditional_t<
+    ::cuda::std::random_access_iterator<_Iter>,
+    ::cuda::std::random_access_iterator_tag,
+    ::cuda::std::conditional_t<::cuda::std::bidirectional_iterator<_Iter>,
+                               ::cuda::std::bidirectional_iterator_tag,
+                               ::cuda::std::conditional_t<::cuda::std::forward_iterator<_Iter>,
+                                                          ::cuda::std::forward_iterator_tag,
+                                                          ::cuda::std::output_iterator_tag>>>;
   using iterator_category = ::cuda::std::output_iterator_tag;
   using difference_type   = ::cuda::std::iter_difference_t<_Iter>;
   using value_type        = void;

--- a/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
@@ -250,7 +250,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr auto operator++(int) noexcept(noexcept(++__current_))
   {
-    if constexpr (::cuda::std::forward_iterator<_Iter> || ::cuda::std::output_iterator<_Iter, value_type>)
+    if constexpr (::cuda::std::__is_cpp17_forward_iterator<_Iter> || ::cuda::std::output_iterator<_Iter, value_type>)
     {
       auto __tmp = *this;
       ++*this;
@@ -391,7 +391,7 @@ public:
   operator<=>(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() <=> ::cuda::std::declval<const _Iter2&>()))
     _CCCL_TRAILING_REQUIRES(bool)(
-      ::cuda::std::random_access_iterator<_Iter2>&& ::cuda::std::three_way_comparable<_Iter2>)
+      ::cuda::std::__is_cpp17_random_access_iterator<_Iter2>&& ::cuda::std::three_way_comparable<_Iter2>)
   {
     return __lhs.__current_ <=> __rhs.__current_;
   }
@@ -402,7 +402,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator<(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ < __rhs.__current_;
   }
@@ -413,7 +413,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator>(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ > __rhs.__current_;
   }
@@ -424,7 +424,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator<=(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ <= __rhs.__current_;
   }
@@ -435,7 +435,7 @@ public:
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator>=(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
     noexcept(::cuda::std::declval<const _Iter2&>() < ::cuda::std::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::random_access_iterator<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
   {
     return __lhs.__current_ >= __rhs.__current_;
   }

--- a/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
@@ -51,7 +51,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 //! @addtogroup iterators
 //! @{
 
-template <class _Iter, class _Fn>
+template <class _Fn, class _Iter>
 class __transform_output_proxy
 {
 private:
@@ -138,7 +138,7 @@ public:
 //!
 //! }
 //! @endcode
-template <class _Iter, class _Fn>
+template <class _Fn, class _Iter>
 class transform_output_iterator
 {
   static_assert(::cuda::std::is_object_v<_Fn>,
@@ -446,10 +446,10 @@ public:
 //! @param __iter The iterator of the input range
 //! @param __fun The output function
 //! @relates transform_output_iterator
-template <class _Iter, class _Fn>
+template <class _Fn, class _Iter>
 [[nodiscard]] _CCCL_API constexpr auto make_transform_output_iterator(_Iter __iter, _Fn __fun)
 {
-  return transform_output_iterator<_Iter, _Fn>{__iter, __fun};
+  return transform_output_iterator<_Fn, _Iter>{__iter, __fun};
 }
 
 //! @}

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -69,9 +69,9 @@ using __tuple_or_pair = typename __tuple_or_pair_impl<_Iterators...>::type;
 template <class... _Iterators>
 struct __zip_iter_constraints
 {
-  static constexpr bool __all_forward       = (::cuda::std::forward_iterator<_Iterators> && ...);
-  static constexpr bool __all_bidirectional = (::cuda::std::bidirectional_iterator<_Iterators> && ...);
-  static constexpr bool __all_random_access = (::cuda::std::random_access_iterator<_Iterators> && ...);
+  static constexpr bool __all_forward       = (::cuda::std::__is_cpp17_forward_iterator<_Iterators> && ...);
+  static constexpr bool __all_bidirectional = (::cuda::std::__is_cpp17_bidirectional_iterator<_Iterators> && ...);
+  static constexpr bool __all_random_access = (::cuda::std::__is_cpp17_random_access_iterator<_Iterators> && ...);
 
   static constexpr bool __all_equality_comparable = (::cuda::std::equality_comparable<_Iterators> && ...);
 

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -224,6 +224,10 @@ public:
   using reference        = __tuple_or_pair<::cuda::std::iter_reference_t<_Iterators>...>;
   using difference_type  = ::cuda::std::common_type_t<::cuda::std::iter_difference_t<_Iterators>...>;
 
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using pointer = void;
+
   template <class... _OtherIters>
   static constexpr bool __all_convertible =
     (::cuda::std::convertible_to<_OtherIters, _Iterators> && ...)

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -807,18 +807,24 @@ _CCCL_CONCEPT __has_iterator_concept_convertible_to = _CCCL_REQUIRES_EXPR((_Iter
   (typename(typename _Iter::iterator_concept), requires(is_convertible_v<typename _Iter::iterator_concept, _Tag>));
 
 template <class _Iter>
-inline constexpr bool __is_cpp17_input_iterator = __has_iterator_category_convertible_to<_Iter, input_iterator_tag>;
+inline constexpr bool __is_cpp17_input_iterator =
+  __has_iterator_category_convertible_to<_Iter, input_iterator_tag>
+  || __has_iterator_concept_convertible_to<_Iter, input_iterator_tag>;
 
 template <class _Iter>
-inline constexpr bool __is_cpp17_forward_iterator = __has_iterator_category_convertible_to<_Iter, forward_iterator_tag>;
+inline constexpr bool __is_cpp17_forward_iterator =
+  __has_iterator_category_convertible_to<_Iter, forward_iterator_tag>
+  || __has_iterator_concept_convertible_to<_Iter, forward_iterator_tag>;
 
 template <class _Iter>
 inline constexpr bool __is_cpp17_bidirectional_iterator =
-  __has_iterator_category_convertible_to<_Iter, bidirectional_iterator_tag>;
+  __has_iterator_category_convertible_to<_Iter, bidirectional_iterator_tag>
+  || __has_iterator_concept_convertible_to<_Iter, bidirectional_iterator_tag>;
 
 template <class _Iter>
 inline constexpr bool __is_cpp17_random_access_iterator =
-  __has_iterator_category_convertible_to<_Iter, random_access_iterator_tag>;
+  __has_iterator_category_convertible_to<_Iter, random_access_iterator_tag>
+  || __has_iterator_concept_convertible_to<_Iter, random_access_iterator_tag>;
 
 // __is_cpp17_contiguous_iterator determines if an iterator is known by
 // libc++ to be contiguous, either because it advertises itself as such

--- a/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/iterator_traits.compile.pass.cpp
@@ -8,7 +8,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// Test iterator category and iterator concepts.
+
 #include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
 
 #include "test_macros.h"
 #include "types.h"
@@ -20,17 +24,13 @@
 template <template <class...> class Traits>
 __host__ __device__ void test()
 {
-  using Iter       = cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>;
+  using Iter       = cuda::constant_iterator<int>;
   using IterTraits = Traits<Iter>;
-
-  static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
-  static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+  static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
   static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
-  static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
-  static_assert(
-    cuda::std::same_as<typename IterTraits::reference, cuda::__transform_input_output_proxy<int*, PlusOne, TimesTwo>>);
-  static_assert(cuda::std::input_or_output_iterator<cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>>);
-  static_assert(cuda::std::output_iterator<cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>, int>);
+  static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+  static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+  static_assert(cuda::std::random_access_iterator<Iter>);
   static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/counting_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/counting_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,258 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Test iterator category and iterator concepts.
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+#include "types.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+struct Decrementable
+{
+  using difference_type = int;
+
+#if TEST_HAS_SPACESHIP()
+  auto operator<=>(const Decrementable&) const = default;
+#else
+  __host__ __device__ bool operator==(const Decrementable&) const;
+  __host__ __device__ bool operator!=(const Decrementable&) const;
+
+  __host__ __device__ bool operator<(const Decrementable&) const;
+  __host__ __device__ bool operator<=(const Decrementable&) const;
+  __host__ __device__ bool operator>(const Decrementable&) const;
+  __host__ __device__ bool operator>=(const Decrementable&) const;
+#endif // TEST_HAS_SPACESHIP()
+
+  __host__ __device__ constexpr Decrementable& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr Decrementable operator++(int)
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr Decrementable& operator--()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr Decrementable operator--(int)
+  {
+    return *this;
+  }
+};
+
+struct Incrementable
+{
+  using difference_type = int;
+
+#if TEST_HAS_SPACESHIP()
+  auto operator<=>(const Incrementable&) const = default;
+#else
+  __host__ __device__ bool operator==(const Incrementable&) const;
+  __host__ __device__ bool operator!=(const Incrementable&) const;
+
+  __host__ __device__ bool operator<(const Incrementable&) const;
+  __host__ __device__ bool operator<=(const Incrementable&) const;
+  __host__ __device__ bool operator>(const Incrementable&) const;
+  __host__ __device__ bool operator>=(const Incrementable&) const;
+#endif // TEST_HAS_SPACESHIP()
+
+  __host__ __device__ constexpr Incrementable& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr Incrementable operator++(int)
+  {
+    return *this;
+  }
+};
+
+struct BigType
+{
+  char buffer[128];
+
+  using difference_type = int;
+
+#if TEST_HAS_SPACESHIP()
+  auto operator<=>(const BigType&) const = default;
+#else
+  __host__ __device__ bool operator==(const BigType&) const;
+  __host__ __device__ bool operator!=(const BigType&) const;
+
+  __host__ __device__ bool operator<(const BigType&) const;
+  __host__ __device__ bool operator<=(const BigType&) const;
+  __host__ __device__ bool operator>(const BigType&) const;
+  __host__ __device__ bool operator>=(const BigType&) const;
+#endif // TEST_HAS_SPACESHIP()
+
+  __host__ __device__ constexpr BigType& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr BigType operator++(int)
+  {
+    return *this;
+  }
+};
+
+struct CharDifferenceType
+{
+  using difference_type = signed char;
+
+#if TEST_HAS_SPACESHIP()
+  auto operator<=>(const CharDifferenceType&) const = default;
+#else
+  __host__ __device__ bool operator==(const CharDifferenceType&) const;
+  __host__ __device__ bool operator!=(const CharDifferenceType&) const;
+
+  __host__ __device__ bool operator<(const CharDifferenceType&) const;
+  __host__ __device__ bool operator<=(const CharDifferenceType&) const;
+  __host__ __device__ bool operator>(const CharDifferenceType&) const;
+  __host__ __device__ bool operator>=(const CharDifferenceType&) const;
+#endif // TEST_HAS_SPACESHIP()
+
+  __host__ __device__ constexpr CharDifferenceType& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr CharDifferenceType operator++(int)
+  {
+    return *this;
+  }
+};
+
+template <class T>
+_CCCL_CONCEPT HasIteratorCategory =
+  _CCCL_REQUIRES_EXPR((T))(typename(typename cuda::std::ranges::iterator_t<T>::iterator_category));
+
+template <template <class...> class Traits>
+__host__ __device__ void test()
+{
+  {
+    using Iter       = cuda::counting_iterator<char>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, char>);
+    static_assert(sizeof(typename IterTraits::difference_type) > sizeof(char));
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, int>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<short>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, short>);
+    static_assert(sizeof(typename IterTraits::difference_type) > sizeof(short));
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, int>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<int>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(sizeof(typename IterTraits::difference_type) > sizeof(int));
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    // If we're compiling for 32 bit or windows, int and long are the same size, so long long is the correct difference
+    // type.
+#if INTPTR_MAX == INT32_MAX || defined(_WIN32)
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, long long>);
+#else
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, long>);
+#endif
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<long>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, long>);
+    // Same as below, if there is no type larger than long, we can just use that.
+    static_assert(sizeof(typename IterTraits::difference_type) >= sizeof(long));
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, long long>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<long long>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, long long>);
+    // No integer is larger than long long, so it is OK to use long long as the difference type here:
+    // https://eel.is/c++draft/range.iota.view#1.3
+    static_assert(sizeof(typename IterTraits::difference_type) >= sizeof(long long));
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, long long>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<Decrementable>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, Decrementable>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, int>);
+    static_assert(cuda::std::__is_cpp17_bidirectional_iterator<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<Incrementable>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, Incrementable>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, int>);
+    static_assert(cuda::std::__is_cpp17_forward_iterator<Iter>);
+  }
+  { // nothing to do here
+    using Iter = cuda::counting_iterator<NotIncrementable>;
+    static_assert(!HasIteratorCategory<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<BigType>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, BigType>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, int>);
+    static_assert(cuda::std::__is_cpp17_forward_iterator<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<CharDifferenceType>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, CharDifferenceType>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, signed char>);
+    static_assert(cuda::std::__is_cpp17_forward_iterator<Iter>);
+  }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/discard_iterator/iterator_traits.compile.pass.cpp
@@ -13,20 +13,32 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
-template <class>
-void print() = delete;
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
+__host__ __device__ void test()
+{
+  using Iter       = cuda::discard_iterator;
+  using IterTraits = Traits<Iter>;
+
+  static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+  static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+  static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+  static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+  static_assert(cuda::std::same_as<typename IterTraits::reference, void>);
+  static_assert(cuda::std::input_or_output_iterator<cuda::discard_iterator>);
+  static_assert(cuda::std::output_iterator<cuda::discard_iterator, float>);
+  static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+}
 
 __host__ __device__ void test()
 {
-  using IterTraits = cuda::std::iterator_traits<cuda::discard_iterator>;
-
-  static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
-  static_assert(cuda::std::same_as<IterTraits::value_type, void>);
-  static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
-  static_assert(cuda::std::same_as<IterTraits::pointer, void>);
-  static_assert(cuda::std::same_as<IterTraits::reference, void>);
-  static_assert(cuda::std::input_or_output_iterator<cuda::discard_iterator>);
-  static_assert(cuda::std::output_iterator<cuda::discard_iterator, float>);
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/iterator_traits.compile.pass.cpp
@@ -13,30 +13,45 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
 __host__ __device__ void test()
 {
   {
-    using baseIter             = random_access_iterator<int*>;
-    using permutation_iterator = cuda::permutation_iterator<baseIter, baseIter>;
-    using iterTraits           = cuda::std::iterator_traits<permutation_iterator>;
+    using baseIter   = random_access_iterator<int*>;
+    using Iter       = cuda::permutation_iterator<baseIter, baseIter>;
+    using IterTraits = cuda::std::iterator_traits<Iter>;
 
-    static_assert(cuda::std::same_as<iterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
-    static_assert(cuda::std::same_as<iterTraits::value_type, int>);
-    static_assert(cuda::std::same_as<iterTraits::difference_type, cuda::std::ptrdiff_t>);
-    static_assert(cuda::std::same_as<iterTraits::pointer, void>);
-    static_assert(cuda::std::same_as<iterTraits::reference, int&>);
+    static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::same_as<IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<IterTraits::reference, int&>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
   }
   { // still random access
-    using baseIter             = contiguous_iterator<int*>;
-    using permutation_iterator = cuda::permutation_iterator<baseIter, baseIter>;
-    using iterTraits           = cuda::std::iterator_traits<permutation_iterator>;
+    using baseIter   = contiguous_iterator<int*>;
+    using Iter       = cuda::permutation_iterator<baseIter, baseIter>;
+    using IterTraits = cuda::std::iterator_traits<Iter>;
 
-    static_assert(cuda::std::same_as<iterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
-    static_assert(cuda::std::same_as<iterTraits::value_type, int>);
-    static_assert(cuda::std::same_as<iterTraits::difference_type, cuda::std::ptrdiff_t>);
-    static_assert(cuda::std::same_as<iterTraits::pointer, void>);
-    static_assert(cuda::std::same_as<iterTraits::reference, int&>);
+    static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::same_as<IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<IterTraits::reference, int&>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
   }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/shuffle_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Test iterator category and iterator concepts.
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+#include "types.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
+__host__ __device__ void test()
+{
+  {
+    using Iter       = cuda::shuffle_iterator<char, fake_bijection<>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, char>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::difference_type,
+                                       cuda::std::make_signed_t<typename IterTraits::value_type>>);
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, signed char>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  {
+    using Iter       = cuda::shuffle_iterator<short, fake_bijection<>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, short>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::difference_type,
+                                       cuda::std::make_signed_t<typename IterTraits::value_type>>);
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, short>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  {
+    using Iter       = cuda::shuffle_iterator<size_t, fake_bijection<>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, size_t>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::difference_type,
+                                       cuda::std::make_signed_t<typename IterTraits::value_type>>);
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Test iterator category and iterator concepts.
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+#include "types.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
+__host__ __device__ void test()
+{
+  {
+    using Iter       = cuda::strided_iterator<int*, int>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  {
+    using Iter       = cuda::strided_iterator<int*, Stride<2>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Test iterator category and iterator concepts.
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+#include "types.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
+__host__ __device__ void test()
+{
+  {
+    using Iter       = cuda::tabulate_output_iterator<basic_functor>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+#if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
+    static_assert(cuda::std::output_iterator<Iter, int>);
+#endif // !_CCCL_ARCH(ARM64)
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  {
+    using Iter       = cuda::tabulate_output_iterator<basic_functor, char>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, char>);
+#if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
+    static_assert(cuda::std::output_iterator<Iter, int>);
+#endif // !_CCCL_ARCH(ARM64)
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/compare.pass.cpp
@@ -46,7 +46,7 @@ __host__ __device__ constexpr bool test()
   assert(!(iter2 != iter2));
 
 #if TEST_HAS_SPACESHIP()
-  static_assert(cuda::std::three_way_comparable<cuda::transform_input_output_iterator<int>>);
+  static_assert(cuda::std::three_way_comparable<cuda::transform_input_output_iterator<PlusOne, PlusOne, int*>>);
   assert((iter1 <=> iter2) == cuda::std::strong_ordering::less);
   assert((iter1 <=> iter1) == cuda::std::strong_ordering::equal);
   assert((iter2 <=> iter1) == cuda::std::strong_ordering::greater);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/ctor.default.pass.cpp
@@ -20,22 +20,22 @@
 __host__ __device__ constexpr bool test()
 {
   {
-    cuda::transform_input_output_iterator<random_access_iterator<int*>, PlusOne, PlusOne> iter;
+    cuda::transform_input_output_iterator<PlusOne, PlusOne, random_access_iterator<int*>> iter;
     assert(iter.base() == random_access_iterator<int*>{});
   }
 
   {
-    const cuda::transform_input_output_iterator<random_access_iterator<int*>, PlusOne, PlusOne> iter;
+    const cuda::transform_input_output_iterator<PlusOne, PlusOne, random_access_iterator<int*>> iter;
     assert(iter.base() == random_access_iterator<int*>{});
   }
 
   {
     static_assert(
       !cuda::std::is_default_constructible_v<
-        cuda::transform_input_output_iterator<random_access_iterator<int*>, NotDefaultConstructiblePlusOne, PlusOne>>);
+        cuda::transform_input_output_iterator<NotDefaultConstructiblePlusOne, PlusOne, random_access_iterator<int*>>>);
     static_assert(
       !cuda::std::is_default_constructible_v<
-        cuda::transform_input_output_iterator<random_access_iterator<int*>, PlusOne, NotDefaultConstructiblePlusOne>>);
+        cuda::transform_input_output_iterator<PlusOne, NotDefaultConstructiblePlusOne, random_access_iterator<int*>>>);
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/ctor.value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/ctor.value.pass.cpp
@@ -40,7 +40,7 @@ __host__ __device__ constexpr bool test()
 #endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     static_assert(
       cuda::std::is_same_v<decltype(iter),
-                           cuda::transform_input_output_iterator<random_access_iterator<int*>, InputFn, OutputFn>>);
+                           cuda::transform_input_output_iterator<InputFn, OutputFn, random_access_iterator<int*>>>);
   }
 
   { // CTAD
@@ -52,11 +52,11 @@ __host__ __device__ constexpr bool test()
     buffer[2] = 2;
 
     static_assert(noexcept(cuda::transform_input_output_iterator{buffer + 2, input_func, output_func}));
-    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_input_output_iterator<int*, InputFn, OutputFn>>);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_input_output_iterator<InputFn, OutputFn, int*>>);
   }
 
   {
-    cuda::transform_input_output_iterator<random_access_iterator<int*>, InputFn, OutputFn> iter{
+    cuda::transform_input_output_iterator<InputFn, OutputFn, random_access_iterator<int*>> iter{
       random_access_iterator{buffer + 2}, input_func, output_func};
     assert(base(iter.base()) == buffer + 2);
     assert(*iter == input_func(buffer[2]));
@@ -66,20 +66,20 @@ __host__ __device__ constexpr bool test()
 
 #if !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     // The test iterators are not `is_nothrow_move_constructible`
-    static_assert(!noexcept(cuda::transform_input_output_iterator<random_access_iterator<int*>, InputFn, OutputFn>{
+    static_assert(!noexcept(cuda::transform_input_output_iterator<InputFn, OutputFn, random_access_iterator<int*>>{
       random_access_iterator{buffer + 2}, input_func, output_func}));
 #endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
   }
 
   {
-    cuda::transform_input_output_iterator<int*, InputFn, OutputFn> iter{buffer + 2, input_func, output_func};
+    cuda::transform_input_output_iterator<InputFn, OutputFn, int*> iter{buffer + 2, input_func, output_func};
     assert(iter.base() == buffer + 2);
     assert(*iter == input_func(buffer[2]));
     *iter = 3;
     assert(buffer[2] == output_func(3));
 
     static_assert(
-      noexcept(cuda::transform_input_output_iterator<int*, InputFn, OutputFn>{buffer + 2, input_func, output_func}));
+      noexcept(cuda::transform_input_output_iterator<InputFn, OutputFn, int*>{buffer + 2, input_func, output_func}));
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/iterator_traits.compile.pass.cpp
@@ -10,6 +10,7 @@
 
 #include <cuda/iterator>
 
+#include "test_iterators.h"
 #include "test_macros.h"
 #include "types.h"
 
@@ -20,18 +21,36 @@
 template <template <class...> class Traits>
 __host__ __device__ void test()
 {
-  using Iter       = cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>;
-  using IterTraits = Traits<Iter>;
+  {
+    using Iter       = cuda::transform_input_output_iterator<PlusOne, TimesTwo, int*>;
+    using IterTraits = Traits<Iter>;
 
-  static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
-  static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
-  static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
-  static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
-  static_assert(
-    cuda::std::same_as<typename IterTraits::reference, cuda::__transform_input_output_proxy<int*, PlusOne, TimesTwo>>);
-  static_assert(cuda::std::input_or_output_iterator<cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>>);
-  static_assert(cuda::std::output_iterator<cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>, int>);
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+    static_assert(
+      cuda::std::same_as<typename IterTraits::reference, cuda::__transform_input_output_proxy<PlusOne, TimesTwo, int*>>);
+    static_assert(cuda::std::input_or_output_iterator<Iter>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  {
+    using Iter       = cuda::transform_input_output_iterator<PlusOne, TimesTwo, random_access_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+    static_assert(
+      cuda::std::same_as<typename IterTraits::reference,
+                         cuda::__transform_input_output_proxy<PlusOne, TimesTwo, random_access_iterator<int*>>>);
+    static_assert(cuda::std::input_or_output_iterator<Iter>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
 }
 
 __host__ __device__ void test()

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/member_typedefs.compile.pass.cpp
@@ -21,24 +21,24 @@
 __host__ __device__ void test()
 {
   {
-    using Iter = cuda::transform_input_output_iterator<int*, PlusOne, TimesTwo>;
+    using Iter = cuda::transform_input_output_iterator<PlusOne, TimesTwo, int*>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
-    static_assert(cuda::std::same_as<Iter::reference, cuda::__transform_input_output_proxy<int*, PlusOne, TimesTwo>>);
+    static_assert(cuda::std::same_as<Iter::reference, cuda::__transform_input_output_proxy<PlusOne, TimesTwo, int*>>);
     static_assert(cuda::std::same_as<Iter::value_type, int>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::output_iterator<Iter, int>);
   }
 
   {
-    using Iter = cuda::transform_input_output_iterator<random_access_iterator<int*>, PlusOne, TimesTwo>;
+    using Iter = cuda::transform_input_output_iterator<PlusOne, TimesTwo, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
     static_assert(
       cuda::std::same_as<Iter::reference,
-                         cuda::__transform_input_output_proxy<random_access_iterator<int*>, PlusOne, TimesTwo>>);
+                         cuda::__transform_input_output_proxy<PlusOne, TimesTwo, random_access_iterator<int*>>>);
     static_assert(cuda::std::same_as<Iter::value_type, int>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::output_iterator<Iter, int>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/ctor.pass.cpp
@@ -92,10 +92,10 @@ __host__ __device__ constexpr void test(Fn fun)
 
   { // default initialization
     constexpr bool can_default_init = cuda::std::default_initializable<Iter> && cuda::std::default_initializable<Fn>;
-    static_assert(cuda::std::default_initializable<cuda::transform_iterator<Iter, Fn>> == can_default_init);
+    static_assert(cuda::std::default_initializable<cuda::transform_iterator<Fn, Iter>> == can_default_init);
     if constexpr (can_default_init)
     {
-      [[maybe_unused]] cuda::transform_iterator<Iter, Fn> iter{};
+      [[maybe_unused]] cuda::transform_iterator<Fn, Iter> iter{};
     }
   }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter, class Fn>
+_CCCL_CONCEPT HasIterCategory =
+  _CCCL_REQUIRES_EXPR((Iter, Fn))(typename(typename cuda::transform_iterator<Iter, Fn>::iterator_category));
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
+__host__ __device__ constexpr bool test()
+{
+  {
+    using Iter       = cuda::transform_iterator<int*, Increment>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+  {
+    // Member typedefs for random access iterator.
+    using Iter       = cuda::transform_iterator<random_access_iterator<int*>, Increment>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+  {
+    // Member typedefs for random access iterator, LWG3798 rvalue reference.
+    using Iter       = cuda::transform_iterator<random_access_iterator<int*>, IncrementRvalueRef>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+  {
+    // Member typedefs for random access iterator/not-lvalue-ref.
+    using Iter       = cuda::transform_iterator<random_access_iterator<int*>, PlusOneMutable>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+  {
+    // Member typedefs for bidirectional iterator.
+    using Iter       = cuda::transform_iterator<bidirectional_iterator<int*>, Increment>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::bidirectional_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::bidirectional_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_bidirectional_iterator<Iter>);
+  }
+  {
+    // Member typedefs for forward iterator.
+    using Iter       = cuda::transform_iterator<forward_iterator<int*>, Increment>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::forward_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::forward_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_forward_iterator<Iter>);
+  }
+  { // Nopthing to do here
+    using Iter = cuda::transform_iterator<cpp17_input_iterator<int*>, Increment>;
+    static_assert(!HasIterCategory<cpp17_input_iterator<int*>, Increment>);
+    static_assert(cuda::std::__is_cpp17_input_iterator<Iter>);
+  }
+
+  {
+    // Ensure we can work with other cuda iterators
+    using Iter       = cuda::transform_iterator<cuda::counting_iterator<int>, TimesTwo>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  {
+    // Ensure we can work with other cuda iterators
+    using Iter       = cuda::std::reverse_iterator<cuda::transform_iterator<cuda::counting_iterator<int>, TimesTwo>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  return true;
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.compile.pass.cpp
@@ -28,7 +28,7 @@ template <template <class...> class Traits>
 __host__ __device__ constexpr bool test()
 {
   {
-    using Iter       = cuda::transform_iterator<int*, Increment>;
+    using Iter       = cuda::transform_iterator<Increment, int*>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
@@ -38,7 +38,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for random access iterator.
-    using Iter       = cuda::transform_iterator<random_access_iterator<int*>, Increment>;
+    using Iter       = cuda::transform_iterator<Increment, random_access_iterator<int*>>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
@@ -48,7 +48,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for random access iterator, LWG3798 rvalue reference.
-    using Iter       = cuda::transform_iterator<random_access_iterator<int*>, IncrementRvalueRef>;
+    using Iter       = cuda::transform_iterator<IncrementRvalueRef, random_access_iterator<int*>>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
@@ -58,7 +58,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for random access iterator/not-lvalue-ref.
-    using Iter       = cuda::transform_iterator<random_access_iterator<int*>, PlusOneMutable>;
+    using Iter       = cuda::transform_iterator<PlusOneMutable, random_access_iterator<int*>>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
@@ -68,7 +68,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for bidirectional iterator.
-    using Iter       = cuda::transform_iterator<bidirectional_iterator<int*>, Increment>;
+    using Iter       = cuda::transform_iterator<Increment, bidirectional_iterator<int*>>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
@@ -78,7 +78,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for forward iterator.
-    using Iter       = cuda::transform_iterator<forward_iterator<int*>, Increment>;
+    using Iter       = cuda::transform_iterator<Increment, forward_iterator<int*>>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
@@ -87,14 +87,14 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::__is_cpp17_forward_iterator<Iter>);
   }
   { // Nopthing to do here
-    using Iter = cuda::transform_iterator<cpp17_input_iterator<int*>, Increment>;
-    static_assert(!HasIterCategory<cpp17_input_iterator<int*>, Increment>);
+    using Iter = cuda::transform_iterator<Increment, cpp17_input_iterator<int*>>;
+    static_assert(!HasIterCategory<Increment, cpp17_input_iterator<int*>>);
     static_assert(cuda::std::__is_cpp17_input_iterator<Iter>);
   }
 
   {
     // Ensure we can work with other cuda iterators
-    using Iter       = cuda::transform_iterator<cuda::counting_iterator<int>, TimesTwo>;
+    using Iter       = cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
@@ -105,7 +105,7 @@ __host__ __device__ constexpr bool test()
 
   {
     // Ensure we can work with other cuda iterators
-    using Iter       = cuda::std::reverse_iterator<cuda::transform_iterator<cuda::counting_iterator<int>, TimesTwo>>;
+    using Iter       = cuda::std::reverse_iterator<cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/make_transform_iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/make_transform_iterator.pass.cpp
@@ -25,7 +25,7 @@ __host__ __device__ constexpr void test()
 
   {
     auto iter = cuda::make_transform_iterator(Iter{buffer}, PlusOne{});
-    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_iterator<Iter, PlusOne>>);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_iterator<PlusOne, Iter>>);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.compile.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class Iter, class Fn>
 _CCCL_CONCEPT HasIterCategory =
-  _CCCL_REQUIRES_EXPR((Iter, Fn))(typename(typename cuda::transform_iterator<Iter, Fn>::iterator_category));
+  _CCCL_REQUIRES_EXPR((Iter, Fn))(typename(typename cuda::transform_iterator<Fn, Iter>::iterator_category));
 
 __host__ __device__ constexpr bool test()
 {
@@ -29,7 +29,7 @@ __host__ __device__ constexpr bool test()
     static_assert(
       cuda::std::same_as<cuda::std::iterator_traits<int*>::iterator_category, cuda::std::random_access_iterator_tag>);
 
-    using TIter = cuda::transform_iterator<int*, Increment>;
+    using TIter = cuda::transform_iterator<Increment, int*>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -38,7 +38,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for random access iterator.
-    using TIter = cuda::transform_iterator<random_access_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -47,7 +47,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for random access iterator, LWG3798 rvalue reference.
-    using TIter = cuda::transform_iterator<random_access_iterator<int*>, IncrementRvalueRef>;
+    using TIter = cuda::transform_iterator<IncrementRvalueRef, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -56,7 +56,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for random access iterator/not-lvalue-ref.
-    using TIter = cuda::transform_iterator<random_access_iterator<int*>, PlusOneMutable>;
+    using TIter = cuda::transform_iterator<PlusOneMutable, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -65,7 +65,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for bidirectional iterator.
-    using TIter = cuda::transform_iterator<bidirectional_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, bidirectional_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -74,7 +74,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for forward iterator.
-    using TIter = cuda::transform_iterator<forward_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, forward_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -83,7 +83,7 @@ __host__ __device__ constexpr bool test()
   }
   {
     // Member typedefs for input iterator.
-    using TIter = cuda::transform_iterator<cpp17_input_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, cpp17_input_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::input_iterator_tag>);
     static_assert(!HasIterCategory<cpp17_input_iterator<int*>, Increment>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -93,7 +93,7 @@ __host__ __device__ constexpr bool test()
 
   {
     // Ensure we can work with other cuda iterators
-    using TIter = cuda::transform_iterator<cuda::counting_iterator<int>, TimesTwo>;
+    using TIter = cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
@@ -103,7 +103,7 @@ __host__ __device__ constexpr bool test()
 
   {
     // Ensure we can work with other cuda iterators
-    using TIter = cuda::std::reverse_iterator<cuda::transform_iterator<cuda::counting_iterator<int>, TimesTwo>>;
+    using TIter = cuda::std::reverse_iterator<cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.compile.pass.cpp
@@ -105,7 +105,7 @@ __host__ __device__ constexpr bool test()
     // Ensure we can work with other cuda iterators
     using TIter = cuda::std::reverse_iterator<cuda::transform_iterator<cuda::counting_iterator<int>, TimesTwo>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
-    static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/plus_minus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/plus_minus.pass.cpp
@@ -42,8 +42,8 @@ __host__ __device__ constexpr void test()
   }
   else
   {
-    static_assert(!can_plus<cuda::transform_iterator<Iter, PlusOne>>);
-    static_assert(!can_minus<cuda::transform_iterator<Iter, PlusOne>>);
+    static_assert(!can_plus<cuda::transform_iterator<PlusOne, Iter>>);
+    static_assert(!can_minus<cuda::transform_iterator<PlusOne, Iter>>);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/compare.pass.cpp
@@ -46,7 +46,7 @@ __host__ __device__ constexpr bool test()
   assert(!(iter2 != iter2));
 
 #if TEST_HAS_SPACESHIP()
-  static_assert(cuda::std::three_way_comparable<cuda::transform_output_iterator<int>>);
+  static_assert(cuda::std::three_way_comparable<cuda::transform_output_iterator<PlusOne, int*>>);
   assert((iter1 <=> iter2) == cuda::std::strong_ordering::less);
   assert((iter1 <=> iter1) == cuda::std::strong_ordering::equal);
   assert((iter2 <=> iter1) == cuda::std::strong_ordering::greater);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.default.pass.cpp
@@ -20,18 +20,18 @@
 __host__ __device__ constexpr bool test()
 {
   {
-    cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne> iter;
+    cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>> iter;
     assert(iter.base() == random_access_iterator<int*>{});
   }
 
   {
-    const cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne> iter;
+    const cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>> iter;
     assert(iter.base() == random_access_iterator<int*>{});
   }
 
   {
     static_assert(!cuda::std::is_default_constructible_v<
-                  cuda::transform_output_iterator<random_access_iterator<int*>, NotDefaultConstructiblePlusOne>>);
+                  cuda::transform_output_iterator<NotDefaultConstructiblePlusOne, random_access_iterator<int*>>>);
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.value.pass.cpp
@@ -35,7 +35,7 @@ __host__ __device__ constexpr bool test()
     static_assert(!noexcept(cuda::transform_output_iterator{random_access_iterator{buffer + 2}, func}));
 #endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     static_assert(
-      cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<random_access_iterator<int*>, Fn>>);
+      cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<Fn, random_access_iterator<int*>>>);
   }
 
   { // CTAD
@@ -45,11 +45,11 @@ __host__ __device__ constexpr bool test()
     assert(buffer[2] == 3 + 1);
     buffer[2] = 2;
     static_assert(noexcept(cuda::transform_output_iterator{buffer + 2, func}));
-    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<int*, Fn>>);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<Fn, int*>>);
   }
 
   {
-    cuda::transform_output_iterator<random_access_iterator<int*>, Fn> iter{random_access_iterator{buffer + 2}, func};
+    cuda::transform_output_iterator<Fn, random_access_iterator<int*>> iter{random_access_iterator{buffer + 2}, func};
     assert(base(iter.base()) == buffer + 2);
     *iter = 3;
     assert(buffer[2] == 3 + 1);
@@ -57,17 +57,17 @@ __host__ __device__ constexpr bool test()
 #if !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     // The test iterators are not `is_nothrow_move_constructible`
     static_assert(!noexcept(
-      cuda::transform_output_iterator<random_access_iterator<int*>, Fn>{random_access_iterator{buffer + 2}, func}));
+      cuda::transform_output_iterator<Fn, random_access_iterator<int*>>{random_access_iterator{buffer + 2}, func}));
 #endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
   }
 
   {
-    cuda::transform_output_iterator<int*, Fn> iter{buffer + 2, func};
+    cuda::transform_output_iterator<Fn, int*> iter{buffer + 2, func};
     assert(iter.base() == buffer + 2);
     *iter = 3;
     assert(buffer[2] == 3 + 1);
     buffer[2] = 2;
-    static_assert(noexcept(cuda::transform_output_iterator<int*, Fn>{buffer + 2, func}));
+    static_assert(noexcept(cuda::transform_output_iterator<Fn, int*>{buffer + 2, func}));
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/iterator_traits.compile.pass.cpp
@@ -22,7 +22,7 @@ template <template <class...> class Traits>
 __host__ __device__ void test()
 {
   {
-    using Iter       = cuda::transform_output_iterator<int*, PlusOne>;
+    using Iter       = cuda::transform_output_iterator<PlusOne, int*>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
@@ -34,7 +34,7 @@ __host__ __device__ void test()
   }
 
   {
-    using Iter       = cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne>;
+    using Iter       = cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
@@ -46,7 +46,7 @@ __host__ __device__ void test()
   }
 
   {
-    using Iter       = cuda::transform_output_iterator<bidirectional_iterator<int*>, PlusOne>;
+    using Iter       = cuda::transform_output_iterator<PlusOne, bidirectional_iterator<int*>>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
@@ -58,7 +58,7 @@ __host__ __device__ void test()
   }
 
   {
-    using Iter       = cuda::transform_output_iterator<forward_iterator<int*>, PlusOne>;
+    using Iter       = cuda::transform_output_iterator<PlusOne, forward_iterator<int*>>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/iterator_traits.compile.pass.cpp
@@ -10,20 +10,72 @@
 
 #include <cuda/iterator>
 
+#include "test_iterators.h"
 #include "test_macros.h"
 #include "types.h"
 
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
 __host__ __device__ void test()
 {
-  using IterTraits = cuda::std::iterator_traits<cuda::transform_output_iterator<int*, PlusOne>>;
+  {
+    using Iter       = cuda::transform_output_iterator<int*, PlusOne>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
 
-  static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::output_iterator_tag>);
-  static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
-  static_assert(cuda::std::same_as<IterTraits::value_type, void>);
-  static_assert(cuda::std::same_as<IterTraits::pointer, void>);
-  static_assert(cuda::std::same_as<IterTraits::reference, void>);
-  static_assert(cuda::std::input_or_output_iterator<cuda::transform_output_iterator<int*, PlusOne>>);
-  static_assert(cuda::std::output_iterator<cuda::transform_output_iterator<int*, PlusOne>, int>);
+  {
+    using Iter       = cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  {
+    using Iter       = cuda::transform_output_iterator<bidirectional_iterator<int*>, PlusOne>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+    static_assert(cuda::std::__is_cpp17_bidirectional_iterator<Iter>);
+  }
+
+  {
+    using Iter       = cuda::transform_output_iterator<forward_iterator<int*>, PlusOne>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+    static_assert(cuda::std::__is_cpp17_forward_iterator<Iter>);
+  }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/member_typedefs.compile.pass.cpp
@@ -11,8 +11,6 @@
 // Test iterator category and iterator concepts.
 
 #include <cuda/iterator>
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
 
 #include "test_iterators.h"
 #include "test_macros.h"
@@ -22,7 +20,7 @@ __host__ __device__ void test()
 {
   {
     using Iter = cuda::transform_output_iterator<int*, PlusOne>;
-    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
     static_assert(cuda::std::same_as<Iter::reference, void>);
@@ -33,7 +31,29 @@ __host__ __device__ void test()
 
   {
     using Iter = cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne>;
-    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::pointer, void>);
+    static_assert(cuda::std::same_as<Iter::reference, void>);
+    static_assert(cuda::std::same_as<Iter::value_type, void>);
+    static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+  }
+
+  {
+    using Iter = cuda::transform_output_iterator<bidirectional_iterator<int*>, PlusOne>;
+    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::bidirectional_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::pointer, void>);
+    static_assert(cuda::std::same_as<Iter::reference, void>);
+    static_assert(cuda::std::same_as<Iter::value_type, void>);
+    static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+  }
+
+  {
+    using Iter = cuda::transform_output_iterator<forward_iterator<int*>, PlusOne>;
+    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
     static_assert(cuda::std::same_as<Iter::reference, void>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/member_typedefs.compile.pass.cpp
@@ -19,7 +19,7 @@
 __host__ __device__ void test()
 {
   {
-    using Iter = cuda::transform_output_iterator<int*, PlusOne>;
+    using Iter = cuda::transform_output_iterator<PlusOne, int*>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
@@ -30,7 +30,7 @@ __host__ __device__ void test()
   }
 
   {
-    using Iter = cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne>;
+    using Iter = cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
@@ -41,7 +41,7 @@ __host__ __device__ void test()
   }
 
   {
-    using Iter = cuda::transform_output_iterator<bidirectional_iterator<int*>, PlusOne>;
+    using Iter = cuda::transform_output_iterator<PlusOne, bidirectional_iterator<int*>>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
@@ -52,7 +52,7 @@ __host__ __device__ void test()
   }
 
   {
-    using Iter = cuda::transform_output_iterator<forward_iterator<int*>, PlusOne>;
+    using Iter = cuda::transform_output_iterator<PlusOne, forward_iterator<int*>>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// Iterator traits and member typedefs in zip_view::<iterator>.
+
+#include <cuda/iterator>
+#include <cuda/std/tuple>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <class T>
+_CCCL_CONCEPT HasIterCategory = _CCCL_REQUIRES_EXPR((T))(typename(typename T::iterator_category));
+
+struct Foo
+{};
+
+template <template <class...> class Traits>
+__host__ __device__ void test()
+{
+  { // Single iterator should have tuple value type
+    using Iter       = cuda::zip_iterator<int*>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::is_same_v<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::value_type, cuda::std::tuple<int>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  { // Two iterator should have pair value type
+    using Iter       = cuda::zip_iterator<int*, Foo*>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::is_same_v<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::value_type, cuda::std::pair<int, Foo>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  { // !=2 views should have tuple value_type
+    using Iter       = cuda::zip_iterator<int*, Foo*, int*>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::is_same_v<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::value_type, cuda::std::tuple<int, Foo, int>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+
+  { // If one iterator is not random access then the whole zip_iterator is not random access
+    using Iter       = cuda::zip_iterator<int*, Foo*, bidirectional_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::is_same_v<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::value_type, cuda::std::tuple<int, Foo, int>>);
+    static_assert(cuda::std::bidirectional_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_bidirectional_iterator<Iter>);
+  }
+
+  { // If one iterator is not bidirectional_iterator then the whole zip_iterator is not bidirectional_iterator
+    using Iter       = cuda::zip_iterator<forward_iterator<int*>, Foo*, bidirectional_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::is_same_v<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::value_type, cuda::std::tuple<int, Foo, int>>);
+    static_assert(cuda::std::forward_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_forward_iterator<Iter>);
+  }
+
+  { // Nothing here
+    using Iter = cuda::zip_iterator<forward_iterator<int*>, cpp20_input_iterator<Foo*>, bidirectional_iterator<int*>>;
+    static_assert(!HasIterCategory<Iter>);
+    static_assert(cuda::std::__is_cpp17_input_iterator<Iter>);
+  }
+
+  { // nested iterator has the right value type
+    using Iter       = cuda::zip_iterator<int*, cuda::zip_iterator<Foo*, int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::is_same_v<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(
+      cuda::std::is_same_v<typename IterTraits::value_type, cuda::std::pair<int, cuda::std::pair<Foo, int>>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
+  }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/thrust/thrust/iterator/iterator_traits.h
+++ b/thrust/thrust/iterator/iterator_traits.h
@@ -283,25 +283,25 @@ struct iterator_traversal<::cuda::tabulate_output_iterator<Fn, Index>>
   using type = random_access_traversal_tag;
 };
 
-template <class Iter, class InputFn, class OutputFn>
-struct iterator_system<::cuda::transform_input_output_iterator<Iter, InputFn, OutputFn>> : iterator_system<Iter>
+template <class InputFn, class OutputFn, class Iter>
+struct iterator_system<::cuda::transform_input_output_iterator<InputFn, OutputFn, Iter>> : iterator_system<Iter>
 {};
-template <class Iter, class InputFn, class OutputFn>
-struct iterator_traversal<::cuda::transform_input_output_iterator<Iter, InputFn, OutputFn>> : iterator_traversal<Iter>
-{};
-
-template <class Iter, class Fn>
-struct iterator_system<::cuda::transform_output_iterator<Iter, Fn>> : iterator_system<Iter>
-{};
-template <class Iter, class Fn>
-struct iterator_traversal<::cuda::transform_output_iterator<Iter, Fn>> : iterator_traversal<Iter>
+template <class InputFn, class OutputFn, class Iter>
+struct iterator_traversal<::cuda::transform_input_output_iterator<InputFn, OutputFn, Iter>> : iterator_traversal<Iter>
 {};
 
-template <class Iter, class Fn>
-struct iterator_system<::cuda::transform_iterator<Iter, Fn>> : iterator_system<Iter>
+template <class Fn, class Iter>
+struct iterator_system<::cuda::transform_output_iterator<Fn, Iter>> : iterator_system<Iter>
 {};
-template <class Iter, class Fn>
-struct iterator_traversal<::cuda::transform_iterator<Iter, Fn>> : iterator_traversal<Iter>
+template <class Fn, class Iter>
+struct iterator_traversal<::cuda::transform_output_iterator<Fn, Iter>> : iterator_traversal<Iter>
+{};
+
+template <class Fn, class Iter>
+struct iterator_system<::cuda::transform_iterator<Fn, Iter>> : iterator_system<Iter>
+{};
+template <class Fn, class Iter>
+struct iterator_traversal<::cuda::transform_iterator<Fn, Iter>> : iterator_traversal<Iter>
 {};
 
 template <class... Iterators>


### PR DESCRIPTION
Our iterators are based on C++20 standard iterators. With that they offer a lot of new toys, but also a ton of sharp edges.

This happens for the interaction with `std::iterator_traits` as we expect them to be the `C++20` ranges ones and not the C++17 legacy.

Another pain point is the interaction with Thrust iterators. Those commonly do not satisfy the proper C++20 iterator concepts, but still provide all the necessary operations.

Rather than pessimizing all users of thrust iterators we want to make sure they work with the cuda iterators, so that we can replace them step by step.