### PR TITLE
Replace `__all` with fold expression

### DIFF
--- a/libcudacxx/include/cuda/__memory_resource/resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource.h
@@ -83,8 +83,7 @@ _CCCL_CONCEPT resource = _CCCL_REQUIRES_EXPR(
 // We cannot use fold expressions here due to a nvcc bug
 template <class _Resource, class... _Properties>
 _CCCL_CONCEPT synchronous_resource_with = _CCCL_REQUIRES_EXPR((_Resource, variadic _Properties))(
-  requires(synchronous_resource<_Resource>),
-  requires(::cuda::std::__all<has_property<_Resource, _Properties>...>::value));
+  requires(synchronous_resource<_Resource>), requires((has_property<_Resource, _Properties> && ...)));
 
 //! @brief The \c resource_with concept verifies that a type Resource satisfies the `resource`
 //! concept and also satisfies all the provided Properties
@@ -93,7 +92,7 @@ _CCCL_CONCEPT synchronous_resource_with = _CCCL_REQUIRES_EXPR((_Resource, variad
 // We cannot use fold expressions here due to a nvcc bug
 template <class _Resource, class... _Properties>
 _CCCL_CONCEPT resource_with = _CCCL_REQUIRES_EXPR((_Resource, variadic _Properties))(
-  requires(resource<_Resource>), requires(::cuda::std::__all<has_property<_Resource, _Properties>...>::value));
+  requires(resource<_Resource>), requires((has_property<_Resource, _Properties> && ...)));
 
 template <bool _Convertible>
 struct __different_resource__

--- a/libcudacxx/include/cuda/std/__functional/hash.h
+++ b/libcudacxx/include/cuda/std/__functional/hash.h
@@ -639,7 +639,7 @@ using __enable_hash_helper_imp _CCCL_NODEBUG_ALIAS = _Type;
 
 template <class _Type, class... _Keys>
 using __enable_hash_helper _CCCL_NODEBUG_ALIAS =
-  __enable_hash_helper_imp<_Type, enable_if_t<__all<__has_enabled_hash<_Keys>::value...>::value>>;
+  __enable_hash_helper_imp<_Type, enable_if_t<(__has_enabled_hash<_Keys>::value && ...)>>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -239,14 +239,14 @@ public:
 
   // constructors from dynamic values only -- this covers the case for rank() == 0
   _CCCL_TEMPLATE(class... _DynVals)
-  _CCCL_REQUIRES((sizeof...(_DynVals) == __size_dynamic_) && (!__all<__is_std_span_v<_DynVals>...>::value))
+  _CCCL_REQUIRES((sizeof...(_DynVals) == __size_dynamic_) && (!(__is_std_span_v<_DynVals> && ...)))
   _CCCL_API constexpr __maybe_static_array(_DynVals... __vals) noexcept
       : _DynamicValues{static_cast<_TDynamic>(__vals)...}
   {}
 
   // constructors from all values -- here rank will be greater than 0
   _CCCL_TEMPLATE(class... _DynVals)
-  _CCCL_REQUIRES((sizeof...(_DynVals) != __size_dynamic_) && (!__all<__is_std_span_v<_DynVals>...>::value))
+  _CCCL_REQUIRES((sizeof...(_DynVals) != __size_dynamic_) && (!(__is_std_span_v<_DynVals> && ...)))
   _CCCL_API constexpr __maybe_static_array(_DynVals... __vals)
       : _DynamicValues{}
   {
@@ -417,9 +417,8 @@ public:
 
   static_assert(is_integral_v<index_type> && !is_same_v<index_type, bool>,
                 "extents::index_type must be a signed or unsigned integer type");
-  static_assert(
-    __all<(__mdspan_detail::__is_representable_as<index_type>(_Extents) || (_Extents == dynamic_extent))...>::value,
-    "extents ctor: arguments must be representable as index_type and nonnegative");
+  static_assert(((__mdspan_detail::__is_representable_as<index_type>(_Extents) || (_Extents == dynamic_extent)) && ...),
+                "extents ctor: arguments must be representable as index_type and nonnegative");
 
 private:
   static constexpr rank_type __rank_ = sizeof...(_Extents);

--- a/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/sfinae_helpers.h
@@ -26,6 +26,7 @@
 #include <cuda/std/__tuple_dir/tuple_like_ext.h>
 #include <cuda/std/__tuple_dir/tuple_size.h>
 #include <cuda/std/__tuple_dir/tuple_types.h>
+#include <cuda/std/__type_traits/all.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_assignable.h>
@@ -41,12 +42,6 @@
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
-
-template <bool... _Preds>
-struct __all_dummy;
-
-template <bool... _Pred>
-using __all = is_same<__all_dummy<_Pred...>, __all_dummy<((void) _Pred, true)...>>;
 
 struct __tuple_sfinae_base
 {
@@ -64,7 +59,7 @@ struct __tuple_sfinae_base
 
   template <template <class, class...> class _Trait, class... _LArgs, class... _RArgs>
   struct __test<_Trait, __tuple_types<_LArgs...>, __tuple_types<_RArgs...>, true>
-      : __all<_Trait<_LArgs, _RArgs>::value...>
+      : bool_constant<__all_v<_Trait<_LArgs, _RArgs>::value...>>
   {};
 
   template <class _FromArgs, class _ToArgs>

--- a/libcudacxx/include/cuda/std/__type_traits/all.h
+++ b/libcudacxx/include/cuda/std/__type_traits/all.h
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___TYPE_TRAITS_ALL_H
+#define _CUDA_STD___TYPE_TRAITS_ALL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <bool... _Pred>
+inline constexpr bool __all_v = (_Preds && ...);
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___TYPE_TRAITS_ALL_H

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -168,6 +168,7 @@ template <class... Types>
 #include <cuda/std/__tuple_dir/tuple_size.h>
 #include <cuda/std/__tuple_dir/tuple_types.h>
 #include <cuda/std/__tuple_dir/vector_types.h>
+#include <cuda/std/__type_traits/all.h>
 #include <cuda/std/__type_traits/copy_cvref.h>
 #include <cuda/std/__type_traits/maybe_const.h>
 #include <cuda/std/__type_traits/reference_constructs_from_temporary.h>
@@ -514,7 +515,7 @@ template <class _Tp>
 struct __all_default_constructible;
 
 template <class... _Tp>
-struct __all_default_constructible<__tuple_types<_Tp...>> : __all<is_default_constructible_v<_Tp>...>
+struct __all_default_constructible<__tuple_types<_Tp...>> : bool_constant<is_default_constructible_v<_Tp>&&...>
 {};
 
 struct __tuple_variadic_constructor_tag
@@ -523,10 +524,10 @@ struct __tuple_variadic_constructor_tag
 // __tuple_impl
 
 template <class... _Tp>
-inline constexpr bool __tuple_all_copy_assignable_v = (is_copy_assignable_v<_Tp> && ... && true);
+inline constexpr bool __tuple_all_copy_assignable_v = (is_copy_assignable_v<_Tp> && ...);
 
 template <class... _Tp>
-inline constexpr bool __tuple_all_move_assignable_v = (is_move_assignable_v<_Tp> && ... && true);
+inline constexpr bool __tuple_all_move_assignable_v = (is_move_assignable_v<_Tp> && ...);
 
 template <class _Indx, class... _Tp>
 struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl;
@@ -538,7 +539,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...
                                         __tuple_all_copy_assignable_v<_Tp...>,
                                         __tuple_all_move_assignable_v<_Tp...>>
 {
-  _CCCL_API constexpr __tuple_impl() noexcept(__all<is_nothrow_default_constructible_v<_Tp>...>::value)
+  _CCCL_API constexpr __tuple_impl() noexcept(__all_v<is_nothrow_default_constructible_v<_Tp>...>)
       : __tuple_leaf<_Indx, _Tp>()...
   {}
 
@@ -546,7 +547,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...
   // Old MSVC cannot handle the noexept specifier outside of template arguments
   template <class... _Up,
             enable_if_t<sizeof...(_Up) == sizeof...(_Tp), int> = 0,
-            bool __all_nothrow_constructible                   = __all<is_nothrow_constructible_v<_Tp, _Up>...>::value>
+            bool __all_nothrow_constructible                   = (is_nothrow_constructible_v<_Tp, _Up> && ...)>
   _CCCL_API constexpr explicit __tuple_impl(__tuple_variadic_constructor_tag,
                                             _Up&&... __u) noexcept(__all_nothrow_constructible)
       : __tuple_leaf<_Indx, _Tp>(::cuda::std::forward<_Up>(__u))...
@@ -578,7 +579,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...
 
   template <class _Tuple, enable_if_t<__tuple_constructible<_Tuple, tuple<_Tp...>>::value, int> = 0>
   _CCCL_API constexpr __tuple_impl(_Tuple&& __t) noexcept(
-    (__all<is_nothrow_constructible_v<_Tp, __tuple_elem_at<_Tuple, _Indx>>...>::value))
+    __all_v<is_nothrow_constructible_v<_Tp, __tuple_elem_at<_Tuple, _Indx>>...>)
       : __tuple_leaf<_Indx, _Tp>(::cuda::std::forward<__tuple_elem_at<_Tuple, _Indx>>(::cuda::std::get<_Indx>(__t)))...
   {}
 
@@ -591,7 +592,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...
 
   template <class _Tuple, enable_if_t<__tuple_assignable<_Tuple, tuple<_Tp...>>::value, int> = 0>
   _CCCL_API inline __tuple_impl&
-  operator=(_Tuple&& __t) noexcept((__all<is_nothrow_assignable_v<_Tp&, __tuple_elem_at<_Tuple, _Indx>>...>::value))
+  operator=(_Tuple&& __t) noexcept(__all_v<is_nothrow_assignable_v<_Tp&, __tuple_elem_at<_Tuple, _Indx>>...>)
   {
     ::cuda::std::__swallow(__tuple_leaf<_Indx, _Tp>::operator=(
       ::cuda::std::forward<__tuple_elem_at<_Tuple, _Indx>>(::cuda::std::get<_Indx>(__t)))...);
@@ -603,7 +604,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __tuple_impl<__tuple_indices<_Indx...>, _Tp...
   _CCCL_HIDE_FROM_ABI __tuple_impl& operator=(const __tuple_impl&) = default;
   _CCCL_HIDE_FROM_ABI __tuple_impl& operator=(__tuple_impl&&)      = default;
 
-  _CCCL_API inline void swap(__tuple_impl& __t) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
+  _CCCL_API inline void swap(__tuple_impl& __t) noexcept(__all_v<__is_nothrow_swappable<_Tp>::value...>)
   {
     ::cuda::std::__swallow(__tuple_leaf<_Indx, _Tp>::swap(static_cast<__tuple_leaf<_Indx, _Tp>&>(__t))...);
   }
@@ -619,13 +620,12 @@ struct __invalid_tuple_constraints
 template <class... _Tp>
 struct __tuple_constraints
 {
-  static constexpr bool __implicit_default_constructible =
-    __all<__is_implicitly_default_constructible<_Tp>::value...>::value;
+  static constexpr bool __implicit_default_constructible = (__is_implicitly_default_constructible<_Tp>::value && ...);
 
   static constexpr bool __explicit_default_constructible =
-    !__implicit_default_constructible && __all<is_default_constructible_v<_Tp>...>::value;
+    !__implicit_default_constructible && (is_default_constructible_v<_Tp> && ...);
 
-  static constexpr bool __nothrow_default_constructible = __all<is_nothrow_default_constructible_v<_Tp>...>::value;
+  static constexpr bool __nothrow_default_constructible = (is_nothrow_default_constructible_v<_Tp> && ...);
 
   static constexpr bool __implicit_variadic_copy_constructible =
     __tuple_constructible<tuple<const _Tp&...>, tuple<_Tp...>>::value
@@ -635,7 +635,7 @@ struct __tuple_constraints
     __tuple_constructible<tuple<const _Tp&...>, tuple<_Tp...>>::value
     && !__tuple_convertible<tuple<const _Tp&...>, tuple<_Tp...>>::value;
 
-  static constexpr bool __nothrow_variadic_copy_constructible = __all<is_nothrow_copy_constructible_v<_Tp>...>::value;
+  static constexpr bool __nothrow_variadic_copy_constructible = (is_nothrow_copy_constructible_v<_Tp> && ...);
 
   template <class... _Args>
   struct _PackExpandsToThisTuple : false_type
@@ -656,7 +656,7 @@ struct __tuple_constraints
       __tuple_constructible<tuple<_Args...>, tuple<_Tp...>>::value
       && !__tuple_convertible<tuple<_Args...>, tuple<_Tp...>>::value;
 
-    static constexpr bool __nothrow_constructible = __all<is_nothrow_constructible_v<_Tp, _Args>...>::value;
+    static constexpr bool __nothrow_constructible = (is_nothrow_constructible_v<_Tp, _Args> && ...);
   };
 
   template <class... _Args>
@@ -944,9 +944,6 @@ public:
       : __base_(allocator_arg_t(), __a, ::cuda::std::forward<_Tuple>(__t))
   {}
 
-  using _CanCopyAssign = __all<is_copy_assignable_v<_Tp>...>;
-  using _CanMoveAssign = __all<is_move_assignable_v<_Tp>...>;
-
   _CCCL_HIDE_FROM_ABI tuple& operator=(const tuple& __t) = default;
   _CCCL_HIDE_FROM_ABI tuple& operator=(tuple&& __t)      = default;
 
@@ -957,7 +954,7 @@ public:
     return *this;
   }
 
-  _CCCL_API inline void swap(tuple& __t) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
+  _CCCL_API inline void swap(tuple& __t) noexcept(__all_v<__is_nothrow_swappable<_Tp>::value...>)
   {
     __base_.swap(__t.__base_);
   }
@@ -996,7 +993,7 @@ _CCCL_HOST_DEVICE tuple(allocator_arg_t, _Alloc, tuple<_Tp...>) -> tuple<_Tp...>
 
 template <class... _Tp>
 _CCCL_API inline enable_if_t<_And<__is_swappable<_Tp>...>::value, void>
-swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u) noexcept(__all<__is_nothrow_swappable<_Tp>::value...>::value)
+swap(tuple<_Tp...>& __t, tuple<_Tp...>& __u) noexcept(__all_v<__is_nothrow_swappable<_Tp>::value...>)
 {
   __t.swap(__u);
 }

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/variant
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/variant
@@ -232,6 +232,7 @@ C++20
 #include <cuda/std/__type_traits/add_cv.h>
 #include <cuda/std/__type_traits/add_pointer.h>
 #include <cuda/std/__type_traits/add_volatile.h>
+#include <cuda/std/__type_traits/all.h>
 #include <cuda/std/__type_traits/dependent_type.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_array.h>
@@ -1072,7 +1073,7 @@ _LIBCUDACXX_VARIANT_MOVE_CONSTRUCTOR(_Trait::_TriviallyAvailable,
 _LIBCUDACXX_VARIANT_MOVE_CONSTRUCTOR(
   _Trait::_Available,
   _CCCL_API inline __move_constructor(__move_constructor&& __that) noexcept(
-    __all<is_nothrow_move_constructible_v<_Types>...>::value) : __move_constructor(__valueless_t{}) {
+    __all_v<is_nothrow_move_constructible_v<_Types>...>) : __move_constructor(__valueless_t{}) {
     this->__generic_construct(*this, ::cuda::std::move(__that));
   });
 
@@ -1243,7 +1244,7 @@ _LIBCUDACXX_VARIANT_MOVE_ASSIGNMENT(
   _Trait::_Available,
   _CCCL_API inline __move_assignment&
   operator=(__move_assignment&& __that) noexcept(
-    __all<(is_nothrow_move_constructible_v<_Types> && is_nothrow_move_assignable_v<_Types>) ...>::value) {
+    __all_v<(is_nothrow_move_constructible_v<_Types> && is_nothrow_move_assignable_v<_Types>) ...>) {
     this->__generic_assign(::cuda::std::move(__that));
     return *this;
   });
@@ -1500,29 +1501,24 @@ struct __variant_constraints
   template <bool>
   struct __swappable
   {
-    static constexpr bool __is_swappable =
-      __all<(is_move_constructible_v<_Types> && is_swappable_v<_Types>) ...>::value;
-
+    static constexpr bool __is_swappable = ((is_move_constructible_v<_Types> && is_swappable_v<_Types>) && ...);
     static constexpr bool __is_nothrow_swappable =
-      __all<(is_nothrow_move_constructible_v<_Types> && is_nothrow_swappable_v<_Types>) ...>::value;
+      ((is_nothrow_move_constructible_v<_Types> && is_nothrow_swappable_v<_Types>) && ...);
   };
 };
 } // namespace __variant_detail
 
 template <class... _Types>
 class _CCCL_TYPE_VISIBILITY_DEFAULT variant
-    : private __sfinae_base<__all<is_copy_constructible_v<_Types>...>::value,
-                            __all<is_move_constructible_v<_Types>...>::value,
-                            __all<(is_copy_constructible_v<_Types> && is_copy_assignable_v<_Types>) ...>::value,
-                            __all<(is_move_constructible_v<_Types> && is_move_assignable_v<_Types>) ...>::value>
+    : private __sfinae_base<(is_copy_constructible_v<_Types> && ...),
+                            (is_move_constructible_v<_Types> && ...),
+                            ((is_copy_constructible_v<_Types> && is_copy_assignable_v<_Types>) && ...),
+                            ((is_move_constructible_v<_Types> && is_move_assignable_v<_Types>) && ...)>
 {
   static_assert(0 < sizeof...(_Types), "variant must consist of at least one alternative.");
-
-  static_assert(__all<!is_array_v<_Types>...>::value, "variant can not have an array type as an alternative.");
-
-  static_assert(__all<!is_reference_v<_Types>...>::value, "variant can not have a reference type as an alternative.");
-
-  static_assert(__all<!is_void_v<_Types>...>::value, "variant can not have a void type as an alternative.");
+  static_assert((!is_array_v<_Types> && ...), "variant can not have an array type as an alternative.");
+  static_assert((!is_reference_v<_Types> && ...), "variant can not have a reference type as an alternative.");
+  static_assert((!is_void_v<_Types> && ...), "variant can not have a void type as an alternative.");
 
   using __first_type  = variant_alternative_t<0, variant>;
   using __constraints = __variant_detail::__variant_constraints<_Types...>;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/CustomTestLayouts.h
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/CustomTestLayouts.h
@@ -217,13 +217,11 @@ public:
     const extents_type& extents_{};
   };
 
-  template <
-    class... Indices,
-    cuda::std::enable_if_t<sizeof...(Indices) == extents_type::rank(), int>                                        = 0,
-    cuda::std::enable_if_t<cuda::std::__all<cuda::std::integral<Indices>...>::value, int>                          = 0,
-    cuda::std::enable_if_t<cuda::std::__all<cuda::std::is_convertible<Indices, index_type>::value...>::value, int> = 0,
-    cuda::std::enable_if_t<cuda::std::__all<cuda::std::is_nothrow_constructible<index_type, Indices>::value...>::value,
-                           int>                                                                                    = 0>
+  template <class... Indices,
+            cuda::std::enable_if_t<sizeof...(Indices) == extents_type::rank(), int>                          = 0,
+            cuda::std::enable_if_t<(cuda::std::integral_v<Indices> && ...), int>                             = 0,
+            cuda::std::enable_if_t<(cuda::std::is_convertible_v<Indices, index_type> && ...), int>           = 0,
+            cuda::std::enable_if_t<(cuda::std::is_nothrow_constructible_v<index_type, Indices> && ...), int> = 0>
   __host__ __device__ constexpr index_type operator()(Indices... idx) const noexcept
   {
     return rank_accumulator{extents_}(cuda::std::make_index_sequence<sizeof...(Indices)>(), idx...);
@@ -483,13 +481,11 @@ public:
     const extents_type& extents_{};
   };
 
-  template <
-    class... Indices,
-    cuda::std::enable_if_t<sizeof...(Indices) == extents_type::rank(), int>                                        = 0,
-    cuda::std::enable_if_t<cuda::std::__all<cuda::std::integral<Indices>...>::value, int>                          = 0,
-    cuda::std::enable_if_t<cuda::std::__all<cuda::std::is_convertible<Indices, index_type>::value...>::value, int> = 0,
-    cuda::std::enable_if_t<cuda::std::__all<cuda::std::is_nothrow_constructible<index_type, Indices>::value...>::value,
-                           int>                                                                                    = 0>
+  template <class... Indices,
+            cuda::std::enable_if_t<sizeof...(Indices) == extents_type::rank(), int>                          = 0,
+            cuda::std::enable_if_t<(cuda::std::integral_v<Indices> && ...), int>                             = 0,
+            cuda::std::enable_if_t<(cuda::std::is_convertible_v<Indices, index_type> && ...), int>           = 0,
+            cuda::std::enable_if_t<(cuda::std::is_nothrow_constructible_v<index_type, Indices> && ...), int> = 0>
   __host__ __device__ constexpr index_type operator()(Indices... idx) const noexcept
   {
     return offset_

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
@@ -42,12 +42,13 @@ __host__ __device__ constexpr auto& access(MDS mds, int64_t i0)
 }
 
 #if defined(_LIBCUDACXX_HAS_MULTIARG_OPERATOR_BRACKETS)
-template <class MDS,
-          class... Indices,
-          class  = cuda::std::enable_if_t<
-             cuda::std::__all<cuda::std::is_same<decltype(cuda::std::declval<MDS>()[cuda::std::declval<Indices>()...]),
-                                                 typename MDS::reference>::value>::value,
-             int> = 0>
+template <
+  class MDS,
+  class... Indices,
+  class  = cuda::std::enable_if_t<
+     (cuda::std::is_same_v<decltype(cuda::std::declval<MDS>()[cuda::std::declval<Indices>()...]), typename MDS::reference>
+     && ...),
+     int> = 0>
 __host__ __device__ constexpr bool check_operator_constraints(MDS m, Indices... idxs)
 {
   unused(m[idxs...]);


### PR DESCRIPTION
This PR replaces `__all` trait with fold expression if possible. I've kept the `__all_v` trait for cases when `__all` was used inside `noexcept`, because compilers tend to have problems with fold expressions inside `noexcept`.