### PR TITLE
[libcu++] Switch to use cuGetProcAddress to get driver functions

### DIFF
--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -41,6 +41,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_DRIVER
     reinterpret_cast<decltype(::versioned_fn_name)*>(                                           \
       ::cuda::__driver::__get_driver_entry_point(#function_name, major, minor))
 
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 //! @brief Get a driver function pointer for a given API name and optionally specific CUDA version
 //!
 //! For minor version compatibility request the 12.0 version of everything for now, unless requested otherwise
@@ -81,6 +83,8 @@ __get_driver_entry_point(const char* __name, [[maybe_unused]] int __major = 12, 
   }
   return __fn;
 }
+
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 template <typename Fn, typename... Args>
 _CCCL_HOST_API inline void __call_driver_fn(Fn __fn, const char* __err_msg, Args... __args)


### PR DESCRIPTION
RAPIDS need to work with all minor versions of dynamically linked CUDA Runtime, but we use `cudaGetDriverEntryPointByVersion` which is not available in some of the CUDA 12.X releases. This PR switches the Driver API layer to only use the ByVersion case only in 13.X and continue to use the base one for 12.X. ~There is only one case where we specifically request a non-default version of an API and a driver version check was added there to make sure the driver version supports the requested function.

This solution is very likely to be temporary and we will just switch to `dlopen` libcuda.so and use `cuGetProcAddress` instead.~

We should just use the base `cudaGetDriverEntryPoint` to request `cuGetProcAddress` and then just use that instead, it always supported specifying the version. Long term we should just switch to dlopen libcuda.so and get `cuGetProcAddress` this way.