### PR TITLE
Fix imports from cudax to libcu++

### DIFF
--- a/libcudacxx/include/cuda/__algorithm/common.h
+++ b/libcudacxx/include/cuda/__algorithm/common.h
@@ -11,7 +11,7 @@
 #ifndef __CUDA___ALGORITHM_COMMON
 #define __CUDA___ALGORITHM_COMMON
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/__algorithm/copy.h
@@ -11,7 +11,7 @@
 #ifndef __CUDA___ALGORITHM_COPY_H
 #define __CUDA___ALGORITHM_COPY_H
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/__algorithm/fill.h
+++ b/libcudacxx/include/cuda/__algorithm/fill.h
@@ -11,7 +11,7 @@
 #ifndef __CUDA___ALGORITHM_FILL
 #define __CUDA___ALGORITHM_FILL
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/__device/all_devices.h
+++ b/libcudacxx/include/cuda/__device/all_devices.h
@@ -11,7 +11,7 @@
 #ifndef _CUDA___DEVICE_ALL_DEVICES_H
 #define _CUDA___DEVICE_ALL_DEVICES_H
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -11,7 +11,7 @@
 #ifndef _CUDA___DEVICE_ARCH_TRAITS_H
 #define _CUDA___DEVICE_ARCH_TRAITS_H
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/__device/attributes.h
+++ b/libcudacxx/include/cuda/__device/attributes.h
@@ -11,7 +11,7 @@
 #ifndef _CUDA___DEVICE_ATTRIBUTES_H
 #define _CUDA___DEVICE_ATTRIBUTES_H
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/__device/device_ref.h
+++ b/libcudacxx/include/cuda/__device/device_ref.h
@@ -11,7 +11,7 @@
 #ifndef _CUDA___DEVICE_DEVICE_REF_H
 #define _CUDA___DEVICE_DEVICE_REF_H
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/__device/physical_device.h
+++ b/libcudacxx/include/cuda/__device/physical_device.h
@@ -11,7 +11,7 @@
 #ifndef _CUDA___DEVICE_PHYSICAL_DEVICE_H
 #define _CUDA___DEVICE_PHYSICAL_DEVICE_H
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
@@ -106,7 +106,7 @@ public:
   {
     if (__primary_ctx)
     {
-      ::cuda::__driver::__primaryCtxRelease(__device);
+      [[maybe_unused]] const auto __ignore = ::cuda::__driver::__primaryCtxReleaseNoThrow(__device);
     }
   }
 

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -216,11 +216,10 @@ _CCCL_HOST_API inline void __deviceGetName(char* __name_out, int __len, int __or
   return __result;
 }
 
-_CCCL_HOST_API inline void __primaryCtxRelease(::CUdevice __dev)
+[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __primaryCtxReleaseNoThrow(::CUdevice __dev)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxRelease);
-  // TODO we might need to ignore failure here
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to release context for a device", __dev);
+  return static_cast<::cudaError_t>(__driver_fn(__dev));
 }
 
 [[nodiscard]] _CCCL_HOST_API inline bool __isPrimaryCtxActive(::CUdevice __dev)

--- a/libcudacxx/include/cuda/__runtime/ensure_current_context.h
+++ b/libcudacxx/include/cuda/__runtime/ensure_current_context.h
@@ -11,7 +11,7 @@
 #ifndef _CUDA___RUNTIME_ENSURE_CURRENT_CONTEXT_H
 #define _CUDA___RUNTIME_ENSURE_CURRENT_CONTEXT_H
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/__utility/basic_any.h
+++ b/libcudacxx/include/cuda/__utility/basic_any.h
@@ -11,7 +11,7 @@
 #ifndef _CUDA___UTILITY_BASIC_ANY_H
 #define _CUDA___UTILITY_BASIC_ANY_H
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/algorithm
+++ b/libcudacxx/include/cuda/algorithm
@@ -11,7 +11,7 @@
 #ifndef _CUDA_ALGORITHM
 #define _CUDA_ALGORITHM
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/include/cuda/std/__floating_point/fp.h
+++ b/libcudacxx/include/cuda/std/__floating_point/fp.h
@@ -11,7 +11,7 @@
 #ifndef _CUDA_STD___FLOATING_POINT_FP_H
 #define _CUDA_STD___FLOATING_POINT_FP_H
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/common/testing.cuh
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/common/testing.cuh
@@ -11,7 +11,8 @@
 #ifndef __LIBCUDACXX_CCCLRT_COMMON_TESTING_H__
 #define __LIBCUDACXX_CCCLRT_COMMON_TESTING_H__
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
+
 #include <cuda/__driver/driver_api.h>
 
 #include <nv/target>

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/driver_api.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/driver_api.c2h.cu
@@ -57,8 +57,8 @@ C2H_TEST("Call each driver api", "[utility]")
 
   CCCLRT_REQUIRE(driver::__isPrimaryCtxActive(0));
   // Confirm we can reset the primary context with double release
-  driver::__primaryCtxRelease(0);
-  driver::__primaryCtxRelease(0);
+  CCCLRT_REQUIRE(driver::__primaryCtxReleaseNoThrow(0) == cudaSuccess);
+  CCCLRT_REQUIRE(driver::__primaryCtxReleaseNoThrow(0) == cudaSuccess);
 
   CCCLRT_REQUIRE(!driver::__isPrimaryCtxActive(0));
 

--- a/libcudacxx/test/support/truncate_fp.h
+++ b/libcudacxx/test/support/truncate_fp.h
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <cuda/__cccl_config>
+#include <cuda/std/detail/__config>
 
 #if _CCCL_HAS_LONG_DOUBLE()
 __host__ __device__ inline long double truncate_fp(long double val)


### PR DESCRIPTION
We included `<cuda/__cccl_config>` instead of `<cuda/std/detail/__config>` in some files imported from cudax.

I also fixed a potentially throwing destructor marked as `noexcept` in `cuda::physical_device`.