### PR TITLE
Unwrap cuda::zip_iterator/zip_function in thrust::transform

### DIFF
--- a/libcudacxx/include/cuda/__iterator/zip_function.h
+++ b/libcudacxx/include/cuda/__iterator/zip_function.h
@@ -91,6 +91,16 @@ public:
   {
     return ::cuda::std::apply(__fun_, ::cuda::std::forward<_Tuple>(__tuple));
   }
+
+  [[nodiscard]] _CCCL_API constexpr _Fn& __fun() noexcept
+  {
+    return __fun_;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr const _Fn& __fun() const noexcept
+  {
+    return __fun_;
+  }
 };
 
 //! @}

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -593,6 +593,16 @@ public:
   {
     return __zip_apply(__zip_op_iter_swap{}, __lhs.__current_, __rhs.__current_);
   }
+
+  [[nodiscard]] _CCCL_API constexpr __tuple_or_pair<_Iterators...>& __iterators() noexcept
+  {
+    return __current_;
+  }
+
+  [[nodiscard]] _CCCL_API constexpr const __tuple_or_pair<_Iterators...>& __iterators() const noexcept
+  {
+    return __current_;
+  }
 };
 
 template <class... _Iterators>

--- a/thrust/testing/cuda/transform.cu
+++ b/thrust/testing/cuda/transform.cu
@@ -1,6 +1,8 @@
 #include <thrust/execution_policy.h>
 #include <thrust/transform.h>
 
+#include <cuda/iterator>
+
 #include <unittest/unittest.h>
 
 #ifdef THRUST_TEST_DEVICE_SIDE
@@ -392,7 +394,7 @@ private:
 THRUST_NAMESPACE_END
 
 // test that the cuda_cub backend of Thrust unwraps zip_iterators/zip_functions into their input streams
-void TestTransformZipIteratorUnwrapping()
+void TestTransformThrustZipIteratorUnwrapping()
 {
   constexpr int num_items = 100;
   thrust::device_vector<std::int8_t> a(num_items, 1);
@@ -425,4 +427,73 @@ void TestTransformZipIteratorUnwrapping()
     ASSERT_EQUAL(reference, result);
   }
 }
-DECLARE_UNITTEST(TestTransformZipIteratorUnwrapping);
+DECLARE_UNITTEST(TestTransformThrustZipIteratorUnwrapping);
+
+// we specialize zip_function for sum_five, but do nothing in the call operator so the test below would fail if the
+// zip_function is actually called (and not unwrapped)
+_CCCL_BEGIN_NAMESPACE_CUDA
+template <>
+class zip_function<sum_five>
+{
+private:
+  sum_five __fun_;
+
+public:
+  zip_function() = default;
+
+  _CCCL_HOST_DEVICE zip_function(sum_five&& func) noexcept
+      : __fun_(::cuda::std::move(func))
+  {}
+
+  template <typename _Tuple>
+  _CCCL_HOST_DEVICE decltype(auto) operator()(_Tuple&& __tuple) const noexcept
+  {
+    // not calling func, just return a default ctored element, so we would get a wrong result if we were called
+    return decltype(::cuda::std::apply(__fun_, ::cuda::std::forward<_Tuple>(__tuple))){};
+  }
+
+  _CCCL_HOST_DEVICE sum_five& __fun() noexcept
+  {
+    return __fun_;
+  }
+
+  _CCCL_HOST_DEVICE const sum_five& __fun() const noexcept
+  {
+    return __fun_;
+  }
+};
+_CCCL_END_NAMESPACE_CUDA
+
+// test that the cuda_cub backend of Thrust unwraps zip_iterators/zip_functions into their input streams
+void TestTransformCudaZipIteratorUnwrapping()
+{
+  constexpr int num_items = 100;
+  thrust::device_vector<std::int8_t> a(num_items, 1);
+  thrust::device_vector<std::int16_t> b(num_items, 2);
+  thrust::device_vector<std::int32_t> c(num_items, 3);
+  thrust::device_vector<std::int64_t> d(num_items, 4);
+  thrust::device_vector<float> e(num_items, 5);
+
+  thrust::device_vector<double> result(num_items);
+  // SECTION("once") // TODO(bgruber): enable sections when we migrate to Catch2
+  {
+    const auto z = cuda::make_zip_iterator(a.begin(), b.begin(), c.begin(), d.begin(), e.begin());
+    thrust::transform(z, z + num_items, result.begin(), cuda::zip_function(sum_five{}));
+
+    // compute reference and verify
+    thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
+    ASSERT_EQUAL(reference, result);
+  }
+  // SECTION("trice")
+  {
+    const auto z = cuda::make_zip_iterator(
+      cuda::make_zip_iterator(cuda::make_zip_iterator(a.begin(), b.begin(), c.begin(), d.begin(), e.begin())));
+    thrust::transform(
+      z, z + num_items, result.begin(), cuda::zip_function<cuda::zip_function<cuda::zip_function<sum_five>>>{});
+
+    // compute reference and verify
+    thrust::device_vector<double> reference(num_items, 1 + 2 + 3 + 4 + 5);
+    ASSERT_EQUAL(reference, result);
+  }
+}
+DECLARE_UNITTEST(TestTransformCudaZipIteratorUnwrapping);


### PR DESCRIPTION
This allows `cub::DeviceTransform` to optimize better.