### PR TITLE
add a specialization of `__make_tuple_types` for `complex<T>`

### DIFF
--- a/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__fwd/complex.h>
 #include <cuda/std/__fwd/array.h>
 #include <cuda/std/__fwd/complex.h>
 #include <cuda/std/__fwd/tuple.h>
@@ -68,6 +69,17 @@ struct __make_tuple_types_flat<array<_Vt, _Np>, __tuple_indices<_Idx...>>
 template <class _Vt, size_t... _Idx>
 struct __make_tuple_types_flat<complex<_Vt>, __tuple_indices<_Idx...>>
 {
+  static_assert(sizeof...(_Idx) == 2, "__make_tuple_types: complex has only 2 members");
+  template <size_t>
+  using __value_type = _Vt;
+  template <class _Tp, class _ApplyFn = __apply_cvref_fn<_Tp>>
+  using __apply_quals _CCCL_NODEBUG_ALIAS = __tuple_types<__type_call<_ApplyFn, __value_type<_Idx>>...>;
+};
+
+template <class _Vt, size_t... _Idx>
+struct __make_tuple_types_flat<::cuda::complex<_Vt>, __tuple_indices<_Idx...>>
+{
+  static_assert(sizeof...(_Idx) == 2, "__make_tuple_types: complex has only 2 members");
   template <size_t>
   using __value_type = _Vt;
   template <class _Tp, class _ApplyFn = __apply_cvref_fn<_Tp>>

--- a/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
@@ -65,11 +65,13 @@ struct __make_tuple_types_flat<array<_Vt, _Np>, __tuple_indices<_Idx...>>
   using __apply_quals _CCCL_NODEBUG_ALIAS = __tuple_types<__type_call<_ApplyFn, __value_type<_Idx>>...>;
 };
 
-template <class _Vt>
-struct __make_tuple_types_flat<complex<_Vt>, __tuple_indices<0, 1>>
+template <class _Vt, size_t... _Idx>
+struct __make_tuple_types_flat<complex<_Vt>, __tuple_indices<_Idx...>>
 {
+  template <size_t>
+  using __value_type = _Vt;
   template <class _Tp, class _ApplyFn = __apply_cvref_fn<_Tp>>
-  using __apply_quals _CCCL_NODEBUG_ALIAS = __tuple_types<__type_call<_ApplyFn, _Vt>, __type_call<_ApplyFn, _Vt>>;
+  using __apply_quals _CCCL_NODEBUG_ALIAS = __tuple_types<__type_call<_ApplyFn, __value_type<_Idx>>...>;
 };
 
 template <class _Tp,

--- a/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/make_tuple_types.h
@@ -21,6 +21,7 @@
 #endif // no system header
 
 #include <cuda/std/__fwd/array.h>
+#include <cuda/std/__fwd/complex.h>
 #include <cuda/std/__fwd/tuple.h>
 #include <cuda/std/__tuple_dir/tuple_element.h>
 #include <cuda/std/__tuple_dir/tuple_indices.h>
@@ -61,7 +62,14 @@ struct __make_tuple_types_flat<array<_Vt, _Np>, __tuple_indices<_Idx...>>
   template <size_t>
   using __value_type = _Vt;
   template <class _Tp, class _ApplyFn = __apply_cvref_fn<_Tp>>
-  using __apply_quals = __tuple_types<__type_call<_ApplyFn, __value_type<_Idx>>...>;
+  using __apply_quals _CCCL_NODEBUG_ALIAS = __tuple_types<__type_call<_ApplyFn, __value_type<_Idx>>...>;
+};
+
+template <class _Vt>
+struct __make_tuple_types_flat<complex<_Vt>, __tuple_indices<0, 1>>
+{
+  template <class _Tp, class _ApplyFn = __apply_cvref_fn<_Tp>>
+  using __apply_quals _CCCL_NODEBUG_ALIAS = __tuple_types<__type_call<_ApplyFn, _Vt>, __type_call<_ApplyFn, _Vt>>;
 };
 
 template <class _Tp,

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_like.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_like.h
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__fwd/complex.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__fwd/array.h>
 #include <cuda/std/__fwd/complex.h>
@@ -57,6 +58,9 @@ inline constexpr bool __tuple_like_impl<array<_Tp, _Size>> = true;
 
 template <class _Tp>
 inline constexpr bool __tuple_like_impl<complex<_Tp>> = true;
+
+template <class _Tp>
+inline constexpr bool __tuple_like_impl<::cuda::complex<_Tp>> = true;
 
 template <class _Ip, class _Sp, ::cuda::std::ranges::subrange_kind _Kp>
 inline constexpr bool __tuple_like_impl<::cuda::std::ranges::subrange<_Ip, _Sp, _Kp>> = true;

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_like_ext.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_like_ext.h
@@ -21,6 +21,7 @@
 #endif // no system header
 
 #include <cuda/std/__fwd/array.h>
+#include <cuda/__fwd/complex.h>
 #include <cuda/std/__fwd/complex.h>
 #include <cuda/std/__fwd/pair.h>
 #include <cuda/std/__fwd/tuple.h>
@@ -53,6 +54,9 @@ inline constexpr bool __tuple_like_ext<array<_Tp, _Size>> = true;
 
 template <class _Tp>
 inline constexpr bool __tuple_like_ext<complex<_Tp>> = true;
+
+template <class _Tp>
+inline constexpr bool __tuple_like_ext<::cuda::complex<_Tp>> = true;
 
 template <class... _Tp>
 inline constexpr bool __tuple_like_ext<__tuple_types<_Tp...>> = true;

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_like_ext.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_like_ext.h
@@ -20,8 +20,8 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__fwd/array.h>
 #include <cuda/__fwd/complex.h>
+#include <cuda/std/__fwd/array.h>
 #include <cuda/std/__fwd/complex.h>
 #include <cuda/std/__fwd/pair.h>
 #include <cuda/std/__fwd/tuple.h>


### PR DESCRIPTION
## Description

closes #6078

recently `cuda::std::complex` got the `tuple` treatment. but `__make_tuple_types` was not updated to handle `complex` special, like it does for `cuda::std::array`. this PR fixes that.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
