### PR TITLE
Enable `__grid_constant__` with clang-cuda-20 and nvrtc

### DIFF
--- a/libcudacxx/include/cuda/__memory/address_space.h
+++ b/libcudacxx/include/cuda/__memory/address_space.h
@@ -143,8 +143,9 @@ enum class address_space
       return static_cast<bool>(::__isLocal(__ptr));
 #  endif // ^^^ !_CCCL_CUDA_COMPILER(NVCC) && !_CCCL_CUDA_COMPILER(NVRTC) ^^^
     case address_space::grid_constant:
-#  if _CCCL_HAS_GRID_CONSTANT()
-#    if _CCCL_CUDA_COMPILER(NVCC, <, 12, 3) || _CCCL_CUDA_COMPILER(NVRTC, <, 12, 3)
+#  if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 3) || _CCCL_CUDA_COMPILER(NVRTC, >=, 12, 3)
+      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70, (return static_cast<bool>(::__isGridConstant(__ptr));), (return false;))
+#  else // ^^^ has functional __isGridConstant() ^^^ / vvv no functional __isGridConstant() vvv
     {
       NV_IF_ELSE_TARGET(
         NV_PROVIDES_SM_70,
@@ -157,13 +158,7 @@ enum class address_space
          return static_cast<bool>(__ret);),
         (return false;))
     }
-#    else // ^^^ _CCCL_CUDA_COMPILER(NVCC, <, 12, 3) || _CCCL_CUDA_COMPILER(NVRTC, <, 12, 3) ^^^ /
-          // vvv !_CCCL_CUDA_COMPILER(NVCC, <, 12, 3) && !_CCCL_CUDA_COMPILER(NVRTC, <, 12, 3) vvv
-      NV_IF_ELSE_TARGET(NV_PROVIDES_SM_70, (return static_cast<bool>(::__isGridConstant(__ptr));), (return false;))
-#    endif // ^^^ !_CCCL_CUDA_COMPILER(NVCC, <, 12, 3) && !_CCCL_CUDA_COMPILER(NVRTC, <, 12, 3) ^^^
-#  else // ^^^ _CCCL_HAS_GRID_CONSTANT() ^^^ / vvv !_CCCL_HAS_GRID_CONSTANT() vvv
-      return false;
-#  endif // ^^^ !_CCCL_HAS_GRID_CONSTANT() ^^^
+#  endif // ^^^ no functional __isGridConstant() ^^^
     case address_space::cluster_shared:
 #  if _CCCL_CUDA_COMPILER(NVCC, <, 12, 3) || _CCCL_CUDA_COMPILER(NVRTC, <, 12, 3)
     {

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -48,14 +48,14 @@
 #  define _CCCL_PTX_ARCH() __CUDA_ARCH__
 #endif
 
-// Compile with NVCC compiler and only device code, Volta+  GPUs
-#if _CCCL_CUDA_COMPILER(NVCC) && _CCCL_PTX_ARCH() >= 700
+#if ((_CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(NVRTC)) && _CCCL_PTX_ARCH() >= 700) \
+  || _CCCL_CUDA_COMPILER(CLANG, >=, 20)
 #  define _CCCL_HAS_GRID_CONSTANT() 1
 #  define _CCCL_GRID_CONSTANT       __grid_constant__
-#else // ^^^ _CCCL_CUDA_COMPILER(NVCC) ^^^ / vvv !_CCCL_CUDA_COMPILER(NVCC) vvv
+#else // ^^^ has __grid_constant__ ^^^ / vvv no __grid_constant__ vvv
 #  define _CCCL_HAS_GRID_CONSTANT() 0
 #  define _CCCL_GRID_CONSTANT
-#endif // _CCCL_CUDA_COMPILER(NVCC) && _CCCL_PTX_ARCH() >= 700
+#endif // ^^^ no __grid_constant__ ^^^
 
 #if !defined(_CCCL_EXEC_CHECK_DISABLE)
 #  if _CCCL_CUDA_COMPILER(NVCC)

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -48,8 +48,8 @@
 #  define _CCCL_PTX_ARCH() __CUDA_ARCH__
 #endif
 
-#if ((_CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(NVRTC)) && _CCCL_PTX_ARCH() >= 700) \
-  || _CCCL_CUDA_COMPILER(CLANG, >=, 20)
+#if (_CCCL_CUDA_COMPILER(NVCC) || _CCCL_CUDA_COMPILER(NVRTC) || _CCCL_CUDA_COMPILER(CLANG, >=, 20)) \
+  && _CCCL_PTX_ARCH() >= 700
 #  define _CCCL_HAS_GRID_CONSTANT() 1
 #  define _CCCL_GRID_CONSTANT       __grid_constant__
 #else // ^^^ has __grid_constant__ ^^^ / vvv no __grid_constant__ vvv

--- a/libcudacxx/test/libcudacxx/libcxx/macros/grid_constant.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/macros/grid_constant.compile.pass.cpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/__cccl/execution_space.h>
+
+__global__ void test_kernel(const _CCCL_GRID_CONSTANT int value)
+{
+  (void) value;
+}
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
* nvrtc seems to have no problems with `__grid_constant__` when compiling for sm_70+ (https://godbolt.org/z/b1an1MY6f)
* clang-cuda seems to be fine with `__grid_constatn__` since version 20 on all architectures (https://godbolt.org/z/7vYncsron and https://github.com/llvm/llvm-project/blob/release/20.x/clang/docs/ReleaseNotes.rst)

I've also added a minimal test for `_CCCL_GRID_CONSTANT`