### PR TITLE
add missing visibility attributes and workaround nvcc bug

### DIFF
--- a/libcudacxx/include/cuda/__utility/__basic_any/virtual_tables.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/virtual_tables.h
@@ -42,7 +42,7 @@ using __vtable_for _CCCL_NODEBUG_ALIAS = typename __overrides_for_t<_Interface>:
 //! __basic_vtable
 //!
 template <class _Interface, auto... _Mbrs>
-struct _CCCL_DECLSPEC_EMPTY_BASES __basic_vtable
+struct _CCCL_DECLSPEC_EMPTY_BASES _CCCL_TYPE_VISIBILITY_DEFAULT __basic_vtable
     : __rtti_base
     , __virtual_fn<_Mbrs>...
 {
@@ -105,7 +105,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __basic_vtable
 //!
 
 template <class... _Interfaces>
-struct _CCCL_DECLSPEC_EMPTY_BASES __vtable_tuple
+struct _CCCL_DECLSPEC_EMPTY_BASES _CCCL_TYPE_VISIBILITY_DEFAULT __vtable_tuple
     : __rtti_ex<sizeof...(_Interfaces)>
     , __vtable_for<_Interfaces>...
 {

--- a/libcudacxx/include/cuda/std/__concepts/constructible.h
+++ b/libcudacxx/include/cuda/std/__concepts/constructible.h
@@ -138,7 +138,7 @@ _CCCL_CONCEPT __nothrow_initializable_from =
         ? ::cuda::std::is_nothrow_constructible_v<_Tp, _Args...>
         : __nothrow_list_initializable_from<_Tp, _Args...>);
 
-#if !_CCCL_COMPILER(MSVC)
+#if !_CCCL_COMPILER(MSVC) && !_CCCL_CUDA_COMPILER(NVCC, <, 12, 9)
 
 //! Constructible with direct non-list initialization syntax from the result of
 //! a function call expression (often useful for immovable types).


### PR DESCRIPTION
## Description

cudax work on #5975 has required upstream changes to libcudacxx. i want to land those changes separately so that i can iterate on #5975 faster. without the libcudacxx changes, the cudax changes will run far fewer tests in CI.

the changes are:
- add missing visibility attributes on two types in the `__basic_any` implementation.
- extend `__emplaceable_from` concept workaround to older nvcc versions.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
