### PR TITLE
Fix libcu++ lit config arch list

### DIFF
--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -190,7 +190,7 @@ class Configuration(object):
         self.lit_config.note(
             "Deduced compute capabilities are: %s" % deduced_compute_archs
         )
-        deduced_comput_archs_str = ", ".join(
+        deduced_comput_archs_str = ",".join(
             [str(element) for element in deduced_compute_archs]
         )
         return deduced_comput_archs_str


### PR DESCRIPTION
When the CMAKE_CUDA_ARCHITECTURES are native and more than GPU architecture is present in the system, the following error occurs:

```
bgruber@concorde:~/dev/cccl/build_clang$ lit libcudacxx/test/libcudacxx/cuda/pipeline/pipeline_memcpy_async_producer_consumer.pass.cpp -v
...
  File "/home/bgruber/dev/cccl/libcudacxx/test/utils/libcudacxx/test/config.py", line 835, in configure_compile_flags
    subarchitecture = arch[-1]
                      ~~~~^^^^
IndexError: string index out of range
```
This is because a string "120, 86" is produced, which is tokenized into "120", " " and "86", where the space is not a valid integer