### PR TITLE
Split up high-mem compilations in CUB to help out CI runners

### DIFF
--- a/cub/test/catch2_test_block_radix_sort_keys.cu
+++ b/cub/test/catch2_test_block_radix_sort_keys.cu
@@ -1,0 +1,188 @@
+/******************************************************************************
+ * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the NVIDIA CORPORATION nor the
+ *       names of its contributors may be used to endorse or promote products
+ *       derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ ******************************************************************************/
+
+#include <thrust/execution_policy.h>
+
+#include <algorithm>
+#include <type_traits>
+#include <utility>
+
+#include "catch2_test_block_radix_sort.cuh"
+#include <c2h/catch2_test_helper.h> // _CCCL_HAS_NVFP8()
+
+// %PARAM% TEST_MEMOIZE mem 0:1
+// %PARAM% TEST_ALGORITHM alg 0:1
+// %PARAM% TEST_IPT ipt 1:11
+// %PARAM% TEST_RADIX_BITS radbits 1:5
+// %PARAM% TEST_THREADS_IN_BLOCK ipt 32:160
+
+using types =
+  c2h::type_list<std::uint8_t,
+                 std::uint16_t,
+                 std::uint32_t,
+                 std::uint64_t
+#if _CCCL_HAS_NVFP8()
+                 ,
+                 __nv_fp8_e5m2,
+                 __nv_fp8_e4m3
+#endif // _CCCL_HAS_NVFP8()
+                 >;
+using no_value_types = c2h::type_list<cub::NullType>;
+
+using threads_in_block = c2h::enum_type_list<int, TEST_THREADS_IN_BLOCK>;
+using items_per_thread = c2h::enum_type_list<int, TEST_IPT>;
+using radix_bits       = c2h::enum_type_list<int, TEST_RADIX_BITS>;
+using memoize          = c2h::enum_type_list<bool, TEST_MEMOIZE>;
+
+#if TEST_ALGORITHM == 0
+using algorithm = c2h::enum_type_list<cub::BlockScanAlgorithm, cub::BlockScanAlgorithm::BLOCK_SCAN_RAKING>;
+#else
+using algorithm = c2h::enum_type_list<cub::BlockScanAlgorithm, cub::BlockScanAlgorithm::BLOCK_SCAN_WARP_SCANS>;
+#endif
+
+using shmem_config =
+  c2h::enum_type_list<cudaSharedMemConfig, cudaSharedMemBankSizeFourByte, cudaSharedMemBankSizeEightByte>;
+
+using shmem_config_4 = c2h::enum_type_list<cudaSharedMemConfig, cudaSharedMemBankSizeFourByte>;
+
+template <class TestType>
+struct params_t
+{
+  using key_type   = typename c2h::get<0, TestType>;
+  using value_type = typename c2h::get<1, TestType>;
+
+  static constexpr int items_per_thread              = c2h::get<2, TestType>::value;
+  static constexpr int threads_in_block              = c2h::get<3, TestType>::value;
+  static constexpr int tile_size                     = items_per_thread * threads_in_block;
+  static constexpr int radix_bits                    = c2h::get<4, TestType>::value;
+  static constexpr bool memoize                      = c2h::get<5, TestType>::value;
+  static constexpr cub::BlockScanAlgorithm algorithm = c2h::get<6, TestType>::value;
+  static constexpr cudaSharedMemConfig shmem_config  = c2h::get<7, TestType>::value;
+};
+
+template <class T>
+bool binary_equal(
+  const c2h::device_vector<T>& d_output, const c2h::host_vector<T>& h_reference, c2h::device_vector<T>& d_tmp)
+{
+  d_tmp = h_reference;
+
+  using traits_t      = cub::Traits<T>;
+  using bit_ordered_t = typename traits_t::UnsignedBits;
+
+  auto d_output_ptr    = reinterpret_cast<const bit_ordered_t*>(thrust::raw_pointer_cast(d_output.data()));
+  auto d_reference_ptr = reinterpret_cast<const bit_ordered_t*>(thrust::raw_pointer_cast(d_tmp.data()));
+
+  return thrust::equal(c2h::device_policy, d_output_ptr, d_output_ptr + d_output.size(), d_reference_ptr);
+}
+
+C2H_TEST("Block radix sort can sort keys",
+         "[radix][sort][block]",
+         types,
+         no_value_types,
+         items_per_thread,
+         threads_in_block,
+         radix_bits,
+         memoize,
+         algorithm,
+         shmem_config)
+{
+  using params = params_t<TestType>;
+  using type   = typename params::key_type;
+
+  c2h::device_vector<type> d_output(params::tile_size);
+  c2h::device_vector<type> d_input(params::tile_size);
+  c2h::gen(C2H_SEED(2), d_input);
+
+  constexpr int key_size = sizeof(type) * 8;
+  const int begin_bit    = GENERATE_COPY(take(2, random(0, key_size)));
+  const int end_bit      = GENERATE_COPY(take(2, random(begin_bit, key_size)));
+  const bool striped     = GENERATE_COPY(false, true);
+
+  constexpr bool is_descending = false;
+
+  block_radix_sort<params::items_per_thread,
+                   params::threads_in_block,
+                   params::radix_bits,
+                   params::memoize,
+                   params::algorithm,
+                   params::shmem_config>(
+    sort_op_t{},
+    thrust::raw_pointer_cast(d_input.data()),
+    thrust::raw_pointer_cast(d_output.data()),
+    begin_bit,
+    end_bit,
+    striped);
+
+  c2h::host_vector<type> h_reference = radix_sort_reference(d_input, is_descending, begin_bit, end_bit);
+
+  // overwrite `d_input` for comparison
+  REQUIRE(binary_equal(d_output, h_reference, d_input));
+}
+
+C2H_TEST("Block radix sort can sort keys in descending order",
+         "[radix][sort][block]",
+         types,
+         no_value_types,
+         items_per_thread,
+         threads_in_block,
+         radix_bits,
+         memoize,
+         algorithm,
+         shmem_config)
+{
+  using params = params_t<TestType>;
+  using type   = typename params::key_type;
+
+  c2h::device_vector<type> d_output(params::tile_size);
+  c2h::device_vector<type> d_input(params::tile_size);
+  c2h::gen(C2H_SEED(2), d_input);
+
+  constexpr int key_size = sizeof(type) * 8;
+  const int begin_bit    = GENERATE_COPY(take(2, random(0, key_size)));
+  const int end_bit      = GENERATE_COPY(take(2, random(begin_bit, key_size)));
+  const bool striped     = GENERATE_COPY(false, true);
+
+  constexpr bool is_descending = true;
+
+  block_radix_sort<params::items_per_thread,
+                   params::threads_in_block,
+                   params::radix_bits,
+                   params::memoize,
+                   params::algorithm,
+                   params::shmem_config>(
+    descending_sort_op_t{},
+    thrust::raw_pointer_cast(d_input.data()),
+    thrust::raw_pointer_cast(d_output.data()),
+    begin_bit,
+    end_bit,
+    striped);
+
+  c2h::host_vector<type> h_reference = radix_sort_reference(d_input, is_descending, begin_bit, end_bit);
+
+  // overwrite `d_input` for comparison
+  REQUIRE(binary_equal(d_output, h_reference, d_input));
+}

--- a/cub/test/catch2_test_block_radix_sort_keys.cu
+++ b/cub/test/catch2_test_block_radix_sort_keys.cu
@@ -1,29 +1,5 @@
-/******************************************************************************
- * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the NVIDIA CORPORATION nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- ******************************************************************************/
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <thrust/execution_policy.h>
 

--- a/cub/test/catch2_test_block_radix_sort_pairs.cu
+++ b/cub/test/catch2_test_block_radix_sort_pairs.cu
@@ -37,20 +37,8 @@
 // %PARAM% TEST_MEMOIZE mem 0:1
 // %PARAM% TEST_ALGORITHM alg 0:1
 // %PARAM% TEST_IPT ipt 1:11
+// %PARAM% TEST_RADIX_BITS radbits 1:5
 // %PARAM% TEST_THREADS_IN_BLOCK ipt 32:160
-
-using types =
-  c2h::type_list<std::uint8_t,
-                 std::uint16_t,
-                 std::uint32_t,
-                 std::uint64_t
-#if _CCCL_HAS_NVFP8()
-                 ,
-                 __nv_fp8_e5m2,
-                 __nv_fp8_e4m3
-#endif // _CCCL_HAS_NVFP8()
-                 >;
-using no_value_types = c2h::type_list<cub::NullType>;
 
 using key_types =
   c2h::type_list<std::int8_t,
@@ -65,11 +53,12 @@ using key_types =
                  __nv_fp8_e4m3
 #endif // _CCCL_HAS_NVFP8()
                  >;
-using value_types = c2h::type_list<std::int8_t, c2h::custom_type_t<c2h::equal_comparable_t>>;
+using no_value_types = c2h::type_list<cub::NullType>;
+using value_types    = c2h::type_list<std::int8_t, c2h::custom_type_t<c2h::equal_comparable_t>>;
 
 using threads_in_block = c2h::enum_type_list<int, TEST_THREADS_IN_BLOCK>;
 using items_per_thread = c2h::enum_type_list<int, TEST_IPT>;
-using radix_bits       = c2h::enum_type_list<int, 1, 5>;
+using radix_bits       = c2h::enum_type_list<int, TEST_RADIX_BITS>;
 using memoize          = c2h::enum_type_list<bool, TEST_MEMOIZE>;
 
 #if TEST_ALGORITHM == 0
@@ -111,94 +100,6 @@ bool binary_equal(
   auto d_reference_ptr = reinterpret_cast<const bit_ordered_t*>(thrust::raw_pointer_cast(d_tmp.data()));
 
   return thrust::equal(c2h::device_policy, d_output_ptr, d_output_ptr + d_output.size(), d_reference_ptr);
-}
-
-C2H_TEST("Block radix sort can sort keys",
-         "[radix][sort][block]",
-         types,
-         no_value_types,
-         items_per_thread,
-         threads_in_block,
-         radix_bits,
-         memoize,
-         algorithm,
-         shmem_config)
-{
-  using params = params_t<TestType>;
-  using type   = typename params::key_type;
-
-  c2h::device_vector<type> d_output(params::tile_size);
-  c2h::device_vector<type> d_input(params::tile_size);
-  c2h::gen(C2H_SEED(2), d_input);
-
-  constexpr int key_size = sizeof(type) * 8;
-  const int begin_bit    = GENERATE_COPY(take(2, random(0, key_size)));
-  const int end_bit      = GENERATE_COPY(take(2, random(begin_bit, key_size)));
-  const bool striped     = GENERATE_COPY(false, true);
-
-  constexpr bool is_descending = false;
-
-  block_radix_sort<params::items_per_thread,
-                   params::threads_in_block,
-                   params::radix_bits,
-                   params::memoize,
-                   params::algorithm,
-                   params::shmem_config>(
-    sort_op_t{},
-    thrust::raw_pointer_cast(d_input.data()),
-    thrust::raw_pointer_cast(d_output.data()),
-    begin_bit,
-    end_bit,
-    striped);
-
-  c2h::host_vector<type> h_reference = radix_sort_reference(d_input, is_descending, begin_bit, end_bit);
-
-  // overwrite `d_input` for comparison
-  REQUIRE(binary_equal(d_output, h_reference, d_input));
-}
-
-C2H_TEST("Block radix sort can sort keys in descending order",
-         "[radix][sort][block]",
-         types,
-         no_value_types,
-         items_per_thread,
-         threads_in_block,
-         radix_bits,
-         memoize,
-         algorithm,
-         shmem_config)
-{
-  using params = params_t<TestType>;
-  using type   = typename params::key_type;
-
-  c2h::device_vector<type> d_output(params::tile_size);
-  c2h::device_vector<type> d_input(params::tile_size);
-  c2h::gen(C2H_SEED(2), d_input);
-
-  constexpr int key_size = sizeof(type) * 8;
-  const int begin_bit    = GENERATE_COPY(take(2, random(0, key_size)));
-  const int end_bit      = GENERATE_COPY(take(2, random(begin_bit, key_size)));
-  const bool striped     = GENERATE_COPY(false, true);
-
-  constexpr bool is_descending = true;
-
-  block_radix_sort<params::items_per_thread,
-                   params::threads_in_block,
-                   params::radix_bits,
-                   params::memoize,
-                   params::algorithm,
-                   params::shmem_config>(
-    descending_sort_op_t{},
-    thrust::raw_pointer_cast(d_input.data()),
-    thrust::raw_pointer_cast(d_output.data()),
-    begin_bit,
-    end_bit,
-    striped);
-
-  c2h::host_vector<type> h_reference = radix_sort_reference(d_input, is_descending, begin_bit, end_bit);
-
-  // overwrite `d_input` for comparison
-  REQUIRE(binary_equal(d_output, h_reference, d_input));
 }
 
 C2H_TEST("Block radix sort can sort pairs",

--- a/cub/test/catch2_test_block_radix_sort_pairs.cu
+++ b/cub/test/catch2_test_block_radix_sort_pairs.cu
@@ -1,29 +1,5 @@
-/******************************************************************************
- * Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *     * Redistributions of source code must retain the above copyright
- *       notice, this list of conditions and the following disclaimer.
- *     * Redistributions in binary form must reproduce the above copyright
- *       notice, this list of conditions and the following disclaimer in the
- *       documentation and/or other materials provided with the distribution.
- *     * Neither the name of the NVIDIA CORPORATION nor the
- *       names of its contributors may be used to endorse or promote products
- *       derived from this software without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL NVIDIA CORPORATION BE LIABLE FOR ANY
- * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- *
- ******************************************************************************/
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #include <thrust/execution_policy.h>
 

--- a/cub/test/catch2_test_device_for_each_in_extents.cu
+++ b/cub/test/catch2_test_device_for_each_in_extents.cu
@@ -41,6 +41,7 @@
 #include <catch2_test_launch_helper.h>
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
+// %PARAM% TEST_TYPES types 0:1
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceFor::ForEachInExtents, device_for_each_in_extents);
 
@@ -98,32 +99,38 @@ struct LinearStore
  * TEST CASES
  **********************************************************************************************************************/
 
-using index_types =
-  c2h::type_list<int8_t,
-                 uint8_t,
-                 int16_t,
-                 uint16_t,
-                 int32_t,
-                 uint32_t
-#if _CCCL_HAS_INT128()
-                 ,
-                 int64_t,
-                 uint64_t
-#endif
-                 >;
+using index_types = c2h::type_list<
+#if TEST_TYPES == 0
+  int8_t,
+  uint8_t,
+  int16_t,
+  uint16_t
+#elif TEST_TYPES == 1
+  int32_t,
+  uint32_t
+#  if _CCCL_HAS_INT128()
+  ,
+  int64_t,
+  uint64_t
+#  endif // _CCCL_HAS_INT128()
+#endif // TEST_TYPES
+  >;
 
 // int8_t/uint8_t are not enabled because they easily overflow
-using index_types_dynamic =
-  c2h::type_list<int16_t,
-                 uint16_t,
-                 int32_t,
-                 uint32_t
-#if _CCCL_HAS_INT128()
-                 ,
-                 int64_t,
-                 uint64_t
-#endif
-                 >;
+using index_types_dynamic = c2h::type_list<
+#if TEST_TYPES == 0
+  int16_t,
+  uint16_t
+#elif TEST_TYPES == 1
+  int32_t,
+  uint32_t
+#  if _CCCL_HAS_INT128()
+  ,
+  int64_t,
+  uint64_t
+#  endif // _CCCL_HAS_INT128()
+#endif // TEST_TYPES
+  >;
 
 using dimensions =
   c2h::type_list<cuda::std::index_sequence<>,

--- a/cub/test/catch2_test_device_segmented_sort_keys.cu
+++ b/cub/test/catch2_test_device_segmented_sort_keys.cu
@@ -39,22 +39,27 @@
 // FIXME: Graph launch disabled, algorithm syncs internally. WAR exists for device-launch, figure out how to enable for
 // graph launch.
 // %PARAM% TEST_LAUNCH lid 0:1
+// %PARAM% TEST_TYPES types 0:1
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedSort::StableSortKeys, stable_sort_keys);
 
+#if TEST_TYPES == 0
+using key_types = c2h::type_list<bool, std::uint8_t>;
+#elif TEST_TYPES == 1
 using key_types =
-  c2h::type_list<bool,
-                 std::uint8_t,
-                 std::uint64_t
-#if TEST_HALF_T()
+  c2h::type_list<std::uint64_t
+#  if TEST_HALF_T()
                  ,
                  half_t
-#endif // TEST_HALF_T()
-#if TEST_BF_T()
+#  endif // TEST_HALF_T()
+#  if TEST_BF_T()
                  ,
                  bfloat16_t
-#endif // TEST_BF_T()
+#  endif // TEST_BF_T()
                  >;
+#endif
+
+#if TEST_TYPES == 0
 
 C2H_TEST("DeviceSegmentedSortKeys: No segments", "[keys][segmented][sort][device]")
 {
@@ -126,6 +131,8 @@ C2H_TEST("DeviceSegmentedSortKeys: Empty segments", "[keys][segmented][sort][dev
   REQUIRE(values_buffer.selector == 1);
 }
 
+#endif // TEST_TYPES == 0
+
 C2H_TEST("DeviceSegmentedSortKeys: Same size segments, derived keys",
          "[keys][segmented][sort][device][skip-cs-racecheck]",
          key_types)
@@ -190,6 +197,8 @@ C2H_TEST("DeviceSegmentedSortKeys: Unspecified segments, random keys", "[keys][s
   using KeyT = c2h::get<0, TestType>;
   test_unspecified_segments_random<KeyT>(C2H_SEED(4));
 }
+
+#if TEST_TYPES == 0
 
 C2H_TEST("DeviceSegmentedSortKeys: very large number of segments",
          "[keys][segmented][sort][device][skip-cs-memcheck][skip-cs-racecheck][skip-cs-initcheck]",
@@ -278,3 +287,5 @@ catch (std::bad_alloc& e)
 {
   std::cerr << "Skipping segmented sort test, insufficient GPU memory. " << e.what() << "\n";
 }
+
+#endif // TEST_TYPES == 0

--- a/cub/test/catch2_test_device_segmented_sort_pairs.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs.cu
@@ -31,22 +31,28 @@
 // FIXME: Graph launch disabled, algorithm syncs internally. WAR exists for device-launch, figure out how to enable for
 // graph launch.
 // %PARAM% TEST_LAUNCH lid 0:1
+// %PARAM% TEST_TYPES types 0:1
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedSort::StableSortPairs, stable_sort_pairs);
 
+#if TEST_TYPES == 0
+using pair_types = c2h::type_list<c2h::type_list<bool, std::uint8_t>, //
+                                  c2h::type_list<std::int8_t, std::uint64_t>>;
+#elif TEST_TYPES == 1
 using pair_types =
-  c2h::type_list<c2h::type_list<bool, std::uint8_t>,
-                 c2h::type_list<std::int8_t, std::uint64_t>,
-                 c2h::type_list<double, float>
-#if TEST_HALF_T()
+  c2h::type_list<c2h::type_list<double, float>
+#  if TEST_HALF_T()
                  ,
                  c2h::type_list<half_t, std::int8_t>
-#endif // TEST_HALF_T()
-#if TEST_BF_T()
+#  endif // TEST_HALF_T()
+#  if TEST_BF_T()
                  ,
                  c2h::type_list<bfloat16_t, float>
-#endif // TEST_BF_T()
+#  endif // TEST_BF_T()
                  >;
+#endif // TEST_TYPES
+
+#if TEST_TYPES == 0
 
 C2H_TEST("DeviceSegmentedSortPairs: No segments", "[pairs][segmented][sort][device]")
 {
@@ -119,6 +125,8 @@ C2H_TEST("DeviceSegmentedSortPairs: Empty segments", "[pairs][segmented][sort][d
   REQUIRE(keys_buffer.selector == 0);
   REQUIRE(values_buffer.selector == 1);
 }
+
+#endif // TEST_TYPES == 0
 
 C2H_TEST("DeviceSegmentedSortPairs: Same size segments, derived keys/values",
          "[pairs][segmented][sort][device][skip-cs-racecheck]",
@@ -200,6 +208,8 @@ C2H_TEST("DeviceSegmentedSortPairs: Unspecified segments, random key/values",
 
   test_unspecified_segments_random<KeyT, ValueT>(C2H_SEED(4));
 }
+
+#if TEST_TYPES == 0
 
 C2H_TEST("DeviceSegmentedSortPairs: very large num. items and num. segments",
          "[pairs][segmented][sort][device][skip-cs-racecheck][skip-cs-initcheck][skip-cs-synccheck]",
@@ -308,3 +318,5 @@ catch (std::bad_alloc& e)
 {
   std::cerr << "Skipping segmented sort test, insufficient GPU memory. " << e.what() << "\n";
 }
+
+#endif // TEST_TYPES == 0


### PR DESCRIPTION
These tests were consuming >4GB RAM during compilatiion. Splitting them up seems to help the random runner failures we've been seeing.