### PR TITLE
`basic_any` gets better support for storing immovable types

### DIFF
--- a/libcudacxx/include/cuda/__utility/__basic_any/storage.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/storage.h
@@ -46,10 +46,11 @@ _CCCL_BEGIN_NAMESPACE_CUDA
   return __align ? (::cuda::std::max) (__align, alignof(void*)) : __default_small_object_align;
 }
 
-template <class _Tp>
+template <class _Tp, bool _RequiresMovable = true>
 [[nodiscard]] _CCCL_API inline constexpr auto __is_small(size_t __size, size_t __align) noexcept -> bool
 {
-  return (sizeof(_Tp) <= __size) && (__align % alignof(_Tp) == 0) && ::cuda::std::is_nothrow_move_constructible_v<_Tp>;
+  return (sizeof(_Tp) <= __size) && (__align % alignof(_Tp) == 0)
+      && (!_RequiresMovable || ::cuda::std::is_nothrow_move_constructible_v<_Tp>);
 }
 
 _CCCL_API inline void __swap_ptr_ptr(void* __lhs, void* __rhs) noexcept

--- a/libcudacxx/include/cuda/std/__concepts/constructible.h
+++ b/libcudacxx/include/cuda/std/__concepts/constructible.h
@@ -23,8 +23,11 @@
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__concepts/convertible_to.h>
 #include <cuda/std/__concepts/destructible.h>
+#include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__type_traits/add_lvalue_reference.h>
+#include <cuda/std/__type_traits/is_callable.h>
 #include <cuda/std/__type_traits/is_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_constructible.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -101,6 +104,70 @@ _CCCL_CONCEPT copy_constructible = _CCCL_FRAGMENT(__copy_constructible_, _Tp);
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
 _CCCL_END_NAMESPACE_CUDA_STD
+
+//! The code below provides the following concepts in the ::cuda:: namespace:
+//!
+//! - `__list_initializable_from`
+//! - `__nothrow_list_initializable_from`
+//! - `__initializable_from`
+//! - `__nothrow_initializable_from`
+//! - `__emplaceable_from`
+//! - `__nothrow_emplaceable_from`
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+// constructible_from using list initialization syntax.
+template <class _Tp, class... _Args>
+_CCCL_CONCEPT __list_initializable_from =
+  _CCCL_REQUIRES_EXPR((_Tp, variadic _Args), _Args&&... __args)(_Tp{static_cast<_Args&&>(__args)...});
+
+template <class _Tp, class... _Args>
+_CCCL_CONCEPT __nothrow_list_initializable_from =
+  _CCCL_REQUIRES_EXPR((_Tp, variadic _Args), _Args&&... __args)(noexcept(_Tp{static_cast<_Args&&>(__args)...}));
+
+//! Constructible from arguments using either direct non-list initialization or direct
+//! list initialization.
+template <class _Tp, class... _Args>
+_CCCL_CONCEPT __initializable_from =
+  ::cuda::std::constructible_from<_Tp, _Args...> || __list_initializable_from<_Tp, _Args...>;
+
+template <class _Tp, class... _Args>
+_CCCL_CONCEPT __nothrow_initializable_from =
+  __initializable_from<_Tp, _Args...>
+  && (::cuda::std::constructible_from<_Tp, _Args...>
+        ? ::cuda::std::is_nothrow_constructible_v<_Tp, _Args...>
+        : __nothrow_list_initializable_from<_Tp, _Args...>);
+
+#if !_CCCL_COMPILER(MSVC)
+
+//! Constructible with direct non-list initialization syntax from the result of
+//! a function call expression (often useful for immovable types).
+template <class _Tp, class _Fn, class... _Args>
+_CCCL_CONCEPT __emplaceable_from = _CCCL_REQUIRES_EXPR((_Tp, _Fn, variadic _Args), _Fn&& __fn, _Args&&... __args)(
+  _Tp(static_cast<_Fn&&>(__fn)(static_cast<_Args&&>(__args)...)));
+
+template <class _Tp, class _Fn, class... _Args>
+_CCCL_CONCEPT __nothrow_emplaceable_from =
+  _CCCL_REQUIRES_EXPR((_Tp, _Fn, variadic _Args), _Fn&& __fn, _Args&&... __args)(
+    noexcept(_Tp(static_cast<_Fn&&>(__fn)(static_cast<_Args&&>(__args)...))));
+
+#else // ^^^ !_CCCL_COMPILER(MSVC) ^^^ / vvv _CCCL_COMPILER(MSVC) vvv
+
+//! Constructible with direct non-list initialization syntax from the result of
+//! a function call expression (often useful for immovable types). MSVC cannot
+//! use the above formulation because it has poor support for deferred materialization
+//! of temporary object (aka, guaranteed copy elision).
+template <class _Tp, class _Fn, class... _Args>
+_CCCL_CONCEPT __emplaceable_from = _CCCL_REQUIRES_EXPR((_Tp, _Fn, variadic _Args), _Fn&& __fn, _Args&&... __args)(
+  _Same_as(_Tp) static_cast<_Fn&&>(__fn)(static_cast<_Args&&>(__args)...));
+
+template <class _Tp, class _Fn, class... _Args>
+_CCCL_CONCEPT __nothrow_emplaceable_from =
+  __emplaceable_from<_Tp, _Fn, _Args...> && ::cuda::std::__is_nothrow_callable_v<_Fn, _Args...>;
+
+#endif // ^^^ _CCCL_COMPILER(MSVC) ^^^
+
+_CCCL_END_NAMESPACE_CUDA
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__utility/in_place.h
+++ b/libcudacxx/include/cuda/std/__utility/in_place.h
@@ -72,6 +72,35 @@ using __is_inplace_index = __is_inplace_index_imp<remove_cvref_t<_Tp>>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 
+// CCCL extensions below
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+struct _CCCL_TYPE_VISIBILITY_DEFAULT in_place_from_t
+{
+  _CCCL_HIDE_FROM_ABI explicit in_place_from_t() = default;
+};
+_CCCL_GLOBAL_CONSTANT in_place_from_t in_place_from{};
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT in_place_from_type_t
+{
+  _CCCL_HIDE_FROM_ABI explicit in_place_from_type_t() = default;
+};
+template <class _Tp>
+inline constexpr in_place_from_type_t<_Tp> in_place_from_type{};
+
+template <class _Tp>
+struct __is_inplace_from_type_imp : ::cuda::std::false_type
+{};
+template <class _Tp>
+struct __is_inplace_from_type_imp<in_place_from_type_t<_Tp>> : ::cuda::std::true_type
+{};
+
+template <class _Tp>
+using __is_inplace_from_type = __is_inplace_from_type_imp<::cuda::std::remove_cvref_t<_Tp>>;
+
+_CCCL_END_NAMESPACE_CUDA
+
 #include <cuda/std/__cccl/epilogue.h>
 
 #endif // _CUDA_STD___UTILITY_IN_PLACE_H

--- a/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp
@@ -608,6 +608,7 @@ struct BasicAnyTest : BasicAnyTestsFixture<TestType>
                                     return Immovable{};
                                   }}};
     assert(a.has_value());
+    assert(a.__in_situ());
   }
 };
 

--- a/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp
@@ -66,22 +66,6 @@ struct Immovable
   Immovable(Immovable&&) noexcept = delete;
 };
 
-template <class Fn>
-struct EmplaceFrom
-{
-  using type = cuda::std::invoke_result_t<Fn>;
-
-  _CCCL_HOST_DEVICE operator type() &&
-  {
-    return cuda::std::move(fn)();
-  }
-
-  Fn fn;
-};
-
-template <class Fn>
-_CCCL_HOST_DEVICE EmplaceFrom(Fn) -> EmplaceFrom<Fn>;
-
 template <bool Small>
 struct SmallOrLarge
 {
@@ -604,9 +588,9 @@ struct BasicAnyTest : BasicAnyTestsFixture<TestType>
   _CCCL_HOST_DEVICE void test_basic_any_test_for_emplacing_immovable_object()
   {
     // Can emplace an immovable object into a basic_any:
-    cuda::__basic_any<iempty<>> a{cuda::std::in_place_type<Immovable>, EmplaceFrom{[] {
+    cuda::__basic_any<iempty<>> a{cuda::in_place_from_type<Immovable>, [] {
                                     return Immovable{};
-                                  }}};
+                                  }};
     assert(a.has_value());
     assert(a.__in_situ());
   }


### PR DESCRIPTION
## Description

currently `__basic_any` uses direct list initialization syntax when emplacing objects. that mostly works, but it fails when using the "emplace from" trick to emplace an immovable object. in that trick, we initialize an immovable object from an object that is implicitly convertible to the immovable type. that makes use of c++17's guaranteed copy elision to emplace the object without needing to use a move ctor.

the trouble is that `new(buffer) Immovable{ convertible-to-immovable };` does not work if `Immovable` is an aggregate. for that, we need to use direct non-list initialization syntax, like:

```cpp
::new(buffer) Immovable( convertible-to-immovable );
```

this PR supports both forms, first trying direct *non*-list initialization (consistent with `std::construct_at`), and then trying direct list initialization.

(this is important to me because in sender/receiver, operation states are generally immovable. i want a type-erased sender, which requires type-erased operation states; hence the need to emplace an immovable object in a `__basic_any`.

**UPDATE:**

this work exposed a bug where immovable types were _never_ being stored in situ. the decision to store an object in situ or on the heap was considering whether the type was nothrow-movable. obvs, an immovable type is not nothrow-movable, so it was erroneously getting put on the heap.

finally, some older compilers in our matrix struggle with the "emplace from" trick with immovable types. i added an alternate API that lets you pass a callable directly to the `__basic_any` constructor, the result of which is used to direct-initialize the stored object. for this, i needed to add a new constructor tag to `__utility/in_place.h`: `::cuda::in_place_from_type<T>`.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
