### PR TITLE
correct the spelling of the `_LIBCPP_VERSION` macro

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -730,7 +730,7 @@
 // Bring in the bits of the STL we need
 #  if defined(_GLIBCXX_VERSION)
 #    include <bits/move.h> // for move, forward, forward_like, and addressof
-#  elif defined(_LIBCXX_VERSION)
+#  elif defined(_LIBCPP_VERSION)
 #    include <__memory/addressof.h>
 #    include <__utility/as_const.h>
 #    include <__utility/forward.h>
@@ -738,7 +738,7 @@
 #    include <__utility/move.h>
 #  endif
 
-#  if defined(_GLIBCXX_VERSION) || defined(_LIBCXX_VERSION)
+#  if defined(_GLIBCXX_VERSION) || defined(_LIBCPP_VERSION)
 // std::move builtin
 #    if _CCCL_COMPILER(CLANG, >=, 15) || _CCCL_COMPILER(GCC, >=, 15)
 #      define _CCCL_HAS_BUILTIN_STD_MOVE() 1
@@ -765,7 +765,7 @@
       && (__cpp_lib_forward_like >= 202217L)
 #      define _CCCL_HAS_BUILTIN_STD_FORWARD_LIKE() 1
 #    endif
-#  endif // defined(_GLIBCXX_VERSION) || defined(_LIBCXX_VERSION) || defined(_MSVC_STL_VERSION)
+#  endif // defined(_GLIBCXX_VERSION) || defined(_LIBCPP_VERSION) || defined(_MSVC_STL_VERSION)
 #endif // defined(__cplusplus)
 
 #ifndef _CCCL_HAS_BUILTIN_STD_MOVE


### PR DESCRIPTION
## Description

there is no macro `_LIBCXX_VERSION` in libc++. it is spelled `_LIBCPP_VERSION`. this pr corrects the detection of the host compiler's stdlib.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
