### PR TITLE
Use RAPIDS 25.12

### DIFF
--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc10-cuda12.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc10-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc11-cuda12.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc11-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc12-cuda12.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc12-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc13-cuda12.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc13-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc7-cuda12.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc7-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc8-cuda12.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc8-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc9-cuda12.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc9-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm14-cuda12.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm14-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc10-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc10-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc11-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc11-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc12-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc12-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc13-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc13-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc14/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc14-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc14-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc7-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc7-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc8-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc8-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc9-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc9-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm14-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm14-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm15/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm15-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm15-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm16/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm16-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm16-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm17/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm17-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm17-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm18/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm18/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm18-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm18-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm19/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm19/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm19-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm19-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm20/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm20/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm20-cuda12.9",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm20-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-nvhpc25.5/devcontainer.json
+++ b/.devcontainer/cuda12.9-nvhpc25.5/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-nvhpc25.5",
+  "image": "rapidsai/devcontainers:25.12-cpp-nvhpc25.5",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-nvhpc25.7/devcontainer.json
+++ b/.devcontainer/cuda12.9-nvhpc25.7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-nvhpc25.7",
+  "image": "rapidsai/devcontainers:25.12-cpp-nvhpc25.7",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9ext-gcc14/devcontainer.json
+++ b/.devcontainer/cuda12.9ext-gcc14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc14-cuda12.9ext",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc14-cuda12.9ext",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9ext-llvm20/devcontainer.json
+++ b/.devcontainer/cuda12.9ext-llvm20/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm20-cuda12.9ext",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm20-cuda12.9ext",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc11-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc11-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc12-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc12-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-gcc13/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc13-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc13-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-gcc14/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc14-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc14-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm15/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm15/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm15-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm15-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm16/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm16/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm16-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm16-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm17/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm17/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm17-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm17-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm18/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm18/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm18-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm18-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm19/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm19/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm19-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm19-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm20/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm20/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm20-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm20-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0ext-gcc14/devcontainer.json
+++ b/.devcontainer/cuda13.0ext-gcc14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc14-cuda13.0ext",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc14-cuda13.0ext",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0ext-llvm20/devcontainer.json
+++ b/.devcontainer/cuda13.0ext-llvm20/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-llvm20-cuda13.0ext",
+  "image": "rapidsai/devcontainers:25.12-cpp-llvm20-cuda13.0ext",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:25.10-cpp-gcc14-cuda13.0",
+  "image": "rapidsai/devcontainers:25.12-cpp-gcc14-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -92,18 +92,18 @@ jobs:
           CI: true
           RAPIDS_LIBS: ${{ matrix.libs }}
           # Uncomment any of these to customize the git repo and branch for a RAPIDS lib:
-          # RAPIDS_cmake_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_cudf_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_cudf_kafka_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_cugraph_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_cugraph_gnn_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_cuml_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_cumlprims_mg_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_cuvs_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_kvikio_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_raft_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_rmm_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.10"}'
-          # RAPIDS_ucxx_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-0.46"}'
+          # RAPIDS_cmake_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_cudf_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_cudf_kafka_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_cugraph_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_cugraph_gnn_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_cuml_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_cumlprims_mg_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_cuvs_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_kvikio_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_raft_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_rmm_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-25.12"}'
+          # RAPIDS_ucxx_GIT_REPO: '{"upstream": "rapidsai", "tag": "branch-0.47"}'
         run: |
           cat <<"EOF" > "$RUNNER_TEMP/ci.sh"
           #! /usr/bin/env bash

--- a/ci/build_cuda_cccl_python.sh
+++ b/ci/build_cuda_cccl_python.sh
@@ -38,7 +38,7 @@ fi
 
 readonly cuda12_version=12.9.1
 readonly cuda13_version=13.0.1
-readonly devcontainer_version=25.10
+readonly devcontainer_version=25.12
 readonly devcontainer_distro=rockylinux8
 
 if [[ "$(uname -m)" == "aarch64" ]]; then

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -275,7 +275,7 @@ workflows:
 
 
 # The version of the devcontainer images to use from https://hub.docker.com/r/rapidsai/devcontainers
-devcontainer_version: '25.10'
+devcontainer_version: '25.12'
 
 # Compiler versions used for the cuda99.X internal builds:
 cuda99_gcc_version: 14

--- a/ci/rapids/cuda13.0-conda/devcontainer.json
+++ b/ci/rapids/cuda13.0-conda/devcontainer.json
@@ -1,14 +1,14 @@
 {
-  "image": "rapidsai/devcontainers:25.10-cpp-mambaforge-ubuntu24.04",
+  "image": "rapidsai/devcontainers:25.12-cpp-mambaforge-ubuntu24.04",
   "runArgs": [
     "--init",
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-25.10-cuda13.0-conda"
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-25.12-cuda13.0-conda"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
-    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:25.10": {}
+    "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils:25.12": {}
   },
   "overrideFeatureInstallOrder": [
     "ghcr.io/rapidsai/devcontainers/features/rapids-build-utils"

--- a/ci/update_rapids_version.sh
+++ b/ci/update_rapids_version.sh
@@ -29,6 +29,7 @@ function sed_runner() {
 
 # Update CI files
 sed_runner "/devcontainer_version/ s/'[0-9.]*'/'${NEXT_SHORT_TAG}'/g" ci/matrix.yaml
+sed_runner "/devcontainer_version=/ s/=[0-9.]*/=${NEXT_SHORT_TAG}/g" ci/build_cuda_cccl_python.sh
 for FILE in .github/workflows/*.yml; do
   sed_runner "/rapidsai/ s/\"branch-.*\"/\"branch-${NEXT_SHORT_TAG}\"/g" "${FILE}"
   sed_runner "/ucxx/ s/\"branch-.*\"/\"branch-${NEXT_UCXX_SHORT_TAG}\"/g" "${FILE}"


### PR DESCRIPTION
## Description
Updates RAPIDS devcontainers and CI to use 25.12.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
