### PR TITLE
Ignore `Wmaybe-uninitialized` in dispatch_reduce.cuh.

### DIFF
--- a/cub/cub/device/dispatch/dispatch_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce.cuh
@@ -529,8 +529,13 @@ struct DispatchReduce
         kernel_source,
         launcher_factory);
 
+      // Ignore Wmaybe-uninitialized to work around a GCC 13 issue:
+      // https://github.com/NVIDIA/cccl/issues/4053
+      _CCCL_DIAG_PUSH
+      _CCCL_DIAG_SUPPRESS_GCC("-Wmaybe-uninitialized")
       // Dispatch to chained policy
       error = CubDebug(max_policy.Invoke(ptx_version, dispatch));
+      _CCCL_DIAG_POP
       if (cudaSuccess != error)
       {
         break;


### PR DESCRIPTION
## Description

I am seeing https://github.com/NVIDIA/cccl/issues/4053 `-Wmaybe-uninitialized` in `dispatch_reduce.cuh` again, when building cuDF with CCCL `v3.1.0-rc5`.

This indicates that issue #4053 is recurring in `branch/3.1.x`. I previously claimed in #4622 that this was no longer a problem on `main`, and so we made a change only for `branch/3.0.x`. I may have made a mistake somewhere in that assessment. This forward-ports #4054 / #4622 to `main`, which can then be backported to `branch/3.1.x`.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
