### PR TITLE
Skip nightlies on weekend.

### DIFF
--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -460,7 +460,13 @@ def generate_dispatch_job_runner(matrix_job, job_type):
 
     job_info = get_job_type_info(job_type)
     if not job_info["gpu"]:
-        return f"{runner_os}-{cpu}-cpu16"
+        suffix = ""
+        # Special case: Build CUB with `-arch=all` requires a runner with extra memory:
+        is_cub = matrix_job["project"] == "cub"
+        is_arch_all = "sm" in matrix_job and matrix_job["sm"] == "all"
+        if is_cub and is_arch_all and runner_os == "linux":
+            suffix = "m"
+        return f"{runner_os}-{cpu}-cpu16{suffix}"
 
     gpu = get_gpu(matrix_job["gpu"])
     suffix = "-testing" if gpu["testing"] else ""

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@
 # 3.21 is the minimum for the developer build.
 cmake_minimum_required(VERSION 3.15)
 
+# TODO remove before merging.
+set(CMAKE_C_COMPILER_LAUNCHER "" CACHE STRING "Disabling for stress testing runners" FORCE)
+set(CMAKE_CXX_COMPILER_LAUNCHER "" CACHE STRING "Disabling for stress testing runners" FORCE)
+set(CMAKE_CUDA_COMPILER_LAUNCHER "" CACHE STRING "Disabling for stress testing runners" FORCE)
+
+
 # sccache cannot handle the -Fd option generating pdb files:
 if (POLICY CMP0141)
   cmake_policy(SET CMP0141 NEW)

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -68,6 +68,7 @@
         "CCCL_ENABLE_C_EXPERIMENTAL_STF": true,
         "CCCL_IGNORE_DEPRECATED_CPP_DIALECT": true,
         "LIBCUDACXX_ENABLE_LIBCUDACXX_TESTS": true,
+        "CUB_ENABLE_HEADER_TESTING": true,
         "CUB_ENABLE_TESTING": true,
         "CUB_ENABLE_EXAMPLES": true,
         "CUB_ENABLE_DIALECT_CPP17": true,
@@ -182,6 +183,7 @@
       "inherits": "base",
       "cacheVariables": {
         "CCCL_ENABLE_CUB": true,
+        "CUB_ENABLE_HEADER_TESTING": true,
         "CUB_ENABLE_TESTING": true,
         "CUB_ENABLE_EXAMPLES": true,
         "CUB_ENABLE_DIALECT_CPP17": false,

--- a/ci/build_cub.sh
+++ b/ci/build_cub.sh
@@ -22,6 +22,18 @@ else
     echo "Not building with NVCC, disabling RDC and benchmarks."
 fi
 
+# Building for all arches will exceed available memory on CI systems.
+# Reduce build parallelism:
+# if [[ "${CUDA_ARCHS:-}" == "all" ]]; then
+#     if [[ -n "${CMAKE_BUILD_PARALLEL_LEVEL:-}" ]]; then
+#         if [[ "$CMAKE_BUILD_PARALLEL_LEVEL" -gt 1 ]]; then
+#             CMAKE_BUILD_PARALLEL_LEVEL=$((CMAKE_BUILD_PARALLEL_LEVEL / 2))
+#             echo "Reducing CMAKE_BUILD_PARALLEL_LEVEL to $CMAKE_BUILD_PARALLEL_LEVEL for CUB build with '-arch all'."
+#             export CMAKE_BUILD_PARALLEL_LEVEL
+#         fi
+#     fi
+# fi
+
 if [[ "$HOST_COMPILER" == *icpc* || "$HOST_COMPILER" == *nvhpc* ]]; then
     ENABLE_CCCL_BENCHMARKS="false"
 fi

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -21,6 +21,8 @@ workflows:
   #       args: '--preset libcudacxx-cpp20 --lit-tests "cuda/utility/basic_any.pass.cpp"' }
   #
   override:
+    - {jobs: ['build'], project: ['thrust', 'libcudacxx', 'cudax'], std: 'max', sm: 'all-cccl' }
+    - {jobs: ['build'], project: ['cub'], std: 'max', sm: 'all-cccl', cmake_options: '-DCUB_ENABLE_LAUNCH_VARIANTS=OFF'}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:


### PR DESCRIPTION
We don't need to run these when people aren't working regularly, and the weekly matrix has more coverage anyway.

Also cleans up some unused CTK versions.