### PR TITLE
Fix cuda13.0-rapids-conda devcontainer symlink

### DIFF
--- a/.devcontainer/cuda12.9-rapids-conda
+++ b/.devcontainer/cuda12.9-rapids-conda
@@ -1,1 +1,0 @@
-../ci/rapids/cuda12.9-conda

--- a/.devcontainer/cuda13.0-rapids-conda
+++ b/.devcontainer/cuda13.0-rapids-conda
@@ -1,0 +1,1 @@
+../ci/rapids/cuda13.0-conda


### PR DESCRIPTION
## Description
Fix for #5967 / #5898. CCCL/RAPIDS CI is broken with `Requested devcontainer .devcontainer/cuda13.0-rapids-conda/devcontainer.json does not exist`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
