### PR TITLE
for better intellisense in cudax, define `LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE`

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -77,6 +77,7 @@ CompileFlags:
     - -Wno-pragma-system-header-outside-header
     - --no-cuda-version-check
     - -stdlib=libc++
+    - "-DLIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE"
     # report all errors
     - "-ferror-limit=0"
     - "-ftemplate-backtrace-limit=0"


### PR DESCRIPTION
## Description

i want to banish all red squiggles in cudax. to that end, configure clangd to define `LIBCUDACXX_ENABLE_EXPERIMENTAL_MEMORY_RESOURCE`, which most of cudax depends on.


## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
