### PR TITLE
Detect `QNX` for atomics support

### DIFF
--- a/libcudacxx/include/cuda/std/detail/libcxx/include/__config
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/__config
@@ -119,7 +119,7 @@ extern "C++" {
 
 #  if !defined(_LIBCUDACXX_HAS_THREAD_API_PTHREAD) && !defined(_LIBCUDACXX_HAS_THREAD_API_WIN32) \
     && !defined(_LIBCUDACXX_HAS_THREAD_API_EXTERNAL)
-#    if defined(__linux__) || defined(__GNU__) || defined(__APPLE__) \
+#    if defined(__linux__) || defined(__GNU__) || defined(__APPLE__) || _CCCL_OS(QNX) \
       || (defined(__MINGW32__) && _CCCL_HAS_INCLUDE(<pthread.h>))
 #      define _LIBCUDACXX_HAS_THREAD_API_PTHREAD
 #    elif defined(_WIN32)


### PR DESCRIPTION
QNX is providing [pthread](https://www.qnx.com/developers/docs/8.0/com.qnx.doc.neutrino.lib_ref/topic/p/pthread_create.html) support, so there is no reason to not support them.

Fixes nvbug5529628
