### PR TITLE
[Backport 3.1]  Backport iterator fixes

### DIFF
--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -310,7 +310,7 @@ public:
   //! @param __last The end of the input sequence.
   //! @note If `__first == __last` then no memory is allocated
   _CCCL_TEMPLATE(class _Iter)
-  _CCCL_REQUIRES(_CUDA_VSTD::__is_cpp17_forward_iterator<_Iter>::value)
+  _CCCL_REQUIRES(_CUDA_VSTD::__has_forward_traversal<_Iter>)
   _CCCL_HIDE_FROM_ABI async_buffer(const __env_t& __env, _Iter __first, _Iter __last)
       : async_buffer(__env, static_cast<size_type>(_CUDA_VSTD::distance(__first, __last)), ::cuda::experimental::no_init)
   {
@@ -742,7 +742,7 @@ auto make_async_buffer(stream_ref __stream, _Resource&& __mr, size_t __size, ::c
 
 // Iterator range make function
 _CCCL_TEMPLATE(class _Tp, class... _Properties, class _Iter)
-_CCCL_REQUIRES(_CUDA_VSTD::__is_cpp17_forward_iterator<_Iter>::value)
+_CCCL_REQUIRES(_CUDA_VSTD::__has_forward_traversal<_Iter>)
 async_buffer<_Tp, _Properties...>
 make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr, _Iter __first, _Iter __last)
 {
@@ -752,7 +752,7 @@ make_async_buffer(stream_ref __stream, any_resource<_Properties...> __mr, _Iter 
 
 _CCCL_TEMPLATE(class _Tp, class _Resource, class _Iter)
 _CCCL_REQUIRES(_CUDA_VMR::resource<_Resource> _CCCL_AND __has_default_queries<_Resource> _CCCL_AND
-                 _CUDA_VSTD::__is_cpp17_forward_iterator<_Iter>::value)
+                 _CUDA_VSTD::__has_forward_traversal<_Iter>)
 auto make_async_buffer(stream_ref __stream, _Resource&& __mr, _Iter __first, _Iter __last)
 {
   using __buffer_type = __buffer_type_for_props<_Tp, typename _CUDA_VSTD::decay_t<_Resource>::default_queries>;

--- a/libcudacxx/include/cuda/__iterator/constant_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/constant_iterator.h
@@ -32,7 +32,32 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
-//! @brief The \c constant_iterator class represents an iterator in a sequence of repeated values.
+//! @addtogroup iterators
+//! @{
+
+//! @brief The @c constant_iterator class represents an iterator in an infinite sequence of repeated values.
+//! @tparam _Tp the value type of the @c constant_iterator.
+//! @tparam _Index The index type of the @c constant_iterator. It can optionally be specified, but must satisfy
+//! __integer-like__
+//!
+//! This iterator is useful for creating a range filled with the same value without explicitly storing it in memory.
+//! Using @c constant_iterator saves both memory capacity and bandwidth.
+//!
+//! The following code snippet demonstrates how to create a @c constant_iterator whose @c value_type is @c int and whose
+//! value is @c 10.
+//!
+//! @code{.cpp}
+//! #include <cuda/iterator>
+//!
+//! cuda::constant_iterator iter(10);
+//!
+//! *iter;    // returns 10
+//! iter[0];  // returns 10
+//! iter[1];  // returns 10
+//! iter[13]; // returns 10
+//!
+//! // and so on...
+//! @endcode
 template <class _Tp, class _Index = _CUDA_VSTD::ptrdiff_t>
 class constant_iterator
 {
@@ -48,6 +73,11 @@ public:
   using value_type        = _Tp;
   using difference_type   = _CUDA_VSTD::ptrdiff_t;
 
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using reference = _Tp;
+  using pointer   = void;
+
 #if _CCCL_HAS_CONCEPTS()
   _CCCL_HIDE_FROM_ABI constant_iterator()
     requires _CUDA_VSTD::default_initializable<_Tp>
@@ -58,17 +88,17 @@ public:
   _CCCL_API constexpr constant_iterator() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Tp2>) {}
 #endif // !_CCCL_HAS_CONCEPTS()
 
-  //! @brief Creates \c constant_iterator from a \p __value. The index is set to zero
-  //! @param __value The value to store in the \c constant_iterator
+  //! @brief Creates a @c constant_iterator from a value. The index is set to zero
+  //! @param __value The value to store in the @c constant_iterator
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr constant_iterator(_Tp __value) noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Tp>)
       : __value_(_CUDA_VSTD::in_place, _CUDA_VSTD::move(__value))
       , __index_()
   {}
 
-  //! @brief Creates \c constant_iterator from a \p __value and an index
-  //! @param __value The value to store in the \c constant_iterator
-  //! @param __index The index in the sequence represented by this \c constant_iterator
+  //! @brief Creates @c constant_iterator from a value and an index
+  //! @param __value The value to store in the @c constant_iterator
+  //! @param __index The index in the sequence represented by this @c constant_iterator
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(typename _Index2)
   _CCCL_REQUIRES(_CUDA_VSTD::__integer_like<_Index2>)
@@ -115,7 +145,10 @@ public:
   //! @brief Decrements the stored index
   _CCCL_API constexpr constant_iterator& operator--() noexcept
   {
-    _CCCL_ASSERT(__index_ > 0, "The index must be greater than or equal to 0");
+    if constexpr (_CUDA_VSTD::is_signed_v<_Index>)
+    {
+      _CCCL_ASSERT(__index_ > 0, "The index must be greater than or equal to 0");
+    }
     --__index_;
     return *this;
   }
@@ -129,75 +162,20 @@ public:
     return __tmp;
   }
 
-  //! @brief Advances the stored index by \p __n
+  //! @brief Advances a @c constant_iterator by a given number of elements
   //! @param __n The amount of elements to advance
   _CCCL_API constexpr constant_iterator& operator+=(difference_type __n) noexcept
   {
-    _CCCL_ASSERT(__index_ + __n >= 0, "The index must be greater than or equal to 0");
+    if constexpr (_CUDA_VSTD::is_signed_v<_Index>)
+    {
+      _CCCL_ASSERT(__index_ + __n >= 0, "The index must be greater than or equal to 0");
+    }
     __index_ += static_cast<_Index>(__n);
     return *this;
   }
 
-  //! @brief Decrements the stored index by \p __n
-  //! @param __n The amount of elements to decrement
-  _CCCL_API constexpr constant_iterator& operator-=(difference_type __n) noexcept
-  {
-    _CCCL_ASSERT(__index_ - __n >= 0, "The index must be greater than or equal to 0");
-    __index_ -= static_cast<_Index>(__n);
-    return *this;
-  }
-
-  //! @brief Compares two \c constant_iterator for equality. Only compares the index in the sequence
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator==(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
-  {
-    return __lhs.__index_ == __rhs.__index_;
-  }
-#if _CCCL_STD_VER <= 2017
-  //! @brief Compares two \c constant_iterator for inequality. Only compares the index in the sequence
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator!=(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
-  {
-    return __lhs.__index_ != __rhs.__index_;
-  }
-#endif // _CCCL_STD_VER <= 2017
-
-#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-  //! @brief Three-way-compares two \c constant_iterator. Only compares the index in the sequence
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator<=>(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
-  {
-    return __lhs.__index_ <=> __rhs.__index_;
-  }
-#endif // _LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR()
-
-  //! @brief Compares two \c constant_iterator for less than. Only compares the index in the sequence
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator<(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
-  {
-    return __lhs.__index_ < __rhs.__index_;
-  }
-  //! @brief Compares two \c constant_iterator for less equal. Only compares the index in the sequence
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator<=(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
-  {
-    return __lhs.__index_ <= __rhs.__index_;
-  }
-  //! @brief Compares two \c constant_iterator for greater than. Only compares the index in the sequence
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator>(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
-  {
-    return __lhs.__index_ > __rhs.__index_;
-  }
-  //! @brief Compares two \c constant_iterator for greater equal. Only compares the index in the sequence
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator>=(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
-  {
-    return __lhs.__index_ >= __rhs.__index_;
-  }
-
-  //! @brief Advances a \c constant_iterator \p __iter  by \p __n
-  //! @param __iter The \c constant_iterator to advance
+  //! @brief Creates a copy of a @c constant_iterator advanced by a given number of elements
+  //! @param __iter The @c constant_iterator to advance
   //! @param __n The amount of elements to advance
   [[nodiscard]] _CCCL_API friend constexpr constant_iterator
   operator+(constant_iterator __iter, difference_type __n) noexcept
@@ -206,9 +184,9 @@ public:
     return __iter;
   }
 
-  //! @brief Advances a \c constant_iterator \p __iter  by \p __n
+  //! @brief Creates a copy of a @c constant_iterator advanced by a given number of elements
   //! @param __n The amount of elements to advance
-  //! @param __iter The \c constant_iterator to advance
+  //! @param __iter The @c constant_iterator to advance
   [[nodiscard]] _CCCL_API friend constexpr constant_iterator
   operator+(difference_type __n, constant_iterator __iter) noexcept
   {
@@ -216,9 +194,21 @@ public:
     return __iter;
   }
 
-  //! @brief Decrements a \c constant_iterator \p __iter  by \p __n
-  //! @param __iter The \c constant_iterator to decrement
+  //! @brief Decrements a @c constant_iterator by a given number of elements
   //! @param __n The amount of elements to decrement
+  _CCCL_API constexpr constant_iterator& operator-=(difference_type __n) noexcept
+  {
+    if constexpr (_CUDA_VSTD::is_signed_v<_Index>)
+    {
+      _CCCL_ASSERT(__index_ - __n >= 0, "The index must be greater than or equal to 0");
+    }
+    __index_ -= static_cast<_Index>(__n);
+    return *this;
+  }
+
+  //! @brief Creates a copy of a @c constant_iterator decremented by a given number of elements
+  //! @param __n The amount of elements to decrement
+  //! @param __iter The @c constant_iterator to decrement
   [[nodiscard]] _CCCL_API friend constexpr constant_iterator
   operator-(constant_iterator __iter, difference_type __n) noexcept
   {
@@ -226,12 +216,62 @@ public:
     return __iter;
   }
 
-  //! @brief Returns the distance between two \c constant_iterator
+  //! @brief Returns the distance between two @c constant_iterator
   [[nodiscard]] _CCCL_API friend constexpr difference_type
   operator-(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
   {
     return static_cast<difference_type>(__lhs.__index_) - static_cast<difference_type>(__rhs.__index_);
   }
+
+  //! @brief Compares two @c constant_iterator for equality by comparing the index in the sequence
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator==(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
+  {
+    return __lhs.__index_ == __rhs.__index_;
+  }
+
+#if _CCCL_STD_VER <= 2017
+  //! @brief Compares two @c constant_iterator for inequality by comparing the index in the sequence
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator!=(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
+  {
+    return __lhs.__index_ != __rhs.__index_;
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+  //! @brief Three-way-compares two @c constant_iterator by comparing the index in the sequence
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator<=>(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
+  {
+    return __lhs.__index_ <=> __rhs.__index_;
+  }
+#else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
+  //! @brief Compares two @c constant_iterator for less than by comparing the index in the sequence
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator<(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
+  {
+    return __lhs.__index_ < __rhs.__index_;
+  }
+  //! @brief Compares two @c constant_iterator for less equal by comparing the index in the sequence
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator<=(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
+  {
+    return __lhs.__index_ <= __rhs.__index_;
+  }
+  //! @brief Compares two @c constant_iterator for greater than by comparing the index in the sequence
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator>(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
+  {
+    return __lhs.__index_ > __rhs.__index_;
+  }
+  //! @brief Compares two @c constant_iterator for greater equal by comparing the index in the sequence
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator>=(const constant_iterator& __lhs, const constant_iterator& __rhs) noexcept
+  {
+    return __lhs.__index_ >= __rhs.__index_;
+  }
+#endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR()
 };
 
 template <class _Tp>
@@ -241,14 +281,17 @@ _CCCL_TEMPLATE(class _Tp, typename _Index)
 _CCCL_REQUIRES(_CUDA_VSTD::__integer_like<_Index>)
 _CCCL_HOST_DEVICE constant_iterator(_Tp, _Index) -> constant_iterator<_Tp, _Index>;
 
-//! @brief make_constant_iterator creates a bounded \p constant_iterator from a value and an index
-//! @param __value The value to be returned by the \p constant_iterator
-//! @param __index The optional index of the \p constant_iterator representing the position in a sequence. Defaults to 0
+//! @brief Creates a @c constant_iterator from a value and an index
+//! @param __value The value to be stored
+//! @param __index The optional index representing the position in a sequence. Defaults to 0.
+//! @relates constant_iterator
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr auto make_constant_iterator(_Tp __value, _CUDA_VSTD::ptrdiff_t __index = 0)
 {
   return constant_iterator<_Tp>{_CUDA_VSTD::move(__value), __index};
 }
+
+//! @} // end iterators
 
 _LIBCUDACXX_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__iterator/counting_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/counting_iterator.h
@@ -20,6 +20,7 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 #  include <cuda/std/__compare/three_way_comparable.h>
 #endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
@@ -55,6 +56,11 @@
 #include <cuda/std/__cccl/prologue.h>
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
+
+//! @addtogroup iterators
+//! @{
+
+//! @cond
 
 template <class _Int>
 struct __get_wider_signed
@@ -93,15 +99,15 @@ using _IotaDiffT = typename _CUDA_VSTD::conditional_t<
   __get_wider_signed<_Start>>::type;
 
 template <class _Iter>
-_CCCL_CONCEPT __decrementable = _CCCL_REQUIRES_EXPR((_Iter), _Iter __i)(
-  requires(_CUDA_VSTD::incrementable<_Iter>), _Same_as(_Iter&)(--__i), _Same_as(_Iter)(__i--));
+_CCCL_CONCEPT __decrementable = _CCCL_REQUIRES_EXPR((_Iter), _Iter __iter)(
+  requires(_CUDA_VSTD::incrementable<_Iter>), _Same_as(_Iter&)(--__iter), _Same_as(_Iter)(__iter--));
 
 template <class _Iter>
-_CCCL_CONCEPT __advanceable = _CCCL_REQUIRES_EXPR((_Iter), _Iter __i, const _Iter __j, const _IotaDiffT<_Iter> __n)(
+_CCCL_CONCEPT __advanceable = _CCCL_REQUIRES_EXPR((_Iter), _Iter __iter, const _Iter __j, const _IotaDiffT<_Iter> __n)(
   requires(__decrementable<_Iter>),
   requires(_CUDA_VSTD::totally_ordered<_Iter>),
-  _Same_as(_Iter&) __i += __n,
-  _Same_as(_Iter&) __i -= __n,
+  _Same_as(_Iter&) __iter += __n,
+  _Same_as(_Iter&) __iter -= __n,
   requires(_CUDA_VSTD::is_constructible_v<_Iter, decltype(__j + __n)>),
   requires(_CUDA_VSTD::is_constructible_v<_Iter, decltype(__n + __j)>),
   requires(_CUDA_VSTD::is_constructible_v<_Iter, decltype(__j - __n)>),
@@ -117,14 +123,17 @@ struct __counting_iterator_category<_Tp, _CUDA_VSTD::enable_if_t<_CUDA_VSTD::inc
   using iterator_category = _CUDA_VSTD::input_iterator_tag;
 };
 
-//! @brief \p counting_iterator is an iterator which represents a pointer into a range of sequentially changing values.
+//! @endcond
+
+//! @brief A @c counting_iterator represents an iterator into a range of sequentially increasing values.
+//! @tparam _Start the value type of the @c counting_iterator.
+//!
 //! This iterator is useful for creating a range filled with a sequence without explicitly storing it in memory. Using
-//! \p counting_iterator saves memory capacity and bandwidth.
+//! @c counting_iterator saves memory capacity and bandwidth.
 //!
-//! The following code snippet demonstrates how to create a \p counting_iterator whose \c value_type is \c int and which
-//! sequentially increments by \c 1.
+//! The following code snippet demonstrates how to create a @c counting_iterator whose @c value_type is @c int
 //!
-//! @code
+//! @code{.cpp}
 //! #include <cuda/iterator>
 //! ...
 //! // create iterators
@@ -136,44 +145,12 @@ struct __counting_iterator_category<_Tp, _CUDA_VSTD::enable_if_t<_CUDA_VSTD::inc
 //! first[100] // returns 110
 //!
 //! // sum of [first, last)
-//! thrust::reduce(first, last);   // returns 33 (i.e. 10 + 11 + 12)
+//! std::reduce(first, last);   // returns 33 (i.e. 10 + 11 + 12)
 //!
 //! // initialize vector to [0,1,2,..]
 //! cuda::counting_iterator iter(0);
-//! thrust::device_vector<int> vec(500);
-//! thrust::copy(iter, iter + vec.size(), vec.begin());
-//! @endcode
-//!
-//! This next example demonstrates how to use a \p counting_iterator with the \p thrust::copy_if function to compute the
-//! indices of the non-zero elements of a \p device_vector. In this example, we use the \p make_counting_iterator
-//! function to avoid specifying the type of the \p counting_iterator.
-//!
-//! @code
-//! #include <cuda/iterator>
-//! #include <thrust/copy.h>
-//! #include <thrust/functional.h>
-//! #include <thrust/device_vector.h>
-//!
-//! int main()
-//! {
-//!  // this example computes indices for all the nonzero values in a sequence
-//!
-//!  // sequence of zero and nonzero values
-//!  thrust::device_vector<int> stencil{0, 1, 1, 0, 0, 1, 0, 1};
-//!
-//!  // storage for the nonzero indices
-//!  thrust::device_vector<int> indices(8);
-//!
-//!  // use make_counting_iterator to define the sequence [0, 8)
-//!  auto indices_end = thrust::copy_if(cuda::counting_iterator{0},
-//!                                     cuda::counting_iterator{8},
-//!                                     stencil.begin(),
-//!                                     indices.begin(),
-//!                                     ::cuda::std::identity{});
-//!  // indices now contains [1,2,5,7]
-//!
-//!  return 0;
-//! }
+//! std::vector<int> vec(500);
+//! std::copy(iter, iter + vec.size(), vec.begin());
 //! @endcode
 #if _CCCL_HAS_CONCEPTS()
 template <_CUDA_VSTD::weakly_incrementable _Start>
@@ -183,8 +160,12 @@ template <class _Start,
           _CUDA_VSTD::enable_if_t<_CUDA_VSTD::weakly_incrementable<_Start>, int> = 0,
           _CUDA_VSTD::enable_if_t<_CUDA_VSTD::copyable<_Start>, int>             = 0>
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
-struct counting_iterator : public __counting_iterator_category<_Start>
+class counting_iterator : public __counting_iterator_category<_Start>
 {
+private:
+  _Start __value_ = _Start();
+
+public:
   using iterator_concept = _CUDA_VSTD::conditional_t<
     __advanceable<_Start>,
     _CUDA_VSTD::random_access_iterator_tag,
@@ -197,7 +178,10 @@ struct counting_iterator : public __counting_iterator_category<_Start>
   using value_type      = _Start;
   using difference_type = _IotaDiffT<_Start>;
 
-  _Start __value_ = _Start();
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using reference = _Start;
+  using pointer   = void;
 
 #if _CCCL_HAS_CONCEPTS()
   _CCCL_HIDE_FROM_ABI counting_iterator()
@@ -209,17 +193,22 @@ struct counting_iterator : public __counting_iterator_category<_Start>
   _CCCL_API constexpr counting_iterator() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Start2>) {}
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
+  //! @brief Creates a @c counting_iterator from an initial value.
+  //! @param __value The value to store in the @c counting_iterator
   _CCCL_API constexpr explicit counting_iterator(_Start __value) noexcept(
     _CUDA_VSTD::is_nothrow_move_constructible_v<_Start>)
       : __value_(_CUDA_VSTD::move(__value))
   {}
 
+  //! @brief Returns the value currently stored in the @c counting_iterator
   [[nodiscard]] _CCCL_API constexpr _Start operator*() const
     noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Start>)
   {
     return __value_;
   }
 
+  //! @brief Returns the value currently stored in the @c counting_iterator advanced by a number of steps
+  //! @param __n The amount of elements to advance
   _CCCL_TEMPLATE(class _Start2 = _Start)
   _CCCL_REQUIRES(__advanceable<_Start2>)
   [[nodiscard]] _CCCL_API constexpr _Start2 operator[](difference_type __n) const
@@ -236,12 +225,14 @@ struct counting_iterator : public __counting_iterator_category<_Start>
     }
   }
 
+  //! @brief Increments the stored value
   _CCCL_API constexpr counting_iterator& operator++() noexcept(noexcept(++_CUDA_VSTD::declval<_Start&>()))
   {
     ++__value_;
     return *this;
   }
 
+  //! @brief Increments the stored value
   _CCCL_API constexpr auto operator++(int) noexcept(
     noexcept(++_CUDA_VSTD::declval<_Start&>()) && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Start>)
   {
@@ -257,6 +248,7 @@ struct counting_iterator : public __counting_iterator_category<_Start>
     }
   }
 
+  //! @brief Decrements the stored value
   _CCCL_TEMPLATE(class _Start2 = _Start)
   _CCCL_REQUIRES(__decrementable<_Start2>)
   _CCCL_API constexpr counting_iterator& operator--() noexcept(noexcept(--_CUDA_VSTD::declval<_Start2&>()))
@@ -265,6 +257,7 @@ struct counting_iterator : public __counting_iterator_category<_Start>
     return *this;
   }
 
+  //! @brief Decrements the stored value
   _CCCL_TEMPLATE(class _Start2 = _Start)
   _CCCL_REQUIRES(__decrementable<_Start2>)
   _CCCL_API constexpr counting_iterator operator--(int) noexcept(
@@ -275,9 +268,9 @@ struct counting_iterator : public __counting_iterator_category<_Start>
     return __tmp;
   }
 
-  _CCCL_TEMPLATE(class _Start2 = _Start)
-  _CCCL_REQUIRES(__advanceable<_Start2>)
-  _CCCL_API constexpr counting_iterator& operator+=(difference_type __n) noexcept(_CUDA_VSTD::__integer_like<_Start2>)
+  //! @brief Increments the stored value by a given number of elements
+  //! @param __n The number of elements to increment
+  _CCCL_API constexpr counting_iterator& operator+=(difference_type __n) noexcept(_CUDA_VSTD::__integer_like<_Start>)
   {
     if constexpr (_CUDA_VSTD::__integer_like<_Start> && !_CUDA_VSTD::__signed_integer_like<_Start>)
     {
@@ -301,6 +294,31 @@ struct counting_iterator : public __counting_iterator_category<_Start>
     return *this;
   }
 
+  //! @brief Creates a copy of a @c counting_iterator advanced by a given number of elements
+  //! @param __iter The @c counting_iterator to advance
+  //! @param __n The amount of elements to advance
+  _CCCL_TEMPLATE(class _Start2 = _Start)
+  _CCCL_REQUIRES(__advanceable<_Start2>)
+  [[nodiscard]] _CCCL_API friend constexpr counting_iterator
+  operator+(counting_iterator __iter, difference_type __n) noexcept(_CUDA_VSTD::__integer_like<_Start2>)
+  {
+    __iter += __n;
+    return __iter;
+  }
+
+  //! @brief Creates a copy of a @c counting_iterator advanced by a given number of elements
+  //! @param __iter The @c counting_iterator to advance
+  //! @param __n The amount of elements to advance
+  _CCCL_TEMPLATE(class _Start2 = _Start)
+  _CCCL_REQUIRES(__advanceable<_Start2>)
+  [[nodiscard]] _CCCL_API friend constexpr counting_iterator
+  operator+(difference_type __n, counting_iterator __iter) noexcept(_CUDA_VSTD::__integer_like<_Start2>)
+  {
+    return __iter + __n;
+  }
+
+  //! @brief Decrements the stored value by a given number of elements
+  //! @param __n The amount of elements to decrement
   _CCCL_TEMPLATE(class _Start2 = _Start)
   _CCCL_REQUIRES(__advanceable<_Start2>)
   _CCCL_API constexpr counting_iterator& operator-=(difference_type __n) noexcept(_CUDA_VSTD::__integer_like<_Start2>)
@@ -327,98 +345,20 @@ struct counting_iterator : public __counting_iterator_category<_Start>
     return *this;
   }
 
-  _CCCL_TEMPLATE(class _Start2 = _Start)
-  _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable<_Start2>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator==(const counting_iterator& __x, const counting_iterator& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Start2&>() == _CUDA_VSTD::declval<const _Start2&>()))
-  {
-    return __x.__value_ == __y.__value_;
-  }
-
-#if _CCCL_STD_VER <= 2017
-  _CCCL_TEMPLATE(class _Start2 = _Start)
-  _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable<_Start2>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator!=(const counting_iterator& __x, const counting_iterator& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Start2&>() != _CUDA_VSTD::declval<const _Start2&>()))
-  {
-    return __x.__value_ != __y.__value_;
-  }
-#endif // _CCCL_STD_VER <= 2017
-
-  _CCCL_TEMPLATE(class _Start2 = _Start)
-  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered<_Start2>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator<(const counting_iterator& __x, const counting_iterator& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Start2&>() < _CUDA_VSTD::declval<const _Start2&>()))
-  {
-    return __x.__value_ < __y.__value_;
-  }
-
-  _CCCL_TEMPLATE(class _Start2 = _Start)
-  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered<_Start2>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator>(const counting_iterator& __x, const counting_iterator& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Start2&>() < _CUDA_VSTD::declval<const _Start2&>()))
-  {
-    return __y < __x;
-  }
-
-  _CCCL_TEMPLATE(class _Start2 = _Start)
-  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered<_Start2>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator<=(const counting_iterator& __x, const counting_iterator& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Start2&>() < _CUDA_VSTD::declval<const _Start2&>()))
-  {
-    return !(__y < __x);
-  }
-
-  _CCCL_TEMPLATE(class _Start2 = _Start)
-  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered<_Start2>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator>=(const counting_iterator& __x, const counting_iterator& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Start2&>() < _CUDA_VSTD::declval<const _Start2&>()))
-  {
-    return !(__x < __y);
-  }
-
-#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator<=>(const counting_iterator& __x, const counting_iterator& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Start2&>() <=> _CUDA_VSTD::declval<const _Start2&>()))
-    requires _CUDA_VSTD::totally_ordered<_Start> && _CUDA_VSTD::three_way_comparable<_Start>
-  {
-    return __x.__value_ <=> __y.__value_;
-  }
-#endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
-
+  //! @brief Creates a copy of a @c counting_iterator decremented by a given number of elements
+  //! @param __iter The @c counting_iterator to decrement
+  //! @param __n The amount of elements to decrement
   _CCCL_TEMPLATE(class _Start2 = _Start)
   _CCCL_REQUIRES(__advanceable<_Start2>)
   [[nodiscard]] _CCCL_API friend constexpr counting_iterator
-  operator+(counting_iterator __i, difference_type __n) noexcept(_CUDA_VSTD::__integer_like<_Start2>)
+  operator-(counting_iterator __iter, difference_type __n) noexcept(_CUDA_VSTD::__integer_like<_Start2>)
   {
-    __i += __n;
-    return __i;
+    __iter -= __n;
+    return __iter;
   }
 
-  _CCCL_TEMPLATE(class _Start2 = _Start)
-  _CCCL_REQUIRES(__advanceable<_Start2>)
-  [[nodiscard]] _CCCL_API friend constexpr counting_iterator
-  operator+(difference_type __n, counting_iterator __i) noexcept(_CUDA_VSTD::__integer_like<_Start2>)
-  {
-    return __i + __n;
-  }
-
-  _CCCL_TEMPLATE(class _Start2 = _Start)
-  _CCCL_REQUIRES(__advanceable<_Start2>)
-  [[nodiscard]] _CCCL_API friend constexpr counting_iterator
-  operator-(counting_iterator __i, difference_type __n) noexcept(_CUDA_VSTD::__integer_like<_Start2>)
-  {
-    __i -= __n;
-    return __i;
-  }
-
+  //! @brief Returns the distance between two @c counting_iterator
+  //! @return The difference between the stored values
   _CCCL_TEMPLATE(class _Start2 = _Start)
   _CCCL_REQUIRES(__advanceable<_Start2>)
   [[nodiscard]] _CCCL_API friend constexpr difference_type
@@ -443,15 +383,98 @@ struct counting_iterator : public __counting_iterator_category<_Start>
     }
     _CCCL_UNREACHABLE();
   }
+
+  //! @brief Compares two @c counting_iterator for equality.
+  //! @return True if the stored values compare equal
+  _CCCL_TEMPLATE(class _Start2 = _Start)
+  _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable<_Start2>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator==(const counting_iterator& __x, const counting_iterator& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Start2&>() == _CUDA_VSTD::declval<const _Start2&>()))
+  {
+    return __x.__value_ == __y.__value_;
+  }
+
+#if _CCCL_STD_VER <= 2017
+  //! @brief Compares two @c counting_iterator for inequality.
+  //! @return True if the stored values do not compare equal
+  _CCCL_TEMPLATE(class _Start2 = _Start)
+  _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable<_Start2>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator!=(const counting_iterator& __x, const counting_iterator& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Start2&>() != _CUDA_VSTD::declval<const _Start2&>()))
+  {
+    return __x.__value_ != __y.__value_;
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+  //! @brief Three-way compares two @c counting_iterator.
+  //! @return The three-way comparison of the stored values
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator<=>(const counting_iterator& __x, const counting_iterator& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Start2&>() <=> _CUDA_VSTD::declval<const _Start2&>()))
+    requires _CUDA_VSTD::totally_ordered<_Start> && _CUDA_VSTD::three_way_comparable<_Start>
+  {
+    return __x.__value_ <=> __y.__value_;
+  }
+#else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
+  //! @brief Compares two @c counting_iterator for less than.
+  //! @return True if stored values compare less than
+  _CCCL_TEMPLATE(class _Start2 = _Start)
+  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered<_Start2>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator<(const counting_iterator& __x, const counting_iterator& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Start2&>() < _CUDA_VSTD::declval<const _Start2&>()))
+  {
+    return __x.__value_ < __y.__value_;
+  }
+
+  //! @brief Compares two @c counting_iterator for greater than.
+  //! @return True if stored values compare greater than
+  _CCCL_TEMPLATE(class _Start2 = _Start)
+  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered<_Start2>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator>(const counting_iterator& __x, const counting_iterator& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Start2&>() < _CUDA_VSTD::declval<const _Start2&>()))
+  {
+    return __y < __x;
+  }
+
+  //! @brief Compares two @c counting_iterator for less equal.
+  //! @return True if stored values compare less equal
+  _CCCL_TEMPLATE(class _Start2 = _Start)
+  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered<_Start2>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator<=(const counting_iterator& __x, const counting_iterator& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Start2&>() < _CUDA_VSTD::declval<const _Start2&>()))
+  {
+    return !(__y < __x);
+  }
+
+  //! @brief Compares two @c counting_iterator for greater equal.
+  //! @return True if stored values compare greater equal
+  _CCCL_TEMPLATE(class _Start2 = _Start)
+  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered<_Start2>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator>=(const counting_iterator& __x, const counting_iterator& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Start2&>() < _CUDA_VSTD::declval<const _Start2&>()))
+  {
+    return !(__x < __y);
+  }
+#endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 };
 
-//! @brief make_counting_iterator creates a \p counting_iterator from an __integer-like__ \c _Start
-//! @param __start The __integer-like__ \c _Start representing the initial count
+//! @brief Creates a @c counting_iterator from an __integer-like__ @c _Start
+//! @param __start The __integer-like__ @c _Start representing the initial count
+//! @relates counting_iterator
 template <class _Start>
 [[nodiscard]] _CCCL_API constexpr auto make_counting_iterator(_Start __start)
 {
   return counting_iterator<_Start>{__start};
 }
+
+//! @} iterators
 
 _LIBCUDACXX_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__iterator/discard_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/discard_iterator.h
@@ -32,12 +32,15 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
-//! @brief \p discard_iterator is an iterator which represents a special kind of pointer that ignores values written to
+//! @addtogroup iterators
+//! @{
+
+//! @brief @c discard_iterator is an iterator which represents a special kind of pointer that ignores values written to
 //! it upon dereference. This iterator is useful for ignoring the output of certain algorithms without wasting memory
-//! capacity or bandwidth. \p discard_iterator may also be used to count the size of an algorithm's output which may not
+//! capacity or bandwidth. @c discard_iterator may also be used to count the size of an algorithm's output which may not
 //! be known a priori.
 //!
-//! The following code snippet demonstrates how to use \p discard_iterator to ignore one of the output ranges of
+//! The following code snippet demonstrates how to use @c discard_iterator to ignore one of the output ranges of
 //! reduce_by_key
 //!
 //! @code
@@ -87,10 +90,10 @@ public:
   using pointer           = void;
   using reference         = void;
 
-  //! @brief Default constructs a \p discard_iterator at index zero
+  //! @brief Default constructs a @c discard_iterator at index zero
   _CCCL_HIDE_FROM_ABI constexpr discard_iterator() = default;
 
-  //! @brief Constructs a \p discard_iterator with a given \p __index
+  //! @brief Constructs a @c discard_iterator with a given index
   //! @param __index The index used for the discard iterator
   _CCCL_TEMPLATE(class _Integer)
   _CCCL_REQUIRES(_CUDA_VSTD::__integer_like<_Integer>)
@@ -104,13 +107,13 @@ public:
     return __index_;
   }
 
-  //! @brief Dereferences the \c discard_iterator returning a proxy that discards all values that are assigned to it
+  //! @brief Dereferences the @c discard_iterator returning a proxy that discards all values that are assigned to it
   [[nodiscard]] _CCCL_API constexpr __discard_proxy operator*() const noexcept
   {
     return {};
   }
 
-  //! @brief Subscipts the \c discard_iterator returning a proxy that discards all values that are assigned to it
+  //! @brief Subscipts the @c discard_iterator returning a proxy that discards all values that are assigned to it
   [[nodiscard]] _CCCL_API constexpr __discard_proxy operator[](difference_type) const noexcept
   {
     return {};
@@ -146,23 +149,23 @@ public:
     return __tmp;
   }
 
-  //! @brief Returns a copy of this \c discard_iterator advanced by \p __n
+  //! @brief Returns a copy of this @c discard_iterator advanced by a number of elements
   //! @param __n The number of elements to advance
   [[nodiscard]] _CCCL_API constexpr discard_iterator operator+(difference_type __n) const noexcept
   {
     return discard_iterator{__index_ + __n};
   }
 
-  //! @brief Returns a copy of \p __x advanced by \p __n
+  //! @brief Returns a copy of a @c discard_iterator advanced by a number of elements
   //! @param __n The number of elements to advance
-  //! @param __x The original \c discard_iterator
+  //! @param __x The original @c discard_iterator
   [[nodiscard]] _CCCL_API friend constexpr discard_iterator
   operator+(difference_type __n, const discard_iterator& __x) noexcept
   {
     return __x + __n;
   }
 
-  //! @brief Advances the index of this \c discard_iterator by \p __n
+  //! @brief Advances the index of this @c discard_iterator by a number of elements
   //! @param __n The number of elements to advance
   _CCCL_API constexpr discard_iterator& operator+=(difference_type __n) noexcept
   {
@@ -170,16 +173,16 @@ public:
     return *this;
   }
 
-  //! @brief Returns a copy of this \c discard_iterator decremented by \p __n
+  //! @brief Returns a copy of this @c discard_iterator decremented by a number of elements
   //! @param __n The number of elements to decrement
   [[nodiscard]] _CCCL_API constexpr discard_iterator operator-(difference_type __n) const noexcept
   {
     return discard_iterator{__index_ - __n};
   }
 
-  //! @brief Returns the distance between \p __lhs and \p __rhs
-  //! @param __lhs The left \c discard_iterator
-  //! @param __rhs The right \c discard_iterator
+  //! @brief Returns the distance between two @c discard_iterator's
+  //! @param __lhs The left @c discard_iterator
+  //! @param __rhs The right @c discard_iterator
   //! @return __rhs.__index_ - __lhs.__index_
   [[nodiscard]] _CCCL_API friend constexpr difference_type
   operator-(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
@@ -187,8 +190,8 @@ public:
     return __rhs.__index_ - __lhs.__index_;
   }
 
-  //! @brief Returns the distance between \p __lhs a \p default_sentinel
-  //! @param __lhs The left \c discard_iterator
+  //! @brief Returns the distance between a @c default_sentinel and a @c discard_iterator
+  //! @param __lhs The @c discard_iterator
   //! @return -__lhs.__index_
   [[nodiscard]] _CCCL_API friend constexpr difference_type
   operator-(const discard_iterator& __lhs, _CUDA_VSTD::default_sentinel_t) noexcept
@@ -196,8 +199,8 @@ public:
     return static_cast<difference_type>(-__lhs.__index_);
   }
 
-  //! @brief Returns the distance between a \p default_sentinel and \p __rhs
-  //! @param __rhs The right \c discard_iterator
+  //! @brief Returns the distance between a @c discard_iterator and a @c default_sentinel
+  //! @param __rhs The @c discard_iterator
   //! @return __rhs.__index_
   [[nodiscard]] _CCCL_API friend constexpr difference_type
   operator-(_CUDA_VSTD::default_sentinel_t, const discard_iterator& __rhs) noexcept
@@ -205,7 +208,7 @@ public:
     return static_cast<difference_type>(__rhs.__index_);
   }
 
-  //! @brief Decrements the index of the \c discard_iterator by \p __n
+  //! @brief Decrements the index of the @c discard_iterator by a number of elements
   //! @param __n The number of elements to decrement
   _CCCL_API constexpr discard_iterator& operator-=(difference_type __n) noexcept
   {
@@ -213,7 +216,7 @@ public:
     return *this;
   }
 
-  //! @brief Compares two \c discard_iterator for equality by comparing their indices
+  //! @brief Compares two @c discard_iterator for equality by comparing the indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator==(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
@@ -221,7 +224,7 @@ public:
   }
 
 #if _CCCL_STD_VER <= 2017
-  //! @brief Compares two \c discard_iterator for inequality by comparing their indices
+  //! @brief Compares two @c discard_iterator for inequality by comparing the indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator!=(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
@@ -229,7 +232,8 @@ public:
   }
 #endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Compares a \c discard_iterator with \p default_sentinel , true if the index of \p __lhs is zero
+  //! @brief Compares a @c discard_iterator with @c default_sentinel
+  //! @returns True if the index of @param __lhs is zero
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator==(const discard_iterator& __lhs, _CUDA_VSTD::default_sentinel_t) noexcept
   {
@@ -237,21 +241,24 @@ public:
   }
 
 #if _CCCL_STD_VER <= 2017
-  //! @brief Compares a \c discard_iterator with \p default_sentinel , true if the index of \p __lhs is zero
+  //! @brief Compares a @c discard_iterator with @c default_sentinel
+  //! @returns True if the index of @param __lhs is zero
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator==(_CUDA_VSTD::default_sentinel_t, const discard_iterator& __rhs) noexcept
   {
     return __rhs.__index_ == 0;
   }
 
-  //! @brief Compares a \c discard_iterator with \p default_sentinel , true if the index of \p __lhs is not zero
+  //! @brief Compares a @c discard_iterator with @c default_sentinel
+  //! @returns True if the index of @param __lhs is not zero
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator!=(const discard_iterator& __lhs, _CUDA_VSTD::default_sentinel_t) noexcept
   {
     return __lhs.__index_ != 0;
   }
 
-  //! @brief Compares a \c discard_iterator with \p default_sentinel , true if the index of \p __lhs is not zero
+  //! @brief Compares a @c discard_iterator with @c default_sentinel
+  //! @returns True if the index of @param __lhs is not zero
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator!=(_CUDA_VSTD::default_sentinel_t, const discard_iterator& __rhs) noexcept
   {
@@ -260,52 +267,55 @@ public:
 #endif // _CCCL_STD_VER <= 2017
 
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-  //! @brief Three-way-compares two \c discard_iterator by comparing their indices
+  //! @brief Three-way-compares two @c discard_iterator by comparing the indices
   [[nodiscard]] _CCCL_API friend constexpr strong_ordering
   operator<=>(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
     return __lhs.__index_ <=> __rhs.__index_;
   }
-#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-
-  //! @brief Compares two \c discard_iterator for less than by comparing their indices
+#else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
+  //! @brief Compares two @c discard_iterator for less than by comparing the indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator<(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
     return __lhs.__index_ < __rhs.__index_;
   }
 
-  //! @brief Compares two \c discard_iterator for less equal by comparing their indices
+  //! @brief Compares two @c discard_iterator for less equal by comparing the indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator<=(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
     return __lhs.__index_ <= __rhs.__index_;
   }
 
-  //! @brief Compares two \c discard_iterator for greater than by comparing their indices
+  //! @brief Compares two @c discard_iterator for greater than by comparing the indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator>(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
     return __lhs.__index_ > __rhs.__index_;
   }
 
-  //! @brief Compares two \c discard_iterator for greater equal by comparing their indices
+  //! @brief Compares two @c discard_iterator for greater equal by comparing the indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator>=(const discard_iterator& __lhs, const discard_iterator& __rhs) noexcept
   {
     return __lhs.__index_ >= __rhs.__index_;
   }
+#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 };
 
-//! @brief Creates a \p discard_iterator from an optional index.
-//! @param __index The index of the \p discard_iterator within a range. The default index is \c 0.
-//! @return A new \p discard_iterator with \p __index as the couner.
+//! @brief Creates a @c discard_iterator from an optional index.
+//! @param __index The index of the @c discard_iterator within a range. The default index is @c 0.
+//! @return A new @c discard_iterator with @c __index as the counter.
+//! @relates discard_iterator
 _CCCL_TEMPLATE(class _Integer = _CUDA_VSTD::ptrdiff_t)
 _CCCL_REQUIRES(_CUDA_VSTD::__integer_like<_Integer>)
 [[nodiscard]] _CCCL_API constexpr discard_iterator make_discard_iterator(_Integer __index = 0)
 {
   return discard_iterator{__index};
 }
+
+//! @}
 
 _LIBCUDACXX_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__iterator/permutation_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/permutation_iterator.h
@@ -38,24 +38,27 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
-//! @brief \p permutation_iterator is an iterator which represents a pointer into a reordered view of a given range.
-//! \p permutation_iterator is an imprecise name; the reordered view need not be a strict permutation. This iterator is
+//! @addtogroup iterators
+//! @{
+
+//! @brief @c permutation_iterator is an iterator which represents a pointer into a reordered view of a given range.
+//! @c permutation_iterator is an imprecise name; the reordered view need not be a strict permutation. This iterator is
 //! useful for fusing a scatter or gather operation with other algorithms.
 //!
 //! This iterator takes two arguments:
 //!
-//!   - an iterator to the range \c V on which the "permutation" will be applied
-//!   - an iterator to a range of indices defining the reindexing scheme that determines how the elements of \c V will
-//!   be permuted.
+//!   - an iterator to the range @c V on which the "permutation" will be applied, referred to as @c iter below
+//!   - an iterator to a range of indices defining the reindexing scheme that determines how the elements of @c V will
+//!   be permuted, referred to as @c index below
 //!
-//! Note that \p permutation_iterator is not limited to strict permutations of the given range \c V. The distance
-//! between begin and end of the reindexing iterators is allowed to be smaller compared to the size of the range \c V,
-//! in which case the \p permutation_iterator only provides a "permutation" of a subset of \c V. The indices do not
-//! need to be unique. In this same context, it must be noted that the past-the-end \p permutation_iterator is
+//! Note that @c permutation_iterator is not limited to strict permutations of the given range @c V. The distance
+//! between begin and end of the reindexing iterators is allowed to be smaller compared to the size of the range @c V,
+//! in which case the @c permutation_iterator only provides a "permutation" of a subset of @c V. The indices do not
+//! need to be unique. In this same context, it must be noted that the past-the-end @c permutation_iterator is
 //! completely defined by means of the past-the-end iterator to the indices.
 //!
-//! The following code snippet demonstrates how to create a \p permutation_iterator which represents a reordering of the
-//! contents of a \p device_vector.
+//! The following code snippet demonstrates how to create a @c permutation_iterator which represents a reordering of the
+//! contents of a @c device_vector.
 //!
 //! @code
 //! #include <cuda/iterator>
@@ -127,18 +130,18 @@ public:
                 "cuda::permutation_iterator: _Indexs value type must be convertible to iter_difference<Iter>");
 
   //! To actually use operator+ we need the index iterator to be random access
-  static_assert(_CUDA_VSTD::random_access_iterator<_Index>,
+  static_assert(_CUDA_VSTD::__has_random_access_traversal<_Index>,
                 "cuda::permutation_iterator: _Index must be a random access iterator!");
 
   //! To actually use operator+ we need the base iterator to be random access
-  static_assert(_CUDA_VSTD::random_access_iterator<_Iter>,
+  static_assert(_CUDA_VSTD::__has_random_access_traversal<_Iter>,
                 "cuda::permutation_iterator: _Iter must be a random access iterator!");
 
-  //! @brief Default constructs an \p permutation_iterator with a value initialized iterator and index
+  //! @brief Default constructs an @c permutation_iterator with a value initialized iterator and index
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HIDE_FROM_ABI constexpr permutation_iterator() = default;
 
-  //! @brief Constructs an \p permutation_iterator from an iterator and an optional index
+  //! @brief Constructs an @c permutation_iterator from an iterator and an optional index
   //! @param __iter The iterator to to index from
   //! @param __index The iterator with the permutations
   _CCCL_EXEC_CHECK_DISABLE
@@ -148,34 +151,37 @@ public:
       , __index_(__index)
   {}
 
-  //! @brief Returns a const reference to the stored iterator we are indexing from
+  //! @brief Returns a const reference to the stored base iterator @c iter
   [[nodiscard]] _CCCL_API constexpr const _Iter& base() const& noexcept
   {
     return __iter_;
   }
 
-  //! @brief Extracts the stored iterator we are indexing from
+  //! @brief Extracts the stored base iterator @c iter
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr _Iter base() && noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Iter>)
   {
     return _CUDA_VSTD::move(__iter_);
   }
 
-  //! @brief Returns a const reference to the index iterator
+  //! @cond
+  //! @brief Returns a const reference to the stored index iterator @c index
   [[nodiscard]] _CCCL_API constexpr const _Index& __index() const noexcept
   {
     return __index_;
   }
+  //! @endcond
 
   //! @brief Returns the current index
+  //! @return Equivalent to ``*index``
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr difference_type index() const noexcept
   {
     return static_cast<difference_type>(*__index_);
   }
 
-  //! @brief Dereferences the stored iterator offset by \c index()
-  //! @returns __iter_[index()]
+  //! @brief Dereferences the @c permutation_iterator
+  //! @return Equivalent to ``iter[*index]``
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr decltype(auto)
   operator*() noexcept(noexcept(__iter_[static_cast<__iter_difference_t>(*__index_)]))
@@ -183,8 +189,8 @@ public:
     return __iter_[static_cast<__iter_difference_t>(*__index_)];
   }
 
-  //! @brief Dereferences the stored iterator offset by \p index()
-  //! @returns __iter_[index()]
+  //! @brief Dereferences the @c permutation_iterator
+  //! @return Equivalent to ``iter[*index]``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__dereferenceable<const _Iter2>)
@@ -194,9 +200,9 @@ public:
     return __iter_[static_cast<__iter_difference_t>(*__index_)];
   }
 
-  //! @brief Subscripts the stored iterator by \p __n
+  //! @brief Subscripts the @c permutation_iterator by an offset
   //! @param __n The additional offset
-  //! @returns __iter_[__index_[__n]]
+  //! @return Equivalent to ``iter[index[__n]]``
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr decltype(auto)
   operator[](difference_type __n) noexcept(noexcept(__iter_[static_cast<__iter_difference_t>(__index_[__n])]))
@@ -204,9 +210,9 @@ public:
     return __iter_[static_cast<__iter_difference_t>(__index_[__n])];
   }
 
-  //! @brief Subscripts the stored iterator by \p __n
+  //! @brief Subscripts the @c permutation_iterator by an offset
   //! @param __n The additional offset
-  //! @returns __iter_[__index_[__n]]
+  //! @return Equivalent to ``iter[index[__n]]``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__dereferenceable<const _Iter2>)
@@ -216,7 +222,8 @@ public:
     return __iter_[static_cast<__iter_difference_t>(__index_[__n])];
   }
 
-  //! @brief Increments the stored index iterator
+  //! @brief Increments the @c permutation_iterator
+  //! @return Equivalent to ``++index``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr permutation_iterator& operator++() noexcept(noexcept(++__index_))
   {
@@ -224,7 +231,8 @@ public:
     return *this;
   }
 
-  //! @brief Increments the stored index iterator
+  //! @brief Increments the @c permutation_iterator
+  //! @return Equivalent to ``index++``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr permutation_iterator operator++(int) noexcept(
     noexcept(++__index_)
@@ -235,7 +243,8 @@ public:
     return __tmp;
   }
 
-  //! @brief Decrements the stored index iterator
+  //! @brief Increments the @c permutation_iterator
+  //! @return Equivalent to ``--index``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr permutation_iterator& operator--() noexcept(noexcept(--__index_))
   {
@@ -243,7 +252,8 @@ public:
     return *this;
   }
 
-  //! @brief Decrements the stored index iterator
+  //! @brief Increments the @c permutation_iterator
+  //! @return Equivalent to ``index++``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr permutation_iterator operator--(int) noexcept(
     noexcept(--__index_)
@@ -254,30 +264,35 @@ public:
     return __tmp;
   }
 
-  //! @brief Advances the stored index iterator by \p __n
+  //! @brief Advances a @c permutation_iterator by a given number of elements
+  //! @param __iter The original @c permutation_iterator
   //! @param __n The number of elements to advance
-  _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API constexpr permutation_iterator operator+(difference_type __n) const
-    noexcept(noexcept(__index_ + __n) && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter>
-             && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Index>)
-  {
-    return permutation_iterator{__iter_, __index_ + __n};
-  }
-
-  //! @brief Returns a copy of \p __x advanced by \p __n
-  //! @param __n The number of elements to advance
-  //! @param __x The original \c permutation_iterator
+  //! @return Equivalent to ``permutation_iterator{iter, index + __n}``
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
-  operator+(difference_type __n, const permutation_iterator& __x) noexcept(
-    noexcept(__index_ + __n)
+  operator+(const permutation_iterator& __iter, difference_type __n) noexcept( //
+    noexcept(__iter.__index_ + __n)
     && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter> && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Index>)
   {
-    return __x + __n;
+    return permutation_iterator{__iter.__iter_, __iter.__index_ + __n};
   }
 
-  //! @brief Advances the \c permutation_iterator by \p __n
+  //! @brief Advances a @c permutation_iterator by a given number of elements
   //! @param __n The number of elements to advance
+  //! @param __iter The original @c permutation_iterator
+  //! @return Equivalent to ``permutation_iterator{iter, index + __n}``
+  _CCCL_EXEC_CHECK_DISABLE
+  [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
+  operator+(difference_type __n, const permutation_iterator& __iter) noexcept(
+    noexcept(__iter.__index_ + __n)
+    && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter> && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Index>)
+  {
+    return permutation_iterator{__iter.__iter_, __iter.__index_ + __n};
+  }
+
+  //! @brief Advances the @c permutation_iterator by a given number of elements
+  //! @param __n The number of elements to advance
+  //! @return Equivalent to ``index + __n``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr permutation_iterator& operator+=(difference_type __n) noexcept(noexcept(__index_ += __n))
   {
@@ -285,18 +300,22 @@ public:
     return *this;
   }
 
-  //! @brief Returns a copy of the \c permutation_iterator decremented by \p __n
+  //! @brief Decrements a @c permutation_iterator by a given number of elements
+  //! @param __iter The original @c permutation_iterator
   //! @param __n The number of elements to decrement
+  //! @return Equivalent to ``permutation_iterator{iter, index - __n}``
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API constexpr permutation_iterator operator-(difference_type __n) const
-    noexcept(noexcept(__index_ - __n) && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter>
-             && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Index>)
+  [[nodiscard]] _CCCL_API friend constexpr permutation_iterator
+  operator-(const permutation_iterator& __iter, difference_type __n) noexcept( //
+    noexcept(__iter.__index_ - __n)
+    && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter> && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Index>)
   {
-    return permutation_iterator{__iter_, __index_ - __n};
+    return permutation_iterator{__iter.__iter_, __iter.__index_ - __n};
   }
 
-  //! @brief Decrements the \c permutation_iterator by \p __n
+  //! @brief Decrements the @c permutation_iterator by a given number of elements
   //! @param __n The number of elements to decrement
+  //! @return Equivalent to ``index - __n``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr permutation_iterator& operator-=(difference_type __n) noexcept(noexcept(__index_ -= __n))
   {
@@ -304,7 +323,8 @@ public:
     return *this;
   }
 
-  //! @brief Returns the difference in index between two \c permutation_iterators. Returns distance between indices
+  //! @brief Returns the distance between two @c permutation_iterators.
+  //! @return Equivalent to ``__lhs.index - __rhs.index``
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API friend constexpr difference_type
   operator-(const permutation_iterator& __lhs, const permutation_iterator& __rhs) noexcept(__nothrow_difference<_Index>)
@@ -312,7 +332,8 @@ public:
     return __lhs.__index_ - __rhs.__index();
   }
 
-  //! @brief Compares two \c permutation_iterator for equality, by comparing the memory location they point at
+  //! @brief Compares two @c permutation_iterator for equality by comparing @c index
+  //! @return Equivalent to ``__lhs.index == __rhs.index``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherIter, class _OtherOffset)
   _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable_with<_Iter, _OtherIter>)
@@ -324,7 +345,8 @@ public:
   }
 
 #if _CCCL_STD_VER <= 2017
-  //! @brief Compares two \c permutation_iterator for inequality, by comparing the memory location they point at
+  //! @brief Compares two @c permutation_iterator for inequality by comparing @c index
+  //! @return Equivalent to ``__lhs.index != __rhs.index``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherIter, class _OtherOffset)
   _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable_with<_Iter, _OtherIter>)
@@ -340,8 +362,9 @@ public:
   template <class _Iter1, class _Iter2>
   static constexpr bool __nothrow_three_way = noexcept(_CUDA_VSTD::declval<_Iter1>() <=> _CUDA_VSTD::declval<_Iter2>());
 
-  //! @brief Three-way-compares two \c permutation_iterator for inequality, by three-way-comparing the memory location
+  //! @brief Three-way-compares two @c permutation_iterator for inequality by comparing @c index
   //! they point at
+  //! @return Equivalent to ``__lhs.index <=> __rhs.index``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherIter, class _OtherOffset)
   _CCCL_REQUIRES(_CUDA_VSTD::three_way_comparable_with<_Index, _OtherOffset>)
@@ -351,9 +374,9 @@ public:
   {
     return __lhs.__index_ <=> __rhs.__index();
   }
-#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-
-  //! @brief Compares two \c permutation_iterator for less than, by comparing the memory location they point at
+#else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
+  //! @brief Compares two @c permutation_iterator for less than by comparing @c index
+  //! @return Equivalent to ``__lhs.index < __rhs.index``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherIter, class _OtherOffset)
   _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Index, _OtherOffset>)
@@ -364,7 +387,8 @@ public:
     return __lhs.__index_ < __rhs.__index();
   }
 
-  //! @brief Compares two \c permutation_iterator for less equal, by comparing the memory location they point at
+  //! @brief Compares two @c permutation_iterator for less equal by comparing @c index
+  //! @return Equivalent to ``__lhs.index <= __rhs.index``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherIter, class _OtherOffset)
   _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Index, _OtherOffset>)
@@ -375,7 +399,8 @@ public:
     return __lhs.__index_ <= __rhs.__index();
   }
 
-  //! @brief Compares two \c permutation_iterator for greater than, by comparing the memory location they point at
+  //! @brief Compares two @c permutation_iterator for greater than by comparing @c index
+  //! @return Equivalent to ``__lhs.index > __rhs.index``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherIter, class _OtherOffset)
   _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Index, _OtherOffset>)
@@ -386,7 +411,8 @@ public:
     return __lhs.__index_ > __rhs.__index();
   }
 
-  //! @brief Compares two \c permutation_iterator for greater equal, by comparing the memory location they point at
+  //! @brief Compares two @c permutation_iterator for greater equal by comparing @c index
+  //! @return Equivalent to ``__lhs.index >= __rhs.index``
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherIter, class _OtherOffset)
   _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Index, _OtherOffset>)
@@ -396,23 +422,29 @@ public:
   {
     return __lhs.__index_ >= __rhs.__index();
   }
+#endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 };
 
 _CCCL_TEMPLATE(class _Iter, class _Index)
-_CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter> _CCCL_AND _CUDA_VSTD::random_access_iterator<_Index>)
+_CCCL_REQUIRES(
+  _CUDA_VSTD::__has_random_access_traversal<_Iter> _CCCL_AND _CUDA_VSTD::__has_random_access_traversal<_Index>)
 _CCCL_HOST_DEVICE permutation_iterator(_Iter, _Index) -> permutation_iterator<_Iter, _Index>;
 
-//! @brief Creates an \c permutation_iterator from an iterator and an iterator to an integral index
+//! @brief Creates an @c permutation_iterator from a base iterator and an iterator to an integral index
 //! @param __iter The iterator
 //! @param __index The iterator to an integral index
+//! @relates permutation_iterator
 _CCCL_TEMPLATE(class _Iter, class _Index)
-_CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter> _CCCL_AND _CUDA_VSTD::random_access_iterator<_Index>)
+_CCCL_REQUIRES(
+  _CUDA_VSTD::__has_random_access_traversal<_Iter> _CCCL_AND _CUDA_VSTD::__has_random_access_traversal<_Index>)
 [[nodiscard]] _CCCL_API constexpr permutation_iterator<_Iter, _Index>
 make_permutation_iterator(_Iter __iter, _Index __index) noexcept(
   _CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter> && _CUDA_VSTD::is_nothrow_copy_constructible_v<_Index>)
 {
   return permutation_iterator<_Iter, _Index>{__iter, __index};
 }
+
+//! @}
 
 _LIBCUDACXX_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__iterator/strided_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/strided_iterator.h
@@ -38,16 +38,21 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
-//! @brief A \p strided_iterator wraps another iterator and advances it by a specified stride each time it is
+//! @addtogroup iterators
+//! @{
+
+//! @brief A @c strided_iterator wraps another iterator and advances it by a specified stride each time it is
 //! incremented or decremented.
 //!
-//! @param _Iter A random access iterator
-//! @param _Stride Either an \ref __integer-like__ or a \ref __integral-constant-like__ specifying the stride
+//! @tparam _Iter A random access iterator
+//! @tparam _Stride Either an <a href="https://eel.is/c++draft/iterator.concept.winc#4">integer-like</a> or an
+//! <a href="https://eel.is/c++draft/views.contiguous#concept:integral-constant-like">integral-constant-like</a>
+//! specifying the stride
 template <class _Iter, class _Stride = _CUDA_VSTD::iter_difference_t<_Iter>>
 class strided_iterator
 {
 private:
-  static_assert(_CUDA_VSTD::random_access_iterator<_Iter>,
+  static_assert(_CUDA_VSTD::__has_random_access_traversal<_Iter>,
                 "The iterator underlying a strided_iterator must be a random access iterator.");
   static_assert(_CUDA_VSTD::__integer_like<_Stride> || _CUDA_VSTD::__integral_constant_like<_Stride>,
                 "The stride of a strided_iterator must either be an integer-like or integral-constant-like.");
@@ -64,22 +69,34 @@ public:
   using value_type        = _CUDA_VSTD::iter_value_t<_Iter>;
   using difference_type   = _CUDA_VSTD::iter_difference_t<_Iter>;
 
-  //! NOTE: _Iter must be default initializable because it is a random_access_iterator and thereby semiregular
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using reference = value_type;
+  using pointer   = void;
+
+  //! @brief value-initializes both the base iterator and stride
+  //! @note _Iter must be default initializable because it is a random_access_iterator and thereby semiregular
   //!       _Stride must be integer-like or integral_constant_like which requires default constructability
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HIDE_FROM_ABI strided_iterator() = default;
 
-  // We want to avoid constructing a strided_iterator with a value constructed __integer like__ stride, because that
-  // would value construct to 0 and incrementing the iterator would do nothing.
+  //! @brief Constructs a @c strided_iterator from a base iterator
+  //! @param __iter The base iterator
+  //! @note We cannot construct a @c strided_iterator with an
+  //! <a href="https://eel.is/c++draft/iterator.concept.winc#4">integer-like</a> stride, because that would value
+  //! construct to 0 and incrementing the iterator would do nothing.
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Stride2 = _Stride)
-  _CCCL_REQUIRES((!_CUDA_VSTD::__integer_like<_Stride2>) )
+  _CCCL_REQUIRES(_CUDA_VSTD::__integral_constant_like<_Stride2>)
   _CCCL_API constexpr explicit strided_iterator(_Iter __iter) noexcept(
     _CUDA_VSTD::is_nothrow_move_constructible_v<_Iter> && _CUDA_VSTD::is_nothrow_default_constructible_v<_Stride2>)
       : __iter_(_CUDA_VSTD::move(__iter))
       , __stride_()
   {}
 
+  //! @brief Constructs a @c strided_iterator from a base iterator and a stride
+  //! @param __iter The base iterator
+  //! @param __stride The new stride
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr explicit strided_iterator(_Iter __iter, _Stride __stride) noexcept(
     _CUDA_VSTD::is_nothrow_move_constructible_v<_Iter> && _CUDA_VSTD::is_nothrow_move_constructible_v<_Stride>)
@@ -87,13 +104,13 @@ public:
       , __stride_(_CUDA_VSTD::move(__stride))
   {}
 
-  //! @brief Returns a const reference to the iterator stored in this \p transform_iterator
+  //! @brief Returns a const reference to the stored iterator
   [[nodiscard]] _CCCL_API constexpr const _Iter& base() const& noexcept
   {
     return __iter_;
   }
 
-  //! @brief Extracts the iterator stored in this \p transform_iterator
+  //! @brief Extracts the stored iterator
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr _Iter base() && noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Iter>)
   {
@@ -103,18 +120,21 @@ public:
   static constexpr bool __noexcept_stride =
     noexcept(static_cast<difference_type>(_CUDA_VSTD::__de_ice(_CUDA_VSTD::declval<const _Stride&>())));
 
+  //! @brief Returns the current stride as an integral value
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr difference_type stride() const noexcept(__noexcept_stride)
   {
     return static_cast<difference_type>(_CUDA_VSTD::__de_ice(__stride_));
   }
 
+  //! @brief Dereferences the stored base iterator
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr decltype(auto) operator*() noexcept(noexcept(*__iter_))
   {
     return *__iter_;
   }
 
+  //! @brief Dereferences the stored base iterator
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__dereferenceable<const _Iter2>)
@@ -123,6 +143,8 @@ public:
     return *__iter_;
   }
 
+  //! @brief Subscripts the stored base iterator with a given offset times the stride
+  //! @param __n The offset
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr decltype(auto)
   operator[](difference_type __n) noexcept(__noexcept_stride && noexcept(__iter_[__n]))
@@ -130,6 +152,8 @@ public:
     return __iter_[__n * stride()];
   }
 
+  //! @brief Subscripts the stored base iterator with a given offset times the stride
+  //! @param __n The offset
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__dereferenceable<const _Iter2>)
@@ -139,6 +163,7 @@ public:
     return __iter_[__n * stride()];
   }
 
+  //! @brief Increments the stored base iterator by the stride
   // Note: we cannot use __iter_ += stride() in the noexcept clause because that breaks gcc < 9
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr strided_iterator& operator++() noexcept(__noexcept_stride && noexcept(__iter_ += 1))
@@ -147,6 +172,7 @@ public:
     return *this;
   }
 
+  //! @brief Increments the stored base iterator by the stride
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr auto operator++(int) noexcept(
     noexcept(__noexcept_stride && noexcept(__iter_ += 1))
@@ -157,6 +183,7 @@ public:
     return __tmp;
   }
 
+  //! @brief Decrements the stored base iterator by the stride
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr strided_iterator& operator--() noexcept(__noexcept_stride && noexcept(__iter_ -= 1))
   {
@@ -164,6 +191,7 @@ public:
     return *this;
   }
 
+  //! @brief Decrements the stored base iterator by the stride
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr strided_iterator operator--(int) noexcept(
     noexcept(__noexcept_stride && noexcept(__iter_ -= 1))
@@ -174,6 +202,9 @@ public:
     return __tmp;
   }
 
+  //! @brief Advances a @c strided_iterator by a given number of steps
+  //! @param __n The number of steps to increment
+  //! @note Increments the base iterator by @c __n times the stride
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr strided_iterator&
   operator+=(difference_type __n) noexcept(__noexcept_stride && noexcept(__iter_ += 1))
@@ -182,6 +213,30 @@ public:
     return *this;
   }
 
+  //! @brief Returns a copy of a @c strided_iterator incremented by a given number of steps
+  //! @param __iter The @c strided_iterator to advance
+  //! @param __n The number of steps to increment
+  _CCCL_EXEC_CHECK_DISABLE
+  [[nodiscard]] _CCCL_API friend constexpr strided_iterator
+  operator+(strided_iterator __iter, difference_type __n) noexcept(noexcept(__iter_ += __n))
+  {
+    __iter += __n;
+    return __iter;
+  }
+
+  //! @brief Returns a copy of a @c strided_iterator incremented by a given number of steps
+  //! @param __n The number of steps to increment
+  //! @param __iter The @c strided_iterator to advance
+  _CCCL_EXEC_CHECK_DISABLE
+  [[nodiscard]] _CCCL_API friend constexpr strided_iterator
+  operator+(difference_type __n, strided_iterator __iter) noexcept(noexcept(__iter_ + __n))
+  {
+    return __iter + __n;
+  }
+
+  //! @brief Decrements a @c strided_iterator by a given number of steps
+  //! @param __n The number of steps to decrement
+  //! @note Decrements the base iterator by @c __n times the stride
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr strided_iterator&
   operator-=(difference_type __n) noexcept(__noexcept_stride && noexcept(__iter_ -= 1))
@@ -190,104 +245,18 @@ public:
     return *this;
   }
 
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
-  _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable_with<_Iter, _OtherIter>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator==(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter&>() == _CUDA_VSTD::declval<const _OtherIter&>()))
-  {
-    return __x.__iter_ == __y.base();
-  }
-
-#if _CCCL_STD_VER <= 2017
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
-  _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable_with<_Iter, _OtherIter>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator!=(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter&>() == _CUDA_VSTD::declval<const _OtherIter&>()))
-  {
-    return __x.__iter_ != __y.base();
-  }
-#endif // _CCCL_STD_VER <= 2017
-
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
-  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Iter, _OtherIter>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator<(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter&>() < _CUDA_VSTD::declval<const _OtherIter&>()))
-  {
-    return __x.__iter_ < __y.base();
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
-  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Iter, _OtherIter>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator>(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter&>() < _CUDA_VSTD::declval<const _OtherIter&>()))
-  {
-    return __y < __x;
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
-  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Iter, _OtherIter>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator<=(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter&>() < _CUDA_VSTD::declval<const _OtherIter&>()))
-  {
-    return !(__y < __x);
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
-  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Iter, _OtherIter>)
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator>=(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter&>() < _CUDA_VSTD::declval<const _OtherIter&>()))
-  {
-    return !(__x < __y);
-  }
-
-#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
-  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Iter, _OtherIter>)
-  _CCCL_REQUIRES(
-    _CUDA_VSTD::totally_ordered<_Iter, _OtherIter> _CCCL_AND _CUDA_VSTD::three_way_comparable_with<_Iter, _OtherIter>)
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator<=>(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter&>() <=> _CUDA_VSTD::declval<const _OtherIter&>()))
-  {
-    return __x.__iter_ <=> __y.base();
-  }
-#endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
-
+  //! @brief Returns a copy of a @c strided_iterator decremented by a given number of steps
+  //! @param __n The number of steps to decrement
+  //! @param __iter The @c strided_iterator to decrement
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API friend constexpr strided_iterator
-  operator+(strided_iterator __i, difference_type __n) noexcept(noexcept(__iter_ += __n))
+  operator-(strided_iterator __iter, difference_type __n) noexcept(noexcept(__iter_ -= __n))
   {
-    __i += __n;
-    return __i;
+    __iter -= __n;
+    return __iter;
   }
 
-  _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API friend constexpr strided_iterator
-  operator+(difference_type __n, strided_iterator __i) noexcept(noexcept(__iter_ + __n))
-  {
-    return __i + __n;
-  }
-
-  _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API friend constexpr strided_iterator
-  operator-(strided_iterator __i, difference_type __n) noexcept(noexcept(__iter_ -= __n))
-  {
-    __i -= __n;
-    return __i;
-  }
-
+  //! @brief Returns distance between two @c strided_iterator's in units of the stride
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
   _CCCL_REQUIRES(_CUDA_VSTD::sized_sentinel_for<_OtherIter, _Iter>)
@@ -300,19 +269,115 @@ public:
     _CCCL_ASSERT(__diff % __x.stride() == 0, "Underlying iterator difference must be divisible by the stride");
     return __diff / __x.stride();
   }
+
+  //! @brief Compares two @c strided_iterator's for equality by comparing the stored iterators
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
+  _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable_with<_Iter, _OtherIter>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator==(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter&>() == _CUDA_VSTD::declval<const _OtherIter&>()))
+  {
+    return __x.__iter_ == __y.base();
+  }
+
+#if _CCCL_STD_VER <= 2017
+  //! @brief Compares two @c strided_iterator's for inequality by comparing the stored iterators
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
+  _CCCL_REQUIRES(_CUDA_VSTD::equality_comparable_with<_Iter, _OtherIter>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator!=(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter&>() == _CUDA_VSTD::declval<const _OtherIter&>()))
+  {
+    return __x.__iter_ != __y.base();
+  }
+#endif // _CCCL_STD_VER <= 2017
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+  //! @brief Threeway-compares two @c strided_iterator's by comparing the stored iterators
+  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
+  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Iter, _OtherIter>)
+  _CCCL_REQUIRES(
+    _CUDA_VSTD::totally_ordered<_Iter, _OtherIter> _CCCL_AND _CUDA_VSTD::three_way_comparable_with<_Iter, _OtherIter>)
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator<=>(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter&>() <=> _CUDA_VSTD::declval<const _OtherIter&>()))
+  {
+    return __x.__iter_ <=> __y.base();
+  }
+#else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
+
+  //! @brief Compares two @c strided_iterator's for less than by comparing the stored iterators
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
+  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Iter, _OtherIter>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator<(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter&>() < _CUDA_VSTD::declval<const _OtherIter&>()))
+  {
+    return __x.__iter_ < __y.base();
+  }
+
+  //! @brief Compares two @c strided_iterator's for greater than by comparing the stored iterators
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
+  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Iter, _OtherIter>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator>(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter&>() < _CUDA_VSTD::declval<const _OtherIter&>()))
+  {
+    return __y < __x;
+  }
+
+  //! @brief Compares two @c strided_iterator's for less equal by comparing the stored iterators
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
+  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Iter, _OtherIter>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator<=(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter&>() < _CUDA_VSTD::declval<const _OtherIter&>()))
+  {
+    return !(__y < __x);
+  }
+
+  //! @brief Compares two @c strided_iterator's for greater equal by comparing the stored iterators
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _OtherIter, class _OtherStride)
+  _CCCL_REQUIRES(_CUDA_VSTD::totally_ordered_with<_Iter, _OtherIter>)
+  [[nodiscard]] _CCCL_API friend constexpr bool
+  operator>=(const strided_iterator& __x, const strided_iterator<_OtherIter, _OtherStride>& __y) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter&>() < _CUDA_VSTD::declval<const _OtherIter&>()))
+  {
+    return !(__x < __y);
+  }
+#endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 };
 
 template <class _Iter, typename _Stride>
 _CCCL_HOST_DEVICE strided_iterator(_Iter, _Stride) -> strided_iterator<_Iter, _Stride>;
 
-//! @brief make_strided_iterator creates a \p strided_iterator from a random access iterator and an optional stride
+//! @brief Creates a @c strided_iterator from a random access iterator
 //! @param __iter The random_access iterator
-//! @param __stride The optional stride. Is value initialized if not provided
-template <class _Iter, class _Stride = _CUDA_VSTD::iter_difference_t<_Iter>>
-[[nodiscard]] _CCCL_API constexpr auto make_strided_iterator(_Iter __iter, _Stride __stride = {})
+//! @relates strided_iterator
+_CCCL_TEMPLATE(class _Stride, class _Iter)
+_CCCL_REQUIRES(_CUDA_VSTD::__integral_constant_like<_Stride>)
+[[nodiscard]] _CCCL_API constexpr auto make_strided_iterator(_Iter __iter)
 {
-  return strided_iterator<_Iter, _Stride>{_CUDA_VSTD::move(__iter), _CUDA_VSTD::move(__stride)};
+  return strided_iterator<_Iter, _Stride>{_CUDA_VSTD::move(__iter)};
 }
+
+//! @brief Creates a @c strided_iterator from a random access iterator and a stride
+//! @param __iter The random_access iterator
+//! @param __stride The new stride
+//! @relates strided_iterator
+template <class _Iter, class _Stride>
+[[nodiscard]] _CCCL_API constexpr auto make_strided_iterator(_Iter __iter, _Stride __stride)
+{
+  return strided_iterator<_Iter, _Stride>{_CUDA_VSTD::move(__iter), __stride};
+}
+
+//! @} // end iterators
 
 _LIBCUDACXX_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
@@ -39,6 +39,36 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
+//! @addtogroup iterators
+//! @{
+
+//! @brief @c tabulate_output_iterator is a special kind of output iterator which, whenever a value is assigned to a
+//! dereferenced iterator, calls the given callable with the index that corresponds to the offset of the dereferenced
+//! iterator and the assigned value.
+//!
+//! The following code snippet demonstrates how to create a @c tabulate_output_iterator which prints the index and the
+//! assigned value.
+//!
+//! @code
+//! #include <cuda/iterator>
+//!
+//! struct print_op
+//! {
+//!   __host__ __device__ void operator()(int index, float value) const
+//!   {
+//!     printf("%d: %f\n", index, value);
+//!   }
+//! };
+//!
+//! int main()
+//! {
+//!   auto tabulate_it = cuda::make_tabulate_output_iterator(print_op{});
+//!
+//!   tabulate_it[0] =  1.0f;    // prints: 0: 1.0
+//!   tabulate_it[1] =  3.0f;    // prints: 1: 3.0
+//!   tabulate_it[9] =  5.0f;    // prints: 9: 5.0
+//! }
+//! @endcode
 template <class _Fn, class _Index = _CUDA_VSTD::ptrdiff_t>
 class tabulate_output_iterator;
 
@@ -79,33 +109,6 @@ public:
   }
 };
 
-//! @p tabulate_output_iterator is a special kind of output iterator which, whenever a value is assigned to a
-//! dereferenced iterator, calls the given callable with the index that corresponds to the offset of the dereferenced
-//! iterator and the assigned value.
-//!
-//! The following code snippet demonstrated how to create a \p tabulate_output_iterator which prints the index and the
-//! assigned value.
-//!
-//! @code
-//! #include <cuda/iterator>
-//!
-//! struct print_op
-//! {
-//!   __host__ __device__ void operator()(int index, float value) const
-//!   {
-//!     printf("%d: %f\n", index, value);
-//!   }
-//! };
-//!
-//! int main()
-//! {
-//!   auto tabulate_it = cuda::make_tabulate_output_iterator(print_op{});
-//!
-//!   tabulate_it[0] =  1.0f;    // prints: 0: 1.0
-//!   tabulate_it[1] =  3.0f;    // prints: 1: 3.0
-//!   tabulate_it[9] =  5.0f;    // prints: 9: 5.0
-//! }
-//! @endcode
 template <class _Fn, class _Index>
 class tabulate_output_iterator
 {
@@ -118,7 +121,7 @@ public:
   using iterator_category = _CUDA_VSTD::random_access_iterator_tag;
   using difference_type   = _Index;
   using value_type        = void;
-  using pointer           = void*;
+  using pointer           = void;
   using reference         = void;
 
 #if _CCCL_HAS_CONCEPTS()
@@ -133,7 +136,9 @@ public:
   _CCCL_API constexpr tabulate_output_iterator() noexcept(_CUDA_VSTD::is_nothrow_default_constructible_v<_Fn2>) {}
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
-  //! @brief Constructs a \p tabulate_output_iterator with a given functor \p __func and and optional index
+  //! @brief Constructs a @c tabulate_output_iterator with a given functor and an optional index
+  //! @param __func the output function
+  //! @param __index the position in the output sequence
   _CCCL_API constexpr tabulate_output_iterator(_Fn __func, _Index __index = 0) noexcept(
     _CUDA_VSTD::is_nothrow_move_constructible_v<_Fn>)
       : __func_(_CUDA_VSTD::in_place, _CUDA_VSTD::move(__func))
@@ -146,44 +151,44 @@ public:
     return __index_;
   }
 
-  //! @brief Dereferences the \c tabulate_output_iterator returning a proxy that applies the stored function and index
-  //! on assignment
+  //! @brief Dereferences the @c tabulate_output_iterator
+  //! @returns A proxy that applies the stored function and index on assignment
   [[nodiscard]] _CCCL_API constexpr auto operator*() const noexcept
   {
     return __tabulate_proxy<_Fn, _Index>{const_cast<_Fn&>(*__func_), __index_};
   }
 
-  //! @brief Dereferences the \c tabulate_output_iterator returning a proxy that applies the stored function and index
-  //! on assignment
+  //! @brief Dereferences the @c tabulate_output_iterator
+  //! @returns A proxy that applies the stored function and index on assignment
   [[nodiscard]] _CCCL_API constexpr auto operator*() noexcept
   {
     return __tabulate_proxy<_Fn, _Index>{*__func_, __index_};
   }
 
-  //! @brief Subscripts the \c tabulate_output_iterator returning a proxy that applies the stored function and advanced
-  //! index on assignment
+  //! @brief Subscripts the @c tabulate_output_iterator with a given offset
   //! @param __n The additional offset to advance the stored index
+  //! @returns A proxy that applies the stored function and index on assignment
   [[nodiscard]] _CCCL_API constexpr auto operator[](difference_type __n) const noexcept
   {
     return __tabulate_proxy<_Fn, _Index>{const_cast<_Fn&>(*__func_), __index_ + __n};
   }
 
-  //! @brief Subscripts the \c tabulate_output_iterator returning a proxy that applies the stored function and advanced
-  //! index on assignment
+  //! @brief Subscripts the @c tabulate_output_iterator with a given offset
   //! @param __n The additional offset to advance the stored index
+  //! @returns A proxy that applies the stored function and index on assignment
   [[nodiscard]] _CCCL_API constexpr auto operator[](difference_type __n) noexcept
   {
     return __tabulate_proxy<_Fn, _Index>{*__func_, __index_ + __n};
   }
 
-  //! @brief Increments the stored index
+  //! @brief Increments the @c tabulate_output_iterator by incrementing the stored index
   _CCCL_API constexpr tabulate_output_iterator& operator++() noexcept
   {
     ++__index_;
     return *this;
   }
 
-  //! @brief Increments the stored index
+  //! @brief Increments the @c tabulate_output_iterator by incrementing the stored index
   _CCCL_API constexpr tabulate_output_iterator operator++(int) noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Fn>)
   {
     tabulate_output_iterator __tmp = *this;
@@ -191,14 +196,14 @@ public:
     return __tmp;
   }
 
-  //! @brief Decrements the stored index
+  //! @brief Decrements the @c tabulate_output_iterator by decrementing the stored index
   _CCCL_API constexpr tabulate_output_iterator& operator--() noexcept
   {
     --__index_;
     return *this;
   }
 
-  //! @brief Decrements the stored index
+  //! @brief Decrements the @c tabulate_output_iterator by decrementing the stored index
   _CCCL_API constexpr tabulate_output_iterator operator--(int) noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Fn>)
   {
     tabulate_output_iterator __tmp = *this;
@@ -206,7 +211,7 @@ public:
     return __tmp;
   }
 
-  //! @brief Returns a copy of this \c tabulate_output_iterator advanced by \p __n
+  //! @brief Returns a copy of this @c tabulate_output_iterator advanced a given number of elements
   //! @param __n The number of elements to advance
   [[nodiscard]] _CCCL_API constexpr tabulate_output_iterator operator+(difference_type __n) const
     noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Fn>)
@@ -214,17 +219,17 @@ public:
     return tabulate_output_iterator{*__func_, __index_ + __n};
   }
 
-  //! @brief Returns a copy of a \c tabulate_output_iterator \p __iter advanced by \p __n
+  //! @brief Returns a copy of a @c tabulate_output_iterator advanced a given number of elements
   //! @param __n The number of elements to advance
-  //! @param __iter The original \c tabulate_output_iterator
+  //! @param __iter The original @c tabulate_output_iterator
   [[nodiscard]] _CCCL_API friend constexpr tabulate_output_iterator
-  operator+(difference_type __n,
-            const tabulate_output_iterator& __iter) noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Fn>)
+  operator+(difference_type __n, const tabulate_output_iterator& __iter) //
+    noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Fn>)
   {
     return __iter + __n;
   }
 
-  //! @brief Advances the index of this \c tabulate_output_iterator by \p __n
+  //! @brief Advances the @c tabulate_output_iterator by a given number of elements
   //! @param __n The number of elements to advance
   _CCCL_API constexpr tabulate_output_iterator& operator+=(difference_type __n) noexcept
   {
@@ -232,22 +237,22 @@ public:
     return *this;
   }
 
-  //! @brief Returns a copy of this \c tabulate_output_iterator decremented by \p __n
-  //! @param __n The number of elements to decrement
+  //! @brief Returns a copy of this @c tabulate_output_iterator decremented a given number of elements
+  //! @param __n The number of elements to decremented
   [[nodiscard]] _CCCL_API constexpr tabulate_output_iterator operator-(difference_type __n) const
     noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Fn>)
   {
     return tabulate_output_iterator{*__func_, __index_ - __n};
   }
 
-  //! @brief Returns the distance between two \c tabulate_output_iterator 's
+  //! @brief Returns the distance between two @c tabulate_output_iterator 's
   [[nodiscard]] _CCCL_API friend constexpr difference_type
   operator-(const tabulate_output_iterator& __lhs, const tabulate_output_iterator& __rhs) noexcept
   {
     return __rhs.__index_ - __lhs.__index_;
   }
 
-  //! @brief Decrements the index of the \c tabulate_output_iterator by \p __n
+  //! @brief Decrements the @c tabulate_output_iterator by a given number of elements
   //! @param __n The number of elements to decrement
   _CCCL_API constexpr tabulate_output_iterator& operator-=(difference_type __n) noexcept
   {
@@ -255,7 +260,7 @@ public:
     return *this;
   }
 
-  //! @brief Compares two \c tabulate_output_iterator for equality by comparing their indices
+  //! @brief Compares two @c tabulate_output_iterator for equality by comparing their indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator==(const tabulate_output_iterator& __lhs, const tabulate_output_iterator& __rhs) noexcept
   {
@@ -263,7 +268,7 @@ public:
   }
 
 #if _CCCL_STD_VER <= 2017
-  //! @brief Compares two \c tabulate_output_iterator for inequality by comparing their indices
+  //! @brief Compares two @c tabulate_output_iterator for inequality by comparing their indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator!=(const tabulate_output_iterator& __lhs, const tabulate_output_iterator& __rhs) noexcept
   {
@@ -272,41 +277,41 @@ public:
 #endif // _CCCL_STD_VER <= 2017
 
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-  //! @brief Three-way-compares two \c tabulate_output_iterator by comparing their indices
+  //! @brief Three-way-compares two @c tabulate_output_iterator by comparing their indices
   [[nodiscard]] _CCCL_API friend constexpr strong_ordering
   operator<=>(const tabulate_output_iterator& __lhs, const tabulate_output_iterator& __rhs) noexcept
   {
     return __lhs.__index_ <=> __rhs.__index_;
   }
-#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-
-  //! @brief Compares two \c tabulate_output_iterator for less than by comparing their indices
+#else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
+  //! @brief Compares two @c tabulate_output_iterator for less than by comparing their indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator<(const tabulate_output_iterator& __lhs, const tabulate_output_iterator& __rhs) noexcept
   {
     return __lhs.__index_ < __rhs.__index_;
   }
 
-  //! @brief Compares two \c tabulate_output_iterator for less equal by comparing their indices
+  //! @brief Compares two @c tabulate_output_iterator for less equal by comparing their indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator<=(const tabulate_output_iterator& __lhs, const tabulate_output_iterator& __rhs) noexcept
   {
     return __lhs.__index_ <= __rhs.__index_;
   }
 
-  //! @brief Compares two \c tabulate_output_iterator for greater than by comparing their indices
+  //! @brief Compares two @c tabulate_output_iterator for greater than by comparing their indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator>(const tabulate_output_iterator& __lhs, const tabulate_output_iterator& __rhs) noexcept
   {
     return __lhs.__index_ > __rhs.__index_;
   }
 
-  //! @brief Compares two \c tabulate_output_iterator for greater equal by comparing their indices
+  //! @brief Compares two @c tabulate_output_iterator for greater equal by comparing their indices
   [[nodiscard]] _CCCL_API friend constexpr bool
   operator>=(const tabulate_output_iterator& __lhs, const tabulate_output_iterator& __rhs) noexcept
   {
     return __lhs.__index_ >= __rhs.__index_;
   }
+#endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 };
 
 template <class _Fn>
@@ -316,15 +321,19 @@ _CCCL_TEMPLATE(class _Fn, class _Index)
 _CCCL_REQUIRES(_CUDA_VSTD::__integer_like<_Index>)
 _CCCL_HOST_DEVICE tabulate_output_iterator(_Fn, _Index) -> tabulate_output_iterator<_Fn, _Index>;
 
-//! @brief Creates a \p tabulate_output_iterator from an optional index.
-//! @param __index The index of the \p tabulate_output_iterator within a range. The default index is \c 0.
-//! @return A new \p tabulate_output_iterator with \p __index as the couner.
+//! @brief Creates a @c tabulate_output_iterator from an output function and an optional index.
+//! @param __func The output function
+//! @param __index The index of the @c tabulate_output_iterator within a range. The default index is @c 0.
+//! @return A new @c tabulate_output_iterator with @c __index as the counter.
+//! @relates tabulate_output_iterator
 _CCCL_TEMPLATE(class _Fn, class _Integer = _CUDA_VSTD::ptrdiff_t)
 _CCCL_REQUIRES(_CUDA_VSTD::__integer_like<_Integer>)
 [[nodiscard]] _CCCL_API constexpr auto make_tabulate_output_iterator(_Fn __func, _Integer __index = 0)
 {
   return tabulate_output_iterator{_CUDA_VSTD::move(__func), __index};
 }
+
+//! @}
 
 _LIBCUDACXX_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -174,7 +174,7 @@ public:
 
   // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
   // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
-  using reference = value_type;
+  using reference = ::cuda::std::invoke_result_t<_Fn&, ::cuda::std::iter_reference_t<_Iter>>;
   using pointer   = void;
 
   //! @brief Default constructs a @c transform_iterator with a value initialized iterator and functor
@@ -219,7 +219,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>)
-  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator*() const
+  [[nodiscard]] _CCCL_API constexpr reference operator*() const
     noexcept(noexcept(_CUDA_VSTD::invoke(*__func_, *__current_)))
   {
     return _CUDA_VSTD::invoke(*__func_, *__current_);
@@ -232,7 +232,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES((!_CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>) )
-  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator*() const
+  [[nodiscard]] _CCCL_API constexpr reference operator*() const
     noexcept(noexcept(_CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), *__current_)))
   {
     return _CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), *__current_);
@@ -241,8 +241,7 @@ public:
 
   //! @brief Dereferences the stored iterator and applies the stored functor to the result
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API constexpr decltype(auto)
-  operator*() noexcept(noexcept(_CUDA_VSTD::invoke(*__func_, *__current_)))
+  [[nodiscard]] _CCCL_API constexpr reference operator*() noexcept(noexcept(_CUDA_VSTD::invoke(*__func_, *__current_)))
   {
     return _CUDA_VSTD::invoke(*__func_, *__current_);
   }
@@ -253,7 +252,7 @@ public:
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__has_random_access_traversal<_Iter2> _CCCL_AND
                    _CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>)
-  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator[](difference_type __n) const
+  [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type __n) const
     noexcept(__transform_iterator_nothrow_subscript<const _Fn, _Iter2>)
   {
     return _CUDA_VSTD::invoke(*__func_, __current_[__n]);
@@ -268,7 +267,7 @@ public:
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__has_random_access_traversal<_Iter2> _CCCL_AND(
     !_CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>))
-  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator[](difference_type __n) const
+  [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type __n) const
     noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
   {
     return _CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), __current_[__n]);
@@ -280,7 +279,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
-  [[nodiscard]] _CCCL_API constexpr decltype(auto)
+  [[nodiscard]] _CCCL_API constexpr reference
   operator[](difference_type __n) noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
   {
     return _CUDA_VSTD::invoke(*__func_, __current_[__n]);

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -47,12 +47,15 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
+//! @addtogroup iterators
+//! @{
+
 template <class, class, class = void>
 struct __transform_iterator_category_base
 {};
 
-template <class _Iter, class _Fn>
-struct __transform_iterator_category_base<_Iter, _Fn, _CUDA_VSTD::enable_if_t<_CUDA_VSTD::forward_iterator<_Iter>>>
+template <class _Fn, class _Iter>
+struct __transform_iterator_category_base<_Fn, _Iter, _CUDA_VSTD::enable_if_t<_CUDA_VSTD::__has_forward_traversal<_Iter>>>
 {
   using _Cat = typename _CUDA_VSTD::iterator_traits<_Iter>::iterator_category;
 
@@ -64,21 +67,21 @@ struct __transform_iterator_category_base<_Iter, _Fn, _CUDA_VSTD::enable_if_t<_C
     _CUDA_VSTD::input_iterator_tag>;
 };
 
-template <class _Fn, class _Iter, bool = _CUDA_VSTD::random_access_iterator<_Iter>>
+template <class _Fn, class _Iter, bool = (_CUDA_VSTD::__has_random_access_traversal<_Iter>)>
 inline constexpr bool __transform_iterator_nothrow_subscript = false;
 
 template <class _Fn, class _Iter>
 inline constexpr bool __transform_iterator_nothrow_subscript<_Fn, _Iter, true> =
   noexcept(_CUDA_VSTD::invoke(_CUDA_VSTD::declval<_Fn&>(), _CUDA_VSTD::declval<_Iter&>()[0]));
 
-//! @brief \p transform_iterator is an iterator which represents a pointer into a range of values after transformation
-//! by a function. This iterator is useful for creating a range filled with the result of applying an operation to
+//! @brief @c transform_iterator is an iterator which represents a pointer into a range of values after transformation
+//! by a functor. This iterator is useful for creating a range filled with the result of applying an operation to
 //! another range without either explicitly storing it in memory, or explicitly executing the transformation. Using
-//! \p transform_iterator facilitates kernel fusion by deferring the execution of a transformation until the value is
+//! @c transform_iterator facilitates kernel fusion by deferring the execution of a transformation until the value is
 //! needed while saving both memory capacity and bandwidth.
 //!
-//! The following code snippet demonstrates how to create a \p transform_iterator which represents the result of
-//! \c sqrtf applied to the contents of a \p thrust::device_vector.
+//! The following code snippet demonstrates how to create a @c transform_iterator which represents the result of
+//! @c sqrtf applied to the contents of a @c thrust::device_vector.
 //!
 //! @code
 //! #include <cuda/iterator>
@@ -111,8 +114,8 @@ inline constexpr bool __transform_iterator_nothrow_subscript<_Fn, _Iter, true> =
 //! }
 //! @endcode
 //!
-//! This next example demonstrates how to use a \p transform_iterator with the \p thrust::reduce function to compute the
-//! sum of squares of a sequence. We will create temporary \p transform_iterators utilising class template argument
+//! This next example demonstrates how to use a @c transform_iterator with the @c thrust::reduce functor to compute the
+//! sum of squares of a sequence. We will create temporary @c transform_iterators utilising class template argument
 //! deduction avoid explicitly specifying their type:
 //!
 //! @code
@@ -145,10 +148,10 @@ inline constexpr bool __transform_iterator_nothrow_subscript<_Fn, _Iter, true> =
 //!   return 0;
 //! }
 //! @endcode
-template <class _Iter, class _Fn>
-class transform_iterator : public __transform_iterator_category_base<_Iter, _Fn>
+template <class _Fn, class _Iter>
+class transform_iterator : public __transform_iterator_category_base<_Fn, _Iter>
 {
-  static_assert(_CUDA_VSTD::is_object_v<_Fn>, "cuda::transform_iterator requires that _Fn is a function object");
+  static_assert(_CUDA_VSTD::is_object_v<_Fn>, "cuda::transform_iterator requires that _Fn is a functor object");
   static_assert(_CUDA_VSTD::regular_invocable<_Fn&, _CUDA_VSTD::iter_reference_t<_Iter>>,
                 "cuda::transform_iterator requires that _Fn is invocable with iter_reference_t<_Iter>");
   static_assert(_CUDA_VSTD::__can_reference<_CUDA_VSTD::invoke_result_t<_Fn&, _CUDA_VSTD::iter_reference_t<_Iter>>>,
@@ -169,7 +172,12 @@ public:
   using value_type = _CUDA_VSTD::remove_cvref_t<_CUDA_VSTD::invoke_result_t<_Fn&, _CUDA_VSTD::iter_reference_t<_Iter>>>;
   using difference_type = _CUDA_VSTD::iter_difference_t<_Iter>;
 
-  //! @brief Default constructs a \p transform_iterator with a value initialized iterator and functor
+  // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
+  // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
+  using reference = value_type;
+  using pointer   = void;
+
+  //! @brief Default constructs a @c transform_iterator with a value initialized iterator and functor
 #if _CCCL_HAS_CONCEPTS()
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HIDE_FROM_ABI transform_iterator()
@@ -184,30 +192,30 @@ public:
   {}
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
-  //! @brief Constructs a \p transform_iterator with a given \p __iter iterator and \p __func functor
+  //! @brief Constructs a @c transform_iterator with a given iterator and functor
   //! @param __iter The iterator to transform
   //! @param __func The functor to apply to the iterator
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr transform_iterator(_Iter __current, _Fn __func_) noexcept(
+  _CCCL_API constexpr transform_iterator(_Iter __iter, _Fn __func) noexcept(
     _CUDA_VSTD::is_nothrow_move_constructible_v<_Iter> && _CUDA_VSTD::is_nothrow_move_constructible_v<_Fn>)
-      : __current_(_CUDA_VSTD::move(__current))
-      , __func_(_CUDA_VSTD::in_place, _CUDA_VSTD::move(__func_))
+      : __current_(_CUDA_VSTD::move(__iter))
+      , __func_(_CUDA_VSTD::in_place, _CUDA_VSTD::move(__func))
   {}
 
-  //! @brief Returns a const reference to the iterator stored in this \p transform_iterator
+  //! @brief Returns a const reference to the stored iterator
   [[nodiscard]] _CCCL_API constexpr const _Iter& base() const& noexcept
   {
     return __current_;
   }
 
-  //! @brief Extracts the iterator stored in this \p transform_iterator
+  //! @brief Extracts the stored iterator
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr _Iter base() && noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Iter>)
   {
     return _CUDA_VSTD::move(__current_);
   }
 
-  //! @brief Invokes the stored functor with the value pointed to by the stored iterator
+  //! @brief Dereferences the stored iterator and applies the stored functor to the result
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>)
@@ -217,12 +225,65 @@ public:
     return _CUDA_VSTD::invoke(*__func_, *__current_);
   }
 
-  //! @brief Invokes the stored functor with the value pointed to by the stored iterator
+  //! @cond
+  //! @brief Dereferences the stored iterator and applies the stored functor to the result
+  //! @note This is a cludge against the fact that the iterator concepts requires `const Iter` but a user might have
+  //! forgotten to const qualify the call operator
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES((!_CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>) )
+  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator*() const
+    noexcept(noexcept(_CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), *__current_)))
+  {
+    return _CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), *__current_);
+  }
+  //! @endcond
+
+  //! @brief Dereferences the stored iterator and applies the stored functor to the result
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr decltype(auto)
   operator*() noexcept(noexcept(_CUDA_VSTD::invoke(*__func_, *__current_)))
   {
     return _CUDA_VSTD::invoke(*__func_, *__current_);
+  }
+
+  //! @brief Subscripts the stored iterator by a number of elements and applies the stored functor to the result
+  //! @param __n The number of elements to advance by
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES(_CUDA_VSTD::__has_random_access_traversal<_Iter2> _CCCL_AND
+                   _CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>)
+  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator[](difference_type __n) const
+    noexcept(__transform_iterator_nothrow_subscript<const _Fn, _Iter2>)
+  {
+    return _CUDA_VSTD::invoke(*__func_, __current_[__n]);
+  }
+
+  //! @cond
+  //! @brief Subscripts the stored iterator by a number of elements and applies the stored functor to the result
+  //! @param __n The number of elements to advance by
+  //! @note This is a cludge against the fact that the iterator concepts requires `const Iter` but a user might have
+  //! forgotten to const qualify the call operator
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES(_CUDA_VSTD::__has_random_access_traversal<_Iter2> _CCCL_AND(
+    !_CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>))
+  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator[](difference_type __n) const
+    noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
+  {
+    return _CUDA_VSTD::invoke(const_cast<_Fn&>(*__func_), __current_[__n]);
+  }
+  //! @endcond
+
+  //! @brief Subscripts the stored iterator by a number of elements and applies the stored functor to the result
+  //! @param __n The number of elements to advance by
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Iter2 = _Iter)
+  _CCCL_REQUIRES(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
+  [[nodiscard]] _CCCL_API constexpr decltype(auto)
+  operator[](difference_type __n) noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
+  {
+    return _CUDA_VSTD::invoke(*__func_, __current_[__n]);
   }
 
   //! @brief Increments the stored iterator
@@ -237,7 +298,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr auto operator++(int) noexcept(noexcept(++__current_))
   {
-    if constexpr (_CUDA_VSTD::forward_iterator<_Iter>)
+    if constexpr (_CUDA_VSTD::__has_forward_traversal<_Iter>)
     {
       auto __tmp = *this;
       ++*this;
@@ -252,7 +313,7 @@ public:
   //! @brief Decrements the stored iterator
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(_CUDA_VSTD::bidirectional_iterator<_Iter2>)
+  _CCCL_REQUIRES(_CUDA_VSTD::__has_bidirectional_traversal<_Iter2>)
   _CCCL_API constexpr transform_iterator& operator--() noexcept(noexcept(--__current_))
   {
     --__current_;
@@ -262,7 +323,7 @@ public:
   //! @brief Decrements the stored iterator
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(_CUDA_VSTD::bidirectional_iterator<_Iter2>)
+  _CCCL_REQUIRES(_CUDA_VSTD::__has_bidirectional_traversal<_Iter2>)
   _CCCL_API constexpr transform_iterator
   operator--(int) noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter> && noexcept(--__current_))
   {
@@ -271,54 +332,72 @@ public:
     return __tmp;
   }
 
-  //! @brief Advances this \c transform_iterator by \p __n
-  //! @param __n The number of elements to advance
+  //! @brief Increments the @c transform_iterator by a given number of elements
+  //! @param __n The number of elements to increment
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  _CCCL_REQUIRES(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
   _CCCL_API constexpr transform_iterator& operator+=(difference_type __n) noexcept(noexcept(__current_ += __n))
   {
     __current_ += __n;
     return *this;
   }
 
-  //! @brief Decrements this \c transform_iterator by \p __n
+  //! @brief Returns a copy of a @c transform_iterator advanced by a given number of elements
+  //! @param __iter The @c transform_iterator to advance
+  //! @param __n The amount of elements to increment
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto operator+(const transform_iterator& __iter, difference_type __n)
+    _CCCL_TRAILING_REQUIRES(transform_iterator)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
+  {
+    return transform_iterator{__iter.__current_ + __n, *__iter.__func_};
+  }
+
+  //! @brief Returns a copy of a @c transform_iterator advanced by a given number of elements
+  //! @param __n The amount of elements to increment
+  //! @param __iter The @c transform_iterator to advance
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto operator+(difference_type __n, const transform_iterator& __iter)
+    _CCCL_TRAILING_REQUIRES(transform_iterator)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
+  {
+    return transform_iterator{__iter.__current_ + __n, *__iter.__func_};
+  }
+
+  //! @brief Decrements the @c transform_iterator by a given number of elements
   //! @param __n The number of elements to decrement
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter2>)
+  _CCCL_REQUIRES(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
   _CCCL_API constexpr transform_iterator& operator-=(difference_type __n) noexcept(noexcept(__current_ -= __n))
   {
     __current_ -= __n;
     return *this;
   }
 
-  //! @brief Subscripts the stored iterator by \p __n and applies the stored functor to the result
-  //! @param __n The additional offset
-  //! @returns _CUDA_VSTD::invoke(__func_, __current_[__n])
+  //! @brief Returns a copy of a @c transform_iterator decremented by a given number of elements
+  //! @param __iter The @c transform_iterator to decrement
+  //! @param __n The amount of elements to decrement
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter2> _CCCL_AND
-                   _CUDA_VSTD::regular_invocable<const _Fn&, _CUDA_VSTD::iter_reference_t<const _Iter2>>)
-  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator[](difference_type __n) const
-    noexcept(__transform_iterator_nothrow_subscript<const _Fn, _Iter2>)
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto operator-(const transform_iterator& __iter, difference_type __n)
+    _CCCL_TRAILING_REQUIRES(transform_iterator)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
   {
-    return _CUDA_VSTD::invoke(*__func_, __current_[__n]);
+    return transform_iterator{__iter.__current_ - __n, *__iter.__func_};
   }
 
-  //! @brief Subscripts the stored iterator by \p __n and applies the stored functor to the result
-  //! @param __n The additional offset
-  //! @returns _CUDA_VSTD::invoke(__func_, __current_[__n])
+  //! @brief Returns the distance between two @c transform_iterator
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_TEMPLATE(class _Iter2 = _Iter)
-  _CCCL_REQUIRES(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  [[nodiscard]] _CCCL_API constexpr decltype(auto)
-  operator[](difference_type __n) noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator-(const transform_iterator& __lhs, const transform_iterator& __rhs)
+    _CCCL_TRAILING_REQUIRES(difference_type)(_CUDA_VSTD::sized_sentinel_for<_Iter2, _Iter2>)
   {
-    return _CUDA_VSTD::invoke(*__func_, __current_[__n]);
+    return __lhs.__current_ - __rhs.__current_;
   }
 
-  //! @brief Compares two \c transform_iterator for equality, directly comparing the stored iterators
+  //! @brief Compares two @c transform_iterator for equality by comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
@@ -330,7 +409,7 @@ public:
   }
 
 #if _CCCL_STD_VER <= 2017
-  //! @brief Compares two \c transform_iterator for inequality, directly comparing the stored iterators
+  //! @brief Compares two @c transform_iterator for inequality by comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
@@ -342,121 +421,76 @@ public:
   }
 #endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Compares two \c transform_iterator for less than, directly comparing the stored iterators
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator<(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return __lhs.__current_ < __rhs.__current_;
-  }
-
-  //! @brief Compares two \c transform_iterator for greater than, directly comparing the stored iterators
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator>(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return __lhs.__current_ > __rhs.__current_;
-  }
-
-  //! @brief Compares two \c transform_iterator for less equal, directly comparing the stored iterators
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator<=(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return __lhs.__current_ <= __rhs.__current_;
-  }
-
-  //! @brief Compares two \c transform_iterator for greater equal, directly comparing the stored iterators
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator>=(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return __lhs.__current_ >= __rhs.__current_;
-  }
-
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-  //! @brief Three-way-compares two \c transform_iterator, directly three-way-comparing the stored iterators
+  //! @brief Three-way-compares two @c transform_iterator, directly three-way-comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator<=>(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
     noexcept(_CUDA_VSTD::declval<const _Iter2&>() <=> _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>&& _CUDA_VSTD::three_way_comparable<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(
+      _CUDA_VSTD::__has_random_access_traversal<_Iter2>&& _CUDA_VSTD::three_way_comparable<_Iter2>)
   {
     return __lhs.__current_ <=> __rhs.__current_;
   }
-#endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
-
-  //! @brief Returns a copy of the \c transform_iterator \p __i advanced by \p __n
-  //! @param __i The \c transform_iterator to advance
-  //! @param __n The number of elements to advance
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto operator+(const transform_iterator& __i, difference_type __n)
-    _CCCL_TRAILING_REQUIRES(transform_iterator)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return transform_iterator{__i.__current_ + __n, *__i.__func_};
-  }
-
-  //! @brief Returns a copy of the \c transform_iterator \p __i advanced by \p __n
-  //! @param __n The number of elements to advance
-  //! @param __i The \c transform_iterator to advance
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto operator+(difference_type __n, const transform_iterator& __i)
-    _CCCL_TRAILING_REQUIRES(transform_iterator)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return transform_iterator{__i.__current_ + __n, *__i.__func_};
-  }
-
-  //! @brief Returns a copy of the the \c transform_iterator \p __i decremented by \p __n
-  //! @param __i The \c transform_iterator to decrement
-  //! @param __n The number of elements to decrement
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto operator-(const transform_iterator& __i, difference_type __n)
-    _CCCL_TRAILING_REQUIRES(transform_iterator)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return transform_iterator{__i.__current_ - __n, *__i.__func_};
-  }
-
-  //! @brief Returns the distance between \p __lhs and \p __rhs
-  //! @param __lhs The left \c transform_iterator
-  //! @param __rhs The right \c transform_iterator
-  //! @return The distance between the stored iterators
+#else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
+  //! @brief Compares two @c transform_iterator for less than by comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
-  operator-(const transform_iterator& __lhs, const transform_iterator& __rhs)
-    _CCCL_TRAILING_REQUIRES(difference_type)(_CUDA_VSTD::sized_sentinel_for<_Iter2, _Iter2>)
+  operator<(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
   {
-    return __lhs.__current_ - __rhs.__current_;
+    return __lhs.__current_ < __rhs.__current_;
   }
+
+  //! @brief Compares two @c transform_iterator for greater than by comparing the stored iterators
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator>(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
+  {
+    return __lhs.__current_ > __rhs.__current_;
+  }
+
+  //! @brief Compares two @c transform_iterator for less equal by comparing the stored iterators
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator<=(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
+  {
+    return __lhs.__current_ <= __rhs.__current_;
+  }
+
+  //! @brief Compares two @c transform_iterator for greater equal by comparing the stored iterators
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator>=(const transform_iterator& __lhs, const transform_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
+  {
+    return __lhs.__current_ >= __rhs.__current_;
+  }
+#endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 };
 
-//! @brief make_transform_iterator creates a \p transform_iterator from an \c _Iter and a \c _Fn.
-//!
-//! @param __iter The \c Iterator pointing to the input range of the newly created \p transform_iterator.
-//! @param __fun The \c _Fn used to transform the range pointed to by @param __iter in the newly created
-//! \p transform_iterator.
-//! @return A new \p transform_iterator which transforms the range at @param __iter by @param __fun.
-template <class _Iter, class _Fn>
+//! @brief Creates a @c transform_iterator from a base iterator and a functor
+//! @param __iter The iterator of the input range
+//! @param __fun The functor used to transform the input range
+//! @relates transform_iterator
+template <class _Fn, class _Iter>
 [[nodiscard]] _CCCL_API constexpr auto make_transform_iterator(_Iter __iter, _Fn __fun)
 {
-  return transform_iterator<_Iter, _Fn>{__iter, __fun};
+  return transform_iterator<_Fn, _Iter>{__iter, __fun};
 }
+
+//! @}
 
 _LIBCUDACXX_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_output_iterator.h
@@ -48,7 +48,10 @@
 
 _LIBCUDACXX_BEGIN_NAMESPACE_CUDA
 
-template <class _Iter, class _Fn>
+//! @addtogroup iterators
+//! @{
+
+template <class _Fn, class _Iter>
 class __transform_output_proxy
 {
 private:
@@ -96,13 +99,13 @@ public:
   }
 };
 
-//! @brief \p transform_output_iterator is a special kind of output iterator which transforms a value written upon
+//! @brief @c transform_output_iterator is a special kind of output iterator which transforms a value written upon
 //! dereference. This iterator is useful for transforming an output from algorithms without explicitly storing the
 //! intermediate result in the memory and applying subsequent transformation, thereby avoiding wasting memory capacity
-//! and bandwidth. Using \p transform_iterator facilitates kernel fusion by deferring execution of transformation until
+//! and bandwidth. Using @c transform_iterator facilitates kernel fusion by deferring execution of transformation until
 //! the value is written while saving both memory capacity and bandwidth.
 //!
-//! The following code snippet demonstrated how to create a \p transform_output_iterator which applies \c sqrtf to the
+//! The following code snippet demonstrated how to create a @c transform_output_iterator which applies @c sqrtf to the
 //! assigning value.
 //!
 //! @code
@@ -136,7 +139,7 @@ public:
 //!
 //! }
 //! @endcode
-template <class _Iter, class _Fn>
+template <class _Fn, class _Iter>
 class transform_output_iterator
 {
   static_assert(_CUDA_VSTD::is_object_v<_Fn>, "cuda::transform_output_iterator requires that _Fn is a function object");
@@ -145,19 +148,21 @@ public:
   _Iter __current_{};
   _CUDA_VRANGES::__movable_box<_Fn> __func_{};
 
-  using _Cat = typename _CUDA_VSTD::iterator_traits<_Iter>::iterator_category;
+  using iterator_concept = _CUDA_VSTD::conditional_t<
+    _CUDA_VSTD::random_access_iterator<_Iter>,
+    _CUDA_VSTD::random_access_iterator_tag,
+    _CUDA_VSTD::conditional_t<_CUDA_VSTD::bidirectional_iterator<_Iter>,
+                              _CUDA_VSTD::bidirectional_iterator_tag,
+                              _CUDA_VSTD::conditional_t<_CUDA_VSTD::forward_iterator<_Iter>,
+                                                        _CUDA_VSTD::forward_iterator_tag,
+                                                        _CUDA_VSTD::output_iterator_tag>>>;
+  using iterator_category = _CUDA_VSTD::output_iterator_tag;
+  using difference_type   = _CUDA_VSTD::iter_difference_t<_Iter>;
+  using value_type        = void;
+  using pointer           = void;
+  using reference         = void;
 
-  using iterator_category =
-    _CUDA_VSTD::conditional_t<_CUDA_VSTD::derived_from<_Cat, _CUDA_VSTD::contiguous_iterator_tag>,
-                              _CUDA_VSTD::random_access_iterator_tag,
-                              _Cat>;
-  using iterator_concept = iterator_category;
-  using difference_type  = _CUDA_VSTD::iter_difference_t<_Iter>;
-  using value_type       = void;
-  using pointer          = void;
-  using reference        = void;
-
-  //! @brief Default constructs a \p transform_output_iterator with a value initialized iterator and functor
+  //! @brief Default constructs a @c transform_output_iterator with a value initialized iterator and functor
 #if _CCCL_HAS_CONCEPTS()
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_HIDE_FROM_ABI transform_output_iterator()
@@ -172,23 +177,23 @@ public:
   {}
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
-  //! @brief Constructs a \p transform_output_iterator with a given \p __iter iterator and \p __func functor
+  //! @brief Constructs a @c transform_output_iterator with a given iterator and output functor
   //! @param __iter The iterator to transform
-  //! @param __func The functor to apply to the iterator
+  //! @param __func The output function to apply to the iterator on assignment
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr transform_output_iterator(_Iter __current, _Fn __func_) noexcept(
+  _CCCL_API constexpr transform_output_iterator(_Iter __iter, _Fn __func) noexcept(
     _CUDA_VSTD::is_nothrow_move_constructible_v<_Iter> && _CUDA_VSTD::is_nothrow_move_constructible_v<_Fn>)
-      : __current_(_CUDA_VSTD::move(__current))
-      , __func_(_CUDA_VSTD::in_place, _CUDA_VSTD::move(__func_))
+      : __current_(_CUDA_VSTD::move(__iter))
+      , __func_(_CUDA_VSTD::in_place, _CUDA_VSTD::move(__func))
   {}
 
-  //! @brief Returns a const reference to the iterator stored in this \p transform_output_iterator
+  //! @brief Returns a const reference to the stored iterator
   [[nodiscard]] _CCCL_API constexpr const _Iter& base() const& noexcept
   {
     return __current_;
   }
 
-  //! @brief Extracts the iterator stored in this \p transform_output_iterator
+  //! @brief Extracts the stored iterator
   _CCCL_EXEC_CHECK_DISABLE
   [[nodiscard]] _CCCL_API constexpr _Iter base() && noexcept(_CUDA_VSTD::is_nothrow_move_constructible_v<_Iter>)
   {
@@ -209,8 +214,9 @@ public:
     return __transform_output_proxy{__current_, *__func_};
   }
 
-  //! @brief Returns a proxy that transforms the input upon assignment storing the current iterator advanced by \p __n
-  //! @param __n The additional offset
+  //! @brief Subscripts the @c transform_output_iterator
+  //! @returns A proxy that transforms the input upon assignment storing the current iterator advanced by a given
+  //! @param __n The number of elements to advance by
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__iter_can_subscript<_Iter2>)
@@ -220,8 +226,9 @@ public:
     return __transform_output_proxy{__current_ + __n, const_cast<_Fn&>(*__func_)};
   }
 
-  //! @brief Returns a proxy that transforms the input upon assignment storing the current iterator advanced by \p __n
-  //! @param __n The additional offset
+  //! @brief Subscripts the @c transform_output_iterator
+  //! @returns A proxy that transforms the input upon assignment storing the current iterator advanced by a given
+  //! @param __n The number of elements to advance by
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__iter_can_subscript<_Iter2>)
@@ -243,7 +250,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_API constexpr auto operator++(int) noexcept(noexcept(++__current_))
   {
-    if constexpr (_CUDA_VSTD::forward_iterator<_Iter> || _CUDA_VSTD::output_iterator<_Iter, value_type>)
+    if constexpr (_CUDA_VSTD::__has_forward_traversal<_Iter> || _CUDA_VSTD::output_iterator<_Iter, value_type>)
     {
       auto __tmp = *this;
       ++*this;
@@ -277,8 +284,8 @@ public:
     return __tmp;
   }
 
-  //! @brief Advances this \c transform_output_iterator by \p __n
-  //! @param __n The number of elements to advance
+  //! @brief Increments the @c transform_output_iterator by a given number of elements
+  //! @param __n The number of elements to increment
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(_CUDA_VSTD::__iter_can_plus_equal<_Iter2>)
@@ -288,7 +295,35 @@ public:
     return *this;
   }
 
-  //! @brief Decrements this \c transform_output_iterator by \p __n
+  //! @brief Returns a copy of a @c transform_output_iterator incremented by a given number of elements
+  //! @param __iter The @c transform_output_iterator to increment
+  //! @param __n The number of elements to increment
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator+(const transform_output_iterator& __iter,
+            difference_type __n) noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter2>
+                                          && noexcept(_CUDA_VSTD::declval<const _Iter2&>() + difference_type{}))
+    _CCCL_TRAILING_REQUIRES(transform_output_iterator)(_CUDA_VSTD::__iter_can_plus<_Iter2>)
+  {
+    return transform_output_iterator{__iter.__current_ + __n, *__iter.__func_};
+  }
+
+  //! @brief Returns a copy of a @c transform_output_iterator incremented by a given number of elements
+  //! @param __n The number of elements to increment
+  //! @param __iter The @c transform_output_iterator to increment
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator+(difference_type __n, const transform_output_iterator& __iter) noexcept(
+    _CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter2>
+    && noexcept(_CUDA_VSTD::declval<const _Iter2&>() + difference_type{}))
+    _CCCL_TRAILING_REQUIRES(transform_output_iterator)(_CUDA_VSTD::__iter_can_plus<_Iter2>)
+  {
+    return transform_output_iterator{__iter.__current_ + __n, *__iter.__func_};
+  }
+
+  //! @brief Decrements the @c transform_output_iterator by a given number of elements
   //! @param __n The number of elements to decrement
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
@@ -299,7 +334,32 @@ public:
     return *this;
   }
 
-  //! @brief Compares two \c transform_output_iterator for equality, directly comparing the stored iterators
+  //! @brief Returns a copy of a @c transform_output_iterator decremented by a given number of elements
+  //! @param __iter The @c transform_output_iterator to decrement
+  //! @param __n The number of elements to decrement
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator-(const transform_output_iterator& __iter,
+            difference_type __n) noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter2>
+                                          && noexcept(_CUDA_VSTD::declval<const _Iter2&>() - difference_type{}))
+    _CCCL_TRAILING_REQUIRES(transform_output_iterator)(_CUDA_VSTD::__iter_can_minus<_Iter2>)
+  {
+    return transform_output_iterator{__iter.__current_ - __n, *__iter.__func_};
+  }
+
+  //! @brief Returns the distance between two @c transform_output_iterator
+  _CCCL_EXEC_CHECK_DISABLE
+  template <class _Iter2 = _Iter>
+  [[nodiscard]] _CCCL_API friend constexpr auto
+  operator-(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() - _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(difference_type)(_CUDA_VSTD::sized_sentinel_for<_Iter2, _Iter2>)
+  {
+    return __lhs.__current_ - __rhs.__current_;
+  }
+
+  //! @brief Compares two @c transform_output_iterator for equality by comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
@@ -311,7 +371,7 @@ public:
   }
 
 #if _CCCL_STD_VER <= 2017
-  //! @brief Compares two \c transform_output_iterator for inequality, directly comparing the stored iterators
+  //! @brief Compares two @c transform_output_iterator for inequality by comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
@@ -323,131 +383,76 @@ public:
   }
 #endif // _CCCL_STD_VER <= 2017
 
-  //! @brief Compares two \c transform_output_iterator for less than, directly comparing the stored iterators
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator<(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return __lhs.__current_ < __rhs.__current_;
-  }
-
-  //! @brief Compares two \c transform_output_iterator for greater than, directly comparing the stored iterators
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator>(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return __lhs.__current_ > __rhs.__current_;
-  }
-
-  //! @brief Compares two \c transform_output_iterator for less equal, directly comparing the stored iterators
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator<=(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return __lhs.__current_ <= __rhs.__current_;
-  }
-
-  //! @brief Compares two \c transform_output_iterator for greater equal, directly comparing the stored iterators
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter2 = _Iter>
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator>=(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>)
-  {
-    return __lhs.__current_ >= __rhs.__current_;
-  }
-
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-  //! @brief Three-way-compares two \c transform_output_iterator, directly three-way-comparing the stored iterators
+  //! @brief Three-way-compares two @c transform_output_iterator by three-way-comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
   operator<=>(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
     noexcept(_CUDA_VSTD::declval<const _Iter2&>() <=> _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::random_access_iterator<_Iter2>&& _CUDA_VSTD::three_way_comparable<_Iter2>)
+    _CCCL_TRAILING_REQUIRES(bool)(
+      _CUDA_VSTD::__has_random_access_traversal<_Iter2>&& _CUDA_VSTD::three_way_comparable<_Iter2>)
   {
     return __lhs.__current_ <=> __rhs.__current_;
   }
-#endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
-
-  //! @brief Returns a copy of the \c transform_output_iterator \p __i advanced by \p __n
-  //! @param __i The \c transform_output_iterator to advance
-  //! @param __n The number of elements to advance
+#else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR() vvv
+  //! @brief Compares two @c transform_output_iterator for less than by comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
-  operator+(const transform_output_iterator& __i,
-            difference_type __n) noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter2>
-                                          && noexcept(_CUDA_VSTD::declval<const _Iter2&>() + difference_type{}))
-    _CCCL_TRAILING_REQUIRES(transform_output_iterator)(_CUDA_VSTD::__iter_can_plus<_Iter2>)
+  operator<(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
   {
-    return transform_output_iterator{__i.__current_ + __n, *__i.__func_};
+    return __lhs.__current_ < __rhs.__current_;
   }
 
-  //! @brief Returns a copy of the \c transform_output_iterator \p __i advanced by \p __n
-  //! @param __n The number of elements to advance
-  //! @param __i The \c transform_output_iterator to advance
+  //! @brief Compares two @c transform_output_iterator for greater than by comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
-  operator+(difference_type __n, const transform_output_iterator& __i) noexcept(
-    _CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter2>
-    && noexcept(_CUDA_VSTD::declval<const _Iter2&>() + difference_type{}))
-    _CCCL_TRAILING_REQUIRES(transform_output_iterator)(_CUDA_VSTD::__iter_can_plus<_Iter2>)
+  operator>(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
   {
-    return transform_output_iterator{__i.__current_ + __n, *__i.__func_};
+    return __lhs.__current_ > __rhs.__current_;
   }
 
-  //! @brief Returns a copy of the the \c transform_output_iterator \p __i decremented by \p __n
-  //! @param __i The \c transform_output_iterator to decrement
-  //! @param __n The number of elements to decrement
+  //! @brief Compares two @c transform_output_iterator for less equal by comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
-  operator-(const transform_output_iterator& __i,
-            difference_type __n) noexcept(_CUDA_VSTD::is_nothrow_copy_constructible_v<_Iter2>
-                                          && noexcept(_CUDA_VSTD::declval<const _Iter2&>() - difference_type{}))
-    _CCCL_TRAILING_REQUIRES(transform_output_iterator)(_CUDA_VSTD::__iter_can_minus<_Iter2>)
+  operator<=(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
   {
-    return transform_output_iterator{__i.__current_ - __n, *__i.__func_};
+    return __lhs.__current_ <= __rhs.__current_;
   }
 
-  //! @brief Returns the distance between \p __lhs and \p __rhs
-  //! @param __lhs The left \c transform_output_iterator
-  //! @param __rhs The right \c transform_output_iterator
-  //! @return The distance between the stored iterators
+  //! @brief Compares two @c transform_output_iterator for greater equal by comparing the stored iterators
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Iter2 = _Iter>
   [[nodiscard]] _CCCL_API friend constexpr auto
-  operator-(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
-    noexcept(_CUDA_VSTD::declval<const _Iter2&>() - _CUDA_VSTD::declval<const _Iter2&>()))
-    _CCCL_TRAILING_REQUIRES(difference_type)(_CUDA_VSTD::sized_sentinel_for<_Iter2, _Iter2>)
+  operator>=(const transform_output_iterator& __lhs, const transform_output_iterator& __rhs) noexcept(
+    noexcept(_CUDA_VSTD::declval<const _Iter2&>() < _CUDA_VSTD::declval<const _Iter2&>()))
+    _CCCL_TRAILING_REQUIRES(bool)(_CUDA_VSTD::__has_random_access_traversal<_Iter2>)
   {
-    return __lhs.__current_ - __rhs.__current_;
+    return __lhs.__current_ >= __rhs.__current_;
   }
+#endif // !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 };
 
-//! @brief make_transform_output_iterator creates a \p transform_output_iterator from an \c _Iter and a \c _Fn.
-//!
-//! @param __iter The \c Iterator pointing to the input range of the newly created \p transform_output_iterator.
-//! @param __fun The \c _Fn used to transform the range pointed to by @param __iter in the newly created
-//! @p transform_output_iterator.
-//! @return A new \p transform_output_iterator which transforms the range at @param __iter by @param __fun.
-template <class _Iter, class _Fn>
+//! @brief Creates a @c transform_output_iterator from an iterator and an output function.
+//! @param __iter The iterator of the input range
+//! @param __fun The output function
+//! @relates transform_output_iterator
+template <class _Fn, class _Iter>
 [[nodiscard]] _CCCL_API constexpr auto make_transform_output_iterator(_Iter __iter, _Fn __fun)
 {
-  return transform_output_iterator<_Iter, _Fn>{__iter, __fun};
+  return transform_output_iterator<_Fn, _Iter>{__iter, __fun};
 }
+
+//! @}
 
 _LIBCUDACXX_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/std/__algorithm/copy_n.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy_n.h
@@ -33,8 +33,8 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator,
           class _Size,
           class _OutputIterator,
-          enable_if_t<__is_cpp17_input_iterator<_InputIterator>::value, int>          = 0,
-          enable_if_t<!__is_cpp17_random_access_iterator<_InputIterator>::value, int> = 0>
+          enable_if_t<__has_input_traversal<_InputIterator>, int>          = 0,
+          enable_if_t<!__has_random_access_traversal<_InputIterator>, int> = 0>
 _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _OutputIterator
 copy_n(_InputIterator __first, _Size __orig_n, _OutputIterator __result)
 {
@@ -58,7 +58,7 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _InputIterator,
           class _Size,
           class _OutputIterator,
-          enable_if_t<__is_cpp17_random_access_iterator<_InputIterator>::value, int> = 0>
+          enable_if_t<__has_random_access_traversal<_InputIterator>, int> = 0>
 _CCCL_API constexpr _OutputIterator copy_n(_InputIterator __first, _Size __orig_n, _OutputIterator __result)
 {
   using _IntegralSize = decltype(__convert_to_integral(__orig_n));

--- a/libcudacxx/include/cuda/std/__algorithm/max_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/max_element.h
@@ -32,8 +32,7 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _Compare, class _ForwardIterator>
 _CCCL_API constexpr _ForwardIterator __max_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
-  static_assert(__is_cpp17_input_iterator<_ForwardIterator>::value,
-                "_CUDA_VSTD::max_element requires a ForwardIterator");
+  static_assert(__has_input_traversal<_ForwardIterator>, "_CUDA_VSTD::max_element requires a ForwardIterator");
   if (__first != __last)
   {
     _ForwardIterator __i = __first;

--- a/libcudacxx/include/cuda/std/__algorithm/min_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min_element.h
@@ -66,7 +66,7 @@ template <class _ForwardIterator, class _Compare>
 [[nodiscard]] _CCCL_API constexpr _ForwardIterator
 min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
-  static_assert(__is_cpp17_input_iterator<_ForwardIterator>::value, "std::min_element requires a ForwardIterator");
+  static_assert(__has_input_traversal<_ForwardIterator>, "std::min_element requires a ForwardIterator");
   static_assert(__is_callable<_Compare, decltype(*__first), decltype(*__first)>::value,
                 "The comparator has to be callable");
 

--- a/libcudacxx/include/cuda/std/__algorithm/minmax_element.h
+++ b/libcudacxx/include/cuda/std/__algorithm/minmax_element.h
@@ -118,8 +118,7 @@ template <class _ForwardIterator, class _Compare>
 [[nodiscard]] _CCCL_API constexpr pair<_ForwardIterator, _ForwardIterator>
 minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp)
 {
-  static_assert(__is_cpp17_input_iterator<_ForwardIterator>::value,
-                "_CUDA_VSTD::minmax_element requires a ForwardIterator");
+  static_assert(__has_input_traversal<_ForwardIterator>, "_CUDA_VSTD::minmax_element requires a ForwardIterator");
   static_assert(__is_callable<_Compare, decltype(*__first), decltype(*__first)>::value,
                 "The comparator has to be callable");
   auto __proj = identity();

--- a/libcudacxx/include/cuda/std/__algorithm/unwrap_iter.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unwrap_iter.h
@@ -41,7 +41,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 // "unwrapped" result back into the original iterator type. Doing that is the job of __rewrap_iter.
 
 // Default case - we can't unwrap anything
-template <class _Iter, bool = __is_cpp17_contiguous_iterator<_Iter>::value>
+template <class _Iter, bool = __has_contiguous_traversal<_Iter>>
 struct __unwrap_iter_impl
 {
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__iterator/advance.h
+++ b/libcudacxx/include/cuda/std/__iterator/advance.h
@@ -42,11 +42,11 @@ _CCCL_API constexpr void advance(_InputIter& __i, _Distance __orig_n)
 {
   using _Difference = typename iterator_traits<_InputIter>::difference_type;
   _Difference __n   = static_cast<_Difference>(_CUDA_VSTD::__convert_to_integral(__orig_n));
-  if constexpr (__is_cpp17_random_access_iterator<_InputIter>::value) // To support pointers to incomplete types
+  if constexpr (__has_random_access_traversal<_InputIter>) // To support pointers to incomplete types
   {
     __i += __n;
   }
-  else if constexpr (__is_cpp17_bidirectional_iterator<_InputIter>::value)
+  else if constexpr (__has_bidirectional_traversal<_InputIter>)
   {
     if (__n >= 0)
     {

--- a/libcudacxx/include/cuda/std/__iterator/bounded_iter.h
+++ b/libcudacxx/include/cuda/std/__iterator/bounded_iter.h
@@ -41,7 +41,7 @@ _LIBCUDACXX_BEGIN_NAMESPACE_STD
 // Arithmetic operations are allowed and the bounds of the resulting iterator
 // are not checked. Hence, it is possible to create an iterator pointing outside
 // its range, but it is not possible to dereference it.
-template <class _Iterator, class = enable_if_t<__is_cpp17_contiguous_iterator<_Iterator>::value>>
+template <class _Iterator, class = enable_if_t<__has_contiguous_traversal<_Iterator>>>
 struct __bounded_iter
 {
   using value_type        = typename iterator_traits<_Iterator>::value_type;
@@ -230,8 +230,7 @@ _CCCL_API constexpr __bounded_iter<_It> __make_bounded_iter(_It __it, _It __begi
 
 #if _CCCL_STD_VER <= 2017
 template <class _Iterator>
-struct __is_cpp17_contiguous_iterator<__bounded_iter<_Iterator>> : true_type
-{};
+inline constexpr bool __has_contiguous_traversal<__bounded_iter<_Iterator>> = true;
 #endif // _CCCL_STD_VER <= 2017
 
 template <class _Iterator>

--- a/libcudacxx/include/cuda/std/__iterator/distance.h
+++ b/libcudacxx/include/cuda/std/__iterator/distance.h
@@ -39,7 +39,7 @@ template <class _InputIter>
 [[nodiscard]] _CCCL_API constexpr typename iterator_traits<_InputIter>::difference_type
 distance(_InputIter __first, _InputIter __last)
 {
-  if constexpr (__is_cpp17_random_access_iterator<_InputIter>::value) // To support pointers to incomplete types
+  if constexpr (__has_random_access_traversal<_InputIter>) // To support pointers to incomplete types
   {
     return __last - __first;
   }

--- a/libcudacxx/include/cuda/std/__iterator/next.h
+++ b/libcudacxx/include/cuda/std/__iterator/next.h
@@ -32,11 +32,11 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 _CCCL_TEMPLATE(class _InputIter)
-_CCCL_REQUIRES(__is_cpp17_input_iterator<_InputIter>::value)
+_CCCL_REQUIRES(__has_input_traversal<_InputIter>)
 [[nodiscard]] _CCCL_API constexpr _InputIter
 next(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n = 1)
 {
-  _CCCL_ASSERT(__n >= 0 || __is_cpp17_bidirectional_iterator<_InputIter>::value,
+  _CCCL_ASSERT(__n >= 0 || __has_bidirectional_traversal<_InputIter>,
                "Attempt to next(it, n) with negative n on a non-bidirectional iterator");
 
   _CUDA_VSTD::advance(__x, __n);

--- a/libcudacxx/include/cuda/std/__iterator/prev.h
+++ b/libcudacxx/include/cuda/std/__iterator/prev.h
@@ -32,12 +32,11 @@
 _LIBCUDACXX_BEGIN_NAMESPACE_STD
 
 _CCCL_TEMPLATE(class _InputIter)
-_CCCL_REQUIRES(__is_cpp17_input_iterator<_InputIter>::value)
+_CCCL_REQUIRES(__has_input_traversal<_InputIter>)
 [[nodiscard]] _CCCL_API constexpr _InputIter
 prev(_InputIter __x, typename iterator_traits<_InputIter>::difference_type __n = 1)
 {
-  _CCCL_ASSERT(__n <= 0 || __is_cpp17_bidirectional_iterator<_InputIter>::value,
-               "Attempt to prev(it, +n) on a non-bidi iterator");
+  _CCCL_ASSERT(__n <= 0 || __has_bidirectional_traversal<_InputIter>, "Attempt to prev(it, +n) on a non-bidi iterator");
   _CUDA_VSTD::advance(__x, -__n);
   return __x;
 }

--- a/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
@@ -90,7 +90,7 @@ private:
 #endif // !_LIBCUDACXX_ABI_NO_ITERATOR_BASES
 
 #if _CCCL_STD_VER > 2017
-  static_assert(__is_cpp17_bidirectional_iterator<_Iter>::value || bidirectional_iterator<_Iter>,
+  static_assert(__has_bidirectional_traversal<_Iter> || bidirectional_iterator<_Iter>,
                 "reverse_iterator<It> requires It to be a bidirectional iterator.");
 #endif // _CCCL_STD_VER > 2017
 
@@ -101,7 +101,7 @@ public:
   using iterator_type = _Iter;
 
   using iterator_category =
-    _If<__is_cpp17_random_access_iterator<_Iter>::value,
+    _If<__has_random_access_traversal<_Iter>,
         random_access_iterator_tag,
         typename iterator_traits<_Iter>::iterator_category>;
   using pointer          = typename iterator_traits<_Iter>::pointer;
@@ -395,11 +395,11 @@ class __unconstrained_reverse_iterator
   _Iter __iter_;
 
 public:
-  static_assert(__is_cpp17_bidirectional_iterator<_Iter>::value || bidirectional_iterator<_Iter>);
+  static_assert(__has_bidirectional_traversal<_Iter> || bidirectional_iterator<_Iter>);
 
   using iterator_type = _Iter;
   using iterator_category =
-    _If<__is_cpp17_random_access_iterator<_Iter>::value, random_access_iterator_tag, __iterator_category_type<_Iter>>;
+    _If<__has_random_access_traversal<_Iter>, random_access_iterator_tag, __iterator_category_type<_Iter>>;
   using pointer         = __iterator_pointer_type<_Iter>;
   using value_type      = iter_value_t<_Iter>;
   using difference_type = iter_difference_t<_Iter>;

--- a/libcudacxx/include/cuda/std/__iterator/wrap_iter.h
+++ b/libcudacxx/include/cuda/std/__iterator/wrap_iter.h
@@ -223,8 +223,7 @@ operator+(typename __wrap_iter<_Iter1>::difference_type __n, __wrap_iter<_Iter1>
 
 #if _CCCL_STD_VER <= 2017
 template <class _It>
-struct __is_cpp17_contiguous_iterator<__wrap_iter<_It>> : true_type
-{};
+inline constexpr bool __has_contiguous_traversal<__wrap_iter<_It>> = true;
 #endif
 
 template <class _It>

--- a/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
+++ b/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
@@ -346,7 +346,7 @@ uninitialized_move_n(_InputIterator __ifirst, _Size __n, _ForwardIterator __ofir
 //
 // This function assumes that destructors do not throw, and that the allocator is bound to
 // the correct type.
-template <class _Alloc, class _BidirIter, enable_if_t<__is_cpp17_bidirectional_iterator<_BidirIter>::value, int> = 0>
+template <class _Alloc, class _BidirIter, enable_if_t<__has_bidirectional_traversal<_BidirIter>, int> = 0>
 _CCCL_API constexpr void
 __allocator_destroy_multidimensional(_Alloc& __alloc, _BidirIter __first, _BidirIter __last) noexcept
 {

--- a/libcudacxx/include/cuda/std/__ranges/iota_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/iota_view.h
@@ -80,22 +80,22 @@ public:
 
     [[nodiscard]] _CCCL_API friend constexpr bool operator==(const __iterator& __x, const __sentinel& __y)
     {
-      return __x.__value_ == __y.__bound_sentinel_;
+      return *__x == __y.__bound_sentinel_;
     }
 #if _CCCL_STD_VER <= 2017
     [[nodiscard]] _CCCL_API friend constexpr bool operator==(const __sentinel& __x, const __iterator& __y)
     {
-      return __x.__bound_sentinel_ == __y.__value_;
+      return __x.__bound_sentinel_ == *__y;
     }
 
     [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const __iterator& __x, const __sentinel& __y)
     {
-      return __x.__value_ != __y.__bound_sentinel_;
+      return *__x != __y.__bound_sentinel_;
     }
 
     [[nodiscard]] _CCCL_API friend constexpr bool operator!=(const __sentinel& __x, const __iterator& __y)
     {
-      return __x.__bound_sentinel_ != __y.__value_;
+      return __x.__bound_sentinel_ != *__y;
     }
 #endif // _CCCL_STD_VER <= 2017
 
@@ -104,7 +104,7 @@ public:
     [[nodiscard]] _CCCL_API friend constexpr iter_difference_t<_Start>
     operator-(const __iterator& __x, const __sentinel& __y)
     {
-      return __x.__value_ - __y.__bound_sentinel_;
+      return *__x - __y.__bound_sentinel_;
     }
 
     _CCCL_TEMPLATE(class _BoundSentinel2 = _BoundSentinel)
@@ -157,19 +157,19 @@ public:
   _CCCL_TEMPLATE(class _BoundSentinel2 = _BoundSentinel)
   _CCCL_REQUIRES(same_as<_Start, _BoundSentinel2>)
   _CCCL_API constexpr iota_view(__iterator __first, __iterator __last)
-      : iota_view(_CUDA_VSTD::move(__first.__value_), _CUDA_VSTD::move(__last.__value_))
+      : iota_view(::cuda::std::move(*__first), ::cuda::std::move(*__last))
   {}
 
   _CCCL_TEMPLATE(class _BoundSentinel2 = _BoundSentinel)
   _CCCL_REQUIRES(same_as<_BoundSentinel2, unreachable_sentinel_t>)
   _CCCL_API constexpr iota_view(__iterator __first, _BoundSentinel __last)
-      : iota_view(_CUDA_VSTD::move(__first.__value_), _CUDA_VSTD::move(__last))
+      : iota_view(::cuda::std::move(*__first), ::cuda::std::move(__last))
   {}
 
   _CCCL_TEMPLATE(class _BoundSentinel2 = _BoundSentinel)
   _CCCL_REQUIRES((!same_as<_Start, _BoundSentinel2>) _CCCL_AND(!same_as<_Start, unreachable_sentinel_t>))
   _CCCL_API constexpr iota_view(__iterator __first, __sentinel __last)
-      : iota_view(_CUDA_VSTD::move(__first.__value_), _CUDA_VSTD::move(__last.__bound_sentinel_))
+      : iota_view(::cuda::std::move(*__first), ::cuda::std::move(__last.__bound_sentinel_))
   {}
 
   [[nodiscard]] _CCCL_API constexpr __iterator begin() const

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
@@ -229,8 +229,7 @@ _CCCL_API inline _SampleIterator __sample(
 {
   typedef typename iterator_traits<_PopulationIterator>::iterator_category _PopCategory;
   typedef typename iterator_traits<_PopulationIterator>::difference_type _Difference;
-  static_assert(__is_cpp17_forward_iterator<_PopulationIterator>::value
-                  || __is_cpp17_random_access_iterator<_SampleIterator>::value,
+  static_assert(__has_forward_traversal<_PopulationIterator> || __has_random_access_traversal<_SampleIterator>,
                 "SampleIterator must meet the requirements of RandomAccessIterator");
   typedef typename common_type<_Distance, _Difference>::type _CommonType;
   _CCCL_ASSERT(__n >= 0, "N must be a positive number.");

--- a/libcudacxx/include/cuda/std/inplace_vector
+++ b/libcudacxx/include/cuda/std/inplace_vector
@@ -737,7 +737,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Iter)
-  _CCCL_REQUIRES(__is_cpp17_input_iterator<_Iter>::value _CCCL_AND(!__is_cpp17_forward_iterator<_Iter>::value))
+  _CCCL_REQUIRES(__has_input_traversal<_Iter> _CCCL_AND(!__has_forward_traversal<_Iter>))
   _CCCL_API constexpr inplace_vector(_Iter __first, _Iter __last)
       : __base()
   {
@@ -748,7 +748,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Iter)
-  _CCCL_REQUIRES(__is_cpp17_forward_iterator<_Iter>::value)
+  _CCCL_REQUIRES(__has_forward_traversal<_Iter>)
   _CCCL_API constexpr inplace_vector(_Iter __first, _Iter __last)
       : __base()
   {
@@ -874,7 +874,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Iter)
-  _CCCL_REQUIRES(__is_cpp17_input_iterator<_Iter>::value _CCCL_AND(!__is_cpp17_forward_iterator<_Iter>::value))
+  _CCCL_REQUIRES(__has_input_traversal<_Iter> _CCCL_AND(!__has_forward_traversal<_Iter>))
   _CCCL_API constexpr void assign(_Iter __first, _Iter __last)
   {
     iterator __end = this->end();
@@ -895,7 +895,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Iter)
-  _CCCL_REQUIRES(__is_cpp17_forward_iterator<_Iter>::value)
+  _CCCL_REQUIRES(__has_forward_traversal<_Iter>)
   _CCCL_API constexpr void assign(_Iter __first, _Iter __last)
   {
     const auto __count = static_cast<size_type>(_CUDA_VSTD::distance(__first, __last));
@@ -1183,7 +1183,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Iter)
-  _CCCL_REQUIRES(__is_cpp17_input_iterator<_Iter>::value _CCCL_AND(!__is_cpp17_forward_iterator<_Iter>::value))
+  _CCCL_REQUIRES(__has_input_traversal<_Iter> _CCCL_AND(!__has_forward_traversal<_Iter>))
   _CCCL_API constexpr iterator insert(const_iterator __cpos, _Iter __first, _Iter __last)
   {
     // add all new elements to the back then rotate
@@ -1199,7 +1199,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Iter)
-  _CCCL_REQUIRES(__is_cpp17_forward_iterator<_Iter>::value)
+  _CCCL_REQUIRES(__has_forward_traversal<_Iter>)
   _CCCL_API constexpr iterator insert(const_iterator __cpos, _Iter __first, _Iter __last)
   {
     const auto __pos   = static_cast<size_type>(__cpos - this->cbegin());
@@ -1739,7 +1739,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Iter)
-  _CCCL_REQUIRES(__is_cpp17_input_iterator<_Iter>::value)
+  _CCCL_REQUIRES(__has_input_traversal<_Iter>)
   _CCCL_API constexpr inplace_vector(_Iter __first, _Iter __last)
       : __base()
   {
@@ -1789,7 +1789,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Iter)
-  _CCCL_REQUIRES(__is_cpp17_input_iterator<_Iter>::value)
+  _CCCL_REQUIRES(__has_input_traversal<_Iter>)
   _CCCL_API constexpr void assign(_Iter __first, _Iter __last)
   {
     if (__first != __last)
@@ -1945,7 +1945,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Iter)
-  _CCCL_REQUIRES(__is_cpp17_input_iterator<_Iter>::value)
+  _CCCL_REQUIRES(__has_input_traversal<_Iter>)
   _CCCL_API constexpr iterator insert(const_iterator, _Iter __first, _Iter __last)
   {
     if (__first != __last)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/iterator_traits.compile.pass.cpp
@@ -8,10 +8,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cuda/iterator>
+// Test iterator category and iterator concepts.
 
-#include "test_iterators.h"
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
 #include "test_macros.h"
+#include "types.h"
 
 #if !TEST_COMPILER(NVRTC)
 #  include <iterator>
@@ -20,16 +24,13 @@
 template <template <class...> class Traits>
 __host__ __device__ void test()
 {
-  using Iter       = cuda::discard_iterator;
+  using Iter       = cuda::constant_iterator<int>;
   using IterTraits = Traits<Iter>;
-
   static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
-  static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+  static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+  static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
   static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
-  static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
-  static_assert(cuda::std::same_as<typename IterTraits::reference, void>);
-  static_assert(cuda::std::input_or_output_iterator<cuda::discard_iterator>);
-  static_assert(cuda::std::output_iterator<cuda::discard_iterator, float>);
+  static_assert(cuda::std::random_access_iterator<Iter>);
   static_assert(cuda::std::__has_random_access_traversal<Iter>);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/member_typedefs.compile.pass.cpp
@@ -25,6 +25,7 @@ __host__ __device__ void test()
   static_assert(cuda::std::same_as<Iter::value_type, int>);
   static_assert(cuda::std::is_signed_v<Iter::difference_type>);
   static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
+  static_assert(cuda::std::random_access_iterator<Iter>);
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/counting_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/counting_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,258 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Test iterator category and iterator concepts.
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+#include "types.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+struct Decrementable
+{
+  using difference_type = int;
+
+#if TEST_HAS_SPACESHIP()
+  auto operator<=>(const Decrementable&) const = default;
+#else
+  __host__ __device__ bool operator==(const Decrementable&) const;
+  __host__ __device__ bool operator!=(const Decrementable&) const;
+
+  __host__ __device__ bool operator<(const Decrementable&) const;
+  __host__ __device__ bool operator<=(const Decrementable&) const;
+  __host__ __device__ bool operator>(const Decrementable&) const;
+  __host__ __device__ bool operator>=(const Decrementable&) const;
+#endif // TEST_HAS_SPACESHIP()
+
+  __host__ __device__ constexpr Decrementable& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr Decrementable operator++(int)
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr Decrementable& operator--()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr Decrementable operator--(int)
+  {
+    return *this;
+  }
+};
+
+struct Incrementable
+{
+  using difference_type = int;
+
+#if TEST_HAS_SPACESHIP()
+  auto operator<=>(const Incrementable&) const = default;
+#else
+  __host__ __device__ bool operator==(const Incrementable&) const;
+  __host__ __device__ bool operator!=(const Incrementable&) const;
+
+  __host__ __device__ bool operator<(const Incrementable&) const;
+  __host__ __device__ bool operator<=(const Incrementable&) const;
+  __host__ __device__ bool operator>(const Incrementable&) const;
+  __host__ __device__ bool operator>=(const Incrementable&) const;
+#endif // TEST_HAS_SPACESHIP()
+
+  __host__ __device__ constexpr Incrementable& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr Incrementable operator++(int)
+  {
+    return *this;
+  }
+};
+
+struct BigType
+{
+  char buffer[128];
+
+  using difference_type = int;
+
+#if TEST_HAS_SPACESHIP()
+  auto operator<=>(const BigType&) const = default;
+#else
+  __host__ __device__ bool operator==(const BigType&) const;
+  __host__ __device__ bool operator!=(const BigType&) const;
+
+  __host__ __device__ bool operator<(const BigType&) const;
+  __host__ __device__ bool operator<=(const BigType&) const;
+  __host__ __device__ bool operator>(const BigType&) const;
+  __host__ __device__ bool operator>=(const BigType&) const;
+#endif // TEST_HAS_SPACESHIP()
+
+  __host__ __device__ constexpr BigType& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr BigType operator++(int)
+  {
+    return *this;
+  }
+};
+
+struct CharDifferenceType
+{
+  using difference_type = signed char;
+
+#if TEST_HAS_SPACESHIP()
+  auto operator<=>(const CharDifferenceType&) const = default;
+#else
+  __host__ __device__ bool operator==(const CharDifferenceType&) const;
+  __host__ __device__ bool operator!=(const CharDifferenceType&) const;
+
+  __host__ __device__ bool operator<(const CharDifferenceType&) const;
+  __host__ __device__ bool operator<=(const CharDifferenceType&) const;
+  __host__ __device__ bool operator>(const CharDifferenceType&) const;
+  __host__ __device__ bool operator>=(const CharDifferenceType&) const;
+#endif // TEST_HAS_SPACESHIP()
+
+  __host__ __device__ constexpr CharDifferenceType& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr CharDifferenceType operator++(int)
+  {
+    return *this;
+  }
+};
+
+template <class T>
+_CCCL_CONCEPT HasIteratorCategory =
+  _CCCL_REQUIRES_EXPR((T))(typename(typename cuda::std::ranges::iterator_t<T>::iterator_category));
+
+template <template <class...> class Traits>
+__host__ __device__ void test()
+{
+  {
+    using Iter       = cuda::counting_iterator<char>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, char>);
+    static_assert(sizeof(typename IterTraits::difference_type) > sizeof(char));
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, int>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<short>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, short>);
+    static_assert(sizeof(typename IterTraits::difference_type) > sizeof(short));
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, int>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<int>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(sizeof(typename IterTraits::difference_type) > sizeof(int));
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    // If we're compiling for 32 bit or windows, int and long are the same size, so long long is the correct difference
+    // type.
+#if INTPTR_MAX == INT32_MAX || defined(_WIN32)
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, long long>);
+#else
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, long>);
+#endif
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<long>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, long>);
+    // Same as below, if there is no type larger than long, we can just use that.
+    static_assert(sizeof(typename IterTraits::difference_type) >= sizeof(long));
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, long long>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<long long>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, long long>);
+    // No integer is larger than long long, so it is OK to use long long as the difference type here:
+    // https://eel.is/c++draft/range.iota.view#1.3
+    static_assert(sizeof(typename IterTraits::difference_type) >= sizeof(long long));
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, long long>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<Decrementable>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, Decrementable>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, int>);
+    static_assert(cuda::std::__has_bidirectional_traversal<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<Incrementable>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, Incrementable>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, int>);
+    static_assert(cuda::std::__has_forward_traversal<Iter>);
+  }
+  { // nothing to do here
+    using Iter = cuda::counting_iterator<NotIncrementable>;
+    static_assert(!HasIteratorCategory<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<BigType>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, BigType>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, int>);
+    static_assert(cuda::std::__has_forward_traversal<Iter>);
+  }
+  {
+    using Iter       = cuda::counting_iterator<CharDifferenceType>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, CharDifferenceType>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, signed char>);
+    static_assert(cuda::std::__has_forward_traversal<Iter>);
+  }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/counting_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/counting_iterator/member_typedefs.compile.pass.cpp
@@ -115,6 +115,7 @@ __host__ __device__ void test()
     static_assert(sizeof(Iter::difference_type) > sizeof(char));
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, int>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
   {
     using Iter = cuda::counting_iterator<short>;
@@ -124,6 +125,7 @@ __host__ __device__ void test()
     static_assert(sizeof(Iter::difference_type) > sizeof(short));
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, int>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
   {
     using Iter = cuda::counting_iterator<int>;
@@ -139,6 +141,7 @@ __host__ __device__ void test()
 #else
     static_assert(cuda::std::same_as<Iter::difference_type, long>);
 #endif
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
   {
     using Iter = cuda::counting_iterator<long>;
@@ -149,6 +152,7 @@ __host__ __device__ void test()
     static_assert(sizeof(Iter::difference_type) >= sizeof(long));
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, long long>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
   {
     using Iter = cuda::counting_iterator<long long>;
@@ -160,6 +164,7 @@ __host__ __device__ void test()
     static_assert(sizeof(Iter::difference_type) >= sizeof(long long));
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, long long>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
   {
     using Iter = cuda::counting_iterator<Decrementable>;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/permutation_iterator/iterator_traits.compile.pass.cpp
@@ -13,30 +13,45 @@
 #include "test_iterators.h"
 #include "test_macros.h"
 
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
 __host__ __device__ void test()
 {
   {
-    using baseIter             = random_access_iterator<int*>;
-    using permutation_iterator = cuda::permutation_iterator<baseIter, baseIter>;
-    using iterTraits           = cuda::std::iterator_traits<permutation_iterator>;
+    using baseIter   = random_access_iterator<int*>;
+    using Iter       = cuda::permutation_iterator<baseIter, baseIter>;
+    using IterTraits = cuda::std::iterator_traits<Iter>;
 
-    static_assert(cuda::std::same_as<iterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
-    static_assert(cuda::std::same_as<iterTraits::value_type, int>);
-    static_assert(cuda::std::same_as<iterTraits::difference_type, cuda::std::ptrdiff_t>);
-    static_assert(cuda::std::same_as<iterTraits::pointer, void>);
-    static_assert(cuda::std::same_as<iterTraits::reference, int&>);
+    static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::same_as<IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<IterTraits::reference, int&>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
   }
   { // still random access
-    using baseIter             = contiguous_iterator<int*>;
-    using permutation_iterator = cuda::permutation_iterator<baseIter, baseIter>;
-    using iterTraits           = cuda::std::iterator_traits<permutation_iterator>;
+    using baseIter   = contiguous_iterator<int*>;
+    using Iter       = cuda::permutation_iterator<baseIter, baseIter>;
+    using IterTraits = cuda::std::iterator_traits<Iter>;
 
-    static_assert(cuda::std::same_as<iterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
-    static_assert(cuda::std::same_as<iterTraits::value_type, int>);
-    static_assert(cuda::std::same_as<iterTraits::difference_type, cuda::std::ptrdiff_t>);
-    static_assert(cuda::std::same_as<iterTraits::pointer, void>);
-    static_assert(cuda::std::same_as<iterTraits::reference, int&>);
+    static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::same_as<IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<IterTraits::reference, int&>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
   }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,61 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Test iterator category and iterator concepts.
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+#include "types.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
+__host__ __device__ void test()
+{
+  {
+    using Iter       = cuda::strided_iterator<int*, int>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+
+  {
+    using Iter       = cuda::strided_iterator<int*, Stride<2>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/member_typedefs.compile.pass.cpp
@@ -26,6 +26,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::same_as<Iter::value_type, int>);
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
 
   {
@@ -35,6 +36,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::same_as<Iter::value_type, int>);
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/stride.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/stride.pass.cpp
@@ -21,12 +21,12 @@ __host__ __device__ constexpr void test(Stride stride)
 {
   {
     cuda::strided_iterator<int*, Stride> iter;
-    assert(iter.stride() == _CUDA_VSTD::__de_ice(Stride{}));
+    assert(iter.stride() == ::cuda::std::__de_ice(Stride{}));
   }
 
   {
     cuda::strided_iterator<int*, Stride> iter{nullptr, stride};
-    assert(iter.stride() == _CUDA_VSTD::__de_ice(stride));
+    assert(iter.stride() == ::cuda::std::__de_ice(stride));
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/types.h
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/types.h
@@ -17,6 +17,6 @@
 template <cuda::std::ptrdiff_t Val = 2>
 struct Stride : cuda::std::integral_constant<cuda::std::ptrdiff_t, Val>
 {};
-static_assert(_CUDA_VSTD::__integral_constant_like<Stride<2>>);
+static_assert(::cuda::std::__integral_constant_like<Stride<2>>);
 
 #endif // TEST_CUDA_ITERATOR_STRIDED_ITERATOR_H

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Test iterator category and iterator concepts.
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+
+#include "test_macros.h"
+#include "types.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
+__host__ __device__ void test()
+{
+  {
+    using Iter       = cuda::tabulate_output_iterator<basic_functor>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+#if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
+    static_assert(cuda::std::output_iterator<Iter, int>);
+#endif // !_CCCL_ARCH(ARM64)
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+
+  {
+    using Iter       = cuda::tabulate_output_iterator<basic_functor, char>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, char>);
+#if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
+    static_assert(cuda::std::output_iterator<Iter, int>);
+#endif // !_CCCL_ARCH(ARM64)
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/ctor.pass.cpp
@@ -92,10 +92,10 @@ __host__ __device__ constexpr void test(Fn fun)
 
   { // default initialization
     constexpr bool can_default_init = cuda::std::default_initializable<Iter> && cuda::std::default_initializable<Fn>;
-    static_assert(cuda::std::default_initializable<cuda::transform_iterator<Iter, Fn>> == can_default_init);
+    static_assert(cuda::std::default_initializable<cuda::transform_iterator<Fn, Iter>> == can_default_init);
     if constexpr (can_default_init)
     {
-      [[maybe_unused]] cuda::transform_iterator<Iter, Fn> iter{};
+      [[maybe_unused]] cuda::transform_iterator<Fn, Iter> iter{};
     }
   }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.compile.pass.cpp
@@ -1,0 +1,131 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+#include <cuda/std/concepts>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+template <class Iter, class Fn>
+_CCCL_CONCEPT HasIterCategory =
+  _CCCL_REQUIRES_EXPR((Iter, Fn))(typename(typename cuda::transform_iterator<Iter, Fn>::iterator_category));
+
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
+__host__ __device__ constexpr bool test()
+{
+  {
+    using Iter       = cuda::transform_iterator<Increment, int*>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+  {
+    // Member typedefs for random access iterator.
+    using Iter       = cuda::transform_iterator<Increment, random_access_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+  {
+    // Member typedefs for random access iterator, LWG3798 rvalue reference.
+    using Iter       = cuda::transform_iterator<IncrementRvalueRef, random_access_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+  {
+    // Member typedefs for random access iterator/not-lvalue-ref.
+    using Iter       = cuda::transform_iterator<PlusOneMutable, random_access_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+  {
+    // Member typedefs for bidirectional iterator.
+    using Iter       = cuda::transform_iterator<Increment, bidirectional_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::bidirectional_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::bidirectional_iterator<Iter>);
+    static_assert(cuda::std::__has_bidirectional_traversal<Iter>);
+  }
+  {
+    // Member typedefs for forward iterator.
+    using Iter       = cuda::transform_iterator<Increment, forward_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::forward_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::forward_iterator<Iter>);
+    static_assert(cuda::std::__has_forward_traversal<Iter>);
+  }
+  { // Nopthing to do here
+    using Iter = cuda::transform_iterator<Increment, cpp17_input_iterator<int*>>;
+    static_assert(!HasIterCategory<Increment, cpp17_input_iterator<int*>>);
+    static_assert(cuda::std::__has_input_traversal<Iter>);
+  }
+
+  {
+    // Ensure we can work with other cuda iterators
+    using Iter       = cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+
+  {
+    // Ensure we can work with other cuda iterators
+    using Iter       = cuda::std::reverse_iterator<cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<Iter>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+
+  return true;
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.compile.pass.cpp
@@ -32,6 +32,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int&>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
@@ -42,6 +43,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int&>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
@@ -52,6 +54,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int&&>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
@@ -62,6 +65,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
@@ -72,6 +76,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int&>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::bidirectional_iterator<Iter>);
     static_assert(cuda::std::__has_bidirectional_traversal<Iter>);
@@ -82,6 +87,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int&>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::forward_iterator<Iter>);
     static_assert(cuda::std::__has_forward_traversal<Iter>);
@@ -98,6 +104,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
@@ -109,6 +116,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__has_random_access_traversal<Iter>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/make_transform_iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/make_transform_iterator.pass.cpp
@@ -25,7 +25,7 @@ __host__ __device__ constexpr void test()
 
   {
     auto iter = cuda::make_transform_iterator(Iter{buffer}, PlusOne{});
-    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_iterator<Iter, PlusOne>>);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_iterator<PlusOne, Iter>>);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.compile.pass.cpp
@@ -33,6 +33,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }
@@ -42,6 +43,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }
@@ -51,6 +53,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }
@@ -60,6 +63,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }
@@ -69,6 +73,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::bidirectional_iterator<TIter>);
   }
@@ -78,6 +83,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::forward_iterator<TIter>);
   }
@@ -87,6 +93,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::input_iterator_tag>);
     static_assert(!HasIterCategory<cpp17_input_iterator<int*>, Increment>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::input_iterator<TIter>);
   }
@@ -97,6 +104,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }
@@ -107,6 +115,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.compile.pass.cpp
@@ -18,7 +18,7 @@
 
 template <class Iter, class Fn>
 _CCCL_CONCEPT HasIterCategory =
-  _CCCL_REQUIRES_EXPR((Iter, Fn))(typename(typename cuda::transform_iterator<Iter, Fn>::iterator_category));
+  _CCCL_REQUIRES_EXPR((Iter, Fn))(typename(typename cuda::transform_iterator<Fn, Iter>::iterator_category));
 
 __host__ __device__ constexpr bool test()
 {
@@ -29,59 +29,86 @@ __host__ __device__ constexpr bool test()
     static_assert(
       cuda::std::same_as<cuda::std::iterator_traits<int*>::iterator_category, cuda::std::random_access_iterator_tag>);
 
-    using TIter = cuda::transform_iterator<int*, Increment>;
+    using TIter = cuda::transform_iterator<Increment, int*>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
   }
   {
     // Member typedefs for random access iterator.
-    using TIter = cuda::transform_iterator<random_access_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
   }
   {
     // Member typedefs for random access iterator, LWG3798 rvalue reference.
-    using TIter = cuda::transform_iterator<random_access_iterator<int*>, IncrementRvalueRef>;
+    using TIter = cuda::transform_iterator<IncrementRvalueRef, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
   }
   {
     // Member typedefs for random access iterator/not-lvalue-ref.
-    using TIter = cuda::transform_iterator<random_access_iterator<int*>, PlusOneMutable>;
+    using TIter = cuda::transform_iterator<PlusOneMutable, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
   }
   {
     // Member typedefs for bidirectional iterator.
-    using TIter = cuda::transform_iterator<bidirectional_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, bidirectional_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::bidirectional_iterator<TIter>);
   }
   {
     // Member typedefs for forward iterator.
-    using TIter = cuda::transform_iterator<forward_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, forward_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::forward_iterator<TIter>);
   }
   {
     // Member typedefs for input iterator.
-    using TIter = cuda::transform_iterator<cpp17_input_iterator<int*>, Increment>;
+    using TIter = cuda::transform_iterator<Increment, cpp17_input_iterator<int*>>;
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::input_iterator_tag>);
     static_assert(!HasIterCategory<cpp17_input_iterator<int*>, Increment>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::input_iterator<TIter>);
+  }
+
+  {
+    // Ensure we can work with other cuda iterators
+    using TIter = cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>;
+    static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
+  }
+
+  {
+    // Ensure we can work with other cuda iterators
+    using TIter = cuda::std::reverse_iterator<cuda::transform_iterator<TimesTwo, cuda::counting_iterator<int>>>;
+    static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::random_access_iterator<TIter>);
   }
 
   return true;
@@ -90,7 +117,7 @@ __host__ __device__ constexpr bool test()
 int main(int, char**)
 {
   test();
-  static_assert(test(), "");
+  static_assert(test());
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/plus_minus.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/plus_minus.pass.cpp
@@ -42,8 +42,8 @@ __host__ __device__ constexpr void test()
   }
   else
   {
-    static_assert(!can_plus<cuda::transform_iterator<Iter, PlusOne>>);
-    static_assert(!can_minus<cuda::transform_iterator<Iter, PlusOne>>);
+    static_assert(!can_plus<cuda::transform_iterator<PlusOne, Iter>>);
+    static_assert(!can_minus<cuda::transform_iterator<PlusOne, Iter>>);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/compare.pass.cpp
@@ -46,7 +46,7 @@ __host__ __device__ constexpr bool test()
   assert(!(iter2 != iter2));
 
 #if TEST_HAS_SPACESHIP()
-  static_assert(cuda::std::three_way_comparable<cuda::transform_output_iterator<int>>);
+  static_assert(cuda::std::three_way_comparable<cuda::transform_output_iterator<PlusOne, int*>>);
   assert((iter1 <=> iter2) == cuda::std::strong_ordering::less);
   assert((iter1 <=> iter1) == cuda::std::strong_ordering::equal);
   assert((iter2 <=> iter1) == cuda::std::strong_ordering::greater);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.default.pass.cpp
@@ -20,18 +20,18 @@
 __host__ __device__ constexpr bool test()
 {
   {
-    cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne> iter;
+    cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>> iter;
     assert(iter.base() == random_access_iterator<int*>{});
   }
 
   {
-    const cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne> iter;
+    const cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>> iter;
     assert(iter.base() == random_access_iterator<int*>{});
   }
 
   {
     static_assert(!cuda::std::is_default_constructible_v<
-                  cuda::transform_output_iterator<random_access_iterator<int*>, NotDefaultConstructiblePlusOne>>);
+                  cuda::transform_output_iterator<NotDefaultConstructiblePlusOne, random_access_iterator<int*>>>);
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.value.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/ctor.value.pass.cpp
@@ -30,12 +30,12 @@ __host__ __device__ constexpr bool test()
     *iter = 3;
     assert(buffer[2] == 3 + 1);
     buffer[2] = 2;
-#if !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC2019)
+#if !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     // The test iterators are not `is_nothrow_move_constructible`
     static_assert(!noexcept(cuda::transform_output_iterator{random_access_iterator{buffer + 2}, func}));
-#endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC2019)
+#endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     static_assert(
-      cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<random_access_iterator<int*>, Fn>>);
+      cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<Fn, random_access_iterator<int*>>>);
   }
 
   { // CTAD
@@ -45,29 +45,29 @@ __host__ __device__ constexpr bool test()
     assert(buffer[2] == 3 + 1);
     buffer[2] = 2;
     static_assert(noexcept(cuda::transform_output_iterator{buffer + 2, func}));
-    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<int*, Fn>>);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<Fn, int*>>);
   }
 
   {
-    cuda::transform_output_iterator<random_access_iterator<int*>, Fn> iter{random_access_iterator{buffer + 2}, func};
+    cuda::transform_output_iterator<Fn, random_access_iterator<int*>> iter{random_access_iterator{buffer + 2}, func};
     assert(base(iter.base()) == buffer + 2);
     *iter = 3;
     assert(buffer[2] == 3 + 1);
     buffer[2] = 2;
-#if !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC2019)
+#if !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
     // The test iterators are not `is_nothrow_move_constructible`
     static_assert(!noexcept(
-      cuda::transform_output_iterator<random_access_iterator<int*>, Fn>{random_access_iterator{buffer + 2}, func}));
-#endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC2019)
+      cuda::transform_output_iterator<Fn, random_access_iterator<int*>>{random_access_iterator{buffer + 2}, func}));
+#endif // !TEST_COMPILER(GCC, <, 9) && !TEST_COMPILER(MSVC)
   }
 
   {
-    cuda::transform_output_iterator<int*, Fn> iter{buffer + 2, func};
+    cuda::transform_output_iterator<Fn, int*> iter{buffer + 2, func};
     assert(iter.base() == buffer + 2);
     *iter = 3;
     assert(buffer[2] == 3 + 1);
     buffer[2] = 2;
-    static_assert(noexcept(cuda::transform_output_iterator<int*, Fn>{buffer + 2, func}));
+    static_assert(noexcept(cuda::transform_output_iterator<Fn, int*>{buffer + 2, func}));
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/iterator_traits.compile.pass.cpp
@@ -10,20 +10,72 @@
 
 #include <cuda/iterator>
 
+#include "test_iterators.h"
 #include "test_macros.h"
 #include "types.h"
 
+#if !TEST_COMPILER(NVRTC)
+#  include <iterator>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <template <class...> class Traits>
 __host__ __device__ void test()
 {
-  using IterTraits = cuda::std::iterator_traits<cuda::transform_output_iterator<int*, PlusOne>>;
+  {
+    using Iter       = cuda::transform_output_iterator<PlusOne, int*>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
 
-  static_assert(cuda::std::same_as<IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
-  static_assert(cuda::std::same_as<IterTraits::difference_type, cuda::std::ptrdiff_t>);
-  static_assert(cuda::std::same_as<IterTraits::value_type, void>);
-  static_assert(cuda::std::same_as<IterTraits::pointer, void>);
-  static_assert(cuda::std::same_as<IterTraits::reference, void>);
-  static_assert(cuda::std::input_or_output_iterator<cuda::transform_output_iterator<int*, PlusOne>>);
-  static_assert(cuda::std::output_iterator<cuda::transform_output_iterator<int*, PlusOne>, int>);
+  {
+    using Iter       = cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+    static_assert(cuda::std::__has_random_access_traversal<Iter>);
+  }
+
+  {
+    using Iter       = cuda::transform_output_iterator<PlusOne, bidirectional_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+    static_assert(cuda::std::__has_bidirectional_traversal<Iter>);
+  }
+
+  {
+    using Iter       = cuda::transform_output_iterator<PlusOne, forward_iterator<int*>>;
+    using IterTraits = Traits<Iter>;
+    static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<typename IterTraits::pointer, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+    static_assert(cuda::std::__has_forward_traversal<Iter>);
+  }
+}
+
+__host__ __device__ void test()
+{
+  test<cuda::std::iterator_traits>();
+#if !TEST_COMPILER(NVRTC)
+  test<std::iterator_traits>();
+#endif // !TEST_COMPILER(NVRTC)
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/member_typedefs.compile.pass.cpp
@@ -11,8 +11,6 @@
 // Test iterator category and iterator concepts.
 
 #include <cuda/iterator>
-#include <cuda/std/cassert>
-#include <cuda/std/cstdint>
 
 #include "test_iterators.h"
 #include "test_macros.h"
@@ -21,9 +19,9 @@
 __host__ __device__ void test()
 {
   {
-    using Iter = cuda::transform_output_iterator<int*, PlusOne>;
+    using Iter = cuda::transform_output_iterator<PlusOne, int*>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
-    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
     static_assert(cuda::std::same_as<Iter::reference, void>);
     static_assert(cuda::std::same_as<Iter::value_type, void>);
@@ -32,9 +30,31 @@ __host__ __device__ void test()
   }
 
   {
-    using Iter = cuda::transform_output_iterator<random_access_iterator<int*>, PlusOne>;
+    using Iter = cuda::transform_output_iterator<PlusOne, random_access_iterator<int*>>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
-    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::random_access_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::pointer, void>);
+    static_assert(cuda::std::same_as<Iter::reference, void>);
+    static_assert(cuda::std::same_as<Iter::value_type, void>);
+    static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+  }
+
+  {
+    using Iter = cuda::transform_output_iterator<PlusOne, bidirectional_iterator<int*>>;
+    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::bidirectional_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::pointer, void>);
+    static_assert(cuda::std::same_as<Iter::reference, void>);
+    static_assert(cuda::std::same_as<Iter::value_type, void>);
+    static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::ptrdiff_t>);
+    static_assert(cuda::std::output_iterator<Iter, int>);
+  }
+
+  {
+    using Iter = cuda::transform_output_iterator<PlusOne, forward_iterator<int*>>;
+    static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::forward_iterator_tag>);
+    static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::output_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::pointer, void>);
     static_assert(cuda::std::same_as<Iter::reference, void>);
     static_assert(cuda::std::same_as<Iter::value_type, void>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/subscript.pass.cpp
@@ -57,7 +57,7 @@ __host__ __device__ constexpr bool test()
 int main(int, char**)
 {
   test();
-  // static_assert(test(), "");
+  static_assert(test(), "");
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.traits/iterator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/iterator.traits/iterator.pass.cpp
@@ -85,7 +85,7 @@ int main(int, char**)
     static_assert((cuda::std::is_same<It::reference, int&>::value), "");
     static_assert((cuda::std::is_same<It::iterator_category, std::random_access_iterator_tag>::value), "");
 
-    static_assert(cuda::std::__is_cpp17_random_access_iterator<typename std::vector<int>::iterator>::value, "");
+    static_assert(cuda::std::__has_random_access_traversal<typename std::vector<int>::iterator>, "");
   }
 
   { // specialization of std::iterator_traits

--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "nvidia-cuda-nvrtc-cu12",
   "nvidia-nvjitlink-cu12",
   "numba-cuda>=0.18.0",
+  "llvmlite==0.44",                # TODO: remove this once numba-cuda 0.19.2 is released
 ]
 dynamic = ["version"]
 readme = { file = "README.md", content-type = "text/markdown" }

--- a/thrust/testing/constant_iterator.cu
+++ b/thrust/testing/constant_iterator.cu
@@ -25,7 +25,7 @@ void TestConstantIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   static_assert(!cuda::std::output_iterator<it, int>);
   static_assert(cuda::std::input_iterator<it>);

--- a/thrust/testing/counting_iterator.cu
+++ b/thrust/testing/counting_iterator.cu
@@ -61,7 +61,7 @@ void TestCountingIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   static_assert(!cuda::std::output_iterator<it, int>);
   static_assert(cuda::std::input_iterator<it>);

--- a/thrust/testing/discard_iterator.cu
+++ b/thrust/testing/discard_iterator.cu
@@ -21,7 +21,7 @@ void TestDiscardIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   static_assert(cuda::std::output_iterator<it, int>);
   static_assert(cuda::std::input_iterator<it>);

--- a/thrust/testing/offset_iterator.cu
+++ b/thrust/testing/offset_iterator.cu
@@ -22,7 +22,7 @@ void TestOffsetIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   static_assert(cuda::std::output_iterator<it, int>);
   static_assert(cuda::std::input_iterator<it>);

--- a/thrust/testing/permutation_iterator.cu
+++ b/thrust/testing/permutation_iterator.cu
@@ -25,7 +25,7 @@ void TestPermutationIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   static_assert(cuda::std::output_iterator<it, int>);
   static_assert(cuda::std::input_iterator<it>);

--- a/thrust/testing/reverse_iterator.cu
+++ b/thrust/testing/reverse_iterator.cu
@@ -23,7 +23,7 @@ void TestReverseIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   static_assert(cuda::std::output_iterator<it, int>);
   static_assert(cuda::std::input_iterator<it>);

--- a/thrust/testing/tabulate_output_iterator.cu
+++ b/thrust/testing/tabulate_output_iterator.cu
@@ -96,7 +96,7 @@ void TestTabulateOutputIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   // FIXME(bgruber): all up to and including random access should be true
   static_assert(!cuda::std::output_iterator<it, int>);

--- a/thrust/testing/transform_input_output_iterator.cu
+++ b/thrust/testing/transform_input_output_iterator.cu
@@ -34,7 +34,7 @@ void TestTransformInputOutputIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   static_assert(!cuda::std::output_iterator<it, int>);
   static_assert(cuda::std::input_iterator<it>);

--- a/thrust/testing/transform_iterator.cu
+++ b/thrust/testing/transform_iterator.cu
@@ -28,7 +28,7 @@ void TestTransformIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   static_assert(!cuda::std::output_iterator<it, int>);
   static_assert(cuda::std::input_iterator<it>);

--- a/thrust/testing/transform_output_iterator.cu
+++ b/thrust/testing/transform_output_iterator.cu
@@ -27,7 +27,7 @@ void TestTransformOutputIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   static_assert(!cuda::std::output_iterator<it, int>);
   // FIXME(bgruber): all up to and including random access should be true

--- a/thrust/testing/zip_iterator.cu
+++ b/thrust/testing/zip_iterator.cu
@@ -28,7 +28,7 @@ void TestZipIteratorTraits()
 
   static_assert(cuda::std::is_same_v<thrust::iterator_traversal_t<it>, thrust::random_access_traversal_tag>);
 
-  static_assert(cuda::std::__is_cpp17_random_access_iterator<it>::value);
+  static_assert(cuda::std::__has_random_access_traversal<it>);
 
   static_assert(!cuda::std::output_iterator<it, int>);
   static_assert(cuda::std::input_iterator<it>);

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -210,8 +210,7 @@ public:
    *  \param first The beginning of the range.
    *  \param last The end of the range.
    */
-  template <typename InputIterator,
-            ::cuda::std::enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int> = 0>
+  template <typename InputIterator, ::cuda::std::enable_if_t<::cuda::std::__has_input_traversal<InputIterator>, int> = 0>
   vector_base(InputIterator first, InputIterator last);
 
   /*! This constructor builds a vector_base from a range.
@@ -219,8 +218,7 @@ public:
    *  \param last The end of the range.
    *  \param alloc The allocator to use by this vector_base.
    */
-  template <typename InputIterator,
-            ::cuda::std::enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int> = 0>
+  template <typename InputIterator, ::cuda::std::enable_if_t<::cuda::std::__has_input_traversal<InputIterator>, int> = 0>
   vector_base(InputIterator first, InputIterator last, const Alloc& alloc);
 
   /*! The destructor erases the elements.

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -286,8 +286,7 @@ void vector_base<T, Alloc>::range_init(InputIterator first, InputIterator last)
 } // end vector_base::range_init()
 
 template <typename T, typename Alloc>
-template <typename InputIterator,
-          ::cuda::std::enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int>>
+template <typename InputIterator, ::cuda::std::enable_if_t<::cuda::std::__has_input_traversal<InputIterator>, int>>
 vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last)
     : m_storage()
     , m_size(0)
@@ -297,8 +296,7 @@ vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last)
 } // end vector_base::vector_base()
 
 template <typename T, typename Alloc>
-template <typename InputIterator,
-          ::cuda::std::enable_if_t<::cuda::std::__is_cpp17_input_iterator<InputIterator>::value, int>>
+template <typename InputIterator, ::cuda::std::enable_if_t<::cuda::std::__has_input_traversal<InputIterator>, int>>
 vector_base<T, Alloc>::vector_base(InputIterator first, InputIterator last, const Alloc& alloc)
     : m_storage(alloc)
     , m_size(0)

--- a/thrust/thrust/iterator/iterator_traits.h
+++ b/thrust/thrust/iterator/iterator_traits.h
@@ -256,18 +256,18 @@ struct iterator_traversal<::cuda::tabulate_output_iterator<Fn, Index>>
   using type = random_access_traversal_tag;
 };
 
-template <class Iter, class Fn>
-struct iterator_system<::cuda::transform_output_iterator<Iter, Fn>> : iterator_system<Iter>
+template <class Fn, class Iter>
+struct iterator_system<::cuda::transform_output_iterator<Fn, Iter>> : iterator_system<Iter>
 {};
-template <class Iter, class Fn>
-struct iterator_traversal<::cuda::transform_output_iterator<Iter, Fn>> : iterator_traversal<Iter>
+template <class Fn, class Iter>
+struct iterator_traversal<::cuda::transform_output_iterator<Fn, Iter>> : iterator_traversal<Iter>
 {};
 
-template <class Iter, class Fn>
-struct iterator_system<::cuda::transform_iterator<Iter, Fn>> : iterator_system<Iter>
+template <class Fn, class Iter>
+struct iterator_system<::cuda::transform_iterator<Fn, Iter>> : iterator_system<Iter>
 {};
-template <class Iter, class Fn>
-struct iterator_traversal<::cuda::transform_iterator<Iter, Fn>> : iterator_traversal<Iter>
+template <class Fn, class Iter>
+struct iterator_traversal<::cuda::transform_iterator<Fn, Iter>> : iterator_traversal<Iter>
 {};
 
 THRUST_NAMESPACE_END


### PR DESCRIPTION
* Backport #5662
* Backport #5928
* Backport #5929
* Backport #5983

This backports 3 heavily dependent PRs. There were a lot of intermittend merge conflicts, so I put all 3 into a single PR.

I have verified that this brings 3.1 on par with main for the existing cuda iterators