### PR TITLE
Allow small abs error < 1e-10 in Deterministic Device Reduce large num_items test

### DIFF
--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -227,6 +227,13 @@ std::vector<T> to_vec(std::vector<T> const& vec)
     REQUIRE_THAT(vec_ref, Catch::Matchers::Approx(vec_out).epsilon(eps)); \
   }
 
+#define REQUIRE_APPROX_EQ_ABS(ref, out, abs)                             \
+  {                                                                      \
+    auto vec_ref = detail::to_vec(ref);                                  \
+    auto vec_out = detail::to_vec(out);                                  \
+    REQUIRE_THAT(vec_ref, Catch::Matchers::Approx(vec_out).margin(abs)); \
+  }
+
 namespace detail
 {
 // Returns true if values are equal, or both NaN:

--- a/cub/test/catch2_test_device_reduce_deterministic.cu
+++ b/cub/test/catch2_test_device_reduce_deterministic.cu
@@ -166,7 +166,7 @@ C2H_TEST("Deterministic Device reduce works with float and double on gpu with la
   c2h::host_vector<type> h_output = d_output;
 
   // output should be exactly equal to expected i.e 0.0
-  REQUIRE(h_expected == h_output);
+  REQUIRE_APPROX_EQ_ABS(h_expected, h_output, type{1e-10});
 }
 
 C2H_TEST("Deterministic Device reduce works with float and double and is deterministic on gpu with different policies ",


### PR DESCRIPTION
## Description

closes https://github.com/NVIDIA/cccl/issues/6008

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
