### PR TITLE
c.parallel: enable dynamic policies in scan.

### DIFF
--- a/c/parallel/include/cccl/c/scan.h
+++ b/c/parallel/include/cccl/c/scan.h
@@ -35,6 +35,7 @@ typedef struct cccl_device_scan_build_result_t
   bool force_inclusive;
   size_t description_bytes_per_tile;
   size_t payload_bytes_per_tile;
+  void* runtime_policy;
 } cccl_device_scan_build_result_t;
 
 CCCL_C_API CUresult cccl_device_scan_build(

--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -35,6 +35,7 @@
 #include <util/context.h>
 #include <util/errors.h>
 #include <util/indirect_arg.h>
+#include <util/runtime_policy.h>
 #include <util/scan_tile_state.h>
 #include <util/types.h>
 
@@ -51,61 +52,30 @@ namespace scan
 
 struct scan_runtime_tuning_policy
 {
-  int block_size;
-  int items_per_thread;
-  cub::CacheLoadModifier load_modifier;
+  cub::detail::RuntimeScanAgentPolicy scan;
 
-  scan_runtime_tuning_policy Scan() const
+  auto Scan() const
   {
-    return *this;
-  }
-
-  int ItemsPerThread() const
-  {
-    return items_per_thread;
-  }
-
-  int BlockThreads() const
-  {
-    return block_size;
-  }
-
-  cub::CacheLoadModifier LoadModifier() const
-  {
-    return load_modifier;
+    return scan;
   }
 
   void CheckLoadModifier() const
   {
-    if (LoadModifier() == cub::CacheLoadModifier::LOAD_LDG)
+    if (scan.LoadModifier() == cub::CacheLoadModifier::LOAD_LDG)
     {
       throw std::runtime_error("The memory consistency model does not apply to texture "
                                "accesses");
     }
   }
-};
 
-template <typename Tuning, int N>
-Tuning find_tuning(int cc, const Tuning (&tunings)[N])
-{
-  for (const Tuning& tuning : tunings)
+  using MaxPolicy = scan_runtime_tuning_policy;
+
+  template <typename F>
+  cudaError_t Invoke(int, F& op)
   {
-    if (cc >= tuning.cc)
-    {
-      return tuning;
-    }
+    return op.template Invoke<scan_runtime_tuning_policy>(*this);
   }
-
-  return tunings[N - 1];
-}
-
-scan_runtime_tuning_policy get_policy(int /*cc*/, cccl_type_info /*accumulator_type*/)
-{
-  // TODO: we should update this once we figure out a way to reuse
-  // tuning logic from C++. Alternately, we should implement
-  // something better than a hardcoded default:
-  return {128, 4, cub::LOAD_DEFAULT};
-}
+};
 
 static cccl_type_info get_accumulator_type(cccl_op_t /*op*/, cccl_iterator_t /*input_it*/, cccl_value_t init)
 {
@@ -235,7 +205,6 @@ CUresult cccl_device_scan_build_ex(
 
     const int cc                 = cc_major * 10 + cc_minor;
     const cccl_type_info accum_t = scan::get_accumulator_type(op, input_it, init);
-    const auto policy            = scan::get_policy(cc, accum_t);
     const auto accum_cpp         = cccl_type_enum_to_name(accum_t.type);
     const auto input_it_value_t  = cccl_type_enum_to_name(input_it.value_type.type);
     const auto offset_t          = cccl_type_enum_to_name(cccl_type_enum::CCCL_UINT64);
@@ -254,41 +223,70 @@ CUresult cccl_device_scan_build_ex(
 struct __align__({1}) storage_t {{
   char data[{0}];
 }};
+{2}
+{3}
 {4}
-{5}
-struct agent_policy_t {{
-  static constexpr int ITEMS_PER_THREAD = {2};
-  static constexpr int BLOCK_THREADS = {3};
-  static constexpr cub::BlockLoadAlgorithm LOAD_ALGORITHM = cub::BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr cub::CacheLoadModifier LOAD_MODIFIER = cub::LOAD_DEFAULT;
-  static constexpr cub::BlockStoreAlgorithm STORE_ALGORITHM = cub::BLOCK_STORE_WARP_TRANSPOSE;
-  static constexpr cub::BlockScanAlgorithm SCAN_ALGORITHM = cub::BLOCK_SCAN_WARP_SCANS;
-  struct detail {{
-    using delay_constructor_t = cub::detail::default_delay_constructor_t<{7}>;
-  }};
-}};
-struct device_scan_policy {{
-  struct ActivePolicy {{
-    using ScanPolicyT = agent_policy_t;
-  }};
-}};
-{6}
 )XXX";
 
     const std::string& src = std::format(
       src_template,
       input_it.value_type.size, // 0
       input_it.value_type.alignment, // 1
-      policy.items_per_thread, // 2
-      policy.block_size, // 3
-      input_iterator_src, // 4
-      output_iterator_src, // 5
-      op_src, // 6
-      accum_cpp); // 7
+      input_iterator_src, // 2
+      output_iterator_src, // 3
+      op_src); // 4
+
+    const auto output_it_value_t = cccl_type_enum_to_name(output_it.value_type.type);
+
+    const std::string ptx_arch = std::format("-arch=compute_{}{}", cc_major, cc_minor);
+
+    std::vector<const char*> ptx_args = {
+      ptx_arch.c_str(), cub_path, thrust_path, libcudacxx_path, ctk_path, "-rdc=true"};
+
+    cccl::detail::extend_args_with_build_config(ptx_args, config);
+
+    std::string policy_hub_expr = std::format(
+      "cub::detail::scan::policy_hub<{}, {}, {}, {}, {}>",
+      input_it_value_t,
+      output_it_value_t,
+      accum_cpp,
+      offset_t,
+      "op_wrapper");
+
+    nlohmann::json runtime_policy = get_policy(
+      std::format("cub::detail::scan::MakeScanPolicyWrapper({}::MaxPolicy::ActivePolicy{{}})", policy_hub_expr),
+      "#include <cub/device/dispatch/tuning/tuning_scan.cuh>\n" + src,
+      ptx_args);
+
+    auto delay_ctor_info = runtime_policy["DelayConstructor"];
+    std::string delay_ctor_params;
+    for (auto&& param : delay_ctor_info["params"])
+    {
+      delay_ctor_params.append(to_string(param) + ", ");
+    }
+    delay_ctor_params.erase(delay_ctor_params.size() - 2); // remove last ", "
+    auto delay_ctor_t =
+      std::format("cub::detail::{}<{}>", delay_ctor_info["name"].get<std::string>(), delay_ctor_params);
+
+    using cub::detail::RuntimeScanAgentPolicy;
+    auto [scan_policy,
+          scan_policy_str] = RuntimeScanAgentPolicy::from_json(runtime_policy, "ScanPolicyT", delay_ctor_t);
+
+    std::string final_src = std::format(
+      R"XXX(
+{0}
+struct device_scan_policy {{
+  struct ActivePolicy {{
+    {1}
+  }};
+}};
+)XXX",
+      src,
+      scan_policy_str);
 
 #if false // CCCL_DEBUGGING_SWITCH
     fflush(stderr);
-    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", src.c_str());
+    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", final_src.c_str());
     fflush(stdout);
 #endif
 
@@ -317,7 +315,7 @@ struct device_scan_policy {{
 
     nvrtc_link_result result =
       begin_linking_nvrtc_program(num_lto_args, lopts)
-        ->add_program(nvrtc_translation_unit{src.c_str(), name})
+        ->add_program(nvrtc_translation_unit{final_src.c_str(), name})
         ->add_expression({init_kernel_name})
         ->add_expression({scan_kernel_name})
         ->compile_program({args.data(), args.size()})
@@ -341,6 +339,7 @@ struct device_scan_policy {{
     build_ptr->force_inclusive            = force_inclusive;
     build_ptr->description_bytes_per_tile = description_bytes_per_tile;
     build_ptr->payload_bytes_per_tile     = payload_bytes_per_tile;
+    build_ptr->runtime_policy             = new scan::scan_runtime_tuning_policy{scan_policy};
   }
   catch (const std::exception& exc)
   {
@@ -382,7 +381,7 @@ CUresult cccl_device_scan(
       ::cuda::std::size_t,
       void,
       EnforceInclusive,
-      scan::dynamic_scan_policy_t<&scan::get_policy>,
+      scan::scan_runtime_tuning_policy,
       scan::scan_kernel_source,
       cub::detail::CudaDriverLauncherFactory>::
       Dispatch(
@@ -396,7 +395,7 @@ CUresult cccl_device_scan(
         stream,
         {build},
         cub::detail::CudaDriverLauncherFactory{cu_device, build.cc},
-        {scan::get_accumulator_type(op, d_in, init)});
+        *reinterpret_cast<scan::scan_runtime_tuning_policy*>(build.runtime_policy));
 
     error = static_cast<CUresult>(exec_status);
   }

--- a/c/parallel/src/util/runtime_policy.cpp
+++ b/c/parallel/src/util/runtime_policy.cpp
@@ -27,9 +27,6 @@ get_policy(std::string_view policy_wrapper_expr, std::string_view translation_un
   std::string_view tag_name = "c_parallel_get_policy_tag";
   std::string fixed_source  = std::format(
     "{0}\n"
-     "#if _CCCL_HAS_NVFP16()\n"
-     "#include <cuda_fp16.h>\n"
-     "#endif\n"
      "__global__ void ptx_json_emitting_kernel()\n"
      "{{\n"
      "  [[maybe_unused]] auto wrapped = {1};\n"

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -49,6 +49,7 @@
 #include <cub/block/block_store.cuh>
 #include <cub/grid/grid_queue.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
+#include <cub/util_device.cuh>
 
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/is_pointer.h>
@@ -110,6 +111,27 @@ struct AgentScanPolicy : ScalingType
     using delay_constructor_t = DelayConstructorT;
   };
 };
+
+#if defined(CUB_DEFINE_RUNTIME_POLICIES) || defined(CUB_ENABLE_POLICY_PTX_JSON)
+namespace detail
+{
+// Only define this when needed.
+// Because of overload woes, this depends on C++20 concepts. util_device.h checks that concepts are available when
+// either runtime policies or PTX JSON information are enabled, so if they are, this is always valid. The generic
+// version is always defined, and that's the only one needed for regular CUB operations.
+//
+// TODO: enable this unconditionally once concepts are always available
+CUB_DETAIL_POLICY_WRAPPER_DEFINE(
+  ScanAgentPolicy,
+  (GenericAgentPolicy),
+  (BLOCK_THREADS, BlockThreads, int),
+  (ITEMS_PER_THREAD, ItemsPerThread, int),
+  (LOAD_ALGORITHM, LoadAlgorithm, cub::BlockLoadAlgorithm),
+  (LOAD_MODIFIER, LoadModifier, cub::CacheLoadModifier),
+  (STORE_ALGORITHM, StoreAlgorithm, cub::BlockStoreAlgorithm),
+  (SCAN_ALGORITHM, ScanAlgorithm, cub::BlockScanAlgorithm))
+} // namespace detail
+#endif // defined(CUB_DEFINE_RUNTIME_POLICIES) || defined(CUB_ENABLE_POLICY_PTX_JSON)
 
 /******************************************************************************
  * Thread block abstractions

--- a/cub/cub/agent/single_pass_scan_operators.cuh
+++ b/cub/cub/agent/single_pass_scan_operators.cuh
@@ -48,6 +48,7 @@
 #include <cub/detail/uninitialized_copy.cuh>
 #include <cub/thread/thread_load.cuh>
 #include <cub/thread/thread_store.cuh>
+#include <cub/util_device.cuh>
 #include <cub/util_temporary_storage.cuh>
 #include <cub/warp/warp_reduce.cuh>
 
@@ -220,6 +221,14 @@ struct no_delay_constructor_t
   {
     return {};
   }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedConstructor()
+  {
+    using namespace ptx_json;
+    return object<key<"name">() = value<string("no_delay_constructor_t")>(), key<"params">() = array<L2WriteLatency>()>();
+  }
+#endif
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency, unsigned int GridThreshold = 500>
@@ -248,6 +257,15 @@ struct reduce_by_key_delay_constructor_t
   {
     return {};
   }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedConstructor()
+  {
+    using namespace ptx_json;
+    return object<key<"name">()   = value<string("reduce_by_key_delay_constructor_t")>(),
+                  key<"params">() = array<Delay, L2WriteLatency, GridThreshold>()>();
+  }
+#endif
 };
 
 template <unsigned int Delay, unsigned int L2WriteLatency>
@@ -270,6 +288,15 @@ struct fixed_delay_constructor_t
   {
     return {};
   }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedConstructor()
+  {
+    using namespace ptx_json;
+    return object<key<"name">()   = value<string("fixed_delay_constructor_t")>(),
+                  key<"params">() = array<Delay, L2WriteLatency>()>();
+  }
+#endif
 };
 
 template <unsigned int InitialDelay, unsigned int L2WriteLatency>
@@ -295,6 +322,15 @@ struct exponential_backoff_constructor_t
   {
     return {InitialDelay};
   }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedConstructor()
+  {
+    using namespace ptx_json;
+    return object<key<"name">()   = value<string("exponential_backoff_constructor_t")>(),
+                  key<"params">() = array<InitialDelay, L2WriteLatency>()>();
+  }
+#endif
 };
 
 template <unsigned int InitialDelay, unsigned int L2WriteLatency>
@@ -333,6 +369,15 @@ struct exponential_backoff_jitter_constructor_t
   {
     return {InitialDelay, seed};
   }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedConstructor()
+  {
+    using namespace ptx_json;
+    return object<key<"name">()   = value<string("exponential_backoff_jitter_constructor_t")>(),
+                  key<"params">() = array<InitialDelay, L2WriteLatency>()>();
+  }
+#endif
 };
 
 template <unsigned int InitialDelay, unsigned int L2WriteLatency>
@@ -371,6 +416,15 @@ struct exponential_backoff_jitter_window_constructor_t
   {
     return {InitialDelay, seed};
   }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedConstructor()
+  {
+    using namespace ptx_json;
+    return object<key<"name">()   = value<string("exponential_backoff_jitter_window_constructor_t")>(),
+                  key<"params">() = array<InitialDelay, L2WriteLatency>()>();
+  }
+#endif
 };
 
 template <unsigned int InitialDelay, unsigned int L2WriteLatency>
@@ -412,6 +466,15 @@ struct exponential_backon_jitter_window_constructor_t
     max_delay >>= 1;
     return {max_delay, seed};
   }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedConstructor()
+  {
+    using namespace ptx_json;
+    return object<key<"name">()   = value<string("exponential_backon_jitter_window_constructor_t")>(),
+                  key<"params">() = array<InitialDelay, L2WriteLatency>()>();
+  }
+#endif
 };
 
 template <unsigned int InitialDelay, unsigned int L2WriteLatency>
@@ -452,6 +515,15 @@ struct exponential_backon_jitter_constructor_t
     max_delay >>= 1;
     return {max_delay, seed};
   }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedConstructor()
+  {
+    using namespace ptx_json;
+    return object<key<"name">()   = value<string("exponential_backon_jitter_constructor_t")>(),
+                  key<"params">() = array<InitialDelay, L2WriteLatency>()>();
+  }
+#endif
 };
 
 template <unsigned int InitialDelay, unsigned int L2WriteLatency>
@@ -480,6 +552,15 @@ struct exponential_backon_constructor_t
     max_delay >>= 1;
     return {max_delay};
   }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedConstructor()
+  {
+    using namespace ptx_json;
+    return object<key<"name">()   = value<string("exponential_backon_constructor_t")>(),
+                  key<"params">() = array<InitialDelay, L2WriteLatency>()>();
+  }
+#endif
 };
 
 using default_no_delay_constructor_t = no_delay_constructor_t<450>;

--- a/cub/cub/detail/ptx-json/value.h
+++ b/cub/cub/detail/ptx-json/value.h
@@ -67,11 +67,11 @@ struct value<Nested, void>
 {
   __forceinline__ __device__ static void emit()
   {
-    value<Nested>::emit();
+    Nested.emit();
   }
 };
 
-template <int V>
+template <cuda::std::integral auto V>
 struct value<V, void>
 {
   __forceinline__ __device__ static void emit()

--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -469,6 +469,16 @@ struct ScanPolicyWrapper<StaticPolicyT, ::cuda::std::void_t<decltype(StaticPolic
                   "The memory consistency model does not apply to texture "
                   "accesses");
   }
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedPolicy()
+  {
+    using namespace ptx_json;
+    return object<key<"ScanPolicyT">() = Scan().EncodedPolicy(),
+                  key<"DelayConstructor">() =
+                    StaticPolicyT::ScanPolicyT::detail::delay_constructor_t::EncodedConstructor()>();
+  }
+#endif
 };
 
 template <typename PolicyT>

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -579,22 +579,27 @@ namespace detail
 
 #  define CUB_DETAIL_POLICY_WRAPPER_FIELD_VALUE(field) , (int) ap._CCCL_PP_CAT(runtime_, _CCCL_PP_FIRST field)
 
-#  define CUB_DETAIL_POLICY_WRAPPER_AGENT_POLICY(concept_name, ...)                                                    \
-    struct Runtime##concept_name                                                                                       \
-    {                                                                                                                  \
-      _CCCL_PP_FOR_EACH(CUB_DETAIL_POLICY_WRAPPER_FIELD, __VA_ARGS__)                                                  \
-      static std::pair<Runtime##concept_name, std::string>                                                             \
-      from_json(const nlohmann::json& json, std::string_view subpolicy_name)                                           \
-      {                                                                                                                \
-        auto subpolicy = json[subpolicy_name];                                                                         \
-        assert(!subpolicy.is_null());                                                                                  \
-        Runtime##concept_name ap;                                                                                      \
-        _CCCL_PP_FOR_EACH(CUB_DETAIL_POLICY_WRAPPER_GET_FIELD, __VA_ARGS__)                                            \
-        return std::make_pair(                                                                                         \
-          ap,                                                                                                          \
-          std::format("struct {} {{\n" _CCCL_PP_FOR_EACH(CUB_DETAIL_POLICY_WRAPPER_FIELD_STRING, __VA_ARGS__) "}};\n", \
-                      subpolicy_name _CCCL_PP_FOR_EACH(CUB_DETAIL_POLICY_WRAPPER_FIELD_VALUE, __VA_ARGS__)));          \
-      }                                                                                                                \
+#  define CUB_DETAIL_POLICY_WRAPPER_AGENT_POLICY(concept_name, ...)                                                  \
+    struct Runtime##concept_name                                                                                     \
+    {                                                                                                                \
+      _CCCL_PP_FOR_EACH(CUB_DETAIL_POLICY_WRAPPER_FIELD, __VA_ARGS__)                                                \
+      static std::pair<Runtime##concept_name, std::string>                                                           \
+      from_json(const nlohmann::json& json,                                                                          \
+                std::string_view subpolicy_name,                                                                     \
+                std::optional<std::string_view> delay_cons_type = std::nullopt)                                      \
+      {                                                                                                              \
+        auto subpolicy = json[subpolicy_name];                                                                       \
+        assert(!subpolicy.is_null());                                                                                \
+        Runtime##concept_name ap;                                                                                    \
+        _CCCL_PP_FOR_EACH(CUB_DETAIL_POLICY_WRAPPER_GET_FIELD, __VA_ARGS__)                                          \
+        return std::make_pair(                                                                                       \
+          ap,                                                                                                        \
+          std::format(                                                                                               \
+            "struct {} {{\n" _CCCL_PP_FOR_EACH(CUB_DETAIL_POLICY_WRAPPER_FIELD_STRING, __VA_ARGS__) "{} }};\n",      \
+            subpolicy_name _CCCL_PP_FOR_EACH(CUB_DETAIL_POLICY_WRAPPER_FIELD_VALUE, __VA_ARGS__),                    \
+            delay_cons_type ? std::format("struct detail {{ using delay_constructor_t = {}; }}; ", *delay_cons_type) \
+                            : ""));                                                                                  \
+      }                                                                                                              \
     };
 #else
 #  define CUB_DETAIL_POLICY_WRAPPER_AGENT_POLICY(...)


### PR DESCRIPTION
## Description

This PR uses ptx-json to dynamically compute runtime policies for scan. There's some spill into lmem for `double`, will investigate further and fix in a follow-up.

Closes #4359.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
