### PR TITLE
[Backport to 3.1] Fix dereferencing nullptr in thrust::device_reference

### DIFF
--- a/thrust/testing/catch2_test_minimum_system.cu
+++ b/thrust/testing/catch2_test_minimum_system.cu
@@ -1,0 +1,31 @@
+#include <thrust/iterator/detail/minimum_system.h>
+
+#include <cuda/std/type_traits>
+
+#include "catch2_test_helper.h"
+
+template <typename System, typename SeqSystem>
+void check()
+{
+  STATIC_REQUIRE(cuda::std::is_convertible_v<System, SeqSystem>);
+  STATIC_REQUIRE(!cuda::std::is_convertible_v<SeqSystem, System>);
+  STATIC_REQUIRE(cuda::std::is_same_v<thrust::detail::minimum_system_t<SeqSystem, System>, SeqSystem>);
+  STATIC_REQUIRE(cuda::std::is_same_v<thrust::detail::minimum_system_t<System, SeqSystem>, SeqSystem>);
+}
+
+TEST_CASE("host and device systems convert to sequential", "[minimum_system]")
+{
+  using seq      = decltype(thrust::seq);
+  using seq_tag  = decltype(thrust::seq)::tag_type;
+  using dev      = decltype(thrust::device);
+  using dev_tag  = thrust::device_system_tag;
+  using host     = decltype(thrust::host);
+  using host_tag = thrust::host_system_tag;
+
+  check<dev, seq>();
+  check<dev_tag, seq>();
+  check<dev, seq_tag>();
+  check<dev_tag, seq_tag>();
+  check<host, seq_tag>();
+  check<host_tag, seq_tag>();
+}

--- a/thrust/thrust/detail/reference.h
+++ b/thrust/thrust/detail/reference.h
@@ -156,11 +156,9 @@ public:
    */
   _CCCL_HOST_DEVICE void swap(derived_type other)
   {
-    // Avoid default-constructing a system; instead, just use a null pointer
-    // for dispatch. This assumes that `get_value` will not access any system
-    // state.
-    typename thrust::iterator_system<pointer>::type* system = nullptr;
-    swap(system, other);
+    // we cannot construct a system solely from its type, since it may be stateful, so just use the system's tag
+    typename iterator_system_t<pointer>::tag_type tag;
+    swap(&tag, other);
   }
 
   _CCCL_HOST_DEVICE pointer operator&() const
@@ -172,11 +170,9 @@ public:
   // about what system the object is on.
   _CCCL_HOST_DEVICE operator value_type() const
   {
-    // Avoid default-constructing a system; instead, just use a null pointer
-    // for dispatch. This assumes that `get_value` will not access any system
-    // state.
-    typename thrust::iterator_system<pointer>::type* system = nullptr;
-    return convert_to_value_type(system);
+    // we cannot construct a system solely from its type, since it may be stateful, so just use the system's tag
+    typename iterator_system_t<pointer>::tag_type tag;
+    return convert_to_value_type(&tag);
   }
 
   _CCCL_HOST_DEVICE derived_type& operator++()
@@ -347,12 +343,10 @@ private:
   template <typename OtherPointer>
   _CCCL_HOST_DEVICE void assign_from(OtherPointer src) const
   {
-    // Avoid default-constructing systems; instead, just use a null pointer
-    // for dispatch. This assumes that `get_value` will not access any system
-    // state.
-    typename thrust::iterator_system<pointer>::type* system0      = nullptr;
-    typename thrust::iterator_system<OtherPointer>::type* system1 = nullptr;
-    assign_from(system0, system1, src);
+    // we cannot construct a system solely from its type, since it may be stateful, so just use the system's tag
+    typename iterator_system_t<pointer>::tag_type tag0;
+    typename iterator_system_t<OtherPointer>::tag_type tag1;
+    assign_from(&tag0, &tag1, src);
   }
 
   template <typename System, typename OtherPointer>

--- a/thrust/thrust/detail/seq.h
+++ b/thrust/thrust/detail/seq.h
@@ -40,7 +40,7 @@ struct seq_t
       : thrust::system::detail::sequential::execution_policy<seq_t>()
   {}
 
-  // allow any execution_policy to convert to seq_t
+  // allow any execution_policy to convert to the sequential one. required for minimum_system to pick it
   template <typename DerivedPolicy>
   _CCCL_HOST_DEVICE seq_t(const thrust::execution_policy<DerivedPolicy>&)
       : thrust::system::detail::sequential::execution_policy<seq_t>()

--- a/thrust/thrust/iterator/detail/minimum_system.h
+++ b/thrust/thrust/iterator/detail/minimum_system.h
@@ -34,10 +34,15 @@
 THRUST_NAMESPACE_BEGIN
 namespace detail
 {
-
 template <typename... Ts>
 struct unrelated_systems
 {};
+
+template <typename System>
+inline constexpr bool is_unrelated_systems = false;
+
+template <typename... Ts>
+inline constexpr bool is_unrelated_systems<unrelated_systems<Ts...>> = true;
 
 template <typename... Ts>
 _CCCL_HOST_DEVICE auto minimum_system_impl(int) -> minimum_type<Ts...>;

--- a/thrust/thrust/system/cpp/detail/execution_policy.h
+++ b/thrust/thrust/system/cpp/detail/execution_policy.h
@@ -52,7 +52,9 @@ struct execution_policy;
 // specialize execution_policy for tag
 template <>
 struct execution_policy<tag> : thrust::system::detail::sequential::execution_policy<tag>
-{};
+{
+  using tag_type = tag;
+};
 
 // tag's definition comes before the
 // generic definition of execution_policy

--- a/thrust/thrust/system/detail/generic/select_system.h
+++ b/thrust/thrust/system/detail/generic/select_system.h
@@ -67,11 +67,19 @@ select_system(thrust::execution_policy<System1>& system1, thrust::execution_poli
   {
     return thrust::detail::derived_cast(system1);
   }
-  else
+  else if constexpr (::cuda::std::is_same_v<System2, min_sys>)
   {
-    static_assert(::cuda::std::is_same_v<System2, min_sys>);
     return thrust::detail::derived_cast(system2);
   }
+  else if constexpr (thrust::detail::is_unrelated_systems<min_sys>)
+  {
+    static_assert(!sizeof(System1), "Cannot select a system: System1 and System2 are unrelated");
+  }
+  else
+  {
+    static_assert(!sizeof(System1), "select_system failed. Please file a bug report!");
+  }
+  _CCCL_UNREACHABLE();
 }
 
 template <typename System1,

--- a/thrust/thrust/system/detail/sequential/execution_policy.h
+++ b/thrust/thrust/system/detail/sequential/execution_policy.h
@@ -56,7 +56,12 @@ struct execution_policy<tag> : thrust::execution_policy<tag>
 // tag's definition comes before the generic definition of execution_policy
 struct tag : execution_policy<tag>
 {
-  _CCCL_HOST_DEVICE constexpr tag() {}
+  constexpr tag() = default;
+
+  // allow any execution_policy to convert to the sequential tag. required for minimum_system to pick the sequential one
+  template <typename DerivedPolicy>
+  _CCCL_HOST_DEVICE tag(const thrust::execution_policy<DerivedPolicy>&)
+  {}
 };
 
 // allow conversion to tag when it is not a successor

--- a/thrust/thrust/system/detail/sequential/execution_policy.h
+++ b/thrust/thrust/system/detail/sequential/execution_policy.h
@@ -51,7 +51,9 @@ struct execution_policy;
 // specialize execution_policy for tag
 template <>
 struct execution_policy<tag> : thrust::execution_policy<tag>
-{};
+{
+  using tag_type = tag;
+};
 
 // tag's definition comes before the generic definition of execution_policy
 struct tag : execution_policy<tag>
@@ -68,6 +70,8 @@ struct tag : execution_policy<tag>
 template <typename Derived>
 struct execution_policy : thrust::execution_policy<Derived>
 {
+  using tag_type = tag;
+
   // allow conversion to tag
   _CCCL_HOST_DEVICE inline operator tag() const
   {

--- a/thrust/thrust/system/omp/detail/execution_policy.h
+++ b/thrust/thrust/system/omp/detail/execution_policy.h
@@ -55,7 +55,9 @@ struct execution_policy;
 // specialize execution_policy for tag
 template <>
 struct execution_policy<tag> : thrust::system::cpp::detail::execution_policy<tag>
-{};
+{
+  using tag_type = tag;
+};
 
 // tag's definition comes before the
 // generic definition of execution_policy

--- a/thrust/thrust/system/tbb/detail/execution_policy.h
+++ b/thrust/thrust/system/tbb/detail/execution_policy.h
@@ -54,7 +54,9 @@ struct execution_policy;
 // specialize execution_policy for tag
 template <>
 struct execution_policy<tag> : thrust::system::cpp::detail::execution_policy<tag>
-{};
+{
+  using tag_type = tag;
+};
 
 // tag's definition comes before the
 // generic definition of execution_policy


### PR DESCRIPTION
Fix dereferencing nullptr in `thrust::device_reference` (#4226)

* Improve select_system diagnostics
* Add tests for minimum_system and allow any execution policy to convert to the sequantial tag
* Dispatch using system tag instead, which is default constructible.

(cherry-picked from 9fbba01)

+ a few manual fixes
