### PR TITLE
Fix `reference` for `cuda::transform_iterator`

### DIFF
--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -177,7 +177,7 @@ public:
 
   // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
   // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
-  using reference = value_type;
+  using reference = ::cuda::std::invoke_result_t<_Fn&, ::cuda::std::iter_reference_t<_Iter>>;
   using pointer   = void;
 
   //! @brief Default constructs a @c transform_iterator with a value initialized iterator and functor
@@ -222,7 +222,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(::cuda::std::regular_invocable<const _Fn&, ::cuda::std::iter_reference_t<const _Iter2>>)
-  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator*() const
+  [[nodiscard]] _CCCL_API constexpr reference operator*() const
     noexcept(noexcept(::cuda::std::invoke(*__func_, *__current_)))
   {
     return ::cuda::std::invoke(*__func_, *__current_);
@@ -235,7 +235,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES((!::cuda::std::regular_invocable<const _Fn&, ::cuda::std::iter_reference_t<const _Iter2>>) )
-  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator*() const
+  [[nodiscard]] _CCCL_API constexpr reference operator*() const
     noexcept(noexcept(::cuda::std::invoke(const_cast<_Fn&>(*__func_), *__current_)))
   {
     return ::cuda::std::invoke(const_cast<_Fn&>(*__func_), *__current_);
@@ -244,8 +244,7 @@ public:
 
   //! @brief Dereferences the stored iterator and applies the stored functor to the result
   _CCCL_EXEC_CHECK_DISABLE
-  [[nodiscard]] _CCCL_API constexpr decltype(auto)
-  operator*() noexcept(noexcept(::cuda::std::invoke(*__func_, *__current_)))
+  [[nodiscard]] _CCCL_API constexpr reference operator*() noexcept(noexcept(::cuda::std::invoke(*__func_, *__current_)))
   {
     return ::cuda::std::invoke(*__func_, *__current_);
   }
@@ -256,7 +255,7 @@ public:
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>
                    _CCCL_AND ::cuda::std::regular_invocable<const _Fn&, ::cuda::std::iter_reference_t<const _Iter2>>)
-  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator[](difference_type __n) const
+  [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type __n) const
     noexcept(__transform_iterator_nothrow_subscript<const _Fn, _Iter2>)
   {
     return ::cuda::std::invoke(*__func_, __current_[__n]);
@@ -271,7 +270,7 @@ public:
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2> _CCCL_AND(
     !::cuda::std::regular_invocable<const _Fn&, ::cuda::std::iter_reference_t<const _Iter2>>))
-  [[nodiscard]] _CCCL_API constexpr decltype(auto) operator[](difference_type __n) const
+  [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type __n) const
     noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
   {
     return ::cuda::std::invoke(const_cast<_Fn&>(*__func_), __current_[__n]);
@@ -283,7 +282,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Iter2 = _Iter)
   _CCCL_REQUIRES(::cuda::std::__is_cpp17_random_access_iterator<_Iter2>)
-  [[nodiscard]] _CCCL_API constexpr decltype(auto)
+  [[nodiscard]] _CCCL_API constexpr reference
   operator[](difference_type __n) noexcept(__transform_iterator_nothrow_subscript<_Fn, _Iter2>)
   {
     return ::cuda::std::invoke(*__func_, __current_[__n]);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/iterator_traits.compile.pass.cpp
@@ -32,6 +32,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int&>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
@@ -42,6 +43,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int&>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
@@ -52,6 +54,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int&&>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
@@ -62,6 +65,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
@@ -72,6 +76,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int&>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::bidirectional_iterator<Iter>);
     static_assert(cuda::std::__is_cpp17_bidirectional_iterator<Iter>);
@@ -82,6 +87,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int&>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::forward_iterator<Iter>);
     static_assert(cuda::std::__is_cpp17_forward_iterator<Iter>);
@@ -98,6 +104,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);
@@ -109,6 +116,7 @@ __host__ __device__ constexpr bool test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, int>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__is_cpp17_random_access_iterator<Iter>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/member_types.compile.pass.cpp
@@ -33,6 +33,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }
@@ -42,6 +43,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }
@@ -51,6 +53,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }
@@ -60,6 +63,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }
@@ -69,6 +73,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::bidirectional_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::bidirectional_iterator<TIter>);
   }
@@ -78,6 +83,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::forward_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::forward_iterator<TIter>);
   }
@@ -87,6 +93,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::input_iterator_tag>);
     static_assert(!HasIterCategory<cpp17_input_iterator<int*>, Increment>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int&>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::input_iterator<TIter>);
   }
@@ -97,6 +104,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }
@@ -107,6 +115,7 @@ __host__ __device__ constexpr bool test()
     static_assert(cuda::std::same_as<typename TIter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename TIter::value_type, int>);
+    static_assert(cuda::std::same_as<typename TIter::reference, int>);
     static_assert(cuda::std::same_as<typename TIter::difference_type, cuda::std::ptrdiff_t>);
     static_assert(cuda::std::random_access_iterator<TIter>);
   }


### PR DESCRIPTION
Someone forgot that the refernce type should properly match
