### PR TITLE
[libcu++] Simplify `cuda::std::is_convertible`

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -406,10 +406,6 @@
 #  define _CCCL_BUILTIN_IS_CONSTRUCTIBLE(...) __is_constructible(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(is_constructible) && gcc >= 8.0
 
-#if _CCCL_CHECK_BUILTIN(is_convertible_to) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
-#  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible_to(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(is_convertible_to)
-
 #if _CCCL_CHECK_BUILTIN(is_destructible) || _CCCL_COMPILER(MSVC)
 #  define _CCCL_BUILTIN_IS_DESTRUCTIBLE(...) __is_destructible(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(is_destructible)

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -303,10 +303,6 @@
 #  define _CCCL_BUILTIN_IS_CONSTRUCTIBLE(...) __is_constructible(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(is_constructible) && gcc >= 8.0
 
-#if _CCCL_CHECK_BUILTIN(is_convertible_to) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
-#  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible_to(__VA_ARGS__)
-#endif // _CCCL_CHECK_BUILTIN(is_convertible_to)
-
 #if _CCCL_CHECK_BUILTIN(is_destructible) || _CCCL_COMPILER(MSVC)
 #  define _CCCL_BUILTIN_IS_DESTRUCTIBLE(...) __is_destructible(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(is_destructible)

--- a/libcudacxx/include/cuda/std/__type_traits/is_convertible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_convertible.h
@@ -33,7 +33,8 @@
 
 #if _CCCL_CHECK_BUILTIN(is_convertible_to) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
 #  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible_to(__VA_ARGS__)
-#elif _CCCL_CHECK_BUILTIN(is_convertible)
+// gcc 13's builin doesn't properly implement some function conversions
+#elif _CCCL_CHECK_BUILTIN(is_convertible) && !_CCCL_COMPILER(GCC, <, 14)
 #  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible(__VA_ARGS__)
 #endif // ^^^ has builtin is_convertible_to
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_convertible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_convertible.h
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_array.h>
 #include <cuda/std/__type_traits/is_function.h>
@@ -31,46 +32,32 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_CHECK_BUILTIN(is_convertible_to) || _CCCL_COMPILER(MSVC) || _CCCL_COMPILER(NVRTC)
+#  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible_to(__VA_ARGS__)
+// gcc 13's builin doesn't properly implement some function conversions
+#elif _CCCL_CHECK_BUILTIN(is_convertible) && !_CCCL_COMPILER(GCC, <, 14)
+#  define _CCCL_BUILTIN_IS_CONVERTIBLE_TO(...) __is_convertible(__VA_ARGS__)
+#endif // ^^^ has builtin is_convertible_to
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if defined(_CCCL_BUILTIN_IS_CONVERTIBLE_TO) && !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
 
-template <class _T1, class _T2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_convertible : public integral_constant<bool, _CCCL_BUILTIN_IS_CONVERTIBLE_TO(_T1, _T2)>
-{};
-
-template <class _T1, class _T2>
-inline constexpr bool is_convertible_v = _CCCL_BUILTIN_IS_CONVERTIBLE_TO(_T1, _T2);
+template <class _Fm, class _To>
+inline constexpr bool is_convertible_v = _CCCL_BUILTIN_IS_CONVERTIBLE_TO(_Fm, _To);
 
 #  if _CCCL_COMPILER(MSVC) // Workaround for DevCom-1627396
-template <class _Ty>
-struct is_convertible<_Ty&, volatile _Ty&> : true_type
-{};
+template <class _Tp>
+inline constexpr bool is_convertible_v<_Tp&, volatile _Tp&> = true;
 
-template <class _Ty>
-struct is_convertible<volatile _Ty&, volatile _Ty&> : true_type
-{};
+template <class _Tp>
+inline constexpr bool is_convertible_v<volatile _Tp&, volatile _Tp&> = true;
 
-template <class _Ty>
-struct is_convertible<_Ty&, const volatile _Ty&> : true_type
-{};
+template <class _Tp>
+inline constexpr bool is_convertible_v<_Tp&, const volatile _Tp&> = true;
 
-template <class _Ty>
-struct is_convertible<volatile _Ty&, const volatile _Ty&> : true_type
-{};
-
-template <class _Ty>
-inline constexpr bool is_convertible_v<_Ty&, volatile _Ty&> = true;
-
-template <class _Ty>
-inline constexpr bool is_convertible_v<volatile _Ty&, volatile _Ty&> = true;
-
-template <class _Ty>
-inline constexpr bool is_convertible_v<_Ty&, const volatile _Ty&> = true;
-
-template <class _Ty>
-inline constexpr bool is_convertible_v<volatile _Ty&, const volatile _Ty&> = true;
+template <class _Tp>
+inline constexpr bool is_convertible_v<volatile _Tp&, const volatile _Tp&> = true;
 #  endif // _CCCL_COMPILER(MSVC)
 
 #else // ^^^ _CCCL_BUILTIN_IS_CONVERTIBLE_TO ^^^ / vvv !_CCCL_BUILTIN_IS_CONVERTIBLE_TO vvv
@@ -88,121 +75,66 @@ _CCCL_API inline void __test_convert(_Tp);
 _CCCL_END_NV_DIAG_SUPPRESS()
 _CCCL_DIAG_POP
 
-template <class _From, class _To, class = void>
-struct __is_convertible_test : public false_type
-{};
-
+// We can't use template variable here, because gcc emits errors regarding us touching private members.
 template <class _From, class _To>
-struct __is_convertible_test<
-  _From,
-  _To,
-  decltype(::cuda::std::__is_convertible_imp::__test_convert<_To>(::cuda::std::declval<_From>()))> : public true_type
-{};
+_CCCL_API false_type __is_convertible_test(long);
+template <class _From,
+          class _To,
+          class = decltype(::cuda::std::__is_convertible_imp::__test_convert<_To>(::cuda::std::declval<_From>()))>
+_CCCL_API true_type __is_convertible_test(int);
 
 template <class _Tp, bool _IsArray = is_array_v<_Tp>, bool _IsFunction = is_function_v<_Tp>, bool _IsVoid = is_void_v<_Tp>>
-struct __is_array_function_or_void
-{
-  enum
-  {
-    value = 0
-  };
-};
+inline constexpr int __is_array_function_or_void_v = 0;
 template <class _Tp>
-struct __is_array_function_or_void<_Tp, true, false, false>
-{
-  enum
-  {
-    value = 1
-  };
-};
+inline constexpr int __is_array_function_or_void_v<_Tp, true, false, false> = 1;
 template <class _Tp>
-struct __is_array_function_or_void<_Tp, false, true, false>
-{
-  enum
-  {
-    value = 2
-  };
-};
+inline constexpr int __is_array_function_or_void_v<_Tp, false, true, false> = 2;
 template <class _Tp>
-struct __is_array_function_or_void<_Tp, false, false, true>
-{
-  enum
-  {
-    value = 3
-  };
-};
+inline constexpr int __is_array_function_or_void_v<_Tp, false, false, true> = 3;
 } // namespace __is_convertible_imp
-
-template <class _Tp, unsigned = __is_convertible_imp::__is_array_function_or_void<remove_reference_t<_Tp>>::value>
-struct __is_convertible_check
-{
-  static const size_t __v = 0;
-};
-
-template <class _Tp>
-struct __is_convertible_check<_Tp, 0>
-{
-  static const size_t __v = sizeof(_Tp);
-};
 
 template <class _T1,
           class _T2,
-          unsigned _T1_is_array_function_or_void = __is_convertible_imp::__is_array_function_or_void<_T1>::value,
-          unsigned _T2_is_array_function_or_void = __is_convertible_imp::__is_array_function_or_void<_T2>::value>
-struct __is_convertible_fallback
-    : public integral_constant<bool, __is_convertible_imp::__is_convertible_test<_T1, _T2>::value>
-{};
+          int _T1_is_array_function_or_void = __is_convertible_imp::__is_array_function_or_void_v<_T1>,
+          int _T2_is_array_function_or_void = __is_convertible_imp::__is_array_function_or_void_v<_T2>>
+inline constexpr bool __is_convertible_fallback_v =
+  decltype(::cuda::std::__is_convertible_imp::__is_convertible_test<_T1, _T2>(0))::value;
 
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 0, 1> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 0, 1> = false;
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 1, 1> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 1, 1> = false;
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 2, 1> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 2, 1> = false;
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 3, 1> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 3, 1> = false;
 
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 0, 2> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 0, 2> = false;
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 1, 2> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 1, 2> = false;
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 2, 2> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 2, 2> = false;
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 3, 2> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 3, 2> = false;
 
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 0, 3> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 0, 3> = false;
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 1, 3> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 1, 3> = false;
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 2, 3> : public false_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 2, 3> = false;
 template <class _T1, class _T2>
-struct __is_convertible_fallback<_T1, _T2, 3, 3> : public true_type
-{};
+inline constexpr bool __is_convertible_fallback_v<_T1, _T2, 3, 3> = true;
 
-template <class _T1, class _T2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_convertible : public __is_convertible_fallback<_T1, _T2>
-{
-  static const size_t __complete_check1 = __is_convertible_check<_T1>::__v;
-  static const size_t __complete_check2 = __is_convertible_check<_T2>::__v;
-};
+template <class _Fm, class _To>
+inline constexpr bool is_convertible_v = __is_convertible_fallback_v<_Fm, _To>;
 
-template <class _From, class _To>
-inline constexpr bool is_convertible_v = is_convertible<_From, _To>::value;
+#endif // ^^^ !_CCCL_BUILTIN_IS_CONVERTIBLE_TO ^^^
 
-#endif // !_CCCL_BUILTIN_IS_CONVERTIBLE_TO
+template <class _Fm, class _To>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_convertible : bool_constant<is_convertible_v<_Fm, _To>>
+{};
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_convertible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_convertible.pass.cpp
@@ -258,9 +258,9 @@ int main(int, char**)
   // This test requires access control SFINAE which we only have on non-MSVC
   // compilers or when we are using the compiler builtin for
   // is_convertible.
-#if !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
+#if defined(_CCCL_BUILTIN_IS_CONVERTIBLE_TO) && !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
   test_is_not_convertible<NonCopyable&, NonCopyable>();
-#endif // !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
+#endif // defined(_CCCL_BUILTIN_IS_CONVERTIBLE_TO) && !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
 
   // Ensure that CannotInstantiate is not instantiated by is_convertible when it is not needed.
   // For example CannotInstantiate is instantiated as a part of ADL lookup for arguments of type CannotInstantiate*.

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_convertible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_convertible.pass.cpp
@@ -132,9 +132,7 @@ int main(int, char**)
   test_is_not_convertible<Array, Function*>();
   test_is_not_convertible<Array, Array>();
 
-#if !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
   static_assert((!cuda::std::is_convertible<Array, Array&>::value), "");
-#endif // !_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK
   static_assert((cuda::std::is_convertible<Array, const Array&>::value), "");
 #if !TEST_COMPILER(MSVC)
   // TODO: Unclear why this fails.
@@ -143,9 +141,7 @@ int main(int, char**)
 
   static_assert((!cuda::std::is_convertible<const Array, Array&>::value), "");
   static_assert((cuda::std::is_convertible<const Array, const Array&>::value), "");
-#if !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
   static_assert((!cuda::std::is_convertible<Array, volatile Array&>::value), "");
-#endif // !_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK
 
   static_assert((cuda::std::is_convertible<Array, Array&&>::value), "");
   static_assert((cuda::std::is_convertible<Array, const Array&&>::value), "");
@@ -156,10 +152,8 @@ int main(int, char**)
 #endif // !TEST_COMPILER(NVRTC)
   static_assert((cuda::std::is_convertible<Array, const volatile Array&&>::value), "");
   static_assert((cuda::std::is_convertible<const Array, const Array&&>::value), "");
-#if !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
   static_assert((!cuda::std::is_convertible<Array&, Array&&>::value), "");
   static_assert((!cuda::std::is_convertible<Array&&, Array&>::value), "");
-#endif // !_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK
 
   test_is_not_convertible<Array, char>();
   test_is_not_convertible<Array, char&>();
@@ -264,9 +258,9 @@ int main(int, char**)
   // This test requires access control SFINAE which we only have on non-MSVC
   // compilers or when we are using the compiler builtin for
   // is_convertible.
-#if !TEST_COMPILER(MSVC) || !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
+#if !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
   test_is_not_convertible<NonCopyable&, NonCopyable>();
-#endif // !TEST_COMPILER(MSVC) || !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
+#endif // !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
 
   // Ensure that CannotInstantiate is not instantiated by is_convertible when it is not needed.
   // For example CannotInstantiate is instantiated as a part of ADL lookup for arguments of type CannotInstantiate*.

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_convertible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_convertible.pass.cpp
@@ -132,9 +132,7 @@ int main(int, char**)
   test_is_not_convertible<Array, Function*>();
   test_is_not_convertible<Array, Array>();
 
-#if !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
   static_assert((!cuda::std::is_convertible<Array, Array&>::value));
-#endif // !_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK
   static_assert((cuda::std::is_convertible<Array, const Array&>::value));
 #if !TEST_COMPILER(MSVC)
   // TODO: Unclear why this fails.
@@ -143,9 +141,7 @@ int main(int, char**)
 
   static_assert((!cuda::std::is_convertible<const Array, Array&>::value));
   static_assert((cuda::std::is_convertible<const Array, const Array&>::value));
-#if !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
   static_assert((!cuda::std::is_convertible<Array, volatile Array&>::value));
-#endif // !_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK
 
   static_assert((cuda::std::is_convertible<Array, Array&&>::value));
   static_assert((cuda::std::is_convertible<Array, const Array&&>::value));
@@ -156,10 +152,8 @@ int main(int, char**)
 #endif // !TEST_COMPILER(NVRTC)
   static_assert((cuda::std::is_convertible<Array, const volatile Array&&>::value));
   static_assert((cuda::std::is_convertible<const Array, const Array&&>::value));
-#if !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
   static_assert((!cuda::std::is_convertible<Array&, Array&&>::value));
   static_assert((!cuda::std::is_convertible<Array&&, Array&>::value));
-#endif // !_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK
 
   test_is_not_convertible<Array, char>();
   test_is_not_convertible<Array, char&>();
@@ -264,9 +258,7 @@ int main(int, char**)
   // This test requires access control SFINAE which we only have on non-MSVC
   // compilers or when we are using the compiler builtin for
   // is_convertible.
-#if !TEST_COMPILER(MSVC) || !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
   test_is_not_convertible<NonCopyable&, NonCopyable>();
-#endif // !TEST_COMPILER(MSVC) || !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
 
   // Ensure that CannotInstantiate is not instantiated by is_convertible when it is not needed.
   // For example CannotInstantiate is instantiated as a part of ADL lookup for arguments of type CannotInstantiate*.

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_convertible_fallback.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.rel/is_convertible_fallback.pass.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// ADDITIONAL_COMPILE_DEFINITIONS: _LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK
+
 // type_traits
 
 // is_convertible
@@ -20,6 +22,4 @@
 #  pragma clang diagnostic ignored "-Wkeyword-compat"
 #endif
 
-#define _LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK
 #include "is_convertible.pass.cpp"
-#include "test_macros.h"


### PR DESCRIPTION
This PR simplifies the implementation of `cuda::std::is_convertible` and adds support for gcc's `__is_convertible` builtin available since gcc 13.
