### PR TITLE
Provide `cuda::pointer_in_range`

### DIFF
--- a/docs/libcudacxx/extended_api/memory/pointer_in_range.rst
+++ b/docs/libcudacxx/extended_api/memory/pointer_in_range.rst
@@ -1,0 +1,61 @@
+.. _libcudacxx-extended-api-memory-pointer_in_range:
+
+``cuda::pointer_in_range``
+=========================
+
+.. code:: cuda
+
+   template <typename T>
+   [[nodiscard]] __host__ __device__ inline
+   T* pointer_in_range(T* ptr, T* start, T* end) noexcept
+
+Checks whether ``ptr`` lies inside the half-open interval ``[start, end)``. The interval bounds are interpreted using the standard pointer comparison semantics for ``T*``.
+
+**Template parameters**
+
+- ``T``: The type of the pointer being tested.
+
+**Parameters**
+
+- ``ptr``: The pointer being tested.
+- ``start``: Pointer to the first element in the range.
+- ``end``: Pointer one past the last element in the range.
+
+**Return value**
+
+- ``true`` when the pointer lies in ``[start, end)``, ``false`` otherwise.
+
+**Preconditions**
+
+- ``end`` must be strictly greater than ``start``.
+
+Example
+-------
+
+.. code:: cuda
+
+    #include <cuda/memory>
+
+    __global__ void kernel(float* data, size_t count) {
+        float* first = data;
+        float* last  = data + count;
+
+        float* elem_ptr = data + threadIdx.x;
+        if (cuda::pointer_in_range(elem_ptr, first, last)) {
+            *elem_ptr = static_cast<float>(threadIdx.x);
+        }
+    }
+
+    int main() {
+        size_t N          = 32;
+        float* device_ptr = nullptr;
+        cudaMalloc(&device_ptr, N * sizeof(float));
+
+        kernel<<<1, N>>>(device_ptr, N);
+        cudaDeviceSynchronize();
+
+        cudaFree(device_ptr);
+        return 0;
+    }
+
+`See it on Godbolt 🔗 <https://godbolt.org/z/EPfMErjGK>`_

--- a/libcudacxx/include/cuda/__memory/pointer_in_range.h
+++ b/libcudacxx/include/cuda/__memory/pointer_in_range.h
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_MEMORY
-#define _CUDA_MEMORY
+#ifndef _CUDA___MEMORY_POINTER_IN_RANGE_H
+#define _CUDA___MEMORY_POINTER_IN_RANGE_H
 
 #include <cuda/std/detail/__config>
 
@@ -21,15 +21,22 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__memory/address_space.h>
-#include <cuda/__memory/align_down.h>
-#include <cuda/__memory/pointer_in_range.h>
-#include <cuda/__memory/align_up.h>
-#include <cuda/__memory/aligned_size.h>
-#include <cuda/__memory/discard_memory.h>
-#include <cuda/__memory/get_device_address.h>
-#include <cuda/__memory/is_aligned.h>
-#include <cuda/__memory/ptr_rebind.h>
-#include <cuda/std/memory>
+#include <cuda/std/__functional/operations.h>
 
-#endif // _CUDA_MEMORY
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+template <typename _Tp>
+[[nodiscard]] _CCCL_API inline bool pointer_in_range(_Tp* __ptr, _Tp* __start, _Tp* __end) noexcept
+{
+  _CCCL_ASSERT(::cuda::std::greater<const _Tp*>{}(__end, __start),
+               "pointer_in_range: __end must be greater than __start");
+  return ::cuda::std::less_equal<const _Tp*>{}(__start, __ptr) && ::cuda::std::less<const _Tp*>{}(__ptr, __end);
+}
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___MEMORY_POINTER_IN_RANGE_H

--- a/libcudacxx/test/libcudacxx/cuda/memory/pointer_in_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/pointer_in_range.pass.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/memory>
+#include <cuda/std/cassert>
+#include <cuda/std/type_traits>
+
+template <typename Pointer>
+__host__ __device__ void test_in_range([[maybe_unused]] Pointer first, [[maybe_unused]] Pointer last)
+{
+  assert(cuda::pointer_in_range(first, first, last));
+  assert(cuda::pointer_in_range(first + 1, first, last));
+  assert(cuda::pointer_in_range(last - 1, first, last));
+  assert(!cuda::pointer_in_range(last, first, last));
+}
+
+template <typename T>
+__host__ __device__ void test_variants()
+{
+  T values[6] = {};
+  T* first    = values + 1;
+  T* last     = values + 5;
+  test_in_range(first, last);
+}
+
+__host__ __device__ bool test()
+{
+  constexpr auto nullptr_int = static_cast<int*>(nullptr);
+  static_assert(noexcept(cuda::pointer_in_range(nullptr_int, nullptr_int, nullptr_int)));
+  using ret_type = decltype(cuda::pointer_in_range(nullptr_int, nullptr_int, nullptr_int));
+  static_assert(::cuda::std::is_same_v<bool, ret_type>);
+
+  test_variants<int>();
+  test_variants<const int>();
+  test_variants<volatile int>();
+  test_variants<const volatile int>();
+  return true;
+}
+
+int main(int, char**)
+{
+  assert(test());
+  return 0;
+}


### PR DESCRIPTION
## Description

Checking if a pointer is in a given range is very common. The utility has already been proposed in [WG21 P3234](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p3234r0.html). It is already provided by [Boost Core](https://www.boost.org/doc/libs/develop/libs/core/doc/html/core/pointer_in_range.html) and part of libc++/libstdc++ as internal function.

```cpp
template <typename T>
[[nodiscard]] _CCCL_API inline bool pointer_in_range(T* ptr, T* start,  T* end) noexcept
```
