### PR TITLE
Fix licenses.

### DIFF
--- a/cub/test/catch2_test_block_radix_sort_keys.cu
+++ b/cub/test/catch2_test_block_radix_sort_keys.cu
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <thrust/execution_policy.h>
 

--- a/cub/test/catch2_test_block_radix_sort_pairs.cu
+++ b/cub/test/catch2_test_block_radix_sort_pairs.cu
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include <thrust/execution_policy.h>
 


### PR DESCRIPTION
These were mistakenly tagged with the wrong license. CUB is BSD-3, not apache.
