### PR TITLE
Use more inline variables when possible

### DIFF
--- a/libcudacxx/include/cuda/__functional/proclaim_return_type.h
+++ b/libcudacxx/include/cuda/__functional/proclaim_return_type.h
@@ -43,8 +43,7 @@ private:
 public:
   __return_type_wrapper() = delete;
 
-  template <class _Fn,
-            class = ::cuda::std::enable_if_t<::cuda::std::is_same<::cuda::std::decay_t<_Fn>, _DecayFn>::value>>
+  template <class _Fn, class = ::cuda::std::enable_if_t<::cuda::std::is_same_v<::cuda::std::decay_t<_Fn>, _DecayFn>>>
   _CCCL_API constexpr explicit __return_type_wrapper(_Fn&& __fn) noexcept
       : __fn_(::cuda::std::forward<_Fn>(__fn))
   {}
@@ -53,7 +52,7 @@ public:
   _CCCL_API constexpr _Ret operator()(_As&&... __as) & noexcept
   {
 #if !_CCCL_CUDA_COMPILER(NVCC) || defined(__CUDA_ARCH__)
-    static_assert(::cuda::std::is_same<_Ret, typename ::cuda::std::__invoke_of<_DecayFn&, _As...>::type>::value,
+    static_assert(::cuda::std::is_same_v<_Ret, ::cuda::std::invoke_result_t<_DecayFn&, _As...>>,
                   "Return type shall match the proclaimed one exactly");
 #endif // !_CCCL_CUDA_COMPILER(NVCC) || __CUDA_ARCH__
 
@@ -64,7 +63,7 @@ public:
   _CCCL_API constexpr _Ret operator()(_As&&... __as) && noexcept
   {
 #if !_CCCL_CUDA_COMPILER(NVCC) || defined(__CUDA_ARCH__)
-    static_assert(::cuda::std::is_same<_Ret, typename ::cuda::std::__invoke_of<_DecayFn, _As...>::type>::value,
+    static_assert(::cuda::std::is_same_v<_Ret, ::cuda::std::invoke_result_t<_DecayFn, _As...>>,
                   "Return type shall match the proclaimed one exactly");
 #endif // !_CCCL_CUDA_COMPILER(NVCC) || __CUDA_ARCH__
 
@@ -75,7 +74,7 @@ public:
   _CCCL_API constexpr _Ret operator()(_As&&... __as) const& noexcept
   {
 #if !_CCCL_CUDA_COMPILER(NVCC) || defined(__CUDA_ARCH__)
-    static_assert(::cuda::std::is_same<_Ret, typename ::cuda::std::__invoke_of<const _DecayFn&, _As...>::type>::value,
+    static_assert(::cuda::std::is_same_v<_Ret, ::cuda::std::invoke_result_t<const _DecayFn&, _As...>>,
                   "Return type shall match the proclaimed one exactly");
 #endif // !_CCCL_CUDA_COMPILER(NVCC) || __CUDA_ARCH__
 
@@ -86,7 +85,7 @@ public:
   _CCCL_API constexpr _Ret operator()(_As&&... __as) const&& noexcept
   {
 #if !_CCCL_CUDA_COMPILER(NVCC) || defined(__CUDA_ARCH__)
-    static_assert(::cuda::std::is_same<_Ret, typename ::cuda::std::__invoke_of<const _DecayFn, _As...>::type>::value,
+    static_assert(::cuda::std::is_same_v<_Ret, ::cuda::std::invoke_result_t<const _DecayFn, _As...>>,
                   "Return type shall match the proclaimed one exactly");
 #endif // !_CCCL_CUDA_COMPILER(NVCC) || __CUDA_ARCH__
 

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -624,12 +624,11 @@ _CCCL_API constexpr zip_iterator<Iterators...> make_zip_iterator(Iterators... __
 
 _CCCL_END_NAMESPACE_CUDA
 
-// GCC and MSVC2019 have issues determining _IsFancyPointer in C++17 because they fail to instantiate pointer_traits
+// GCC and MSVC2019 have issues determining __is_fancy_pointer in C++17 because they fail to instantiate pointer_traits
 #if (_CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC)) && _CCCL_STD_VER <= 2017
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <class... _Iterators>
-struct _IsFancyPointer<::cuda::zip_iterator<_Iterators...>> : false_type
-{};
+inline constexpr bool __is_fancy_pointer<::cuda::zip_iterator<_Iterators...>> = false;
 _CCCL_END_NAMESPACE_CUDA_STD
 #endif // _CCCL_COMPILER(MSVC) && _CCCL_STD_VER <= 2017
 

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async_tx.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async_tx.h
@@ -55,7 +55,7 @@ _CCCL_DEVICE inline async_contract_fulfillment memcpy_async_tx(
   // memcpy_async when compiling with GCC 4.8.
   // FIXME: remove the #if once GCC 4.8 is no longer supported.
 #    if !_CCCL_COMPILER(GCC) || _CCCL_COMPILER(GCC, >, 4, 8)
-  static_assert(::cuda::std::is_trivially_copyable<_Tp>::value, "memcpy_async_tx requires a trivially copyable type");
+  static_assert(::cuda::std::is_trivially_copyable_v<_Tp>, "memcpy_async_tx requires a trivially copyable type");
 #    endif
   static_assert(16 <= _Alignment, "mempcy_async_tx expects arguments to be at least 16 byte aligned.");
   static_assert(_Alignment >= alignof(_Tp), "alignment must be at least the alignof(T)");

--- a/libcudacxx/include/cuda/std/__algorithm/comp.h
+++ b/libcudacxx/include/cuda/std/__algorithm/comp.h
@@ -40,12 +40,6 @@ struct __equal_to
   }
 };
 
-#if defined(_LIBCUDACXX_HAS_STRING)
-template <class _Lhs, class _Rhs>
-struct __is_trivial_equality_predicate<__equal_to, _Lhs, _Rhs> : true_type
-{};
-#endif // _LIBCUDACXX_HAS_STRING
-
 struct __less
 {
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__algorithm/equal_range.h
+++ b/libcudacxx/include/cuda/std/__algorithm/equal_range.h
@@ -78,7 +78,7 @@ template <class _ForwardIterator, class _Tp, class _Compare>
 equal_range(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp)
 {
   static_assert(__is_callable<_Compare, decltype(*__first), const _Tp&>::value, "The comparator has to be callable");
-  static_assert(is_copy_constructible<_ForwardIterator>::value, "Iterator has to be copy constructible");
+  static_assert(is_copy_constructible_v<_ForwardIterator>, "Iterator has to be copy constructible");
   return ::cuda::std::__equal_range<_ClassicAlgPolicy>(
     ::cuda::std::move(__first),
     ::cuda::std::move(__last),

--- a/libcudacxx/include/cuda/std/__algorithm/iterator_operations.h
+++ b/libcudacxx/include/cuda/std/__algorithm/iterator_operations.h
@@ -109,7 +109,7 @@ struct _IterOps<_ClassicAlgPolicy>
   _CCCL_API constexpr static void __validate_iter_reference()
   {
     static_assert(
-      is_same<__deref_t<_Iter>, typename iterator_traits<remove_cvref_t<_Iter>>::reference>::value,
+      is_same_v<__deref_t<_Iter>, typename iterator_traits<remove_cvref_t<_Iter>>::reference>,
       "It looks like your iterator's `iterator_traits<It>::reference` does not match the return type of "
       "dereferencing the iterator, i.e., calling `*it`. This is undefined behavior according to [input.iterators] "
       "and can lead to dangling reference issues at runtime, so we are flagging this.");
@@ -117,7 +117,7 @@ struct _IterOps<_ClassicAlgPolicy>
 
   // iter_move
   _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter, enable_if_t<is_reference<__deref_t<_Iter>>::value, int> = 0>
+  template <class _Iter, enable_if_t<is_reference_v<__deref_t<_Iter>>, int> = 0>
   _CCCL_API constexpr static
     // If the result of dereferencing `_Iter` is a reference type, deduce the result of calling `::cuda::std::move` on
     // it. Note that the C++03 mode doesn't support `decltype(auto)` as the return type.
@@ -130,7 +130,7 @@ struct _IterOps<_ClassicAlgPolicy>
   }
 
   _CCCL_EXEC_CHECK_DISABLE
-  template <class _Iter, enable_if_t<!is_reference<__deref_t<_Iter>>::value, int> = 0>
+  template <class _Iter, enable_if_t<!is_reference_v<__deref_t<_Iter>>, int> = 0>
   _CCCL_API constexpr static
     // If the result of dereferencing `_Iter` is a value type, deduce the return value of this function to also be a
     // value -- otherwise, after `operator*` returns a temporary, this function would return a dangling reference to

--- a/libcudacxx/include/cuda/std/__algorithm/make_projected.h
+++ b/libcudacxx/include/cuda/std/__algorithm/make_projected.h
@@ -72,7 +72,7 @@ struct _ProjectedPred
 
 template <class _Pred,
           class _Proj,
-          enable_if_t<!(!is_member_pointer<decay_t<_Pred>>::value && __is_identity<decay_t<_Proj>>::value), int> = 0>
+          enable_if_t<!(!is_member_pointer_v<decay_t<_Pred>> && __is_identity_v<decay_t<_Proj>>), int> = 0>
 _CCCL_API constexpr _ProjectedPred<_Pred, _Proj> __make_projected(_Pred& __pred, _Proj& __proj)
 {
   return _ProjectedPred<_Pred, _Proj>(__pred, __proj);
@@ -83,7 +83,7 @@ _CCCL_API constexpr _ProjectedPred<_Pred, _Proj> __make_projected(_Pred& __pred,
 // the call stack when the comparator is invoked, even in an unoptimized build.
 template <class _Pred,
           class _Proj,
-          enable_if_t<!is_member_pointer<decay_t<_Pred>>::value && __is_identity<decay_t<_Proj>>::value, int> = 0>
+          enable_if_t<!is_member_pointer_v<decay_t<_Pred>> && __is_identity_v<decay_t<_Proj>>, int> = 0>
 _CCCL_API constexpr _Pred& __make_projected(_Pred& __pred, _Proj&)
 {
   return __pred;

--- a/libcudacxx/include/cuda/std/__algorithm/pop_heap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/pop_heap.h
@@ -72,9 +72,8 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator, class _Compare>
 _CCCL_API constexpr void pop_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
 {
-  static_assert(::cuda::std::is_copy_constructible<_RandomAccessIterator>::value,
-                "Iterators must be copy constructible.");
-  static_assert(::cuda::std::is_copy_assignable<_RandomAccessIterator>::value, "Iterators must be copy assignable.");
+  static_assert(::cuda::std::is_copy_constructible_v<_RandomAccessIterator>, "Iterators must be copy constructible.");
+  static_assert(::cuda::std::is_copy_assignable_v<_RandomAccessIterator>, "Iterators must be copy assignable.");
 
   typename iterator_traits<_RandomAccessIterator>::difference_type __len = __last - __first;
   ::cuda::std::__pop_heap<_ClassicAlgPolicy>(::cuda::std::move(__first), ::cuda::std::move(__last), __comp, __len);

--- a/libcudacxx/include/cuda/std/__algorithm/push_heap.h
+++ b/libcudacxx/include/cuda/std/__algorithm/push_heap.h
@@ -80,9 +80,8 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _RandomAccessIterator, class _Compare>
 _CCCL_API constexpr void push_heap(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp)
 {
-  static_assert(::cuda::std::is_copy_constructible<_RandomAccessIterator>::value,
-                "Iterators must be copy constructible.");
-  static_assert(::cuda::std::is_copy_assignable<_RandomAccessIterator>::value, "Iterators must be copy assignable.");
+  static_assert(::cuda::std::is_copy_constructible_v<_RandomAccessIterator>, "Iterators must be copy constructible.");
+  static_assert(::cuda::std::is_copy_assignable_v<_RandomAccessIterator>, "Iterators must be copy assignable.");
 
   ::cuda::std::__push_heap<_ClassicAlgPolicy>(::cuda::std::move(__first), ::cuda::std::move(__last), __comp);
 }

--- a/libcudacxx/include/cuda/std/__algorithm/unwrap_iter.h
+++ b/libcudacxx/include/cuda/std/__algorithm/unwrap_iter.h
@@ -75,7 +75,7 @@ struct __unwrap_iter_impl<_Iter, true>
   }
 };
 
-template <class _Iter, class _Impl = __unwrap_iter_impl<_Iter>, enable_if_t<is_copy_constructible<_Iter>::value, int> = 0>
+template <class _Iter, class _Impl = __unwrap_iter_impl<_Iter>, enable_if_t<is_copy_constructible_v<_Iter>, int> = 0>
 _CCCL_API constexpr decltype(_Impl::__unwrap(::cuda::std::declval<_Iter>())) __unwrap_iter(_Iter __i) noexcept
 {
   return _Impl::__unwrap(__i);

--- a/libcudacxx/include/cuda/std/__algorithm/upper_bound.h
+++ b/libcudacxx/include/cuda/std/__algorithm/upper_bound.h
@@ -63,7 +63,7 @@ template <class _ForwardIterator, class _Tp, class _Compare>
 [[nodiscard]] _CCCL_API constexpr _ForwardIterator
 upper_bound(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, _Compare __comp)
 {
-  static_assert(is_copy_constructible<_ForwardIterator>::value, "Iterator has to be copy constructible");
+  static_assert(is_copy_constructible_v<_ForwardIterator>, "Iterator has to be copy constructible");
   return ::cuda::std::__upper_bound<_ClassicAlgPolicy>(
     ::cuda::std::move(__first), ::cuda::std::move(__last), __value, ::cuda::std::move(__comp), ::cuda::std::identity());
 }

--- a/libcudacxx/include/cuda/std/__atomic/api/owned.h
+++ b/libcudacxx/include/cuda/std/__atomic/api/owned.h
@@ -122,14 +122,12 @@ struct __atomic_pointer
 };
 
 template <typename _Tp, thread_scope _Sco = thread_scope_system>
-using __atomic_impl =
-  _If<is_pointer<_Tp>::value,
-      __atomic_pointer<_Tp, __scope_to_tag<_Sco>>,
-      _If<is_floating_point<_Tp>::value,
-          __atomic_arithmetic<_Tp, __scope_to_tag<_Sco>>,
-          _If<is_integral<_Tp>::value,
-              __atomic_bitwise<_Tp, __scope_to_tag<_Sco>>,
-              __atomic_common<_Tp, __scope_to_tag<_Sco>>>>>;
+using __atomic_impl = _If<
+  is_pointer_v<_Tp>,
+  __atomic_pointer<_Tp, __scope_to_tag<_Sco>>,
+  _If<is_floating_point_v<_Tp>,
+      __atomic_arithmetic<_Tp, __scope_to_tag<_Sco>>,
+      _If<is_integral_v<_Tp>, __atomic_bitwise<_Tp, __scope_to_tag<_Sco>>, __atomic_common<_Tp, __scope_to_tag<_Sco>>>>>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__atomic/api/reference.h
+++ b/libcudacxx/include/cuda/std/__atomic/api/reference.h
@@ -103,11 +103,11 @@ struct __atomic_ref_pointer
 
 template <typename _Tp, thread_scope _Sco = thread_scope_system>
 using __atomic_ref_impl =
-  _If<is_pointer<_Tp>::value,
+  _If<is_pointer_v<_Tp>,
       __atomic_ref_pointer<_Tp, __scope_to_tag<_Sco>>,
-      _If<is_floating_point<_Tp>::value,
+      _If<is_floating_point_v<_Tp>,
           __atomic_ref_arithmetic<_Tp, __scope_to_tag<_Sco>>,
-          _If<is_integral<_Tp>::value,
+          _If<is_integral_v<_Tp>,
               __atomic_ref_bitwise<_Tp, __scope_to_tag<_Sco>>,
               __atomic_ref_common<_Tp, __scope_to_tag<_Sco>>>>>;
 

--- a/libcudacxx/include/cuda/std/__atomic/functions/host.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/host.h
@@ -112,14 +112,14 @@ inline bool __atomic_compare_exchange_weak_host(
     __atomic_failure_order_to_int(__failure));
 }
 
-template <typename _Tp, typename _Td, enable_if_t<!is_floating_point<_Tp>::value, int> = 0>
+template <typename _Tp, typename _Td, enable_if_t<!is_floating_point_v<_Tp>, int> = 0>
 inline remove_cv_t<_Tp> __atomic_fetch_add_host(_Tp* __a, _Td __delta, memory_order __order)
 {
   constexpr auto __skip_v = __atomic_ptr_skip_t<_Tp>::__skip;
   return __atomic_fetch_add(__a, __delta * __skip_v, __atomic_order_to_int(__order));
 }
 
-template <typename _Tp, typename _Td, enable_if_t<is_floating_point<_Tp>::value, int> = 0>
+template <typename _Tp, typename _Td, enable_if_t<is_floating_point_v<_Tp>, int> = 0>
 inline remove_cv_t<_Tp> __atomic_fetch_add_host(_Tp* __a, _Td __delta, memory_order __order)
 {
   auto __expected = __atomic_load_host(__a, memory_order_relaxed);
@@ -133,14 +133,14 @@ inline remove_cv_t<_Tp> __atomic_fetch_add_host(_Tp* __a, _Td __delta, memory_or
   return __expected;
 }
 
-template <typename _Tp, typename _Td, enable_if_t<!is_floating_point<_Tp>::value, int> = 0>
+template <typename _Tp, typename _Td, enable_if_t<!is_floating_point_v<_Tp>, int> = 0>
 inline remove_cv_t<_Tp> __atomic_fetch_sub_host(_Tp* __a, _Td __delta, memory_order __order)
 {
   constexpr auto __skip_v = __atomic_ptr_skip_t<_Tp>::__skip;
   return __atomic_fetch_sub(__a, __delta * __skip_v, __atomic_order_to_int(__order));
 }
 
-template <typename _Tp, typename _Td, enable_if_t<is_floating_point<_Tp>::value, int> = 0>
+template <typename _Tp, typename _Td, enable_if_t<is_floating_point_v<_Tp>, int> = 0>
 inline remove_cv_t<_Tp> __atomic_fetch_sub_host(_Tp* __a, _Td __delta, memory_order __order)
 {
   auto __expected = __atomic_load_host(__a, memory_order_relaxed);

--- a/libcudacxx/include/cuda/std/__atomic/order.h
+++ b/libcudacxx/include/cuda/std/__atomic/order.h
@@ -136,7 +136,7 @@ _CCCL_HOST_DEVICE inline constexpr int __atomic_failure_order_to_int(memory_orde
                         : (__order == memory_order_acq_rel ? __ATOMIC_ACQUIRE : __ATOMIC_CONSUME))));
 }
 
-static_assert((is_same<underlying_type<memory_order>::type, __memory_order_underlying_t>::value),
+static_assert((is_same_v<underlying_type<memory_order>::type, __memory_order_underlying_t>),
               "unexpected underlying type for std::memory_order");
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__concepts/same_as.h
+++ b/libcudacxx/include/cuda/std/__concepts/same_as.h
@@ -30,7 +30,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 // [concept.same]
 
 template <class _Tp, class _Up>
-_CCCL_CONCEPT __same_as_impl = _IsSame<_Tp, _Up>::value;
+_CCCL_CONCEPT __same_as_impl = is_same_v<_Tp, _Up>;
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT same_as = __same_as_impl<_Tp, _Up> && __same_as_impl<_Up, _Tp>;

--- a/libcudacxx/include/cuda/std/__expected/expected.h
+++ b/libcudacxx/include/cuda/std/__expected/expected.h
@@ -135,25 +135,24 @@ public:
 
 private:
   template <class _Up, class _OtherErr, class _UfQual, class _OtherErrQual>
-  using __can_convert =
-    _And<is_constructible<_Tp, _UfQual>,
-         is_constructible<_Err, _OtherErrQual>,
-         _Not<is_constructible<_Tp, expected<_Up, _OtherErr>&>>,
-         _Not<is_constructible<_Tp, expected<_Up, _OtherErr>>>,
-         _Not<is_constructible<_Tp, const expected<_Up, _OtherErr>&>>,
-         _Not<is_constructible<_Tp, const expected<_Up, _OtherErr>>>,
-         _Not<is_convertible<expected<_Up, _OtherErr>&, _Tp>>,
-         _Not<is_convertible<expected<_Up, _OtherErr>&&, _Tp>>,
-         _Not<is_convertible<const expected<_Up, _OtherErr>&, _Tp>>,
-         _Not<is_convertible<const expected<_Up, _OtherErr>&&, _Tp>>,
-         _Not<is_constructible<unexpected<_Err>, expected<_Up, _OtherErr>&>>,
-         _Not<is_constructible<unexpected<_Err>, expected<_Up, _OtherErr>>>,
-         _Not<is_constructible<unexpected<_Err>, const expected<_Up, _OtherErr>&>>,
-         _Not<is_constructible<unexpected<_Err>, const expected<_Up, _OtherErr>>>>;
+  static constexpr bool __can_convert =
+    is_constructible_v<_Tp, _UfQual> && is_constructible_v<_Err, _OtherErrQual>
+    && !is_constructible_v<_Tp, expected<_Up, _OtherErr>&> //
+    && !is_constructible_v<_Tp, expected<_Up, _OtherErr>> //
+    && !is_constructible_v<_Tp, const expected<_Up, _OtherErr>&>
+    && !is_constructible_v<_Tp, const expected<_Up, _OtherErr>> //
+    && !is_convertible_v<expected<_Up, _OtherErr>&, _Tp> //
+    && !is_convertible_v<expected<_Up, _OtherErr>&&, _Tp> //
+    && !is_convertible_v<const expected<_Up, _OtherErr>&, _Tp>
+    && !is_convertible_v<const expected<_Up, _OtherErr>&&, _Tp>
+    && !is_constructible_v<unexpected<_Err>, expected<_Up, _OtherErr>&>
+    && !is_constructible_v<unexpected<_Err>, expected<_Up, _OtherErr>>
+    && !is_constructible_v<unexpected<_Err>, const expected<_Up, _OtherErr>&>
+    && !is_constructible_v<unexpected<_Err>, const expected<_Up, _OtherErr>>;
 
 public:
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&>::value _CCCL_AND
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&> _CCCL_AND
                    is_convertible_v<const _Up&, _Tp> _CCCL_AND is_convertible_v<const _OtherErr&, _Err>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 expected(const expected<_Up, _OtherErr>& __other) noexcept(
     is_nothrow_constructible_v<_Tp, const _Up&> && is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
@@ -170,7 +169,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&>::value _CCCL_AND(
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _Up&, const _OtherErr&> _CCCL_AND(
     !is_convertible_v<const _Up&, _Tp> || !is_convertible_v<const _OtherErr&, _Err>))
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit expected(const expected<_Up, _OtherErr>& __other) noexcept(
     is_nothrow_constructible_v<_Tp, const _Up&> && is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
@@ -187,7 +186,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _Up, _OtherErr>::value _CCCL_AND is_convertible_v<_Up, _Tp> _CCCL_AND
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _Up, _OtherErr> _CCCL_AND is_convertible_v<_Up, _Tp> _CCCL_AND
                    is_convertible_v<_OtherErr, _Err>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 expected(expected<_Up, _OtherErr>&& __other) noexcept(
     is_nothrow_constructible_v<_Tp, _Up> && is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
@@ -206,7 +205,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _Up, _OtherErr>::value _CCCL_AND(
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _Up, _OtherErr> _CCCL_AND(
     !is_convertible_v<_Up, _Tp> || !is_convertible_v<_OtherErr, _Err>))
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit expected(expected<_Up, _OtherErr>&& __other) noexcept(
     is_nothrow_constructible_v<_Tp, _Up> && is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
@@ -347,12 +346,9 @@ public:
 private:
   template <class _OtherErrQual>
   static constexpr bool __can_assign_from_unexpected =
-    _And<is_constructible<_Err, _OtherErrQual>,
-         is_assignable<_Err&, _OtherErrQual>,
-         _Lazy<_Or,
-               is_nothrow_constructible<_Err, _OtherErrQual>,
-               is_nothrow_move_constructible<_Tp>,
-               is_nothrow_move_constructible<_Err>>>::value;
+    is_constructible_v<_Err, _OtherErrQual> && is_assignable_v<_Err&, _OtherErrQual>
+    && (is_nothrow_constructible_v<_Err, _OtherErrQual> || is_nothrow_move_constructible_v<_Tp>
+        || is_nothrow_move_constructible_v<_Err>);
 
 public:
   _CCCL_EXEC_CHECK_DISABLE
@@ -1184,13 +1180,12 @@ class expected<void, _Err> : private __expected_move_assign<void, _Err>
   friend class expected;
 
   template <class _Up, class _OtherErr, class _OtherErrQual>
-  using __can_convert =
-    _And<is_void<_Up>,
-         is_constructible<_Err, _OtherErrQual>,
-         _Not<is_constructible<unexpected<_Err>, expected<_Up, _OtherErr>&>>,
-         _Not<is_constructible<unexpected<_Err>, expected<_Up, _OtherErr>>>,
-         _Not<is_constructible<unexpected<_Err>, const expected<_Up, _OtherErr>&>>,
-         _Not<is_constructible<unexpected<_Err>, const expected<_Up, _OtherErr>>>>;
+  static constexpr bool __can_convert =
+    is_void_v<_Up> && is_constructible_v<_Err, _OtherErrQual>
+    && !is_constructible_v<unexpected<_Err>, expected<_Up, _OtherErr>&>
+    && !is_constructible_v<unexpected<_Err>, expected<_Up, _OtherErr>>
+    && !is_constructible_v<unexpected<_Err>, const expected<_Up, _OtherErr>&>
+    && !is_constructible_v<unexpected<_Err>, const expected<_Up, _OtherErr>>;
 
 public:
   using value_type      = void;
@@ -1208,8 +1203,7 @@ public:
   _CCCL_HIDE_FROM_ABI constexpr expected& operator=(expected&&)      = default;
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(
-    __can_convert<_Up, _OtherErr, const _OtherErr&>::value _CCCL_AND is_convertible_v<const _OtherErr&, _Err>)
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _OtherErr&> _CCCL_AND is_convertible_v<const _OtherErr&, _Err>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 expected(const expected<_Up, _OtherErr>& __other) noexcept(
     is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
       : __base(__other.__has_val_)
@@ -1221,8 +1215,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(
-    __can_convert<_Up, _OtherErr, const _OtherErr&>::value _CCCL_AND(!is_convertible_v<const _OtherErr&, _Err>))
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, const _OtherErr&> _CCCL_AND(!is_convertible_v<const _OtherErr&, _Err>))
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit expected(const expected<_Up, _OtherErr>& __other) noexcept(
     is_nothrow_constructible_v<_Err, const _OtherErr&>) // strengthened
       : __base(__other.__has_val_)
@@ -1234,7 +1227,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _OtherErr>::value _CCCL_AND is_convertible_v<_OtherErr, _Err>)
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _OtherErr> _CCCL_AND is_convertible_v<_OtherErr, _Err>)
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20
   expected(expected<_Up, _OtherErr>&& __other) noexcept(is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
       : __base(__other.__has_val_)
@@ -1247,7 +1240,7 @@ public:
   }
 
   _CCCL_TEMPLATE(class _Up, class _OtherErr)
-  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _OtherErr>::value _CCCL_AND(!is_convertible_v<_OtherErr, _Err>))
+  _CCCL_REQUIRES(__can_convert<_Up, _OtherErr, _OtherErr> _CCCL_AND(!is_convertible_v<_OtherErr, _Err>))
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 explicit expected(expected<_Up, _OtherErr>&& __other) noexcept(
     is_nothrow_constructible_v<_Err, _OtherErr>) // strengthened
       : __base(__other.__has_val_)

--- a/libcudacxx/include/cuda/std/__functional/bind.h
+++ b/libcudacxx/include/cuda/std/__functional/bind.h
@@ -52,7 +52,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
 struct is_bind_expression
-    : _If<_IsSame<_Tp, remove_cvref_t<_Tp>>::value, false_type, is_bind_expression<remove_cvref_t<_Tp>>>
+    : _If<is_same_v<_Tp, remove_cvref_t<_Tp>>, false_type, is_bind_expression<remove_cvref_t<_Tp>>>
 {};
 
 template <class _Tp>
@@ -60,7 +60,7 @@ inline constexpr size_t is_bind_expression_v = is_bind_expression<_Tp>::value;
 
 template <class _Tp>
 struct is_placeholder
-    : _If<_IsSame<_Tp, remove_cvref_t<_Tp>>::value, integral_constant<int, 0>, is_placeholder<remove_cvref_t<_Tp>>>
+    : _If<is_same_v<_Tp, remove_cvref_t<_Tp>>, integral_constant<int, 0>, is_placeholder<remove_cvref_t<_Tp>>>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__functional/bind_back.h
+++ b/libcudacxx/include/cuda/std/__functional/bind_back.h
@@ -62,10 +62,10 @@ struct __bind_back_t : __perfect_forward<__bind_back_op<tuple_size_v<_BoundArgs>
 
 template <class _Fn,
           class... _Args,
-          class = enable_if_t<_And<is_constructible<decay_t<_Fn>, _Fn>,
-                                   is_move_constructible<decay_t<_Fn>>,
-                                   is_constructible<decay_t<_Args>, _Args>...,
-                                   is_move_constructible<decay_t<_Args>>...>::value>>
+          class = enable_if_t<__all<is_constructible_v<decay_t<_Fn>, _Fn>,
+                                    is_move_constructible_v<decay_t<_Fn>>,
+                                    is_constructible_v<decay_t<_Args>, _Args>...,
+                                    is_move_constructible_v<decay_t<_Args>>...>::value>>
 // clang-format off
 _CCCL_API constexpr auto __bind_back(_Fn&& __f, _Args&&... __args)
     noexcept(noexcept(__bind_back_t<decay_t<_Fn>, tuple<decay_t<_Args>...>>(::cuda::std::forward<_Fn>(__f), ::cuda::std::forward_as_tuple(::cuda::std::forward<_Args>(__args)...))))

--- a/libcudacxx/include/cuda/std/__functional/function.h
+++ b/libcudacxx/include/cuda/std/__functional/function.h
@@ -408,8 +408,8 @@ public:
     if (__function::__not_null(__f))
     {
       _FunAlloc __af(__a);
-      if (sizeof(_Fun) <= sizeof(__buf_) && is_nothrow_copy_constructible<_Fp>::value
-          && is_nothrow_copy_constructible<_FunAlloc>::value)
+      if (sizeof(_Fun) <= sizeof(__buf_)
+          && is_nothrow_copy_constructible_v<_Fp> && is_nothrow_copy_constructible_v<_FunAlloc>)
       {
         __f_ = ::new ((void*) &__buf_) _Fun(::cuda::std::move(__f), _Alloc(__af));
       }
@@ -423,7 +423,7 @@ public:
     }
   }
 
-  template <class _Fp, class = enable_if_t<!is_same<decay_t<_Fp>, __value_func>::value>>
+  template <class _Fp, class = enable_if_t<!is_same_v<decay_t<_Fp>, __value_func>>>
   _CCCL_API inline explicit __value_func(_Fp&& __f)
       : __value_func(::cuda::std::forward<_Fp>(__f), allocator<_Fp>())
   {}
@@ -598,10 +598,9 @@ union __policy_storage
 // True if _Fun can safely be held in __policy_storage.__small.
 template <typename _Fun>
 struct __use_small_storage
-    : public integral_constant<
-        bool,
-        sizeof(_Fun) <= sizeof(__policy_storage) && alignof(_Fun) <= alignof(__policy_storage)
-          && is_trivially_copy_constructible<_Fun>::value && is_trivially_destructible<_Fun>::value>
+    : public integral_constant<bool,
+                               sizeof(_Fun) <= sizeof(__policy_storage) && alignof(_Fun) <= alignof(__policy_storage)
+                                 && is_trivially_copy_constructible_v<_Fun> && is_trivially_destructible_v<_Fun>>
 {};
 
 // Policy contains information about how to copy, destroy, and move the
@@ -691,7 +690,7 @@ private:
 // Used to choose between perfect forwarding or pass-by-value. Pass-by-value is
 // faster for types that can be passed in registers.
 template <typename _Tp>
-using __fast_forward = conditional_t<is_scalar<_Tp>::value, _Tp, _Tp&&>;
+using __fast_forward = conditional_t<is_scalar_v<_Tp>, _Tp, _Tp&&>;
 
 // __policy_invoker calls an instance of __alloc_func held in __policy_storage.
 
@@ -790,7 +789,7 @@ public:
     }
   }
 
-  template <class _Fp, class = enable_if_t<!is_same<decay_t<_Fp>, __policy_func>::value>>
+  template <class _Fp, class = enable_if_t<!is_same_v<decay_t<_Fp>, __policy_func>>>
   _CCCL_API inline explicit __policy_func(_Fp&& __f)
       : __policy_(__policy::__create_empty())
   {
@@ -997,13 +996,13 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT function<_Rp(_ArgTypes...)>
 
   __func __f_;
 
-  template <class _Fp, bool = _And<_IsNotSame<remove_cvref_t<_Fp>, function>, __invocable<_Fp, _ArgTypes...>>::value>
+  template <class _Fp, bool = !is_same_v<remove_cvref_t<_Fp>, function> && __invocable<_Fp, _ArgTypes...>::value>
   struct __callable;
   template <class _Fp>
   struct __callable<_Fp, true>
   {
     static const bool value =
-      is_void<_Rp>::value || __is_core_convertible<typename __invoke_of<_Fp, _ArgTypes...>::type, _Rp>::value;
+      is_void_v<_Rp> || __is_core_convertible<typename __invoke_of<_Fp, _ArgTypes...>::type, _Rp>::value;
   };
   template <class _Fp>
   struct __callable<_Fp, false>
@@ -1090,7 +1089,7 @@ struct __strip_signature<_Rp (_Gp::*)(_Ap...) const volatile>
 };
 
 template <class _Rp, class _Gp, class... _Ap>
-struct __strip_signature<_Rp (_Gp::*)(_Ap...) &>
+struct __strip_signature<_Rp (_Gp::*)(_Ap...)&>
 {
   using type = _Rp(_Ap...);
 };

--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -594,7 +594,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<long double> : public __scalar_hash<lo
   }
 };
 
-template <class _Tp, bool = is_enum<_Tp>::value>
+template <class _Tp, bool = is_enum_v<_Tp>>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __enum_hash : public __unary_function<_Tp, size_t>
 {
   _CCCL_API inline size_t operator()(_Tp __v) const noexcept
@@ -625,14 +625,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT hash<nullptr_t> : public __unary_function<n
 };
 
 template <class _Key, class _Hash>
-using __check_hash_requirements _CCCL_NODEBUG_ALIAS =
-  integral_constant<bool,
-                    is_copy_constructible<_Hash>::value && is_move_constructible<_Hash>::value
-                      && __invocable_r<size_t, _Hash, _Key const&>::value>;
+using __check_hash_requirements _CCCL_NODEBUG_ALIAS = integral_constant<
+  bool,
+  is_copy_constructible_v<_Hash> && is_move_constructible_v<_Hash> && __invocable_r<size_t, _Hash, _Key const&>::value>;
 
 template <class _Key, class _Hash = hash<_Key>>
 using __has_enabled_hash _CCCL_NODEBUG_ALIAS =
-  integral_constant<bool, __check_hash_requirements<_Key, _Hash>::value && is_default_constructible<_Hash>::value>;
+  integral_constant<bool, __check_hash_requirements<_Key, _Hash>::value && is_default_constructible_v<_Hash>>;
 
 template <class _Type, class>
 using __enable_hash_helper_imp _CCCL_NODEBUG_ALIAS = _Type;

--- a/libcudacxx/include/cuda/std/__functional/identity.h
+++ b/libcudacxx/include/cuda/std/__functional/identity.h
@@ -30,8 +30,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
-struct __is_identity : false_type
-{};
+inline constexpr bool __is_identity_v = false;
 
 struct identity
 {
@@ -45,14 +44,11 @@ struct identity
 };
 
 template <>
-struct __is_identity<identity> : true_type
-{};
+inline constexpr bool __is_identity_v<identity> = true;
 template <>
-struct __is_identity<reference_wrapper<identity>> : true_type
-{};
+inline constexpr bool __is_identity_v<reference_wrapper<identity>> = true;
 template <>
-struct __is_identity<reference_wrapper<const identity>> : true_type
-{};
+inline constexpr bool __is_identity_v<reference_wrapper<const identity>> = true;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__functional/is_transparent.h
+++ b/libcudacxx/include/cuda/std/__functional/is_transparent.h
@@ -29,12 +29,10 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp, class, class = void>
-struct __is_transparent : false_type
-{};
+inline constexpr bool __is_transparent = false;
 
 template <class _Tp, class _Up>
-struct __is_transparent<_Tp, _Up, void_t<typename _Tp::is_transparent>> : true_type
-{};
+inline constexpr bool __is_transparent<_Tp, _Up, void_t<typename _Tp::is_transparent>> = true;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__functional/weak_result_type.h
+++ b/libcudacxx/include/cuda/std/__functional/weak_result_type.h
@@ -31,18 +31,11 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-template <class _Tp>
-struct __has_result_type
-{
-private:
-  template <class _Up>
-  _CCCL_API inline static false_type __test(...);
-  template <class _Up>
-  _CCCL_API inline static true_type __test(typename _Up::result_type* = 0);
+template <class _Tp, class = void>
+inline constexpr bool __has_member_result_type = false;
 
-public:
-  static const bool value = decltype(__test<_Tp>(0))::value;
-};
+template <class _Tp>
+inline constexpr bool __has_member_result_type<_Tp, void_t<typename _Tp::result_type>> = true;
 
 // __weak_result_type
 
@@ -100,7 +93,7 @@ template <class _Tp>
 struct __maybe_derive_from_binary_function<_Tp, false>
 {};
 
-template <class _Tp, bool = __has_result_type<_Tp>::value>
+template <class _Tp, bool = __has_member_result_type<_Tp>>
 struct __weak_result_type_imp // bool is true
     : public __maybe_derive_from_unary_function<_Tp>
     , public __maybe_derive_from_binary_function<_Tp>

--- a/libcudacxx/include/cuda/std/__functional/weak_result_type.h
+++ b/libcudacxx/include/cuda/std/__functional/weak_result_type.h
@@ -53,7 +53,7 @@ private:
   static _CCCL_API inline __unary_function<_Ap, _Rp> __test(const volatile __unary_function<_Ap, _Rp>*);
 
 public:
-  static const bool value = !is_same<decltype(__test((_Tp*) 0)), __two>::value;
+  static const bool value = !is_same_v<decltype(__test((_Tp*) 0)), __two>;
   using type              = decltype(__test((_Tp*) 0));
 };
 
@@ -71,7 +71,7 @@ private:
   static _CCCL_API inline __binary_function<_A1, _A2, _Rp> __test(const volatile __binary_function<_A1, _A2, _Rp>*);
 
 public:
-  static const bool value = !is_same<decltype(__test((_Tp*) 0)), __two>::value;
+  static const bool value = !is_same_v<decltype(__test((_Tp*) 0)), __two>;
   using type              = decltype(__test((_Tp*) 0));
 };
 

--- a/libcudacxx/include/cuda/std/__iterator/advance.h
+++ b/libcudacxx/include/cuda/std/__iterator/advance.h
@@ -37,7 +37,7 @@ _CCCL_EXEC_CHECK_DISABLE
 template <class _InputIter,
           class _Distance,
           class _IntegralDistance = decltype(::cuda::std::__convert_to_integral(::cuda::std::declval<_Distance>())),
-          class                   = enable_if_t<is_integral<_IntegralDistance>::value>>
+          class                   = enable_if_t<is_integral_v<_IntegralDistance>>>
 _CCCL_API constexpr void advance(_InputIter& __i, _Distance __orig_n)
 {
   using _Difference = typename iterator_traits<_InputIter>::difference_type;

--- a/libcudacxx/include/cuda/std/__iterator/bounded_iter.h
+++ b/libcudacxx/include/cuda/std/__iterator/bounded_iter.h
@@ -60,7 +60,7 @@ struct __bounded_iter
   _CCCL_HIDE_FROM_ABI __bounded_iter(__bounded_iter const&) = default;
   _CCCL_HIDE_FROM_ABI __bounded_iter(__bounded_iter&&)      = default;
 
-  template <class _OtherIterator, class = enable_if_t<is_convertible<_OtherIterator, _Iterator>::value>>
+  template <class _OtherIterator, class = enable_if_t<is_convertible_v<_OtherIterator, _Iterator>>>
   _CCCL_API constexpr __bounded_iter(__bounded_iter<_OtherIterator> const& __other) noexcept
       : __current_(__other.__current_)
       , __begin_(__other.__begin_)

--- a/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/incrementable_traits.h
@@ -4,7 +4,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -40,6 +40,18 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
+template <class _Tp, class = void>
+inline constexpr bool __has_member_difference_type = false;
+
+template <class _Tp>
+inline constexpr bool __has_member_difference_type<_Tp, void_t<typename _Tp::difference_type>> = true;
+
+// In C++17 we get issues trying to bind void* to a const& so special case it here
+template <class _Tp>
+_CCCL_CONCEPT __has_integral_minus = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __x, const _Tp& __y)( //
+  requires(!same_as<_Tp, void*>),
+  requires(integral<decltype(__x - __y)>));
+
 #if _CCCL_HAS_CONCEPTS()
 
 // [incrementable.traits]
@@ -58,25 +70,17 @@ template <class _Ip>
 struct incrementable_traits<const _Ip> : incrementable_traits<_Ip>
 {};
 
-template <class _Tp>
-concept __has_member_difference_type = requires { typename _Tp::difference_type; };
-
 template <__has_member_difference_type _Tp>
 struct incrementable_traits<_Tp>
 {
   using difference_type = typename _Tp::difference_type;
 };
 
-template <class _Tp>
-concept __has_integral_minus = requires(const _Tp& __x, const _Tp& __y) {
-  { __x - __y } -> integral;
-};
-
 template <__has_integral_minus _Tp>
   requires(!__has_member_difference_type<_Tp>)
 struct incrementable_traits<_Tp>
 {
-  using difference_type = make_signed_t<decltype(declval<_Tp>() - declval<_Tp>())>;
+  using difference_type = make_signed_t<decltype(::cuda::std::declval<_Tp>() - ::cuda::std::declval<_Tp>())>;
 };
 
 // Let `RI` be `remove_cvref_t<I>`. The type `iter_difference_t<I>` denotes
@@ -103,23 +107,6 @@ template <class _Ip>
 struct incrementable_traits<const _Ip> : incrementable_traits<_Ip>
 {};
 
-template <class _Tp, class = void>
-inline constexpr bool __has_member_difference_type = false;
-
-template <class _Tp>
-inline constexpr bool __has_member_difference_type<_Tp, void_t<typename _Tp::difference_type>> = true;
-
-template <class _Tp, class = void, class = void>
-inline constexpr bool __has_integral_minus = false;
-
-// In C++17 we get issues trying to bind void* to a const& so special case it here
-template <class _Tp>
-inline constexpr bool
-  __has_integral_minus<_Tp,
-                       enable_if_t<!same_as<_Tp, void*>>,
-                       void_t<decltype(::cuda::std::declval<const _Tp&>() - ::cuda::std::declval<const _Tp&>())>> =
-    integral<decltype(::cuda::std::declval<const _Tp&>() - ::cuda::std::declval<const _Tp&>())>;
-
 template <class _Tp>
 struct incrementable_traits<_Tp, enable_if_t<!is_pointer_v<_Tp> && !is_const_v<_Tp> && __has_member_difference_type<_Tp>>>
 {
@@ -131,7 +118,7 @@ struct incrementable_traits<
   _Tp,
   enable_if_t<!is_pointer_v<_Tp> && !is_const_v<_Tp> && !__has_member_difference_type<_Tp> && __has_integral_minus<_Tp>>>
 {
-  using difference_type = make_signed_t<decltype(declval<_Tp>() - declval<_Tp>())>;
+  using difference_type = make_signed_t<decltype(::cuda::std::declval<_Tp>() - ::cuda::std::declval<_Tp>())>;
 };
 
 // Let `RI` be `remove_cvref_t<I>`. The type `iter_difference_t<I>` denotes

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -628,11 +628,11 @@ struct __iterator_traits_member_pointer_or_arrow_or_void<_Ip, enable_if_t<__has_
   using type = typename _Ip::pointer;
 };
 
-template <class _Ip>
-_CCCL_CONCEPT_FRAGMENT(__has_operator_arrow_, requires(_Ip& __i)(__cccl_unused(__i.operator->())));
+template <class _Ip, class = void>
+inline constexpr bool __has_operator_arrow = false;
 
 template <class _Ip>
-_CCCL_CONCEPT __has_operator_arrow = _CCCL_FRAGMENT(__has_operator_arrow_, _Ip);
+inline constexpr bool __has_operator_arrow<_Ip, decltype((void) ::cuda::std::declval<_Ip&>().operator->())> = true;
 
 // Otherwise, if `decltype(declval<I&>().operator->())` is well-formed, then `pointer` names that
 // type.

--- a/libcudacxx/include/cuda/std/__iterator/move_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/move_iterator.h
@@ -411,11 +411,10 @@ public:
 _LIBCUDACXX_CTAD_SUPPORTED_FOR_TYPE(move_iterator);
 _LIBCUDACXX_END_HIDDEN_FRIEND_NAMESPACE(move_iterator)
 
-// Some compilers have issues determining _IsFancyPointer
+// Some compilers have issues determining __is_fancy_pointer
 #if _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC)
 template <class _Iter>
-struct _IsFancyPointer<move_iterator<_Iter>> : _IsFancyPointer<_Iter>
-{};
+inline constexpr bool __is_fancy_pointer<move_iterator<_Iter>> = __is_fancy_pointer<_Iter>;
 #endif // _CCCL_COMPILER(GCC) || _CCCL_COMPILER(MSVC)
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__iterator/readable_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/readable_traits.h
@@ -39,26 +39,31 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-#if _CCCL_HAS_CONCEPTS()
+template <class _Tp, class = void>
+inline constexpr bool __has_member_value_type = false;
 
-// [readable.traits]
-template <class>
+template <class _Tp>
+inline constexpr bool __has_member_value_type<_Tp, void_t<typename _Tp::value_type>> = true;
+
+template <class _Tp, class = void>
+inline constexpr bool __has_member_element_type = false;
+
+template <class _Tp>
+inline constexpr bool __has_member_element_type<_Tp, void_t<typename _Tp::element_type>> = true;
+
+template <class, class = void>
 struct __cond_value_type
 {};
 
 template <class _Tp>
-  requires is_object_v<_Tp>
-struct __cond_value_type<_Tp>
+struct __cond_value_type<_Tp, enable_if_t<is_object_v<_Tp>>>
 {
   using value_type = remove_cv_t<_Tp>;
 };
 
-template <class _Tp>
-concept __has_member_value_type = requires { typename _Tp::value_type; };
+#if _CCCL_HAS_CONCEPTS()
 
-template <class _Tp>
-concept __has_member_element_type = requires { typename _Tp::element_type; };
-
+// [readable.traits]
 template <class>
 struct indirectly_readable_traits
 {};
@@ -97,38 +102,9 @@ template <__has_member_value_type _Tp>
 struct indirectly_readable_traits<_Tp> : __cond_value_type<typename _Tp::value_type>
 {};
 
-// Let `RI` be `remove_cvref_t<I>`. The type `iter_value_t<I>` denotes
-// `indirectly_readable_traits<RI>::value_type` if `iterator_traits<RI>` names a specialization
-// generated from the primary template, and `iterator_traits<RI>::value_type` otherwise.
-template <class _Ip>
-using iter_value_t =
-  typename __select_traits<remove_cvref_t<_Ip>, indirectly_readable_traits<remove_cvref_t<_Ip>>>::value_type;
-
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 
 // [readable.traits]
-template <class, class = void>
-struct __cond_value_type
-{};
-
-template <class _Tp>
-struct __cond_value_type<_Tp, enable_if_t<is_object_v<_Tp>>>
-{
-  using value_type = remove_cv_t<_Tp>;
-};
-
-template <class _Tp, class = void>
-inline constexpr bool __has_member_value_type = false;
-
-template <class _Tp>
-inline constexpr bool __has_member_value_type<_Tp, void_t<typename _Tp::value_type>> = true;
-
-template <class _Tp, class = void>
-inline constexpr bool __has_member_element_type = false;
-
-template <class _Tp>
-inline constexpr bool __has_member_element_type<_Tp, void_t<typename _Tp::element_type>> = true;
-
 template <class, class = void>
 struct indirectly_readable_traits
 {};
@@ -169,14 +145,14 @@ struct indirectly_readable_traits<
     : __cond_value_type<typename _Tp::value_type>
 {};
 
+#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
+
 // Let `RI` be `remove_cvref_t<I>`. The type `iter_value_t<I>` denotes
 // `indirectly_readable_traits<RI>::value_type` if `iterator_traits<RI>` names a specialization
 // generated from the primary template, and `iterator_traits<RI>::value_type` otherwise.
 template <class _Ip>
 using iter_value_t =
   typename __select_traits<remove_cvref_t<_Ip>, indirectly_readable_traits<remove_cvref_t<_Ip>>>::value_type;
-
-#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__iterator/wrap_iter.h
+++ b/libcudacxx/include/cuda/std/__iterator/wrap_iter.h
@@ -53,9 +53,8 @@ public:
       : __i_()
   {}
   template <class _Up>
-  _CCCL_API constexpr __wrap_iter(
-    const __wrap_iter<_Up>& __u,
-    typename enable_if<is_convertible<_Up, iterator_type>::value>::type* = nullptr) noexcept
+  _CCCL_API constexpr __wrap_iter(const __wrap_iter<_Up>& __u,
+                                  typename enable_if<is_convertible_v<_Up, iterator_type>>::type* = nullptr) noexcept
       : __i_(__u.base())
   {}
   _CCCL_API constexpr reference operator*() const noexcept

--- a/libcudacxx/include/cuda/std/__mdspan/concepts.h
+++ b/libcudacxx/include/cuda/std/__mdspan/concepts.h
@@ -57,12 +57,8 @@ namespace __mdspan_detail
 {
 
 // [mdspan.layout.stride.expo]/3
-template <class>
-struct __is_extents : false_type
-{};
-
 template <class _Tp>
-inline constexpr bool __is_extents_v = __is_extents<_Tp>::value;
+inline constexpr bool __is_extents_v = false;
 
 // [mdspan.layout.general]/2
 template <class _Layout, class _Mapping>

--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -687,8 +687,7 @@ namespace __mdspan_detail
 {
 
 template <class _IndexType, size_t... _ExtentsPack>
-struct __is_extents<extents<_IndexType, _ExtentsPack...>> : true_type
-{};
+inline constexpr bool __is_extents_v<extents<_IndexType, _ExtentsPack...>> = true;
 
 // Function to check whether a set of indices are a multidimensional
 // index into extents. This is a word of power in the C++ standard

--- a/libcudacxx/include/cuda/std/__mdspan/layout_left.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_left.h
@@ -50,7 +50,7 @@ template <class _Extents>
 class layout_left::mapping : private __mdspan_ebco<_Extents>
 {
 public:
-  static_assert(__mdspan_detail::__is_extents<_Extents>::value,
+  static_assert(__mdspan_detail::__is_extents_v<_Extents>,
                 "layout_left::mapping template argument must be a specialization of extents.");
 
   using extents_type = _Extents;

--- a/libcudacxx/include/cuda/std/__mdspan/layout_right.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_right.h
@@ -50,7 +50,7 @@ template <class _Extents>
 class layout_right::mapping : private __mdspan_ebco<_Extents>
 {
 public:
-  static_assert(__mdspan_detail::__is_extents<_Extents>::value,
+  static_assert(__mdspan_detail::__is_extents_v<_Extents>,
                 "layout_right::mapping template argument must be a specialization of extents.");
 
   using extents_type = _Extents;

--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -76,7 +76,7 @@ class layout_stride::mapping
                             __mdspan_detail::__possibly_empty_array<typename _Extents::index_type, _Extents::rank()>>
 {
 public:
-  static_assert(__mdspan_detail::__is_extents<_Extents>::value,
+  static_assert(__mdspan_detail::__is_extents_v<_Extents>,
                 "layout_stride::mapping template argument must be a specialization of extents.");
 
   using extents_type = _Extents;

--- a/libcudacxx/include/cuda/std/__memory/allocator_arg_t.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_arg_t.h
@@ -46,7 +46,7 @@ struct __uses_alloc_ctor_imp
 {
   using _RawAlloc _CCCL_NODEBUG_ALIAS = remove_cvref_t<_Alloc>;
   static const bool __ua              = uses_allocator<_Tp, _RawAlloc>::value;
-  static const bool __ic              = is_constructible<_Tp, allocator_arg_t, _Alloc, _Args...>::value;
+  static const bool __ic              = is_constructible_v<_Tp, allocator_arg_t, _Alloc, _Args...>;
   static const int value              = __ua ? 2 - __ic : 0;
 };
 

--- a/libcudacxx/include/cuda/std/__memory/allocator_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_traits.h
@@ -22,6 +22,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__fwd/allocator.h>
 #include <cuda/std/__memory/construct_at.h>
 #include <cuda/std/__memory/pointer_traits.h>
@@ -174,18 +175,17 @@ struct __is_always_equal<_Alloc, true>
 };
 
 // __allocator_traits_rebind
-_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <class _Tp, class _Up, class = void>
-struct __has_rebind_other : false_type
-{};
-template <class _Tp, class _Up>
-struct __has_rebind_other<_Tp, _Up, void_t<typename _Tp::template rebind<_Up>::other>> : true_type
-{};
+inline constexpr bool __has_member_rebind_other = false;
 
-template <class _Tp, class _Up, bool = __has_rebind_other<_Tp, _Up>::value>
+template <class _Tp, class _Up>
+inline constexpr bool __has_member_rebind_other<_Tp, _Up, void_t<typename _Tp::template rebind<_Up>::other>> = true;
+
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+template <class _Tp, class _Up, bool = __has_member_rebind_other<_Tp, _Up>>
 struct __allocator_traits_rebind
 {
-  static_assert(__has_rebind_other<_Tp, _Up>::value, "This allocator has to implement rebind");
+  static_assert(__has_member_rebind_other<_Tp, _Up>, "This allocator has to implement rebind");
   using type _CCCL_NODEBUG_ALIAS = typename _Tp::template rebind<_Up>::other;
 };
 template <template <class, class...> class _Alloc, class _Tp, class... _Args, class _Up>
@@ -204,63 +204,48 @@ using __allocator_traits_rebind_t = typename __allocator_traits_rebind<_Alloc, _
 
 // __has_allocate_hint
 template <class _Alloc, class _SizeType, class _ConstVoidPtr, class = void>
-struct __has_allocate_hint : false_type
-{};
+inline constexpr bool __has_allocate_hint = false;
 
 template <class _Alloc, class _SizeType, class _ConstVoidPtr>
-struct __has_allocate_hint<_Alloc,
-                           _SizeType,
-                           _ConstVoidPtr,
-                           decltype((void) ::cuda::std::declval<_Alloc>().allocate(
-                             ::cuda::std::declval<_SizeType>(), ::cuda::std::declval<_ConstVoidPtr>()))> : true_type
-{};
+inline constexpr bool __has_allocate_hint<
+  _Alloc,
+  _SizeType,
+  _ConstVoidPtr,
+  void_t<decltype((void) ::cuda::std::declval<_Alloc>().allocate(
+    ::cuda::std::declval<_SizeType>(), ::cuda::std::declval<_ConstVoidPtr>()))>> = true;
 
 // __has_construct
-template <class, class _Alloc, class... _Args>
-struct __has_construct_impl : false_type
-{};
-
 template <class _Alloc, class... _Args>
-struct __has_construct_impl<decltype((void) ::cuda::std::declval<_Alloc>().construct(::cuda::std::declval<_Args>()...)),
-                            _Alloc,
-                            _Args...> : true_type
-{};
-
-template <class _Alloc, class... _Args>
-struct __has_construct : __has_construct_impl<void, _Alloc, _Args...>
-{};
+_CCCL_CONCEPT __has_construct = _CCCL_REQUIRES_EXPR((_Alloc, variadic _Args), _Alloc __alloc, _Args&&... __args) //
+  ((__alloc.construct(::cuda::std::forward<_Args>(__args)...)));
 
 // __has_destroy
 template <class _Alloc, class _Pointer, class = void>
-struct __has_destroy : false_type
-{};
+inline constexpr bool __has_destroy = false;
 
 template <class _Alloc, class _Pointer>
-struct __has_destroy<_Alloc,
-                     _Pointer,
-                     decltype((void) ::cuda::std::declval<_Alloc>().destroy(::cuda::std::declval<_Pointer>()))>
-    : true_type
-{};
+inline constexpr bool
+  __has_destroy<_Alloc,
+                _Pointer,
+                void_t<decltype((void) ::cuda::std::declval<_Alloc>().destroy(::cuda::std::declval<_Pointer>()))>> =
+    true;
 
 // __has_max_size
 template <class _Alloc, class = void>
-struct __has_max_size : false_type
-{};
+inline constexpr bool __has_max_size = false;
 
 template <class _Alloc>
-struct __has_max_size<_Alloc, decltype((void) ::cuda::std::declval<_Alloc&>().max_size())> : true_type
-{};
+inline constexpr bool __has_max_size<_Alloc, void_t<decltype((void) ::cuda::std::declval<_Alloc&>().max_size())>> =
+  true;
 
 // __has_select_on_container_copy_construction
 template <class _Alloc, class = void>
-struct __has_select_on_container_copy_construction : false_type
-{};
+inline constexpr bool __has_select_on_container_copy_construction = false;
 
 template <class _Alloc>
-struct __has_select_on_container_copy_construction<
+inline constexpr bool __has_select_on_container_copy_construction<
   _Alloc,
-  decltype((void) ::cuda::std::declval<_Alloc>().select_on_container_copy_construction())> : true_type
-{};
+  void_t<decltype((void) ::cuda::std::declval<_Alloc>().select_on_container_copy_construction())>> = true;
 
 template <class _Tp>
 _CCCL_API constexpr _Tp* __to_raw_pointer(_Tp* __p) noexcept
@@ -291,40 +276,32 @@ _CCCL_API inline auto __to_raw_pointer(const _Pointer& __p, _None...) noexcept
 
 // __is_default_allocator
 template <class _Tp>
-struct __is_default_allocator : false_type
-{};
+inline constexpr bool __is_default_allocator = false;
 
 template <class _Tp>
-struct __is_default_allocator<allocator<_Tp>> : true_type
-{};
+inline constexpr bool __is_default_allocator<allocator<_Tp>> = true;
+
 // __is_cpp17_move_insertable
 template <class _Alloc, class = void>
-struct __is_cpp17_move_insertable : is_move_constructible<typename _Alloc::value_type>
-{};
+inline constexpr bool __is_cpp17_move_insertable = is_move_constructible_v<typename _Alloc::value_type>;
 
 template <class _Alloc>
-struct __is_cpp17_move_insertable<
+inline constexpr bool __is_cpp17_move_insertable<
   _Alloc,
-  enable_if_t<!__is_default_allocator<_Alloc>::value
-              && __has_construct<_Alloc, typename _Alloc::value_type*, typename _Alloc::value_type&&>::value>>
-    : true_type
-{};
+  enable_if_t<__is_default_allocator<_Alloc>
+              && __has_construct<_Alloc, typename _Alloc::value_type*, typename _Alloc::value_type&&>>> = true;
 
 // __is_cpp17_copy_insertable
 template <class _Alloc, class = void>
-struct __is_cpp17_copy_insertable
-    : integral_constant<bool,
-                        is_copy_constructible<typename _Alloc::value_type>::value
-                          && __is_cpp17_move_insertable<_Alloc>::value>
-{};
+inline constexpr bool __is_cpp17_copy_insertable =
+  is_copy_constructible_v<typename _Alloc::value_type> && __is_cpp17_move_insertable<_Alloc>;
 
 template <class _Alloc>
-struct __is_cpp17_copy_insertable<
+inline constexpr bool __is_cpp17_copy_insertable<
   _Alloc,
-  enable_if_t<!__is_default_allocator<_Alloc>::value
-              && __has_construct<_Alloc, typename _Alloc::value_type*, const typename _Alloc::value_type&>::value>>
-    : __is_cpp17_move_insertable<_Alloc>
-{};
+  enable_if_t<!__is_default_allocator<_Alloc>
+              && __has_construct<_Alloc, typename _Alloc::value_type*, const typename _Alloc::value_type&>>> =
+  __is_cpp17_move_insertable<_Alloc>;
 
 template <class _Alloc>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
@@ -354,15 +331,15 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
     return __a.allocate(__n);
   }
 
-  template <class _Ap = _Alloc, enable_if_t<__has_allocate_hint<_Ap, size_type, const_void_pointer>::value, int> = 0>
+  template <class _Ap = _Alloc, enable_if_t<__has_allocate_hint<_Ap, size_type, const_void_pointer>, int> = 0>
   [[nodiscard]] _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static pointer
   allocate(allocator_type& __a, size_type __n, const_void_pointer __hint)
   {
     return __a.allocate(__n, __hint);
   }
-  template <class _Ap                                                                         = _Alloc,
-            class                                                                             = void,
-            enable_if_t<!__has_allocate_hint<_Ap, size_type, const_void_pointer>::value, int> = 0>
+  template <class _Ap                                                                  = _Alloc,
+            class                                                                      = void,
+            enable_if_t<!__has_allocate_hint<_Ap, size_type, const_void_pointer>, int> = 0>
   [[nodiscard]] _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static pointer
   allocate(allocator_type& __a, size_type __n, const_void_pointer)
   {
@@ -374,15 +351,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
     __a.deallocate(__p, __n);
   }
 
-  template <class _Tp, class... _Args, enable_if_t<__has_construct<allocator_type, _Tp*, _Args...>::value, int> = 0>
+  template <class _Tp, class... _Args, enable_if_t<__has_construct<allocator_type, _Tp*, _Args...>, int> = 0>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static void construct(allocator_type& __a, _Tp* __p, _Args&&... __args)
   {
     __a.construct(__p, ::cuda::std::forward<_Args>(__args)...);
   }
-  template <class _Tp,
-            class... _Args,
-            class                                                                     = void,
-            enable_if_t<!__has_construct<allocator_type, _Tp*, _Args...>::value, int> = 0>
+  template <class _Tp, class... _Args, class = void, enable_if_t<!__has_construct<allocator_type, _Tp*, _Args...>, int> = 0>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static void construct(allocator_type&, _Tp* __p, _Args&&... __args)
   {
 #if _CCCL_STD_VER >= 2020
@@ -392,12 +366,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
 #endif
   }
 
-  template <class _Tp, enable_if_t<__has_destroy<allocator_type, _Tp*>::value, int> = 0>
+  template <class _Tp, enable_if_t<__has_destroy<allocator_type, _Tp*>, int> = 0>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static void destroy(allocator_type& __a, _Tp* __p) noexcept
   {
     __a.destroy(__p);
   }
-  template <class _Tp, class = void, enable_if_t<!__has_destroy<allocator_type, _Tp*>::value, int> = 0>
+  template <class _Tp, class = void, enable_if_t<!__has_destroy<allocator_type, _Tp*>, int> = 0>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static void destroy(allocator_type&, _Tp* __p) noexcept
   {
 #if _CCCL_STD_VER >= 2020
@@ -407,26 +381,26 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
 #endif
   }
 
-  template <class _Ap = _Alloc, enable_if_t<__has_max_size<const _Ap>::value, int> = 0>
+  template <class _Ap = _Alloc, enable_if_t<__has_max_size<const _Ap>, int> = 0>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static size_type max_size(const allocator_type& __a) noexcept
   {
     return __a.max_size();
   }
-  template <class _Ap = _Alloc, class = void, enable_if_t<!__has_max_size<const _Ap>::value, int> = 0>
+  template <class _Ap = _Alloc, class = void, enable_if_t<!__has_max_size<const _Ap>, int> = 0>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static size_type max_size(const allocator_type&) noexcept
   {
     return numeric_limits<size_type>::max() / sizeof(value_type);
   }
 
-  template <class _Ap = _Alloc, enable_if_t<__has_select_on_container_copy_construction<const _Ap>::value, int> = 0>
+  template <class _Ap = _Alloc, enable_if_t<__has_select_on_container_copy_construction<const _Ap>, int> = 0>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static allocator_type
   select_on_container_copy_construction(const allocator_type& __a)
   {
     return __a.select_on_container_copy_construction();
   }
-  template <class _Ap                                                                        = _Alloc,
-            class                                                                            = void,
-            enable_if_t<!__has_select_on_container_copy_construction<const _Ap>::value, int> = 0>
+  template <class _Ap                                                                 = _Alloc,
+            class                                                                     = void,
+            enable_if_t<!__has_select_on_container_copy_construction<const _Ap>, int> = 0>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static allocator_type
   select_on_container_copy_construction(const allocator_type& __a)
   {
@@ -437,7 +411,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
   _CCCL_API inline static void
   __construct_forward_with_exception_guarantees(allocator_type& __a, _Ptr __begin1, _Ptr __end1, _Ptr& __begin2)
   {
-    static_assert(__is_cpp17_move_insertable<allocator_type>::value,
+    static_assert(__is_cpp17_move_insertable<allocator_type>,
                   "The specified type does not meet the requirements of Cpp17MoveInsertible");
     for (; __begin1 != __end1; ++__begin1, (void) ++__begin2)
     {
@@ -454,8 +428,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
 
   template <class _Tp>
   _CCCL_API inline static enable_if_t<
-    (__is_default_allocator<allocator_type>::value || !__has_construct<allocator_type, _Tp*, _Tp>::value)
-      && is_trivially_move_constructible<_Tp>::value,
+    (__is_default_allocator<allocator_type> || !__has_construct<allocator_type, _Tp*, _Tp>)
+      && is_trivially_move_constructible_v<_Tp>,
     void>
   __construct_forward_with_exception_guarantees(allocator_type&, _Tp* __begin1, _Tp* __end1, _Tp*& __begin2)
   {
@@ -482,8 +456,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
             class _RawSourceTp = remove_const_t<_SourceTp>,
             class _RawDestTp   = remove_const_t<_DestTp>>
   _CCCL_API inline static enable_if_t<
-    is_trivially_move_constructible<_DestTp>::value && is_same<_RawSourceTp, _RawDestTp>::value
-      && (__is_default_allocator<allocator_type>::value || !__has_construct<allocator_type, _DestTp*, _SourceTp&>::value),
+    is_trivially_move_constructible_v<_DestTp> && is_same_v<_RawSourceTp, _RawDestTp>
+      && (__is_default_allocator<allocator_type> || !__has_construct<allocator_type, _DestTp*, _SourceTp&>),
     void>
   __construct_range_forward(allocator_type&, _SourceTp* __begin1, _SourceTp* __end1, _DestTp*& __begin2)
   {
@@ -499,7 +473,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
   _CCCL_API inline static void
   __construct_backward_with_exception_guarantees(allocator_type& __a, _Ptr __begin1, _Ptr __end1, _Ptr& __end2)
   {
-    static_assert(__is_cpp17_move_insertable<allocator_type>::value,
+    static_assert(__is_cpp17_move_insertable<allocator_type>,
                   "The specified type does not meet the requirements of Cpp17MoveInsertable");
     while (__end1 != __begin1)
     {
@@ -517,8 +491,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT allocator_traits
 
   template <class _Tp>
   _CCCL_API inline static enable_if_t<
-    (__is_default_allocator<allocator_type>::value || !__has_construct<allocator_type, _Tp*, _Tp>::value)
-      && is_trivially_move_constructible<_Tp>::value,
+    (__is_default_allocator<allocator_type> || !__has_construct<allocator_type, _Tp*, _Tp>)
+      && is_trivially_move_constructible_v<_Tp>,
     void>
   __construct_backward_with_exception_guarantees(allocator_type&, _Tp* __begin1, _Tp* __end1, _Tp*& __end2)
   {

--- a/libcudacxx/include/cuda/std/__memory/compressed_pair.h
+++ b/libcudacxx/include/cuda/std/__memory/compressed_pair.h
@@ -203,7 +203,7 @@ public:
   }
 
   _CCCL_API constexpr void
-  swap(__compressed_pair& __x) noexcept(__is_nothrow_swappable<_T1>::value && __is_nothrow_swappable<_T2>::value)
+  swap(__compressed_pair& __x) noexcept(is_nothrow_swappable_v<_T1> && is_nothrow_swappable_v<_T2>)
   {
     using ::cuda::std::swap;
     swap(first(), __x.first());
@@ -213,7 +213,7 @@ public:
 
 template <class _T1, class _T2>
 _CCCL_API constexpr void swap(__compressed_pair<_T1, _T2>& __x, __compressed_pair<_T1, _T2>& __y) noexcept(
-  __is_nothrow_swappable<_T1>::value && __is_nothrow_swappable<_T2>::value)
+  is_nothrow_swappable_v<_T1> && is_nothrow_swappable_v<_T2>)
 {
   __x.swap(__y);
 }

--- a/libcudacxx/include/cuda/std/__memory/destruct_n.h
+++ b/libcudacxx/include/cuda/std/__memory/destruct_n.h
@@ -68,19 +68,19 @@ public:
   template <class _Tp>
   _CCCL_API inline void __incr() noexcept
   {
-    __incr(integral_constant<bool, is_trivially_destructible<_Tp>::value>());
+    __incr(integral_constant<bool, is_trivially_destructible_v<_Tp>>());
   }
 
   template <class _Tp>
   _CCCL_API inline void __set(size_t __s, _Tp*) noexcept
   {
-    __set(__s, integral_constant<bool, is_trivially_destructible<_Tp>::value>());
+    __set(__s, integral_constant<bool, is_trivially_destructible_v<_Tp>>());
   }
 
   template <class _Tp>
   _CCCL_API inline void operator()(_Tp* __p) noexcept
   {
-    __process(__p, integral_constant<bool, is_trivially_destructible<_Tp>::value>());
+    __process(__p, integral_constant<bool, is_trivially_destructible_v<_Tp>>());
   }
 };
 

--- a/libcudacxx/include/cuda/std/__memory/pointer_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/pointer_traits.h
@@ -4,6 +4,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -38,14 +39,12 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp, class = void>
-struct __has_element_type : false_type
-{};
+inline constexpr bool __has_element_type = false;
 
 template <class _Tp>
-struct __has_element_type<_Tp, void_t<typename _Tp::element_type>> : true_type
-{};
+inline constexpr bool __has_element_type<_Tp, void_t<typename _Tp::element_type>> = true;
 
-template <class _Ptr, bool = __has_element_type<_Ptr>::value>
+template <class _Ptr, bool = __has_element_type<_Ptr>>
 struct __pointer_traits_element_type;
 
 template <class _Ptr>
@@ -67,14 +66,12 @@ struct __pointer_traits_element_type<_Sp<_Tp, _Args...>, false>
 };
 
 template <class _Tp, class = void>
-struct __has_difference_type : false_type
-{};
+inline constexpr bool __has_difference_type = false;
 
 template <class _Tp>
-struct __has_difference_type<_Tp, void_t<typename _Tp::difference_type>> : true_type
-{};
+inline constexpr bool __has_difference_type<_Tp, void_t<typename _Tp::difference_type>> = true;
 
-template <class _Ptr, bool = __has_difference_type<_Ptr>::value>
+template <class _Ptr, bool = __has_difference_type<_Ptr>>
 struct __pointer_traits_difference_type
 {
   using type _CCCL_NODEBUG_ALIAS = ptrdiff_t;
@@ -86,22 +83,13 @@ struct __pointer_traits_difference_type<_Ptr, true>
   using type _CCCL_NODEBUG_ALIAS = typename _Ptr::difference_type;
 };
 
-_CCCL_SUPPRESS_DEPRECATED_PUSH
+template <class _Tp, class _Up, class = void>
+inline constexpr bool __has_rebind = false;
+
 template <class _Tp, class _Up>
-struct __has_rebind
-{
-private:
-  template <class _Xp>
-  _CCCL_API inline static false_type __test(...);
-  template <class _Xp>
-  _CCCL_API inline static true_type __test(typename _Xp::template rebind<_Up>* = 0);
+inline constexpr bool __has_rebind<_Tp, _Up, void_t<typename _Tp::template rebind<_Up>>> = true;
 
-public:
-  static const bool value = decltype(__test<_Tp>(0))::value;
-};
-_CCCL_SUPPRESS_DEPRECATED_POP
-
-template <class _Tp, class _Up, bool = __has_rebind<_Tp, _Up>::value>
+template <class _Tp, class _Up, bool = __has_rebind<_Tp, _Up>>
 struct __pointer_traits_rebind
 {
   using type _CCCL_NODEBUG_ALIAS = typename _Tp::template rebind<_Up>;
@@ -190,31 +178,27 @@ _CCCL_API constexpr _Tp* __to_address(_Tp* __p) noexcept
 }
 
 template <class _Pointer, class = void>
-struct _HasToAddress : false_type
-{};
+inline constexpr bool __has_toaddress = false;
 
 template <class _Pointer>
-struct _HasToAddress<_Pointer, decltype((void) pointer_traits<_Pointer>::to_address(declval<const _Pointer&>()))>
-    : true_type
-{};
+inline constexpr bool
+  __has_toaddress<_Pointer,
+                  decltype((void) pointer_traits<_Pointer>::to_address(::cuda::std::declval<const _Pointer&>()))> =
+    true;
 
 template <class _Pointer, class = void>
-struct _HasArrow : false_type
-{};
+inline constexpr bool __has_const_operator_arrow = false;
 
 template <class _Pointer>
-struct _HasArrow<_Pointer, decltype((void) declval<const _Pointer&>().operator->())> : true_type
-{};
+inline constexpr bool
+  __has_const_operator_arrow<_Pointer, decltype((void) ::cuda::std::declval<const _Pointer&>().operator->())> = true;
 
 template <class _Pointer>
-struct _IsFancyPointer
-{
-  static const bool value = _HasArrow<_Pointer>::value || _HasToAddress<_Pointer>::value;
-};
+inline constexpr bool __is_fancy_pointer = __has_const_operator_arrow<_Pointer> || __has_toaddress<_Pointer>;
 
 // enable_if is needed here to avoid instantiating checks for fancy pointers on raw pointers
-template <class _Pointer, class = enable_if_t<_And<is_class<_Pointer>, _IsFancyPointer<_Pointer>>::value>>
-_CCCL_API constexpr decay_t<decltype(__to_address_helper<_Pointer>::__call(declval<const _Pointer&>()))>
+template <class _Pointer, class = enable_if_t<is_class_v<_Pointer>>, class = enable_if_t<__is_fancy_pointer<_Pointer>>>
+_CCCL_API constexpr decay_t<decltype(__to_address_helper<_Pointer>::__call(::cuda::std::declval<const _Pointer&>()))>
 __to_address(const _Pointer& __p) noexcept
 {
   return __to_address_helper<_Pointer>::__call(__p);
@@ -224,7 +208,7 @@ template <class _Pointer, class>
 struct __to_address_helper
 {
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr static decltype(::cuda::std::__to_address(declval<const _Pointer&>().operator->()))
+  _CCCL_API constexpr static decltype(::cuda::std::__to_address(::cuda::std::declval<const _Pointer&>().operator->()))
   __call(const _Pointer& __p) noexcept
   {
     return ::cuda::std::__to_address(__p.operator->());
@@ -232,10 +216,11 @@ struct __to_address_helper
 };
 
 template <class _Pointer>
-struct __to_address_helper<_Pointer, decltype((void) pointer_traits<_Pointer>::to_address(declval<const _Pointer&>()))>
+struct __to_address_helper<_Pointer,
+                           decltype((void) pointer_traits<_Pointer>::to_address(::cuda::std::declval<const _Pointer&>()))>
 {
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API constexpr static decltype(pointer_traits<_Pointer>::to_address(declval<const _Pointer&>()))
+  _CCCL_API constexpr static decltype(pointer_traits<_Pointer>::to_address(::cuda::std::declval<const _Pointer&>()))
   __call(const _Pointer& __p) noexcept
   {
     return pointer_traits<_Pointer>::to_address(__p);

--- a/libcudacxx/include/cuda/std/__memory/pointer_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/pointer_traits.h
@@ -127,7 +127,7 @@ private:
 
 public:
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static pointer
-  pointer_to(conditional_t<is_void<element_type>::value, __nat, element_type>& __r)
+  pointer_to(conditional_t<is_void_v<element_type>, __nat, element_type>& __r)
   {
     return pointer::pointer_to(__r);
   }
@@ -153,7 +153,7 @@ private:
 
 public:
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 static pointer
-  pointer_to(conditional_t<is_void<element_type>::value, __nat, element_type>& __r) noexcept
+  pointer_to(conditional_t<is_void_v<element_type>, __nat, element_type>& __r) noexcept
   {
     return ::cuda::std::addressof(__r);
   }
@@ -173,7 +173,7 @@ struct __to_address_helper;
 template <class _Tp>
 _CCCL_API constexpr _Tp* __to_address(_Tp* __p) noexcept
 {
-  static_assert(!is_function<_Tp>::value, "_Tp is a function type");
+  static_assert(!is_function_v<_Tp>, "_Tp is a function type");
   return __p;
 }
 

--- a/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
+++ b/libcudacxx/include/cuda/std/__memory/uninitialized_algorithms.h
@@ -566,12 +566,10 @@ __uninitialized_allocator_copy_impl(_Alloc& __alloc, _Iter1 __first1, _Sent1 __l
 }
 
 template <class _Alloc, class _Type>
-struct __allocator_has_trivial_copy_construct : _Not<__has_construct<_Alloc, _Type*, const _Type&>>
-{};
+inline constexpr bool __allocator_has_trivial_copy_construct = !__has_construct<_Alloc, _Type*, const _Type&>;
 
 template <class _Type>
-struct __allocator_has_trivial_copy_construct<allocator<_Type>, _Type> : true_type
-{};
+inline constexpr bool __allocator_has_trivial_copy_construct<allocator<_Type>, _Type> = true;
 
 template <class _Alloc,
           class _In,
@@ -581,7 +579,7 @@ template <class _Alloc,
             // using _RawTypeIn because of the allocator<T const> extension
             is_trivially_copy_constructible_v<_RawTypeIn> && is_trivially_copy_assignable_v<_RawTypeIn>
             && is_same_v<remove_const_t<_In>, remove_const_t<_Out>>
-            && __allocator_has_trivial_copy_construct<_Alloc, _RawTypeIn>::value>* = nullptr>
+            && __allocator_has_trivial_copy_construct<_Alloc, _RawTypeIn>>* = nullptr>
 _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _Out*
 __uninitialized_allocator_copy_impl(_Alloc&, _In* __first1, _In* __last1, _Out* __first2)
 {
@@ -620,7 +618,7 @@ template <class _Alloc, class _Iter1, class _Sent1, class _Iter2>
 _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _Iter2
 __uninitialized_allocator_move_if_noexcept(_Alloc& __alloc, _Iter1 __first1, _Sent1 __last1, _Iter2 __first2)
 {
-  static_assert(__is_cpp17_move_insertable<_Alloc>::value,
+  static_assert(__is_cpp17_move_insertable<_Alloc>,
                 "The specified type does not meet the requirements of Cpp17MoveInsertable");
   auto __destruct_first = __first2;
   auto __guard          = ::cuda::std::__make_exception_guard(
@@ -641,12 +639,10 @@ __uninitialized_allocator_move_if_noexcept(_Alloc& __alloc, _Iter1 __first1, _Se
 }
 
 template <class _Alloc, class _Type>
-struct __allocator_has_trivial_move_construct : _Not<__has_construct<_Alloc, _Type*, _Type&&>>
-{};
+inline constexpr bool __allocator_has_trivial_move_construct = !__has_construct<_Alloc, _Type*, _Type&&>;
 
 template <class _Type>
-struct __allocator_has_trivial_move_construct<allocator<_Type>, _Type> : true_type
-{};
+inline constexpr bool __allocator_has_trivial_move_construct<allocator<_Type>, _Type> = true;
 
 #if !_CCCL_COMPILER(GCC)
 template <class _Alloc,
@@ -654,7 +650,7 @@ template <class _Alloc,
           class _Iter2,
           class _Type = typename iterator_traits<_Iter1>::value_type,
           class       = enable_if_t<is_trivially_move_constructible_v<_Type> && is_trivially_move_assignable_v<_Type>
-                                    && __allocator_has_trivial_move_construct<_Alloc, _Type>::value>>
+                                    && __allocator_has_trivial_move_construct<_Alloc, _Type>>>
 _CCCL_API inline _CCCL_CONSTEXPR_CXX20 _Iter2
 __uninitialized_allocator_move_if_noexcept(_Alloc&, _Iter1 __first1, _Iter1 __last1, _Iter2 __first2)
 {

--- a/libcudacxx/include/cuda/std/__memory/unique_ptr.h
+++ b/libcudacxx/include/cuda/std/__memory/unique_ptr.h
@@ -514,7 +514,7 @@ public:
 };
 
 template <class _Tp, class _Dp>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<__is_swappable<_Dp>::value, void>
+_CCCL_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<is_nothrow_swappable_v<_Dp>, void>
 swap(unique_ptr<_Tp, _Dp>& __x, unique_ptr<_Tp, _Dp>& __y) noexcept
 {
   __x.swap(__y);

--- a/libcudacxx/include/cuda/std/__memory/unique_ptr.h
+++ b/libcudacxx/include/cuda/std/__memory/unique_ptr.h
@@ -72,7 +72,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_delete
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void operator()(_Tp* __ptr) const noexcept
   {
     static_assert(sizeof(_Tp) >= 0, "cannot delete an incomplete type");
-    static_assert(!is_void<_Tp>::value, "cannot delete an incomplete type");
+    static_assert(!is_void_v<_Tp>, "cannot delete an incomplete type");
     delete __ptr;
   }
 };
@@ -159,23 +159,22 @@ private:
 
   template <bool _Dummy, class _Deleter = typename __dependent_type<type_identity<deleter_type>, _Dummy>::type>
   using _EnableIfDeleterDefaultConstructible _CCCL_NODEBUG_ALIAS =
-    typename enable_if<is_default_constructible<_Deleter>::value && !is_pointer<_Deleter>::value>::type;
+    typename enable_if<is_default_constructible_v<_Deleter> && !is_pointer_v<_Deleter>>::type;
 
   template <class _ArgType>
   using _EnableIfDeleterConstructible _CCCL_NODEBUG_ALIAS =
-    typename enable_if<is_constructible<deleter_type, _ArgType>::value>::type;
+    typename enable_if<is_constructible_v<deleter_type, _ArgType>>::type;
 
   template <class _UPtr, class _Up>
   using _EnableIfMoveConvertible _CCCL_NODEBUG_ALIAS =
-    typename enable_if<is_convertible<typename _UPtr::pointer, pointer>::value && !is_array<_Up>::value>::type;
+    typename enable_if<is_convertible_v<typename _UPtr::pointer, pointer> && !is_array_v<_Up>>::type;
 
   template <class _UDel>
-  using _EnableIfDeleterConvertible _CCCL_NODEBUG_ALIAS =
-    typename enable_if<(is_reference<_Dp>::value && is_same<_Dp, _UDel>::value)
-                       || (!is_reference<_Dp>::value && is_convertible<_UDel, _Dp>::value)>::type;
+  using _EnableIfDeleterConvertible _CCCL_NODEBUG_ALIAS = typename enable_if<
+    (is_reference_v<_Dp> && is_same_v<_Dp, _UDel>) || (!is_reference_v<_Dp> && is_convertible_v<_UDel, _Dp>)>::type;
 
   template <class _UDel>
-  using _EnableIfDeleterAssignable = typename enable_if<is_assignable<_Dp&, _UDel&&>::value>::type;
+  using _EnableIfDeleterAssignable = typename enable_if<is_assignable_v<_Dp&, _UDel&&>>::type;
 
 public:
   template <bool _Dummy = true, class = _EnableIfDeleterDefaultConstructible<_Dummy>>
@@ -202,7 +201,7 @@ public:
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(pointer __p, _GoodRValRefType<_Dummy> __d) noexcept
       : __ptr_(__p, ::cuda::std::move(__d))
   {
-    static_assert(!is_reference<deleter_type>::value, "rvalue deleter bound to reference");
+    static_assert(!is_reference_v<deleter_type>, "rvalue deleter bound to reference");
   }
 
   template <bool _Dummy = true, class = _EnableIfDeleterConstructible<_BadRValRefType<_Dummy>>>
@@ -319,8 +318,8 @@ private:
   struct _CheckArrayPointerConversion<_FromElem*>
       : integral_constant<
           bool,
-          is_same<_FromElem*, pointer>::value
-            || (is_same<pointer, element_type*>::value && is_convertible<_FromElem (*)[], element_type (*)[]>::value)>
+          is_same_v<_FromElem*, pointer>
+            || (is_same_v<pointer, element_type*> && is_convertible_v<_FromElem (*)[], element_type (*)[]>)>
   {};
 
   typedef __unique_ptr_deleter_sfinae<_Dp> _DeleterSFINAE;
@@ -336,11 +335,11 @@ private:
 
   template <bool _Dummy, class _Deleter = typename __dependent_type<type_identity<deleter_type>, _Dummy>::type>
   using _EnableIfDeleterDefaultConstructible _CCCL_NODEBUG_ALIAS =
-    typename enable_if<is_default_constructible<_Deleter>::value && !is_pointer<_Deleter>::value>::type;
+    typename enable_if<is_default_constructible_v<_Deleter> && !is_pointer_v<_Deleter>>::type;
 
   template <class _ArgType>
   using _EnableIfDeleterConstructible _CCCL_NODEBUG_ALIAS =
-    typename enable_if<is_constructible<deleter_type, _ArgType>::value>::type;
+    typename enable_if<is_constructible_v<deleter_type, _ArgType>>::type;
 
   template <class _Pp>
   using _EnableIfPointerConvertible _CCCL_NODEBUG_ALIAS =
@@ -348,16 +347,15 @@ private:
 
   template <class _UPtr, class _Up, class _ElemT = typename _UPtr::element_type>
   using _EnableIfMoveConvertible _CCCL_NODEBUG_ALIAS = typename enable_if<
-    is_array<_Up>::value && is_same<pointer, element_type*>::value && is_same<typename _UPtr::pointer, _ElemT*>::value
-    && is_convertible<_ElemT (*)[], element_type (*)[]>::value>::type;
+    is_array_v<_Up> && is_same_v<pointer, element_type*> && is_same_v<typename _UPtr::pointer, _ElemT*>
+    && is_convertible_v<_ElemT (*)[], element_type (*)[]>>::type;
 
   template <class _UDel>
   using _EnableIfDeleterConvertible _CCCL_NODEBUG_ALIAS =
-    typename enable_if<(is_reference<_Dp>::value && is_same<_Dp, _UDel>::value)
-                       || (!is_reference<_Dp>::value && is_convertible<_UDel, _Dp>::value)>::type;
+    enable_if_t<(is_reference_v<_Dp> && is_same_v<_Dp, _UDel>) || (!is_reference_v<_Dp> && is_convertible_v<_UDel, _Dp>)>;
 
   template <class _UDel>
-  using _EnableIfDeleterAssignable _CCCL_NODEBUG_ALIAS = typename enable_if<is_assignable<_Dp&, _UDel&&>::value>::type;
+  using _EnableIfDeleterAssignable _CCCL_NODEBUG_ALIAS = enable_if_t<is_assignable_v<_Dp&, _UDel&&>>;
 
 public:
   template <bool _Dummy = true, class = _EnableIfDeleterDefaultConstructible<_Dummy>>
@@ -398,14 +396,14 @@ public:
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(_Pp __p, _GoodRValRefType<_Dummy> __d) noexcept
       : __ptr_(__p, ::cuda::std::move(__d))
   {
-    static_assert(!is_reference<deleter_type>::value, "rvalue deleter bound to reference");
+    static_assert(!is_reference_v<deleter_type>, "rvalue deleter bound to reference");
   }
 
   template <bool _Dummy = true, class = _EnableIfDeleterConstructible<_GoodRValRefType<_Dummy>>>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 unique_ptr(nullptr_t, _GoodRValRefType<_Dummy> __d) noexcept
       : __ptr_(nullptr, ::cuda::std::move(__d))
   {
-    static_assert(!is_reference<deleter_type>::value, "rvalue deleter bound to reference");
+    static_assert(!is_reference_v<deleter_type>, "rvalue deleter bound to reference");
   }
 
   template <class _Pp,

--- a/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
@@ -77,10 +77,7 @@ struct __tuple_sfinae_base
 
 // __tuple_convertible
 
-template <class _Tp,
-          class _Up,
-          bool = __tuple_like_ext<remove_reference_t<_Tp>>::value,
-          bool = __tuple_like_ext<_Up>::value>
+template <class _Tp, class _Up, bool = __tuple_like_ext<remove_reference_t<_Tp>>, bool = __tuple_like_ext<_Up>>
 struct __tuple_convertible : public false_type
 {};
 
@@ -91,10 +88,7 @@ struct __tuple_convertible<_Tp, _Up, true, true>
 
 // __tuple_constructible
 
-template <class _Tp,
-          class _Up,
-          bool = __tuple_like_ext<remove_reference_t<_Tp>>::value,
-          bool = __tuple_like_ext<_Up>::value>
+template <class _Tp, class _Up, bool = __tuple_like_ext<remove_reference_t<_Tp>>, bool = __tuple_like_ext<_Up>>
 struct __tuple_constructible : public false_type
 {};
 
@@ -105,10 +99,7 @@ struct __tuple_constructible<_Tp, _Up, true, true>
 
 // __tuple_assignable
 
-template <class _Tp,
-          class _Up,
-          bool = __tuple_like_ext<remove_reference_t<_Tp>>::value,
-          bool = __tuple_like_ext<_Up>::value>
+template <class _Tp, class _Up, bool = __tuple_like_ext<remove_reference_t<_Tp>>, bool = __tuple_like_ext<_Up>>
 struct __tuple_assignable : public false_type
 {};
 
@@ -133,7 +124,7 @@ struct __tuple_like_with_size_imp<true, _SizeTrait, _Expected> : integral_consta
 
 template <class _Tuple, size_t _ExpectedSize, class _RawTuple = remove_cvref_t<_Tuple>>
 using __tuple_like_with_size _CCCL_NODEBUG_ALIAS =
-  __tuple_like_with_size_imp<__tuple_like_ext<_RawTuple>::value, tuple_size<_RawTuple>, _ExpectedSize>;
+  __tuple_like_with_size_imp<__tuple_like_ext<_RawTuple>, tuple_size<_RawTuple>, _ExpectedSize>;
 
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __check_tuple_constructor_fail
 {

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_like.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_like.h
@@ -37,50 +37,40 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
-struct __tuple_like_impl : false_type
-{};
+inline constexpr bool __tuple_like_impl = false;
 
 template <class _Tp>
-struct __tuple_like_impl<const _Tp> : public __tuple_like_impl<_Tp>
-{};
+inline constexpr bool __tuple_like_impl<const _Tp> = __tuple_like_impl<_Tp>;
 template <class _Tp>
-struct __tuple_like_impl<volatile _Tp> : public __tuple_like_impl<_Tp>
-{};
+inline constexpr bool __tuple_like_impl<volatile _Tp> = __tuple_like_impl<_Tp>;
 template <class _Tp>
-struct __tuple_like_impl<const volatile _Tp> : public __tuple_like_impl<_Tp>
-{};
+inline constexpr bool __tuple_like_impl<const volatile _Tp> = __tuple_like_impl<_Tp>;
 
 template <class... _Tp>
-struct __tuple_like_impl<tuple<_Tp...>> : true_type
-{};
+inline constexpr bool __tuple_like_impl<tuple<_Tp...>> = true;
 
 template <class _T1, class _T2>
-struct __tuple_like_impl<pair<_T1, _T2>> : true_type
-{};
+inline constexpr bool __tuple_like_impl<pair<_T1, _T2>> = true;
 
 template <class _Tp, size_t _Size>
-struct __tuple_like_impl<array<_Tp, _Size>> : true_type
-{};
+inline constexpr bool __tuple_like_impl<array<_Tp, _Size>> = true;
 
 template <class _Tp>
-struct __tuple_like_impl<complex<_Tp>> : true_type
-{};
+inline constexpr bool __tuple_like_impl<complex<_Tp>> = true;
 
 template <class _Ip, class _Sp, ::cuda::std::ranges::subrange_kind _Kp>
-struct __tuple_like_impl<::cuda::std::ranges::subrange<_Ip, _Sp, _Kp>> : true_type
-{};
+inline constexpr bool __tuple_like_impl<::cuda::std::ranges::subrange<_Ip, _Sp, _Kp>> = true;
 
 template <class... _Tp>
-struct __tuple_like_impl<__tuple_types<_Tp...>> : true_type
-{};
+inline constexpr bool __tuple_like_impl<__tuple_types<_Tp...>> = true;
 
 #if _CCCL_STD_VER >= 2014
 template <class _Tp>
-_CCCL_CONCEPT __tuple_like = __tuple_like_impl<remove_cvref_t<_Tp>>::value;
+_CCCL_CONCEPT __tuple_like = __tuple_like_impl<remove_cvref_t<_Tp>>;
 
 template <class _Tp>
 _CCCL_CONCEPT __pair_like = _CCCL_REQUIRES_EXPR((_Tp)) //
-  (requires(__tuple_like_impl<remove_cvref_t<_Tp>>::value), requires(tuple_size<remove_cvref_t<_Tp>>::value == 2));
+  (requires(__tuple_like_impl<remove_cvref_t<_Tp>>), requires(tuple_size<remove_cvref_t<_Tp>>::value == 2));
 #endif // _CCCL_STD_VER >= 2014
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_like_ext.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_like_ext.h
@@ -33,38 +33,29 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
-struct __tuple_like_ext : false_type
-{};
+inline constexpr bool __tuple_like_ext = false;
 
 template <class _Tp>
-struct __tuple_like_ext<const _Tp> : public __tuple_like_ext<_Tp>
-{};
+inline constexpr bool __tuple_like_ext<const _Tp> = __tuple_like_ext<_Tp>;
 template <class _Tp>
-struct __tuple_like_ext<volatile _Tp> : public __tuple_like_ext<_Tp>
-{};
+inline constexpr bool __tuple_like_ext<volatile _Tp> = __tuple_like_ext<_Tp>;
 template <class _Tp>
-struct __tuple_like_ext<const volatile _Tp> : public __tuple_like_ext<_Tp>
-{};
+inline constexpr bool __tuple_like_ext<const volatile _Tp> = __tuple_like_ext<_Tp>;
 
 template <class... _Tp>
-struct __tuple_like_ext<tuple<_Tp...>> : true_type
-{};
+inline constexpr bool __tuple_like_ext<tuple<_Tp...>> = true;
 
 template <class _T1, class _T2>
-struct __tuple_like_ext<pair<_T1, _T2>> : true_type
-{};
+inline constexpr bool __tuple_like_ext<pair<_T1, _T2>> = true;
 
 template <class _Tp, size_t _Size>
-struct __tuple_like_ext<array<_Tp, _Size>> : true_type
-{};
+inline constexpr bool __tuple_like_ext<array<_Tp, _Size>> = true;
 
 template <class _Tp>
-struct __tuple_like_ext<complex<_Tp>> : true_type
-{};
+inline constexpr bool __tuple_like_ext<complex<_Tp>> = true;
 
 template <class... _Tp>
-struct __tuple_like_ext<__tuple_types<_Tp...>> : true_type
-{};
+inline constexpr bool __tuple_like_ext<__tuple_types<_Tp...>> = true;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_size.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_size.h
@@ -41,7 +41,7 @@ using __enable_if_tuple_size_imp = _Tp;
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
 tuple_size<__enable_if_tuple_size_imp<const _Tp,
-                                      enable_if_t<!is_volatile<_Tp>::value>,
+                                      enable_if_t<!is_volatile_v<_Tp>>,
                                       integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value>
 {};
@@ -49,7 +49,7 @@ tuple_size<__enable_if_tuple_size_imp<const _Tp,
 template <class _Tp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT
 tuple_size<__enable_if_tuple_size_imp<volatile _Tp,
-                                      enable_if_t<!is_const<_Tp>::value>,
+                                      enable_if_t<!is_const_v<_Tp>>,
                                       integral_constant<size_t, sizeof(tuple_size<_Tp>)>>>
     : public integral_constant<size_t, tuple_size<_Tp>::value>
 {};
@@ -65,8 +65,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_size<tuple<_Tp...>> : public integral
 {};
 
 template <class... _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-tuple_size<__tuple_types<_Tp...>> : public integral_constant<size_t, sizeof...(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_size<__tuple_types<_Tp...>>
+    : public integral_constant<size_t, sizeof...(_Tp)>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/can_extract_key.h
+++ b/libcudacxx/include/cuda/std/__type_traits/can_extract_key.h
@@ -40,20 +40,19 @@ struct __extract_key_first_tag
 {};
 
 template <class _ValTy, class _Key, class _RawValTy = __remove_const_ref_t<_ValTy>>
-struct __can_extract_key
-    : conditional_t<_IsSame<_RawValTy, _Key>::value, __extract_key_self_tag, __extract_key_fail_tag>
+struct __can_extract_key : conditional_t<is_same_v<_RawValTy, _Key>, __extract_key_self_tag, __extract_key_fail_tag>
 {};
 
 template <class _Pair, class _Key, class _First, class _Second>
 struct __can_extract_key<_Pair, _Key, pair<_First, _Second>>
-    : conditional_t<_IsSame<remove_const_t<_First>, _Key>::value, __extract_key_first_tag, __extract_key_fail_tag>
+    : conditional_t<is_same_v<remove_const_t<_First>, _Key>, __extract_key_first_tag, __extract_key_fail_tag>
 {};
 
 // __can_extract_map_key uses true_type/false_type instead of the tags.
 // It returns true if _Key != _ContainerValueTy (the container is a map not a set)
 // and _ValTy == _Key.
 template <class _ValTy, class _Key, class _ContainerValueTy, class _RawValTy = __remove_const_ref_t<_ValTy>>
-struct __can_extract_map_key : integral_constant<bool, _IsSame<_RawValTy, _Key>::value>
+struct __can_extract_map_key : integral_constant<bool, is_same_v<_RawValTy, _Key>>
 {};
 
 // This specialization returns __extract_key_fail_tag for non-map containers

--- a/libcudacxx/include/cuda/std/__type_traits/decay.h
+++ b/libcudacxx/include/cuda/std/__type_traits/decay.h
@@ -56,9 +56,9 @@ struct __decay_impl<_Up, true>
 {
 public:
   using type _CCCL_NODEBUG_ALIAS =
-    conditional_t<is_array<_Up>::value,
+    conditional_t<is_array_v<_Up>,
                   remove_extent_t<_Up>*,
-                  conditional_t<is_function<_Up>::value, add_pointer_t<_Up>, remove_cv_t<_Up>>>;
+                  conditional_t<is_function_v<_Up>, add_pointer_t<_Up>, remove_cv_t<_Up>>>;
 };
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_assignable.h
@@ -37,8 +37,8 @@ struct __select_2nd
 #if defined(_CCCL_BUILTIN_IS_ASSIGNABLE) && !defined(_LIBCUDACXX_USE_IS_ASSIGNABLE_FALLBACK)
 
 template <class _T1, class _T2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_assignable : public integral_constant<bool, _CCCL_BUILTIN_IS_ASSIGNABLE(_T1, _T2)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_assignable
+    : public integral_constant<bool, _CCCL_BUILTIN_IS_ASSIGNABLE(_T1, _T2)>
 {};
 
 template <class _T1, class _T2>
@@ -54,7 +54,7 @@ _CCCL_API inline
 template <class, class>
 _CCCL_API inline false_type __is_assignable_test(...);
 
-template <class _Tp, class _Arg, bool = is_void<_Tp>::value || is_void<_Arg>::value>
+template <class _Tp, class _Arg, bool = is_void_v<_Tp> || is_void_v<_Arg>>
 struct __is_assignable_imp : public decltype((::cuda::std::__is_assignable_test<_Tp, _Arg>(0)))
 {};
 

--- a/libcudacxx/include/cuda/std/__type_traits/is_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_constructible.h
@@ -52,7 +52,7 @@ struct __cccl_is_constructible;
 template <class _To, class _From>
 struct __is_invalid_base_to_derived_cast
 {
-  static_assert(is_reference<_To>::value, "Wrong specialization");
+  static_assert(is_reference_v<_To>, "Wrong specialization");
   using _RawFrom = remove_cvref_t<_From>;
   using _RawTo   = remove_cvref_t<_To>;
   static const bool value =
@@ -62,7 +62,7 @@ struct __is_invalid_base_to_derived_cast
 template <class _To, class _From>
 struct __is_invalid_lvalue_to_rvalue_cast : false_type
 {
-  static_assert(is_reference<_To>::value, "Wrong specialization");
+  static_assert(is_reference_v<_To>, "Wrong specialization");
 };
 
 template <class _ToRef, class _FromRef>
@@ -107,7 +107,7 @@ struct __is_constructible_helper
   _CCCL_API inline static false_type __test_unary(...);
 };
 
-template <class _Tp, bool = is_void<_Tp>::value>
+template <class _Tp, bool = is_void_v<_Tp>>
 struct __is_default_constructible : decltype(__is_constructible_helper::__test_nary<_Tp>(0))
 {};
 
@@ -150,8 +150,8 @@ struct __cccl_is_constructible<_Tp&&, _A0> : public decltype(__is_constructible_
 
 #if defined(_CCCL_BUILTIN_IS_CONSTRUCTIBLE) && !defined(_LIBCUDACXX_USE_IS_CONSTRUCTIBLE_FALLBACK)
 template <class _Tp, class... _Args>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_constructible : public integral_constant<bool, _CCCL_BUILTIN_IS_CONSTRUCTIBLE(_Tp, _Args...)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_constructible
+    : public integral_constant<bool, _CCCL_BUILTIN_IS_CONSTRUCTIBLE(_Tp, _Args...)>
 {};
 
 template <class _Tp, class... _Args>

--- a/libcudacxx/include/cuda/std/__type_traits/is_convertible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_convertible.h
@@ -36,8 +36,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #if defined(_CCCL_BUILTIN_IS_CONVERTIBLE_TO) && !defined(_LIBCUDACXX_USE_IS_CONVERTIBLE_FALLBACK)
 
 template <class _T1, class _T2>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_convertible : public integral_constant<bool, _CCCL_BUILTIN_IS_CONVERTIBLE_TO(_T1, _T2)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_convertible
+    : public integral_constant<bool, _CCCL_BUILTIN_IS_CONVERTIBLE_TO(_T1, _T2)>
 {};
 
 template <class _T1, class _T2>
@@ -99,10 +99,7 @@ struct __is_convertible_test<
   decltype(::cuda::std::__is_convertible_imp::__test_convert<_To>(::cuda::std::declval<_From>()))> : public true_type
 {};
 
-template <class _Tp,
-          bool _IsArray    = is_array<_Tp>::value,
-          bool _IsFunction = is_function<_Tp>::value,
-          bool _IsVoid     = is_void<_Tp>::value>
+template <class _Tp, bool _IsArray = is_array_v<_Tp>, bool _IsFunction = is_function_v<_Tp>, bool _IsVoid = is_void_v<_Tp>>
 struct __is_array_function_or_void
 {
   enum

--- a/libcudacxx/include/cuda/std/__type_traits/is_function.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_function.h
@@ -43,8 +43,8 @@ inline constexpr bool is_function_v = _CCCL_BUILTIN_IS_FUNCTION(_Tp);
 #else
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_function : public integral_constant<bool, !(is_reference<_Tp>::value || is_const<const _Tp>::value)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_function
+    : public integral_constant<bool, !(is_reference_v<_Tp> || is_const_v<const _Tp>)>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_member_function_pointer.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_member_function_pointer.h
@@ -45,7 +45,7 @@ struct __cccl_is_member_pointer<_Tp _Up::*>
   enum
   {
     __is_member = true,
-    __is_func   = is_function<_Tp>::value,
+    __is_func   = is_function_v<_Tp>,
     __is_obj    = !__is_func,
   };
 };
@@ -53,8 +53,8 @@ struct __cccl_is_member_pointer<_Tp _Up::*>
 #if defined(_CCCL_BUILTIN_IS_MEMBER_FUNCTION_POINTER) && !defined(_LIBCUDACXX_USE_IS_MEMBER_FUNCTION_POINTER_FALLBACK)
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_member_function_pointer : public integral_constant<bool, _CCCL_BUILTIN_IS_MEMBER_FUNCTION_POINTER(_Tp)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_member_function_pointer
+    : public integral_constant<bool, _CCCL_BUILTIN_IS_MEMBER_FUNCTION_POINTER(_Tp)>
 {};
 
 template <class _Tp>
@@ -63,8 +63,8 @@ inline constexpr bool is_member_function_pointer_v = _CCCL_BUILTIN_IS_MEMBER_FUN
 #else // ^^^ _CCCL_BUILTIN_IS_MEMBER_FUNCTION_POINTER ^^^ / vvv !_CCCL_BUILTIN_IS_MEMBER_FUNCTION_POINTER vvv
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_member_function_pointer : public integral_constant<bool, __cccl_is_member_pointer<remove_cv_t<_Tp>>::__is_func>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_member_function_pointer
+    : public integral_constant<bool, __cccl_is_member_pointer<remove_cv_t<_Tp>>::__is_func>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_assignable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_assignable.h
@@ -32,8 +32,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #if defined(_CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE) && !defined(_LIBCUDACXX_USE_IS_NOTHROW_ASSIGNABLE_FALLBACK)
 
 template <class _Tp, class _Arg>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_assignable : public integral_constant<bool, _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(_Tp, _Arg)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_assignable
+    : public integral_constant<bool, _CCCL_BUILTIN_IS_NOTHROW_ASSIGNABLE(_Tp, _Arg)>
 {};
 
 template <class _Tp, class _Arg>
@@ -54,8 +54,8 @@ struct __cccl_is_nothrow_assignable<true, _Tp, _Arg>
 {};
 
 template <class _Tp, class _Arg>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_assignable : public __cccl_is_nothrow_assignable<is_assignable<_Tp, _Arg>::value, _Tp, _Arg>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_assignable
+    : public __cccl_is_nothrow_assignable<is_assignable_v<_Tp, _Arg>, _Tp, _Arg>
 {};
 
 template <class _Tp, class _Arg>

--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_constructible.h
@@ -32,8 +32,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 #if defined(_CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE) && !defined(_LIBCUDACXX_USE_IS_NOTHROW_CONSTRUCTIBLE_FALLBACK)
 
 template <class _Tp, class... _Args>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_constructible : public integral_constant<bool, _CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(_Tp, _Args...)>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_constructible
+    : public integral_constant<bool, _CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE(_Tp, _Args...)>
 {};
 
 template <class _Tp, class... _Args>
@@ -64,12 +64,12 @@ struct __cccl_is_nothrow_constructible</*is constructible*/ false, _IsReference,
 
 template <class _Tp, class... _Args>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_constructible
-    : __cccl_is_nothrow_constructible<is_constructible<_Tp, _Args...>::value, is_reference<_Tp>::value, _Tp, _Args...>
+    : __cccl_is_nothrow_constructible<is_constructible_v<_Tp, _Args...>, is_reference_v<_Tp>, _Tp, _Args...>
 {};
 
 template <class _Tp, size_t _Ns>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_constructible<_Tp[_Ns]>
-    : __cccl_is_nothrow_constructible<is_constructible<_Tp>::value, is_reference<_Tp>::value, _Tp>
+    : __cccl_is_nothrow_constructible<is_constructible_v<_Tp>, is_reference_v<_Tp>, _Tp>
 {};
 
 template <class _Tp, class... _Args>

--- a/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_swappable.h
@@ -159,40 +159,41 @@ struct __is_nothrow_swappable : public integral_constant<bool, __detail::__nothr
 {};
 
 template <class _Tp, class _Up>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_swappable_with : public integral_constant<bool, __detail::__swappable_with<_Tp, _Up>::value>
+inline constexpr bool is_swappable_with_v = __detail::__swappable_with<_Tp, _Up>::value;
+
+template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value>
+inline constexpr bool is_swappable_v = false;
+
+template <class _Tp>
+inline constexpr bool is_swappable_v<_Tp, true> =
+  is_swappable_with_v<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<_Tp>>;
+
+template <class _Tp, class _Up>
+inline constexpr bool is_nothrow_swappable_with_v = __detail::__nothrow_swappable_with<_Tp, _Up>::value;
+
+template <class _Tp, bool = __cccl_is_referenceable<_Tp>::value>
+inline constexpr bool is_nothrow_swappable_v = false;
+
+template <class _Tp>
+inline constexpr bool is_nothrow_swappable_v<_Tp, true> =
+  is_nothrow_swappable_with_v<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<_Tp>>;
+
+template <class _Tp, class _Up>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_swappable_with : public bool_constant<is_swappable_with_v<_Tp, _Up>>
 {};
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_swappable
-    : public conditional_t<__cccl_is_referenceable<_Tp>::value,
-                           is_swappable_with<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<_Tp>>,
-                           false_type>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_swappable : public bool_constant<is_swappable_v<_Tp>>
 {};
 
 template <class _Tp, class _Up>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_swappable_with : public integral_constant<bool, __detail::__nothrow_swappable_with<_Tp, _Up>::value>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_swappable_with
+    : public bool_constant<is_nothrow_swappable_with_v<_Tp, _Up>>
 {};
 
 template <class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_swappable
-    : public conditional_t<__cccl_is_referenceable<_Tp>::value,
-                           is_nothrow_swappable_with<add_lvalue_reference_t<_Tp>, add_lvalue_reference_t<_Tp>>,
-                           false_type>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_swappable : public bool_constant<is_nothrow_swappable_v<_Tp>>
 {};
-
-template <class _Tp, class _Up>
-inline constexpr bool is_swappable_with_v = is_swappable_with<_Tp, _Up>::value;
-
-template <class _Tp>
-inline constexpr bool is_swappable_v = is_swappable<_Tp>::value;
-
-template <class _Tp, class _Up>
-inline constexpr bool is_nothrow_swappable_with_v = is_nothrow_swappable_with<_Tp, _Up>::value;
-
-template <class _Tp>
-inline constexpr bool is_nothrow_swappable_v = is_nothrow_swappable<_Tp>::value;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/make_signed.h
+++ b/libcudacxx/include/cuda/std/__type_traits/make_signed.h
@@ -50,7 +50,7 @@ using __signed_types =
 #  endif // _CCCL_HAS_INT128()
               >;
 
-template <class _Tp, bool = is_integral<_Tp>::value || is_enum<_Tp>::value>
+template <class _Tp, bool = is_integral_v<_Tp> || is_enum_v<_Tp>>
 struct __make_signed_impl
 {};
 

--- a/libcudacxx/include/cuda/std/__type_traits/make_unsigned.h
+++ b/libcudacxx/include/cuda/std/__type_traits/make_unsigned.h
@@ -52,7 +52,7 @@ using __unsigned_types =
 #  endif // _CCCL_HAS_INT128()
               >;
 
-template <class _Tp, bool = is_integral<_Tp>::value || is_enum<_Tp>::value>
+template <class _Tp, bool = is_integral_v<_Tp> || is_enum_v<_Tp>>
 struct __make_unsigned_impl
 {};
 

--- a/libcudacxx/include/cuda/std/__type_traits/promote.h
+++ b/libcudacxx/include/cuda/std/__type_traits/promote.h
@@ -51,7 +51,7 @@ struct __numeric_type
   _CCCL_API inline static long double __test(long double);
 
   using type              = decltype(__test(declval<_Tp>()));
-  static const bool value = _IsNotSame<type, void>::value;
+  static const bool value = !is_same_v<type, void>;
 };
 
 template <>

--- a/libcudacxx/include/cuda/std/__utility/convert_to_integral.h
+++ b/libcudacxx/include/cuda/std/__utility/convert_to_integral.h
@@ -60,7 +60,7 @@ _CCCL_API constexpr unsigned long long __convert_to_integral(unsigned long long 
 }
 
 template <typename _Fp>
-_CCCL_API constexpr enable_if_t<is_floating_point<_Fp>::value, long long> __convert_to_integral(_Fp __val)
+_CCCL_API constexpr enable_if_t<is_floating_point_v<_Fp>, long long> __convert_to_integral(_Fp __val)
 {
   return __val;
 }
@@ -77,7 +77,7 @@ _CCCL_API constexpr __uint128_t __convert_to_integral(__uint128_t __val)
 }
 #endif // _CCCL_HAS_INT128()
 
-template <class _Tp, bool = is_enum<_Tp>::value>
+template <class _Tp, bool = is_enum_v<_Tp>>
 struct __sfinae_underlying_type
 {
   using type            = typename underlying_type<_Tp>::type;

--- a/libcudacxx/include/cuda/std/__utility/exchange.h
+++ b/libcudacxx/include/cuda/std/__utility/exchange.h
@@ -32,7 +32,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 _CCCL_EXEC_CHECK_DISABLE
 template <class _T1, class _T2 = _T1>
 _CCCL_API constexpr _T1 exchange(_T1& __obj, _T2&& __new_value) noexcept(
-  is_nothrow_move_constructible<_T1>::value && is_nothrow_assignable<_T1&, _T2>::value)
+  is_nothrow_move_constructible_v<_T1> && is_nothrow_assignable_v<_T1&, _T2>)
 {
   _T1 __old_value = ::cuda::std::move(__obj);
   __obj           = ::cuda::std::forward<_T2>(__new_value);

--- a/libcudacxx/include/cuda/std/__utility/forward.h
+++ b/libcudacxx/include/cuda/std/__utility/forward.h
@@ -46,7 +46,7 @@ template <class _Tp>
 template <class _Tp>
 [[nodiscard]] _CCCL_INTRINSIC _CCCL_API constexpr _Tp&& forward(remove_reference_t<_Tp>&& __t) noexcept
 {
-  static_assert(!is_lvalue_reference<_Tp>::value, "cannot forward an rvalue as an lvalue");
+  static_assert(!is_lvalue_reference_v<_Tp>, "cannot forward an rvalue as an lvalue");
   return static_cast<_Tp&&>(__t);
 }
 

--- a/libcudacxx/include/cuda/std/__utility/integer_sequence.h
+++ b/libcudacxx/include/cuda/std/__utility/integer_sequence.h
@@ -194,7 +194,7 @@ template <class _Tp, _Tp... _Ip>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT integer_sequence
 {
   using value_type = _Tp;
-  static_assert(is_integral<_Tp>::value, "std::integer_sequence can only be instantiated with an integral type");
+  static_assert(is_integral_v<_Tp>, "std::integer_sequence can only be instantiated with an integral type");
   static _CCCL_API constexpr size_t size() noexcept
   {
     return sizeof...(_Ip);
@@ -223,7 +223,7 @@ using __make_integer_sequence_unchecked _CCCL_NODEBUG_ALIAS =
 template <class _Tp, _Tp _Ep>
 struct __make_integer_sequence_checked
 {
-  static_assert(is_integral<_Tp>::value, "std::make_integer_sequence can only be instantiated with an integral type");
+  static_assert(is_integral_v<_Tp>, "std::make_integer_sequence can only be instantiated with an integral type");
   static_assert(0 <= _Ep, "std::make_integer_sequence must have a non-negative sequence length");
   // Workaround GCC bug by preventing bad installations when 0 <= _Ep
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=68929

--- a/libcudacxx/include/cuda/std/__utility/move.h
+++ b/libcudacxx/include/cuda/std/__utility/move.h
@@ -59,7 +59,7 @@ template <class _Tp>
 
 template <class _Tp>
 using __move_if_noexcept_result_t =
-  conditional_t<!is_nothrow_move_constructible<_Tp>::value && is_copy_constructible<_Tp>::value, const _Tp&, _Tp&&>;
+  conditional_t<!is_nothrow_move_constructible_v<_Tp> && is_copy_constructible_v<_Tp>, const _Tp&, _Tp&&>;
 
 template <class _Tp>
 [[nodiscard]] _CCCL_INTRINSIC _CCCL_API constexpr __move_if_noexcept_result_t<_Tp> move_if_noexcept(_Tp& __x) noexcept

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -505,7 +505,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #endif // _CCCL_STD_VER >= 2023
 
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20 void
-  swap(pair& __p) noexcept(__is_nothrow_swappable<_T1>::value && __is_nothrow_swappable<_T2>::value)
+  swap(pair& __p) noexcept(is_nothrow_swappable_v<_T1> && is_nothrow_swappable_v<_T2>)
   {
     using ::cuda::std::swap;
     swap(this->first, __p.first);
@@ -514,7 +514,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
 #if _CCCL_STD_VER >= 2023
   _CCCL_API constexpr void swap(const pair& __p) const
-    noexcept(__is_nothrow_swappable<const _T1>::value && __is_nothrow_swappable<const _T2>::value)
+    noexcept(is_nothrow_swappable_v<const _T1> && is_nothrow_swappable_v<const _T2>)
   {
     using ::cuda::std::swap;
     swap(this->first, __p.first);
@@ -614,16 +614,15 @@ struct common_type<pair<_T1, _T2>, pair<_U1, _U2>>
 #endif // _CCCL_STD_VER >= 2023
 
 template <class _T1, class _T2>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<__is_swappable<_T1>::value && __is_swappable<_T2>::value, void>
-swap(pair<_T1, _T2>& __x,
-     pair<_T1, _T2>& __y) noexcept((__is_nothrow_swappable<_T1>::value && __is_nothrow_swappable<_T2>::value))
+_CCCL_API inline _CCCL_CONSTEXPR_CXX20 enable_if_t<is_nothrow_swappable_v<_T1> && is_nothrow_swappable_v<_T2>, void>
+swap(pair<_T1, _T2>& __x, pair<_T1, _T2>& __y) noexcept((is_nothrow_swappable_v<_T1> && is_nothrow_swappable_v<_T2>) )
 {
   __x.swap(__y);
 }
 
 #if _CCCL_STD_VER >= 2023
 template <class _T1, class _T2>
-  requires(__is_swappable<const _T1>::value && __is_swappable<const _T2>::value)
+  requires(is_nothrow_swappable_v<const _T1> && is_nothrow_swappable_v<const _T2>)
 _CCCL_API constexpr void swap(const pair<_T1, _T2>& __x, const pair<_T1, _T2>& __y) noexcept(noexcept(__x.swap(__y)))
 {
   __x.swap(__y);

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -285,7 +285,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   template <class... _Args1, class... _Args2>
   _CCCL_API inline _CCCL_CONSTEXPR_CXX20
   pair(piecewise_construct_t __pc, tuple<_Args1...> __first_args, tuple<_Args2...> __second_args) noexcept(
-    (is_nothrow_constructible<_T1, _Args1...>::value && is_nothrow_constructible<_T2, _Args2...>::value))
+    (is_nothrow_constructible_v<_T1, _Args1...> && is_nothrow_constructible_v<_T2, _Args2...>) )
       : __base(__pc,
                __first_args,
                __second_args,
@@ -403,7 +403,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
   // std assignments
 #if !_CCCL_COMPILER(NVRTC)
-  template <class _UT1 = _T1, enable_if_t<is_copy_assignable<_UT1>::value && is_copy_assignable<_T2>::value, int> = 0>
+  template <class _UT1 = _T1, enable_if_t<is_copy_assignable_v<_UT1> && is_copy_assignable_v<_T2>, int> = 0>
   _CCCL_HOST constexpr pair& operator=(::std::pair<_T1, _T2> const& __p) noexcept(
     is_nothrow_copy_assignable_v<_T1> && is_nothrow_copy_assignable_v<_T2>)
   {
@@ -412,7 +412,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
     return *this;
   }
 
-  template <class _UT1 = _T1, enable_if_t<is_move_assignable<_UT1>::value && is_move_assignable<_T2>::value, int> = 0>
+  template <class _UT1 = _T1, enable_if_t<is_move_assignable_v<_UT1> && is_move_assignable_v<_T2>, int> = 0>
   _CCCL_HOST constexpr pair& operator=(::std::pair<_T1, _T2>&& __p) noexcept(
     is_nothrow_copy_assignable_v<_T1> && is_nothrow_copy_assignable_v<_T2>)
   {

--- a/libcudacxx/include/cuda/std/array
+++ b/libcudacxx/include/cuda/std/array
@@ -93,7 +93,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT array
     ::cuda::std::fill_n(__elems_, _Size, __u);
   }
 
-  _CCCL_API constexpr void swap(array& __a) noexcept(__is_nothrow_swappable<_Tp>::value)
+  _CCCL_API constexpr void swap(array& __a) noexcept(is_nothrow_swappable_v<_Tp>)
   {
     ::cuda::std::swap_ranges(__elems_, __elems_ + _Size, __a.data());
   }
@@ -434,7 +434,7 @@ template <class _Tp, size_t _Size>
 }
 
 _CCCL_TEMPLATE(class _Tp, size_t _Size)
-_CCCL_REQUIRES((_Size == 0) || __is_swappable<_Tp>::value)
+_CCCL_REQUIRES((_Size == 0) || is_nothrow_swappable_v<_Tp>)
 _CCCL_API constexpr void swap(array<_Tp, _Size>& __x, array<_Tp, _Size>& __y) noexcept(noexcept(__x.swap(__y)))
 {
   __x.swap(__y);

--- a/libcudacxx/include/cuda/std/atomic
+++ b/libcudacxx/include/cuda/std/atomic
@@ -353,16 +353,14 @@ _CCCL_API inline void atomic_notify_all(atomic<_Tp>* __o) noexcept
 // atomic_fetch_add
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
-                             _Tp>
+_CCCL_API inline enable_if_t<(is_integral_v<_Tp> && !is_same_v<_Tp, bool>) || is_floating_point_v<_Tp>, _Tp>
 atomic_fetch_add(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_add(__op);
 }
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
-                             _Tp>
+_CCCL_API inline enable_if_t<(is_integral_v<_Tp> && !is_same_v<_Tp, bool>) || is_floating_point_v<_Tp>, _Tp>
 atomic_fetch_add(atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_add(__op);
@@ -383,16 +381,14 @@ _CCCL_API inline _Tp* atomic_fetch_add(atomic<_Tp*>* __o, ptrdiff_t __op) noexce
 // atomic_fetch_add_explicit
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
-                             _Tp>
+_CCCL_API inline enable_if_t<(is_integral_v<_Tp> && !is_same_v<_Tp, bool>) || is_floating_point_v<_Tp>, _Tp>
 atomic_fetch_add_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_add(__op, __m);
 }
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
-                             _Tp>
+_CCCL_API inline enable_if_t<(is_integral_v<_Tp> && !is_same_v<_Tp, bool>) || is_floating_point_v<_Tp>, _Tp>
 atomic_fetch_add_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_add(__op, __m);
@@ -413,16 +409,14 @@ _CCCL_API inline _Tp* atomic_fetch_add_explicit(atomic<_Tp*>* __o, ptrdiff_t __o
 // atomic_fetch_sub
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
-                             _Tp>
+_CCCL_API inline enable_if_t<(is_integral_v<_Tp> && !is_same_v<_Tp, bool>) || is_floating_point_v<_Tp>, _Tp>
 atomic_fetch_sub(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_sub(__op);
 }
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
-                             _Tp>
+_CCCL_API inline enable_if_t<(is_integral_v<_Tp> && !is_same_v<_Tp, bool>) || is_floating_point_v<_Tp>, _Tp>
 atomic_fetch_sub(atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_sub(__op);
@@ -443,16 +437,14 @@ _CCCL_API inline _Tp* atomic_fetch_sub(atomic<_Tp*>* __o, ptrdiff_t __op) noexce
 // atomic_fetch_sub_explicit
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
-                             _Tp>
+_CCCL_API inline enable_if_t<(is_integral_v<_Tp> && !is_same_v<_Tp, bool>) || is_floating_point_v<_Tp>, _Tp>
 atomic_fetch_sub_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_sub(__op, __m);
 }
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<(is_integral<_Tp>::value && !is_same<_Tp, bool>::value) || is_floating_point<_Tp>::value,
-                             _Tp>
+_CCCL_API inline enable_if_t<(is_integral_v<_Tp> && !is_same_v<_Tp, bool>) || is_floating_point_v<_Tp>, _Tp>
 atomic_fetch_sub_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_sub(__op, __m);
@@ -473,14 +465,14 @@ _CCCL_API inline _Tp* atomic_fetch_sub_explicit(atomic<_Tp*>* __o, ptrdiff_t __o
 // atomic_fetch_and
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_and(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_and(__op);
 }
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_and(atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_and(__op);
@@ -489,14 +481,14 @@ atomic_fetch_and(atomic<_Tp>* __o, _Tp __op) noexcept
 // atomic_fetch_and_explicit
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_and_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_and(__op, __m);
 }
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_and_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_and(__op, __m);
@@ -505,14 +497,14 @@ atomic_fetch_and_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 // atomic_fetch_or
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_or(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_or(__op);
 }
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_or(atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_or(__op);
@@ -521,14 +513,14 @@ atomic_fetch_or(atomic<_Tp>* __o, _Tp __op) noexcept
 // atomic_fetch_or_explicit
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_or_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_or(__op, __m);
 }
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_or_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_or(__op, __m);
@@ -537,14 +529,14 @@ atomic_fetch_or_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 // atomic_fetch_xor
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_xor(volatile atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_xor(__op);
 }
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_xor(atomic<_Tp>* __o, _Tp __op) noexcept
 {
   return __o->fetch_xor(__op);
@@ -553,14 +545,14 @@ atomic_fetch_xor(atomic<_Tp>* __o, _Tp __op) noexcept
 // atomic_fetch_xor_explicit
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_xor_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_xor(__op, __m);
 }
 
 template <class _Tp>
-_CCCL_API inline enable_if_t<is_integral<_Tp>::value && !is_same<_Tp, bool>::value, _Tp>
+_CCCL_API inline enable_if_t<is_integral_v<_Tp> && !is_same_v<_Tp, bool>, _Tp>
 atomic_fetch_xor_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) noexcept
 {
   return __o->fetch_xor(__op, __m);

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -55,7 +55,7 @@ template <class _Int>
 struct __avoid_promotions
 {
   using __base =
-    conditional_t<(sizeof(_Int) >= sizeof(int)), _Int, conditional_t<is_unsigned<_Int>::value, unsigned int, signed int>>;
+    conditional_t<(sizeof(_Int) >= sizeof(int)), _Int, conditional_t<is_unsigned_v<_Int>, unsigned int, signed int>>;
 
   _CCCL_HIDE_FROM_ABI constexpr __avoid_promotions() = default;
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/algorithm
@@ -832,7 +832,7 @@ _CCCL_HOST_DEVICE void __sort(_RandomAccessIterator __first, _RandomAccessIterat
   typedef typename iterator_traits<_RandomAccessIterator>::difference_type difference_type;
   typedef typename iterator_traits<_RandomAccessIterator>::value_type value_type;
   const difference_type __limit =
-    is_trivially_copy_constructible<value_type>::value && is_trivially_copy_assignable<value_type>::value ? 30 : 6;
+    is_trivially_copy_constructible_v<value_type> && is_trivially_copy_assignable_v<value_type> ? 30 : 6;
   while (true)
   {
   __restart:
@@ -1403,7 +1403,7 @@ _CCCL_HOST_DEVICE void __stable_sort_move(
 template <class _Tp>
 struct __stable_sort_switch
 {
-  static const unsigned value = 128 * is_trivially_copy_assignable<_Tp>::value;
+  static const unsigned value = 128 * is_trivially_copy_assignable_v<_Tp>;
 };
 
 template <class _Compare, class _RandomAccessIterator>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/chrono
@@ -43,7 +43,7 @@ template <class Rep, class Period = ratio<1>>
 class duration
 {
     static_assert(!__is_duration<Rep>::value, "A duration representation can not be a duration");
-    static_assert(__is_ratio<Period>::value, "Second template parameter of duration must be a std::ratio");
+    static_assert(__is_ratio_v<Period>, "Second template parameter of duration must be a std::ratio");
     static_assert(Period::num > 0, "duration period must be positive");
 public:
     typedef Rep rep;
@@ -1042,7 +1042,7 @@ template <class _Rep, class _Period>
 class _CCCL_TYPE_VISIBILITY_DEFAULT duration
 {
   static_assert(!__is_duration<_Rep>::value, "A duration representation can not be a duration");
-  static_assert(__is_ratio<_Period>::value, "Second template parameter of duration must be a std::ratio");
+  static_assert(__is_ratio_v<_Period>, "Second template parameter of duration must be a std::ratio");
   static_assert(_Period::num > 0, "duration period must be positive");
 
   template <class _R1, class _R2>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -1046,7 +1046,7 @@ _CCCL_API constexpr size_t __find_idx(size_t __i, const bool (&__matches)[_Nx])
 template <class _T1, class... _Args>
 struct __find_exactly_one_checked
 {
-  static constexpr bool __matches[sizeof...(_Args)] = {is_same<_T1, _Args>::value...};
+  static constexpr bool __matches[sizeof...(_Args)] = {is_same_v<_T1, _Args>...};
   static constexpr size_t value                     = __find_detail::__find_idx(0, __matches);
   static_assert(value != __not_found, "type not found in type list");
   static_assert(value != __ambiguous, "type occurs more than once in type list");
@@ -1055,7 +1055,7 @@ struct __find_exactly_one_checked
 template <class _T1>
 struct __find_exactly_one_checked<_T1>
 {
-  static_assert(!is_same<_T1, _T1>::value, "type not in empty type list");
+  static_assert(!is_same_v<_T1, _T1>, "type not in empty type list");
 };
 
 } // namespace __find_detail

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -1223,7 +1223,7 @@ template <class... _Types, class _Tuple0, class _Tuple1, class... _Tuples>
 struct __tuple_cat_return_1<tuple<_Types...>, true, _Tuple0, _Tuple1, _Tuples...>
     : public __tuple_cat_return_1<
         typename __tuple_cat_type<tuple<_Types...>, __make_tuple_types_t<remove_cvref_t<_Tuple0>>>::type,
-        __tuple_like_impl<remove_reference_t<_Tuple1>>::value,
+        __tuple_like_impl<remove_reference_t<_Tuple1>>,
         _Tuple1,
         _Tuples...>
 {};
@@ -1233,7 +1233,7 @@ struct __tuple_cat_return;
 
 template <class _Tuple0, class... _Tuples>
 struct __tuple_cat_return<_Tuple0, _Tuples...>
-    : public __tuple_cat_return_1<tuple<>, __tuple_like_impl<remove_reference_t<_Tuple0>>::value, _Tuple0, _Tuples...>
+    : public __tuple_cat_return_1<tuple<>, __tuple_like_impl<remove_reference_t<_Tuple0>>, _Tuple0, _Tuples...>
 {};
 
 template <>

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -226,7 +226,7 @@ class __tuple_leaf;
 _CCCL_EXEC_CHECK_DISABLE
 template <size_t _Ip, class _Hp, __tuple_leaf_specialization _Ep>
 _CCCL_API inline void swap(__tuple_leaf<_Ip, _Hp, _Ep>& __x,
-                           __tuple_leaf<_Ip, _Hp, _Ep>& __y) noexcept(__is_nothrow_swappable<_Hp>::value)
+                           __tuple_leaf<_Ip, _Hp, _Ep>& __y) noexcept(is_nothrow_swappable_v<_Hp>)
 {
   swap(__x.get(), __y.get());
 }
@@ -312,7 +312,7 @@ public:
     return *this;
   }
 
-  _CCCL_API inline int swap(__tuple_leaf& __t) noexcept(__is_nothrow_swappable<__tuple_leaf>::value)
+  _CCCL_API inline int swap(__tuple_leaf& __t) noexcept(is_nothrow_swappable_v<__tuple_leaf>)
   {
     ::cuda::std::swap(*this, __t);
     return 0;
@@ -398,7 +398,7 @@ public:
     return *this;
   }
 
-  _CCCL_API inline int swap(__tuple_leaf& __t) noexcept(__is_nothrow_swappable<__tuple_leaf>::value)
+  _CCCL_API inline int swap(__tuple_leaf& __t) noexcept(is_nothrow_swappable_v<__tuple_leaf>)
   {
     ::cuda::std::swap(*this, __t);
     return 0;
@@ -488,7 +488,7 @@ public:
   }
 
   _CCCL_EXEC_CHECK_DISABLE
-  _CCCL_API inline int swap(__tuple_leaf& __t) noexcept(__is_nothrow_swappable<__tuple_leaf>::value)
+  _CCCL_API inline int swap(__tuple_leaf& __t) noexcept(is_nothrow_swappable_v<__tuple_leaf>)
   {
     ::cuda::std::swap(*this, __t);
     return 0;
@@ -603,7 +603,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...
   _CCCL_HIDE_FROM_ABI __tuple_impl& operator=(const __tuple_impl&) = default;
   _CCCL_HIDE_FROM_ABI __tuple_impl& operator=(__tuple_impl&&)      = default;
 
-  _CCCL_API inline void swap(__tuple_impl& __t) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
+  _CCCL_API inline void swap(__tuple_impl& __t) noexcept(__all<is_nothrow_swappable_v<_Tp>...>::value)
   {
     ::cuda::std::__swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t))...);
   }
@@ -957,7 +957,7 @@ public:
     return *this;
   }
 
-  _CCCL_API inline void swap(tuple& __t) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
+  _CCCL_API inline void swap(tuple& __t) noexcept(__all<is_nothrow_swappable_v<_Tp>...>::value)
   {
     __base_.swap(__t.__base_);
   }
@@ -995,8 +995,8 @@ template <class _Alloc, class... _Tp>
 _CCCL_HOST_DEVICE tuple(allocator_arg_t, _Alloc, tuple<_Tp...>) -> tuple<_Tp...>;
 
 template <class... _Tp>
-_CCCL_API inline enable_if_t<_And<__is_swappable<_Tp>...>::value, void>
-swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
+_CCCL_API inline enable_if_t<__all<is_nothrow_swappable_v<_Tp>...>::value, void>
+swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u) noexcept(__all<is_nothrow_swappable_v<_Tp>...>::value)
 {
   __t.swap(__u);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/variant
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/variant
@@ -347,13 +347,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT variant_alternative<_Ip, const _Tp> : add_c
 {};
 
 template <size_t _Ip, class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-variant_alternative<_Ip, volatile _Tp> : add_volatile<variant_alternative_t<_Ip, _Tp>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT variant_alternative<_Ip, volatile _Tp>
+    : add_volatile<variant_alternative_t<_Ip, _Tp>>
 {};
 
 template <size_t _Ip, class _Tp>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-variant_alternative<_Ip, const volatile _Tp> : add_cv<variant_alternative_t<_Ip, _Tp>>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT variant_alternative<_Ip, const volatile _Tp>
+    : add_cv<variant_alternative_t<_Ip, _Tp>>
 {};
 
 template <size_t _Ip, class... _Types>
@@ -900,8 +900,8 @@ public:                                                           \
   _CCCL_HIDE_FROM_ABI __dtor& operator=(__dtor&&)      = default;
 
 template <class... _Types>
-class _CCCL_TYPE_VISIBILITY_DEFAULT
-__dtor<__traits<_Types...>, _Trait::_TriviallyAvailable> : public __base<_Trait::_TriviallyAvailable, _Types...>
+class _CCCL_TYPE_VISIBILITY_DEFAULT __dtor<__traits<_Types...>, _Trait::_TriviallyAvailable>
+    : public __base<_Trait::_TriviallyAvailable, _Types...>
 {
   _LIBCUDACXX_VARIANT_DESTRUCTOR_BODY(_Trait::_TriviallyAvailable)
   _CCCL_HIDE_FROM_ABI ~__dtor() = default;
@@ -914,8 +914,8 @@ protected:
 };
 
 template <class... _Types>
-class _CCCL_TYPE_VISIBILITY_DEFAULT
-__dtor<__traits<_Types...>, _Trait::_Available> : public __base<_Trait::_Available, _Types...>
+class _CCCL_TYPE_VISIBILITY_DEFAULT __dtor<__traits<_Types...>, _Trait::_Available>
+    : public __base<_Trait::_Available, _Types...>
 {
   struct __visitor
   {
@@ -972,8 +972,8 @@ private:
 };
 
 template <class... _Types>
-class _CCCL_TYPE_VISIBILITY_DEFAULT
-__dtor<__traits<_Types...>, _Trait::_Unavailable> : public __base<_Trait::_Unavailable, _Types...>
+class _CCCL_TYPE_VISIBILITY_DEFAULT __dtor<__traits<_Types...>, _Trait::_Unavailable>
+    : public __base<_Trait::_Unavailable, _Types...>
 {
   _LIBCUDACXX_VARIANT_DESTRUCTOR_BODY(_Trait::_Unavailable)
   _CCCL_API inline ~__dtor() = delete;
@@ -1048,22 +1048,22 @@ protected:
 template <class _Traits, _Trait = _Traits::__move_constructible_trait>
 class _CCCL_TYPE_VISIBILITY_DEFAULT __move_constructor;
 
-#define _LIBCUDACXX_VARIANT_MOVE_CONSTRUCTOR(move_constructible_trait, move_constructor)                 \
-  template <class... _Types>                                                                             \
-  class _CCCL_TYPE_VISIBILITY_DEFAULT                                                                    \
-  __move_constructor<__traits<_Types...>, move_constructible_trait> : public __ctor<__traits<_Types...>> \
-  {                                                                                                      \
-    using __base_type = __ctor<__traits<_Types...>>;                                                     \
-                                                                                                         \
-  public:                                                                                                \
-    using __base_type::__base_type;                                                                      \
-    using __base_type::operator=;                                                                        \
-                                                                                                         \
-    _CCCL_HIDE_FROM_ABI __move_constructor(const __move_constructor&)            = default;              \
-    _CCCL_HIDE_FROM_ABI ~__move_constructor()                                    = default;              \
-    _CCCL_HIDE_FROM_ABI __move_constructor& operator=(const __move_constructor&) = default;              \
-    _CCCL_HIDE_FROM_ABI __move_constructor& operator=(__move_constructor&&)      = default;              \
-    move_constructor                                                                                     \
+#define _LIBCUDACXX_VARIANT_MOVE_CONSTRUCTOR(move_constructible_trait, move_constructor)                \
+  template <class... _Types>                                                                            \
+  class _CCCL_TYPE_VISIBILITY_DEFAULT __move_constructor<__traits<_Types...>, move_constructible_trait> \
+      : public __ctor<__traits<_Types...>>                                                              \
+  {                                                                                                     \
+    using __base_type = __ctor<__traits<_Types...>>;                                                    \
+                                                                                                        \
+  public:                                                                                               \
+    using __base_type::__base_type;                                                                     \
+    using __base_type::operator=;                                                                       \
+                                                                                                        \
+    _CCCL_HIDE_FROM_ABI __move_constructor(const __move_constructor&)            = default;             \
+    _CCCL_HIDE_FROM_ABI ~__move_constructor()                                    = default;             \
+    _CCCL_HIDE_FROM_ABI __move_constructor& operator=(const __move_constructor&) = default;             \
+    _CCCL_HIDE_FROM_ABI __move_constructor& operator=(__move_constructor&&)      = default;             \
+    move_constructor                                                                                    \
   }
 
 _LIBCUDACXX_VARIANT_MOVE_CONSTRUCTOR(_Trait::_TriviallyAvailable,
@@ -1083,22 +1083,22 @@ _LIBCUDACXX_VARIANT_MOVE_CONSTRUCTOR(_Trait::_Unavailable, __move_constructor(__
 template <class _Traits, _Trait = _Traits::__copy_constructible_trait>
 class _CCCL_TYPE_VISIBILITY_DEFAULT __copy_constructor;
 
-#define _LIBCUDACXX_VARIANT_COPY_CONSTRUCTOR(copy_constructible_trait, copy_constructor)                             \
-  template <class... _Types>                                                                                         \
-  class _CCCL_TYPE_VISIBILITY_DEFAULT                                                                                \
-  __copy_constructor<__traits<_Types...>, copy_constructible_trait> : public __move_constructor<__traits<_Types...>> \
-  {                                                                                                                  \
-    using __base_type = __move_constructor<__traits<_Types...>>;                                                     \
-                                                                                                                     \
-  public:                                                                                                            \
-    using __base_type::__base_type;                                                                                  \
-    using __base_type::operator=;                                                                                    \
-                                                                                                                     \
-    _CCCL_HIDE_FROM_ABI __copy_constructor(__copy_constructor&&)                 = default;                          \
-    _CCCL_HIDE_FROM_ABI ~__copy_constructor()                                    = default;                          \
-    _CCCL_HIDE_FROM_ABI __copy_constructor& operator=(const __copy_constructor&) = default;                          \
-    _CCCL_HIDE_FROM_ABI __copy_constructor& operator=(__copy_constructor&&)      = default;                          \
-    copy_constructor                                                                                                 \
+#define _LIBCUDACXX_VARIANT_COPY_CONSTRUCTOR(copy_constructible_trait, copy_constructor)                \
+  template <class... _Types>                                                                            \
+  class _CCCL_TYPE_VISIBILITY_DEFAULT __copy_constructor<__traits<_Types...>, copy_constructible_trait> \
+      : public __move_constructor<__traits<_Types...>>                                                  \
+  {                                                                                                     \
+    using __base_type = __move_constructor<__traits<_Types...>>;                                        \
+                                                                                                        \
+  public:                                                                                               \
+    using __base_type::__base_type;                                                                     \
+    using __base_type::operator=;                                                                       \
+                                                                                                        \
+    _CCCL_HIDE_FROM_ABI __copy_constructor(__copy_constructor&&)                 = default;             \
+    _CCCL_HIDE_FROM_ABI ~__copy_constructor()                                    = default;             \
+    _CCCL_HIDE_FROM_ABI __copy_constructor& operator=(const __copy_constructor&) = default;             \
+    _CCCL_HIDE_FROM_ABI __copy_constructor& operator=(__copy_constructor&&)      = default;             \
+    copy_constructor                                                                                    \
   }
 
 _LIBCUDACXX_VARIANT_COPY_CONSTRUCTOR(
@@ -1218,22 +1218,22 @@ protected:
 template <class _Traits, _Trait = _Traits::__move_assignable_trait>
 class _CCCL_TYPE_VISIBILITY_DEFAULT __move_assignment;
 
-#define _LIBCUDACXX_VARIANT_MOVE_ASSIGNMENT(move_assignable_trait, move_assignment)                        \
-  template <class... _Types>                                                                               \
-  class _CCCL_TYPE_VISIBILITY_DEFAULT                                                                      \
-  __move_assignment<__traits<_Types...>, move_assignable_trait> : public __assignment<__traits<_Types...>> \
-  {                                                                                                        \
-    using __base_type = __assignment<__traits<_Types...>>;                                                 \
-                                                                                                           \
-  public:                                                                                                  \
-    using __base_type::__base_type;                                                                        \
-    using __base_type::operator=;                                                                          \
-                                                                                                           \
-    _CCCL_HIDE_FROM_ABI __move_assignment(const __move_assignment&)            = default;                  \
-    _CCCL_HIDE_FROM_ABI __move_assignment(__move_assignment&&)                 = default;                  \
-    _CCCL_HIDE_FROM_ABI ~__move_assignment()                                   = default;                  \
-    _CCCL_HIDE_FROM_ABI __move_assignment& operator=(const __move_assignment&) = default;                  \
-    move_assignment                                                                                        \
+#define _LIBCUDACXX_VARIANT_MOVE_ASSIGNMENT(move_assignable_trait, move_assignment)                 \
+  template <class... _Types>                                                                        \
+  class _CCCL_TYPE_VISIBILITY_DEFAULT __move_assignment<__traits<_Types...>, move_assignable_trait> \
+      : public __assignment<__traits<_Types...>>                                                    \
+  {                                                                                                 \
+    using __base_type = __assignment<__traits<_Types...>>;                                          \
+                                                                                                    \
+  public:                                                                                           \
+    using __base_type::__base_type;                                                                 \
+    using __base_type::operator=;                                                                   \
+                                                                                                    \
+    _CCCL_HIDE_FROM_ABI __move_assignment(const __move_assignment&)            = default;           \
+    _CCCL_HIDE_FROM_ABI __move_assignment(__move_assignment&&)                 = default;           \
+    _CCCL_HIDE_FROM_ABI ~__move_assignment()                                   = default;           \
+    _CCCL_HIDE_FROM_ABI __move_assignment& operator=(const __move_assignment&) = default;           \
+    move_assignment                                                                                 \
   }
 
 _LIBCUDACXX_VARIANT_MOVE_ASSIGNMENT(
@@ -1255,22 +1255,22 @@ _LIBCUDACXX_VARIANT_MOVE_ASSIGNMENT(_Trait::_Unavailable, __move_assignment& ope
 template <class _Traits, _Trait = _Traits::__copy_assignable_trait>
 class _CCCL_TYPE_VISIBILITY_DEFAULT __copy_assignment;
 
-#define _LIBCUDACXX_VARIANT_COPY_ASSIGNMENT(copy_assignable_trait, copy_assignment)                             \
-  template <class... _Types>                                                                                    \
-  class _CCCL_TYPE_VISIBILITY_DEFAULT                                                                           \
-  __copy_assignment<__traits<_Types...>, copy_assignable_trait> : public __move_assignment<__traits<_Types...>> \
-  {                                                                                                             \
-    using __base_type = __move_assignment<__traits<_Types...>>;                                                 \
-                                                                                                                \
-  public:                                                                                                       \
-    using __base_type::__base_type;                                                                             \
-    using __base_type::operator=;                                                                               \
-                                                                                                                \
-    _CCCL_HIDE_FROM_ABI __copy_assignment(const __copy_assignment&)       = default;                            \
-    _CCCL_HIDE_FROM_ABI __copy_assignment(__copy_assignment&&)            = default;                            \
-    _CCCL_HIDE_FROM_ABI ~__copy_assignment()                              = default;                            \
-    _CCCL_HIDE_FROM_ABI __copy_assignment& operator=(__copy_assignment&&) = default;                            \
-    copy_assignment                                                                                             \
+#define _LIBCUDACXX_VARIANT_COPY_ASSIGNMENT(copy_assignable_trait, copy_assignment)                 \
+  template <class... _Types>                                                                        \
+  class _CCCL_TYPE_VISIBILITY_DEFAULT __copy_assignment<__traits<_Types...>, copy_assignable_trait> \
+      : public __move_assignment<__traits<_Types...>>                                               \
+  {                                                                                                 \
+    using __base_type = __move_assignment<__traits<_Types...>>;                                     \
+                                                                                                    \
+  public:                                                                                           \
+    using __base_type::__base_type;                                                                 \
+    using __base_type::operator=;                                                                   \
+                                                                                                    \
+    _CCCL_HIDE_FROM_ABI __copy_assignment(const __copy_assignment&)       = default;                \
+    _CCCL_HIDE_FROM_ABI __copy_assignment(__copy_assignment&&)            = default;                \
+    _CCCL_HIDE_FROM_ABI ~__copy_assignment()                              = default;                \
+    _CCCL_HIDE_FROM_ABI __copy_assignment& operator=(__copy_assignment&&) = default;                \
+    copy_assignment                                                                                 \
   }
 
 _LIBCUDACXX_VARIANT_COPY_ASSIGNMENT(
@@ -1500,10 +1500,10 @@ struct __variant_constraints
   template <bool>
   struct __swappable
   {
-    static constexpr bool __is_swappable =
+    static constexpr bool __is_swappable_v =
       __all<(is_move_constructible_v<_Types> && is_swappable_v<_Types>) ...>::value;
 
-    static constexpr bool __is_nothrow_swappable =
+    static constexpr bool __is_nothrow_swappable_v =
       __all<(is_nothrow_move_constructible_v<_Types> && is_nothrow_swappable_v<_Types>) ...>::value;
   };
 };
@@ -1679,8 +1679,8 @@ public:
 
   template <bool _Dummy       = true,
             class _Constraint = __swap_constraint<_Dummy>,
-            class             = enable_if_t<_Constraint::__is_swappable>>
-  _CCCL_API inline void swap(variant& __that) noexcept(_Constraint::__is_nothrow_swappable)
+            class             = enable_if_t<_Constraint::__is_swappable_v>>
+  _CCCL_API inline void swap(variant& __that) noexcept(_Constraint::__is_nothrow_swappable_v)
   {
     __impl_.__swap(__that.__impl_);
   }

--- a/libcudacxx/include/cuda/std/ratio
+++ b/libcudacxx/include/cuda/std/ratio
@@ -212,11 +212,10 @@ template <intmax_t _Num, intmax_t _Den>
 constexpr intmax_t ratio<_Num, _Den>::den;
 
 template <class _Tp>
-struct __is_ratio : false_type
-{};
+inline constexpr bool __is_ratio_v = false;
+
 template <intmax_t _Num, intmax_t _Den>
-struct __is_ratio<ratio<_Num, _Den>> : true_type
-{};
+inline constexpr bool __is_ratio_v<ratio<_Num, _Den>> = true;
 
 using atto  = ratio<1LL, 1000000000000000000LL>;
 using femto = ratio<1LL, 1000000000000000LL>;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/static_requirements.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/static_requirements.pass.cpp
@@ -101,7 +101,7 @@ template <class M, size_t... Idxs>
 __host__ __device__ void test_mapping_requirements(cuda::std::index_sequence<Idxs...>)
 {
   using E = typename M::extents_type;
-  static_assert(cuda::std::__mdspan_detail::__is_extents<E>::value, "");
+  static_assert(cuda::std::__mdspan_detail::__is_extents_v<E>, "");
   static_assert(cuda::std::is_copy_constructible<M>::value, "");
   static_assert(cuda::std::is_nothrow_move_constructible<M>::value, "");
   static_assert(cuda::std::is_nothrow_move_assignable<M>::value, "");

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/static_requirements.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/static_requirements.pass.cpp
@@ -101,7 +101,7 @@ template <class M, size_t... Idxs>
 __host__ __device__ void test_mapping_requirements(cuda::std::index_sequence<Idxs...>)
 {
   using E = typename M::extents_type;
-  static_assert(cuda::std::__mdspan_detail::__is_extents<E>::value, "");
+  static_assert(cuda::std::__mdspan_detail::__is_extents_v<E>, "");
   static_assert(cuda::std::is_copy_constructible<M>::value, "");
   static_assert(cuda::std::is_nothrow_move_constructible<M>::value, "");
   static_assert(cuda::std::is_nothrow_move_assignable<M>::value, "");

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_swappable_include_order.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_swappable_include_order.pass.cpp
@@ -32,7 +32,7 @@ int main(int, char**)
   // Use a builtin type so we don't get ADL lookup.
   typedef double T[17][29];
   {
-    static_assert(cuda::std::__is_swappable<T>::value, "");
+    static_assert(cuda::std::is_nothrow_swappable_v<T>, "");
     static_assert(cuda::std::is_swappable_v<T>, "");
   }
   {


### PR DESCRIPTION
Instantiating types is expensive so we should try and use the inline variables as much as possible