### PR TITLE
Bump catch2 to 3.8.1.

### DIFF
--- a/cmake/CCCLGetDependencies.cmake
+++ b/cmake/CCCLGetDependencies.cmake
@@ -14,7 +14,7 @@ endmacro()
 
 macro(cccl_get_catch2)
   include("${_cccl_cpm_file}")
-  CPMAddPackage("gh:catchorg/Catch2@3.8.0")
+  CPMAddPackage("gh:catchorg/Catch2@3.8.1")
 endmacro()
 
 macro(cccl_get_fmt)


### PR DESCRIPTION
This release contains fixes that will address NVBug 5540541, which reported a number of issues with UDLs such as:

catch2/internal/catch_stringref.hpp:114:28: error: identifier '_sr' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
