### PR TITLE
Split up cub.test.iterator to fix nightly NVHPC OOMs, add CI memory monitoring script.

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -286,13 +286,31 @@ function build_preset() {
 
     local preset_dir="${BUILD_DIR}/${PRESET}"
     local sccache_json="${preset_dir}/sccache_stats.json"
+    local memmon_log="${preset_dir}/memmon.log"
 
     source "./sccache_stats.sh" "start" || :
+
+    # Track memory usage on CI:
+    if [[ -n "${GITHUB_ACTIONS:-}" || -n "${MEMMON:-}" ]]; then
+      util/memmon.sh --start \
+          --log-threshold ${MEMMON_LOG_THRESHOLD:-2} \
+          --print-threshold ${MEMMON_PRINT_THRESHOLD:-5} \
+          --log-file "$memmon_log" \
+          --poll ${MEMMON_POLL_INTERVAL:-5} \
+          || :
+    fi
 
     pushd .. > /dev/null
     status=0
     run_command "$GROUP_NAME" cmake --build --preset=$PRESET -v || status=$?
     popd > /dev/null
+
+    if [[ -n "${GITHUB_ACTIONS:-}" || -n "${MEMMON:-}" ]]; then
+      util/memmon.sh --stop || :
+      echo "::group::📝 Memory Usage"
+      head -n20 "$memmon_log" || :
+      echo "::endgroup::"
+    fi
 
     sccache --show-adv-stats --stats-format=json > "${sccache_json}" || :
 

--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -168,6 +168,11 @@ source ./pretty_printing.sh
 print_environment_details() {
   begin_group "⚙️ Environment Details"
 
+  echo "free -h:"
+  free -h || :
+
+  echo "nproc=$(nproc || :)"
+
   echo "pwd=$(pwd)"
 
   print_var_values \

--- a/ci/util/memmon.sh
+++ b/ci/util/memmon.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pid_file="/tmp/.memmon.pid"
+
+log_threshold="2"
+print_threshold="5"
+poll_interval="5"
+log_file="$PWD/memmon.log"
+mode=""
+
+usage() {
+  cat <<'USAGE'
+Monitors running processes for high memory usage, logging and reporting peaks above specified thresholds.
+
+Usage: memmon.sh (--start | --stop | --monitor | --help)
+        [--log-threshold <GB>]   # Write to log file if process exceeds this memory (default 2 GB)
+        [--print-threshold <GB>] # Print to stdout if process exceeds this memory (default 5 GB)
+        [--poll <seconds>]       # Poll interval for checking processes (default 5 seconds)
+        [--log-file <file>]      # Log file path (default ./memmon.log)
+
+Modes:
+
+  --start    Start monitoring in the background (writes pid to /tmp/.memmon.pid)
+  --stop     Stop monitoring (kills pid in /tmp/.memmon.pid)
+  --monitor  Run monitoring in the foreground (for testing/debugging)
+
+Example Session:
+
+  memmon.sh --start                 # Start monitoring
+  launch_memory_intensive_processes # Do work
+  memmon.sh --stop                  # Stop monitoring and write log
+  cat memmon.log                    # View log
+USAGE
+}
+
+error() {
+  echo "memmon: $*" >&2
+  exit 1
+}
+
+error_usage() {
+  echo "memmon: $*" >&2
+  usage
+  exit 1
+}
+
+ensure_absolute_log() {
+  case "$log_file" in
+    /*) return ;;
+    *)
+      local dir="$(cd "$(dirname "$log_file")" && pwd)"
+      local base="$(basename "$log_file")"
+      log_file="$dir/$base"
+      ;;
+  esac
+}
+
+to_kib() {
+  awk -v gib="$1" 'BEGIN {printf "%.0f", gib * 1024 * 1024}'
+}
+
+format_gib() {
+  awk -v rss="$1" 'BEGIN {printf "%.3f", rss/1024/1024}'
+}
+
+format_threshold() {
+  awk -v val="$1" 'BEGIN {printf "%.3f", val + 0}'
+}
+
+declare -A MEMMON_MAX_RSS
+declare -A MEMMON_CMD
+declare -A MEMMON_TARGET
+
+get_cmdline() {
+  local pid="$1"
+  local cmdline_file="/proc/$pid/cmdline"
+  local raw
+
+  # Attempt to read from /proc first for accuracy
+  if [[ -r "$cmdline_file" ]]; then
+    raw="$(tr '\0' ' ' <"$cmdline_file" 2>/dev/null)"
+    # Clean up whitespace
+    raw="${raw//$'\n'/ }"
+    raw="${raw//$'\r'/ }"
+    raw="${raw//$'\t'/ }"
+    while [[ "$raw" == *' ' ]]; do
+      raw="${raw% }"
+    done
+    if [[ -n "$raw" ]]; then
+      printf '%s' "$raw"
+      return 0
+    fi
+  fi
+  # Fallback to ps if /proc is unavailable
+  raw="$(ps -wwp "$pid" -o command= 2>/dev/null | head -n1)"
+  # Clean up whitespace
+  raw="${raw//$'\n'/ }"
+  raw="${raw//$'\r'/ }"
+  raw="${raw//$'\t'/ }"
+  if [[ -n "$raw" ]]; then
+    printf '%s' "$raw"
+    return 0
+  fi
+  printf '[command unavailable]'
+}
+
+extract_target() {
+  local cmd="$1"
+  # Try to locate the name of the cmake target:
+  if [[ "$cmd" =~ CMakeFiles/([^[:space:]]*)\.dir ]]; then
+    printf '%s' "${BASH_REMATCH[1]}"
+  else
+    printf '-'
+  fi
+}
+
+start_memmon() {
+  # Check if already running
+  if [[ -f "$pid_file" ]]; then
+    local existing_pid="$(<"$pid_file")"
+    if kill -0 "$existing_pid" 2>/dev/null; then
+      error "already running (pid $existing_pid)"
+    fi
+    rm -f "$pid_file"
+  fi
+
+  ensure_absolute_log
+
+  # Start monitoring in the background
+  "$0" --monitor \
+       --log-threshold "$log_threshold" \
+       --print-threshold "$print_threshold" \
+       --poll "$poll_interval" \
+       --log-file "$log_file" &
+  local child_pid=$!
+  echo "$child_pid" >"$pid_file"
+  echo "memmon started (pid $child_pid, log-threshold ${log_threshold}GB, print-threshold ${print_threshold}GB, log $log_file)"
+}
+
+stop_memmon() {
+  if [[ ! -f "$pid_file" ]]; then
+    error "not running"
+  fi
+  local running_pid="$(<"$pid_file")"
+  if ! kill -0 "$running_pid" 2>/dev/null; then
+    rm -f "$pid_file"
+    error "not running"
+  fi
+
+  # Attempt graceful shutdown
+  kill "$running_pid" 2>/dev/null || true
+
+  for _ in {1..20}; do
+    if ! kill -0 "$running_pid" 2>/dev/null; then
+      break
+    fi
+    sleep 0.25
+  done
+
+  # Force kill if still running
+  if kill -0 "$running_pid" 2>/dev/null; then
+    kill -9 "$running_pid" 2>/dev/null || true
+  fi
+
+  # Wait for pid file to be removed
+  for _ in {1..20}; do
+    [[ ! -f "$pid_file" ]] && break
+    sleep 0.25
+  done
+  [[ -f "$pid_file" ]] && rm -f "$pid_file"
+  echo "memmon stopped"
+}
+
+monitor_mem() {
+  MEMMON_MAX_RSS=()
+  MEMMON_CMD=()
+  MEMMON_TARGET=()
+
+  ensure_absolute_log
+
+  local log_threshold_kib="$(to_kib "$log_threshold")"
+  local print_threshold_kib="$(to_kib "$print_threshold")"
+
+  local running=true
+
+  cleanup() {
+    trap - INT TERM EXIT
+    mkdir -p "$(dirname "$log_file")"
+    {
+      printf "peak-mem | PID | target | command-line\n"
+      if [[ ${#MEMMON_MAX_RSS[@]} -eq 0 ]]; then
+        printf "No processes exceeded %s GB\n" "$(format_threshold "$log_threshold")"
+      else
+        local tmp="$(mktemp)"
+        for pid in "${!MEMMON_MAX_RSS[@]}"; do
+          printf "%s\t%s\t%s\t%s\n" "${MEMMON_MAX_RSS[$pid]}" "$pid" "${MEMMON_TARGET[$pid]}" "${MEMMON_CMD[$pid]}" >>"$tmp"
+        done
+        sort -nr -k1,1 "$tmp" | while IFS=$'\t' read -r peak pid target cmd; do
+          local mem_gib="$(format_gib "$peak")"
+          printf "%s GB | %s | %s | %s\n" "$mem_gib" "$pid" "$target" "$cmd"
+        done
+        rm -f "$tmp"
+      fi
+    } >"$log_file"
+    echo "memmon log written to $log_file"
+    rm -f "$pid_file"
+  }
+
+  trap 'running=false' INT TERM
+  trap cleanup EXIT
+
+  while $running; do
+    while read -r pid rss; do
+      [[ -z "$pid" || -z "$rss" ]] && continue
+      [[ "$pid" =~ ^[0-9]+$ ]] || continue
+      [[ "$rss" =~ ^[0-9]+$ ]] || continue
+      if (( rss >= log_threshold_kib )); then
+        local current=${MEMMON_MAX_RSS[$pid]:-0}
+        if (( rss > current )); then
+          MEMMON_MAX_RSS[$pid]=$rss
+          MEMMON_CMD[$pid]=$(get_cmdline "$pid")
+          MEMMON_TARGET[$pid]=$(extract_target "${MEMMON_CMD[$pid]}")
+          if (( rss >= print_threshold_kib )); then
+            local mem_gib="$(format_gib "$rss")"
+            printf 'memmon: %s GB | %s | %s | %s\n' "$mem_gib" "$pid" "${MEMMON_TARGET[$pid]}" "${MEMMON_CMD[$pid]}"
+          fi
+        fi
+      fi
+    done < <(ps -eo pid=,rss=)
+
+    if ! sleep "$poll_interval"; then
+      break
+    fi
+  done
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --log-threshold)
+      [[ $# -lt 2 ]] && error "--log-threshold requires a value"
+      log_threshold="$2"
+      shift 2
+      ;;
+    --print-threshold)
+      [[ $# -lt 2 ]] && error "--print-threshold requires a value"
+      print_threshold="$2"
+      shift 2
+      ;;
+    --log-file)
+      [[ $# -lt 2 ]] && error "--log-file requires a value"
+      log_file="$2"
+      shift 2
+      ;;
+    --poll)
+      [[ $# -lt 2 ]] && error "--poll requires a value"
+      poll_interval="$2"
+      shift 2
+      ;;
+    --start)
+      [[ -n "$mode" ]] && error "Specify only one of --start or --stop"
+      mode="start"
+      shift
+      ;;
+    --stop)
+      [[ -n "$mode" ]] && error "Specify only one of --start or --stop"
+      mode="stop"
+      shift
+      ;;
+    --monitor)
+      mode="monitor"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      error_usage "Unknown option: $1"
+      ;;
+  esac
+done
+
+if [[ -z "$mode" ]]; then
+  error_usage "Must specify one of --start or --stop or --monitor"
+fi
+
+case "$mode" in
+  start)
+    start_memmon
+    ;;
+  stop)
+    stop_memmon
+    ;;
+  monitor)
+    monitor_mem
+    ;;
+  *)
+    error_usage "Unhandled mode: $mode"
+    ;;
+esac

--- a/cub/test/catch2_test_iterator.cu
+++ b/cub/test/catch2_test_iterator.cu
@@ -42,38 +42,31 @@
 
 #include <c2h/catch2_test_helper.h>
 
-using scalar_types = c2h::type_list<std::int8_t, std::int16_t, std::int32_t, std::int64_t, float, double>;
+// %PARAM% TEST_VEC_SIZE types 1:2:3:4
 
-using types = cuda::std::__type_push_back<
-  scalar_types,
-  char2,
-  short2,
-  int2,
-  long2,
-  longlong2,
-  float2,
-  double2,
-  char3,
-  short3,
-  int3,
-  long3,
-  longlong3,
-  float3,
-  double3,
-  char4,
-  short4,
-  int4,
-  float4,
-#if _CCCL_CTK_AT_LEAST(13, 0)
-  long4_16a,
-  longlong4_16a,
-  double4_16a,
-#else // _CCCL_CTK_AT_LEAST(13, 0)
-  long4,
-  longlong4,
-  double4,
-#endif // _CCCL_CTK_AT_LEAST(13, 0)
-  c2h::custom_type_t<c2h::equal_comparable_t, c2h::accumulateable_t>>;
+#if TEST_VEC_SIZE == 1
+using types = c2h::type_list<std::int8_t, std::int16_t, std::int32_t, std::int64_t, float, double>;
+#elif TEST_VEC_SIZE == 2
+using types = c2h::type_list<char2, short2, int2, long2, longlong2, float2, double2>;
+#elif TEST_VEC_SIZE == 3
+using types = c2h::type_list<char3, short3, int3, long3, longlong3, float3, double3>;
+#elif TEST_VEC_SIZE == 4
+using types =
+  c2h::type_list<char4,
+                 short4,
+                 int4,
+                 float4,
+#  if _CCCL_CTK_AT_LEAST(13, 0)
+                 long4_16a,
+                 longlong4_16a,
+                 double4_16a,
+#  else // _CCCL_CTK_AT_LEAST(13, 0)
+                 long4,
+                 longlong4,
+                 double4,
+#  endif // _CCCL_CTK_AT_LEAST(13, 0)
+                 c2h::custom_type_t<c2h::equal_comparable_t, c2h::accumulateable_t>>;
+#endif
 
 template <typename InputIteratorT, typename T>
 __global__ void test_iterator_kernel(InputIteratorT d_in, T* d_out, InputIteratorT* d_itrs)


### PR DESCRIPTION
Adds a `memmon.sh` script that tracks running processes and their RAM usage, reporting excessive usage to a log file (>2GB) and to stdout while the process is running (>5GB). Runs automatically in CI and prints the highest RAM users at the end of the build.

Also split up the `cub.*.test.iterator` test into 4 executables, as this was seen consuming the most memory on the NVHPC builds that appear to be OOM'ing the nightly runners.

<details><summary>Before:</summary>
<pre>  peak-mem | PID | target | command-line
  6.154 GB | 74831 | cub.cpp17.test.iterator | /opt/nvidia/hpc_sdk/Linux_x86_64/25.5/compilers/bin/tools/nvcpfe -- --llalign -D__GNUC__=11 -D__GNUC_MINOR__=4 -D__GNUC_PATCHLEVEL__=0 -D__linux -D__linux__ -D__ELF__ -D__NO_MATH_INLINES -D__LP64__ -D__x86_64 -D__x86_64__ -D__LONG_MAX__=9223372036854775807L -D__SIZE_TYPE__=unsigned long int -D__PTRDIFF_TYPE__=long int -D__amd64 -D__amd64__ -D__k8 -D__k8__ -D__MMX__ -D__SSE_MATH__ -D__MMX_WITH_SSE__ -D__SSE__ -D__SSE2__ -D__SSE2_MATH__ -D__SSE3__ -D__SSSE3__ -D__SSE4_1__ -D__SSE4_2__ -D__ABM__ -D__ADX__ -D__AES__ -D__AMX_BF16__ -D__AMX_INT8__ -D__AMX_TILE__ -D__AVX__ -D__AVX2__ -D__AVX512BF16__ -D__AVX512BITALG__ -D__AVX512BW__ -D__AVX512CD__ -D__AVX512DQ__ -D__AVX512F__ -D__AVX512FP16__ -D__AVX512IFMA__ -D__AVX512VBMI__ -D__AVX512VBMI2__ -D__AVX512VL__ -D__AVX512VNNI__ -D__AVX512VPOPCNTDQ__ -D__AVXVNNI__ -D__BMI__ -D__BMI2__ -D__CLDEMOTE__ -D__CLFLUSHOPT__ -D__CLWB__ -D__CX16__ -D__F16C__ -D__FMA__ -D__FSGSBASE__ -D__FXSR__ -D__GFNI__ -D__LZCNT__ -D__MOVBE__ -D__MO
  5.588 GB | 72818 | - | /opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/bin/../nvvm/bin/cicc --c++17 --pgc++ --gnu_version=110400 --pgi_version=250500 --pgi_llvm --diag_warn out_of_order_ctor_init --display_error_number --orig_src_file_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --orig_src_path_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --allow_managed --pending_instantiations=1000 --display_error_number --promote_warnings -arch compute_90 -m64 --no-version-ident -ftz=0 -prec_div=1 -prec_sqrt=1 -fmad=1 --include_file_name tmpxft_00011471_00000000-3_catch2_test_iterator.fatbin.c -tused --module_id_file_name /tmp/tmpxft_00011471_00000000-4_catch2_test_iterator.module_id --gen_c_file_name /tmp/tmpxft_00011471_00000000-8_catch2_test_iterator.compute_90.cudafe1.c --stub_file_name /tmp/tmpxft_00011471_00000000-8_catch2_test_iterator.compute_90.cudafe1.stub.c --gen_device_file_name /tmp/tmpxft_00011471_00000000-8_catch2_test_iterator.compute_90.cudafe1.gpu /tmp/tmpxft_00011471_00000000-13_catch
  5.452 GB | 71835 | - | /opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/bin/../nvvm/bin/cicc --c++17 --pgc++ --gnu_version=110400 --pgi_version=250500 --pgi_llvm --diag_warn out_of_order_ctor_init --display_error_number --orig_src_file_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --orig_src_path_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --allow_managed --pending_instantiations=1000 --display_error_number --promote_warnings -arch compute_80 -m64 --no-version-ident -ftz=0 -prec_div=1 -prec_sqrt=1 -fmad=1 --include_file_name tmpxft_00011471_00000000-3_catch2_test_iterator.fatbin.c -tused --module_id_file_name /tmp/tmpxft_00011471_00000000-4_catch2_test_iterator.module_id --gen_c_file_name /tmp/tmpxft_00011471_00000000-9_catch2_test_iterator.compute_80.cudafe1.c --stub_file_name /tmp/tmpxft_00011471_00000000-9_catch2_test_iterator.compute_80.cudafe1.stub.c --gen_device_file_name /tmp/tmpxft_00011471_00000000-9_catch2_test_iterator.compute_80.cudafe1.gpu /tmp/tmpxft_00011471_00000000-12_catch
  5.434 GB | 74176 | - | /opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/bin/../nvvm/bin/cicc --c++17 --pgc++ --gnu_version=110400 --pgi_version=250500 --pgi_llvm --diag_warn out_of_order_ctor_init --display_error_number --orig_src_file_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --orig_src_path_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --allow_managed --pending_instantiations=1000 --display_error_number --promote_warnings -arch compute_120 -m64 --no-version-ident -ftz=0 -prec_div=1 -prec_sqrt=1 -fmad=1 --include_file_name tmpxft_00011471_00000000-3_catch2_test_iterator.fatbin.c -tused --module_id_file_name /tmp/tmpxft_00011471_00000000-4_catch2_test_iterator.module_id --gen_c_file_name /tmp/tmpxft_00011471_00000000-6_catch2_test_iterator.compute_120.cudafe1.c --stub_file_name /tmp/tmpxft_00011471_00000000-6_catch2_test_iterator.compute_120.cudafe1.stub.c --gen_device_file_name /tmp/tmpxft_00011471_00000000-6_catch2_test_iterator.compute_120.cudafe1.gpu /tmp/tmpxft_00011471_00000000-15_c
  5.430 GB | 73484 | - | /opt/nvidia/hpc_sdk/Linux_x86_64/25.5/cuda/12.9/bin/../nvvm/bin/cicc --c++17 --pgc++ --gnu_version=110400 --pgi_version=250500 --pgi_llvm --diag_warn out_of_order_ctor_init --display_error_number --orig_src_file_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --orig_src_path_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --allow_managed --pending_instantiations=1000 --display_error_number --promote_warnings -arch compute_100 -m64 --no-version-ident -ftz=0 -prec_div=1 -prec_sqrt=1 -fmad=1 --include_file_name tmpxft_00011471_00000000-3_catch2_test_iterator.fatbin.c -tused --module_id_file_name /tmp/tmpxft_00011471_00000000-4_catch2_test_iterator.module_id --gen_c_file_name /tmp/tmpxft_00011471_00000000-7_catch2_test_iterator.compute_100.cudafe1.c --stub_file_name /tmp/tmpxft_00011471_00000000-7_catch2_test_iterator.compute_100.cudafe1.stub.c --gen_device_file_name /tmp/tmpxft_00011471_00000000-7_catch2_test_iterator.compute_100.cudafe1.gpu /tmp/tmpxft_00011471_00000000-14_c
</pre></details>

<details><summary>After:</summary>
<pre>
peak-mem | PID | target | command-line
2.029 GB | 190424 | - | /opt/nvidia/hpc_sdk/Linux_x86_64/25.7/cuda/12.9/bin/../nvvm/bin/cicc --c++17 --pgc++ --gnu_version=110400 --pgi_version=250700 --pgi_llvm --diag_warn out_of_order_ctor_init --display_error_number --orig_src_file_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --orig_src_path_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --allow_managed --pending_instantiations=1000 --display_error_number --promote_warnings -arch compute_75 -m64 --no-version-ident -ftz=0 -prec_div=1 -prec_sqrt=1 -fmad=1 --include_file_name tmpxft_0002e645_00000000-3_catch2_test_iterator.fatbin.c -tused --module_id_file_name /tmp/tmpxft_0002e645_00000000-4_catch2_test_iterator.module_id --gen_c_file_name /tmp/tmpxft_0002e645_00000000-10_catch2_test_iterator.compute_75.cudafe1.c --stub_file_name /tmp/tmpxft_0002e645_00000000-10_catch2_test_iterator.compute_75.cudafe1.stub.c --gen_device_file_name /tmp/tmpxft_0002e645_00000000-10_catch2_test_iterator.compute_75.cudafe1.gpu /tmp/tmpxft_0002e645_00000000-11_catch2_test_iterator.compute_75.cpp1.ii -o /tmp/tmpxft_0002e645_00000000-10_catch2_test_iterator.compute_75.ptx
2.023 GB | 190531 | - | /opt/nvidia/hpc_sdk/Linux_x86_64/25.7/cuda/12.9/bin/../nvvm/bin/cicc --c++17 --pgc++ --gnu_version=110400 --pgi_version=250700 --pgi_llvm --diag_warn out_of_order_ctor_init --display_error_number --orig_src_file_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --orig_src_path_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --allow_managed --pending_instantiations=1000 --display_error_number --promote_warnings -arch compute_80 -m64 --no-version-ident -ftz=0 -prec_div=1 -prec_sqrt=1 -fmad=1 --include_file_name tmpxft_0002e645_00000000-3_catch2_test_iterator.fatbin.c -tused --module_id_file_name /tmp/tmpxft_0002e645_00000000-4_catch2_test_iterator.module_id --gen_c_file_name /tmp/tmpxft_0002e645_00000000-9_catch2_test_iterator.compute_80.cudafe1.c --stub_file_name /tmp/tmpxft_0002e645_00000000-9_catch2_test_iterator.compute_80.cudafe1.stub.c --gen_device_file_name /tmp/tmpxft_0002e645_00000000-9_catch2_test_iterator.compute_80.cudafe1.gpu /tmp/tmpxft_0002e645_00000000-12_catch2_test_iterator.compute_80.cpp1.ii -o /tmp/tmpxft_0002e645_00000000-9_catch2_test_iterator.compute_80.ptx
2.020 GB | 190767 | - | /opt/nvidia/hpc_sdk/Linux_x86_64/25.7/cuda/12.9/bin/../nvvm/bin/cicc --c++17 --pgc++ --gnu_version=110400 --pgi_version=250700 --pgi_llvm --diag_warn out_of_order_ctor_init --display_error_number --orig_src_file_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --orig_src_path_name /home/coder/cccl/cub/test/catch2_test_iterator.cu --allow_managed --pending_instantiations=1000 --display_error_number --promote_warnings -arch compute_120 -m64 --no-version-ident -ftz=0 -prec_div=1 -prec_sqrt=1 -fmad=1 --include_file_name tmpxft_0002e645_00000000-3_catch2_test_iterator.fatbin.c -tused --module_id_file_name /tmp/tmpxft_0002e645_00000000-4_catch2_test_iterator.module_id --gen_c_file_name /tmp/tmpxft_0002e645_00000000-6_catch2_test_iterator.compute_120.cudafe1.c --stub_file_name /tmp/tmpxft_0002e645_00000000-6_catch2_test_iterator.compute_120.cudafe1.stub.c --gen_device_file_name /tmp/tmpxft_0002e645_00000000-6_catch2_test_iterator.compute_120.cudafe1.gpu /tmp/tmpxft_0002e645_00000000-15_catch2_test_iterator.compute_120.cpp1.ii -o /tmp/tmpxft_0002e645_00000000-6_catch2_test_iterator.compute_120.ptx
</pre>

All other cub.test.iterator TUs < 2GB
</details>

