### PR TITLE
Add some ramblings about symbol visibility

### DIFF
--- a/docs/cub/developer/visibility.rst
+++ b/docs/cub/developer/visibility.rst
@@ -48,30 +48,16 @@ between the two TUs, but the kernel itself will be mangled as the same symbol, w
 
 A more detailed description can be found :ref:`here <cub-developer-guide-visibility-different-architectures>`.
 
-Possible Solutions
--------------------
+Proposed Solutions:
+--------------------
 
-For a while, the solution to these issues consisted of wrapping CUB/Thrust namespaces with
-the ``THRUST_CUB_WRAPPED_NAMESPACE`` macro so that different shared libraries have different symbols.
-This solution has poor discoverability, since issues present themselves in forms of segmentation faults, hangs,
-wrong results, etc. To eliminate the symbol visibility issues on our end, we follow the following rules:
+We can solve the first two problems by marking all kernels as ``hidden`` This ensures that we do not leak kernels.
 
-    #. Hiding symbols accepting kernel pointers:
-       it's important that an API accepting kernel pointers (e.g. ``triple_chevron``) always resides in the same
-       library as the code taking this pointers.
+However, there is no proper solution for the architecture problem. We can internally ensure that all our symbols are
+properly mangled, but even that falls short the moment we need to consider architecture families.
 
-    #. Hiding all kernels:
-       it's important that kernels always reside in the same library as the API using these kernels.
-
-    #. Incorporating GPU architectures into symbol names:
-       it's important that kernels compiled for a given GPU architecture are always used by the host
-       API compiled for that architecture.
-
-To satisfy (1), the visibility of ``thrust::cuda_cub::detail::triple_chevron`` is hidden.
-
-To satisfy (2), instead of annotating kernels as ``__global__`` we annotate them as
-``CUB_DETAIL_KERNEL_ATTRIBUTES``. Apart from annotating a kernel as global function, the macro also
-contains an attribute to set the visibility to hidden.
-
-To satisfy (3), CUB symbols are placed inside an inline namespace containing the set of
-GPU architectures for which the TU is being compiled.
+Furthermore, we cannot require our users to use all the same workarounds we do. What we *can* do is ensure that all
+kernels are unique symbols, so that if we call a kernel internally we kow that it is always the correct one.
+For that we can either use an inline namespace or preferably a deduced non-type template argument that uniquely
+represents the architectures a library is compiled for. The latter has the clear benefit that it is much shorter than #
+the current inline namespace name, as mangling of an integer is relatively short and simple.

--- a/docs/cub/developer/visibility.rst
+++ b/docs/cub/developer/visibility.rst
@@ -9,6 +9,7 @@ Symbol Visibility
 
    visibility/host_stub_visibility
    visibility/device_kernel_visibility
+   visibility/different_architectures
 
 Using CUB/Thrust in shared libraries is a known source of issues. This relates to the visibility of the kernel functions
 but also of the stub functions NVCC generates to actually call the kernel.
@@ -33,6 +34,19 @@ inside ``lib_b`` instead of ``lib_b::foo``, or vice versa. The CUDA runtime from
 the kernel function pointer we passed from ``lib_b``.
 
 A more detailed description can be found :ref:`here <cub-developer-guide-visibility-device-kernel-visibility>`.
+
+Problem 3: linking TUs compiled for different architectures
+------------------------------------------------------------
+
+This is orthogonal to the visibility of the functions themself but relates to ODR violations in case a TU is compiled
+for different architectures. As new architectures come out, we adopt new features to provide the best possible
+performance for all existing architectures.
+
+However, consider a kernel that contains an `NV_IF_TARGET` that conditionally selects different architecture features.
+If we build 2 TUs for different architectures then we will end up in a situation that the kernel implementation differs
+between the two TUs, but the kernel itself will be mangled as the same symbol, which is a clear ODR violation.
+
+A more detailed description can be found :ref:`here <cub-developer-guide-visibility-different-architectures>`.
 
 Possible Solutions
 -------------------

--- a/docs/cub/developer/visibility.rst
+++ b/docs/cub/developer/visibility.rst
@@ -8,6 +8,7 @@ Symbol Visibility
    :maxdepth: 1
 
    visibility/host_stub_visibility
+   visibility/device_kernel_visibility
 
 Using CUB/Thrust in shared libraries is a known source of issues. This relates to the visibility of the kernel functions
 but also of the stub functions NVCC generates to actually call the kernel.
@@ -21,6 +22,17 @@ That stub function has weak linkage, so if both libraries try to launch ``kernel
 and the other kernel launch ^might silently fail.
 
 A more detailed description can be found :ref:`here <cub-developer-guide-visibility-host-stub-visibility>`.
+
+Problem 2: Calling kernels from inside a shared library
+--------------------------------------------------------
+
+This is quite similar to Problem 1 above. Again a project links two shared libraries ``lib_a`` and ``lib_b``. However,
+this time we call a library function ``foo`` that takes a function pointer to a kernel as an argument and invokes it.
+If ``foo`` has weak external linkage (e.g ``thrust::triple_chevron``) we might end up calling ``lib_a::foo`` from a
+inside ``lib_b`` instead of ``lib_b::foo``, or vice versa. The CUDA runtime from ``lib_a`` will not be able to call
+the kernel function pointer we passed from ``lib_b``.
+
+A more detailed description can be found :ref:`here <cub-developer-guide-visibility-device-kernel-visibility>`.
 
 Possible Solutions
 -------------------

--- a/docs/cub/developer/visibility.rst
+++ b/docs/cub/developer/visibility.rst
@@ -3,12 +3,32 @@
 Symbol Visibility
 ==================
 
-Using CUB/Thrust in shared libraries is a known source of issues.
+.. toctree::
+   :glob:
+   :maxdepth: 1
+
+   visibility/host_stub_visibility
+
+Using CUB/Thrust in shared libraries is a known source of issues. This relates to the visibility of the kernel functions
+but also of the stub functions NVCC generates to actually call the kernel.
+
+Problem 1: Selecting the right kernel stub
+-------------------------------------------
+
+Consider a project that links two shared libraries ``lib_a`` and ``lib_b`` that involve a kernel call of some global
+``kernel``. The compiler will generate a stub function that handles actually launching the kernel via the CUDA runtime.
+That stub function has weak linkage, so if both libraries try to launch ``kernel`` only one host stub will be selected
+and the other kernel launch ^might silently fail.
+
+A more detailed description can be found :ref:`here <cub-developer-guide-visibility-host-stub-visibility>`.
+
+Possible Solutions
+-------------------
+
 For a while, the solution to these issues consisted of wrapping CUB/Thrust namespaces with
 the ``THRUST_CUB_WRAPPED_NAMESPACE`` macro so that different shared libraries have different symbols.
-This solution has poor discoverability,
-since issues present themselves in forms of segmentation faults, hangs, wrong results, etc.
-To eliminate the symbol visibility issues on our end, we follow the following rules:
+This solution has poor discoverability, since issues present themselves in forms of segmentation faults, hangs,
+wrong results, etc. To eliminate the symbol visibility issues on our end, we follow the following rules:
 
     #. Hiding symbols accepting kernel pointers:
        it's important that an API accepting kernel pointers (e.g. ``triple_chevron``) always resides in the same

--- a/docs/cub/developer/visibility/device_kernel_visibility.rst
+++ b/docs/cub/developer/visibility/device_kernel_visibility.rst
@@ -1,0 +1,133 @@
+.. _cub-developer-guide-visibility-device-kernel-visibility:
+
+
+Device Kernel Visibility Issue
+-------------------------------
+
+Consider the following simple TU:
+
+.. code:: cpp
+
+    template <class T>
+    __global__ void kernel(T *val) {
+        ::printf("kernel: set val = 42\n");
+        *val = 42;
+    }
+
+   int main() {
+     int *ptr{};
+     kernel<<<1, 1>>>(ptr);
+   }
+
+The cuda compiler frontend will turn this into:
+
+.. code:: cpp
+
+   template< class T>
+   static void __wrapper__device_stub_kernel(T *&ptr) {
+     ::cudaLaunchKernel(0, 0, 0, 0, 0, 0);
+   }
+
+   // stub host function
+   template< class T>
+   void kernel(T *ptr) {
+     __wrapper__device_stub_kernel<T>(ptr);
+   }
+
+   int main() {
+     int *ptr{};
+     (__cudaPushCallConfiguration(1, 1)) ? (void)0 : kernel(ptr);
+   }
+
+   static void __device_stub__Z6kernelIiEvPT_(int *__par0) {
+     __cudaLaunchPrologue(1);
+     __cudaSetupArgSimple(__par0, 0UL);
+     __cudaLaunch(((char *)((void ( *)(int *))kernel )));
+   }
+
+   template<> void __wrapper__device_stub_kernel(int *&__cuda_0) {
+     __device_stub__Z6kernelIiEvPT_( (int *&)__cuda_0);
+   }
+
+The CUDA runtime is going to use the address of ``template<> void kernel(T *ptr)`` (in the following ``h_kernel``)
+as a key in the host stub function (``h_kernel``) - device function (``d_kernel``) mapping. This works fine if
+there is only a single source of truth for the stub function ``h_kernel``.
+
+However, imagine that there are two shared libraries: ``lib_a`` and ``lib_b`` both instantiating different ``kernel``
+instances, e.g ``d_kernel<int>`` and ``d_kernel<size_t>``.
+
+.. code-block:: cmake
+
+    project(DeviceKernelVisibility CUDA CXX)
+
+    add_executable(device_kernel_visibility main.cu)
+    add_library(lib_a SHARED tu_a.cu)
+    add_library(lib_b SHARED tu_b.cu)
+    target_link_libraries(device_kernel_visibility PRIVATE lib_a lib_b)
+
+Each library will have it's own fatbinary: ``d_kernel<int>_a`` and ``d_kernel<size_t>_b`` as well as host stub functions
+``h_kernel<int>_a`` and ``h_kernel<size_t>_b``.
+
+=== ============= ============
+lib host          device
+=== ============= ============
+a   0xh_kernel_a  0xd_kernel_a
+b   0xh_kernel_b  0xd_kernel_b
+=== ============= ============
+
+In contrast to
+:ref:`Problem 1 <cub-developer-guide-visibility-host-stub-visibility>` the host stubs will get a different mangled name
+and so the right stub function will always be selected.
+
+Now imagine that both libraries are going to defer launching of their kernels to a function ``foo`` common to both
+``lib_a`` and ``lib_b``, which has weak external linkage. This might happen in ``CUB``, because it launches
+kernels through the ``thrust::triple_chevron`` helper.
+
+Similar to :ref:`Problem 1 <cub-developer-guide-visibility-host-stub-visibility>` the linker will pick one of the two
+weak symbols and subsequently ``lib_a`` will try to pass its own kernel ``d_kernel<int>_a`` to ``lib_b::foo``.
+
+However, the CUDA runtime in ``lib_b`` will not find any kernel registered at the address of ``d_kernel<int>_a`` and
+will fail to launch the kernel.
+
+A simple example program that exemplifies this can be found
+`on github <https://github.com/NVIDIA/cccl/tree/main/docs/cub/developer/visibility/examples/device_kernel_visibility>`_
+
+.. code-block:: bash
+
+   ./device_kernel_visibility/device_kernel_visibility
+   a: kernel stub address: 0x7fdec19e13eb                      <== launching kernel_a from a
+   a: kernel is in mapping: no error
+   b: launched kernel
+   a: kernel: set val = 42
+   a: synchronized stream
+   a: copied from device to host
+   a: out: 42
+   a: kernel was launched: out == 42                           <== everything is fine
+
+   a: defers launch to b
+   b: kernel stub address: 0x7fdec19e13eb                      <== launch kernel_a from b
+   b: kernel NOT found in mapping: invalid device function     <== kernel_a is not found in b mapping
+   b: FAILED to launch kernel                                  <== unable to launch the kernel from b
+   b: synchronized stream
+   b: copied from device to host
+   b: out: 0
+   b: kernel was NOT actually launched: out != 42
+
+   b: kernel stub address: 0x7fdec19333eb                      <== launch kernel_b from b
+   b: kernel is in mapping: no error
+   b: launched kernel
+   b: kernel: set val = 42
+   b: synchronized stream
+   b: copied from device to host
+   b: out: 42
+   b: kernel was launched: out == 42                           <== everything is fine
+
+   b: defers launch to a
+   a: kernel stub address: 0x7fdec19333eb                      <== launching kernel_b from a
+   a: kernel NOT found in mapping: invalid device function     <== same issue as above
+   a: FAILED to launch kernel
+   b: kernel: set val = 42
+   a: synchronized stream
+   a: copied from device to host
+   a: out: 42
+   a: kernel was launched: out == 42                           <==  kernel launch somehow succeeded

--- a/docs/cub/developer/visibility/different_architectures.rst
+++ b/docs/cub/developer/visibility/different_architectures.rst
@@ -1,0 +1,185 @@
+.. _cub-developer-guide-visibility-different-architectures:
+
+Linking TUs compiled with different architectures
+--------------------------------------------------
+
+Consider the following simple library:
+
+.. code:: cpp
+
+    template <int... Archs>
+    __host__ __device__ constexpr int sum_archs() noexcept {
+      return (Archs + ... + 0);
+    }
+
+    // kernel with architecture dependent symbol name and functionality
+    template <class T, auto Archs = sum_archs<__CUDA_ARCH_LIST__>()>
+    __global__ void kernel(T *val) {
+      *val = sum_archs<__CUDA_ARCH_LIST__>();
+    }
+
+    __attribute__((visibility("hidden"))) __forceinline__ int use_kernel() {
+      int *d_val{};
+      cudaMalloc(&d_val, sizeof(size_t));
+      kernel<<<1, 1>>>(d_val);
+      int ret;
+      if (cudaMemcpy(&ret, d_val, sizeof(size_t), cudaMemcpyDeviceToHost) !=
+          cudaSuccess) {
+        std::printf("c: FAILED to copy from device to host\n");
+      }
+      return ret;
+    }
+
+    template <class T = int> struct some_class_with_kernel {
+      T val_;
+
+      some_class_with_kernel();
+      __forceinline__ some_class_with_kernel(T) { val_ = use_kernel(); }
+    };
+
+We have a kernel that does some architecture dependent work. This could be relying on some hardware feature that is
+dependent on the current architecture.
+
+.. code:: cpp
+
+  #include "kernel.cuh"
+
+  int main() {
+    some_class_with_kernel with_inline{1};
+    std::printf("a: value of class with inlined constructor: %d\n",
+                with_inline.val_);
+
+    some_class_with_kernel from_library{};
+    std::printf("a: value of class with constructor from library: %d\n",
+                from_library.val_);
+  }
+
+Importantly, one of the constructors for that class is put into a shared library, whereas the other one happens to be
+inlined. If a user now links two different libraries, the outcome of the initialization of ``some_class_with_kernel``
+will depend on whether the inlined constructor is called and which of the libraries is loaded first by the linker.
+
+Even worse, the state of a class depends on whether the constructor has been inlined or not and the order in which
+the linker loads the libraries.
+
+.. code:: cmake
+
+  project(CUBVisDifferentArchitectures CUDA CXX)
+
+  add_library(cubvis_different_architectures_lib_a SHARED tu_a.cu)
+  set_target_properties(cubvis_different_architectures_lib_a PROPERTIES CUDA_ARCHITECTURES "86;90a")
+
+  add_library(cubvis_different_architectures_lib_b SHARED tu_b.cu)
+  set_target_properties(cubvis_different_architectures_lib_b PROPERTIES CUDA_ARCHITECTURES "75;86;90a")
+
+  add_executable(cubvis_different_architectures main.cu)
+  set_target_properties(cubvis_different_architectures PROPERTIES CUDA_ARCHITECTURES "75;86")
+
+  target_link_libraries(cubvis_different_architectures PRIVATE
+    cubvis_different_architectures_lib_a
+    cubvis_different_architectures_lib_b)
+
+  add_executable(cubvis_different_architectures_switched main.cu)
+  set_target_properties(cubvis_different_architectures_switched PROPERTIES CUDA_ARCHITECTURES "75;86")
+
+  target_link_libraries(cubvis_different_architectures_switched PRIVATE
+    cubvis_different_architectures_lib_b
+    cubvis_different_architectures_lib_a)
+
+Execution the two libraries will result in the following:
+
+.. code:: bash
+
+  ./different_architectures/different_architectures
+  a: value of class with inlined constructor: 1610       <<<--- from main
+  a: value of class with constructor from library: 1760  <<<--- from lib_a
+
+  ./different_architectures/different_architectures_switched
+  a: value of class with inlined constructor: 1610       <<<--- from main
+  a: value of class with constructor from library: 2510  <<<--- from lib_b
+
+
+One solution would be to bake the architectures into the symbol name of the class, either via a defaulted template
+argument or an inline namespace. That way the usage of the non-inlined kernel would result in a linker error, because
+we did not provide a matching implementation.
+
+.. code:: bash
+
+  tmpxft_00048dff_00000000-6_main.compute_86.cudafe1.cpp:(.text.startup+0xc0):
+  undefined reference to `some_class_with_kernel<int, 5120ul>::some_class_with_kernel()'
+
+However, if all the functionality is within a non-inlined function we would still get different results, because all
+kernel definitions would be internal to the respective library.
+
+.. code:: cpp
+
+  // In tu_a.cu and tu_b.cu
+  void non_inlined_function() {
+    some_class_with_kernel with_inline{1};
+    std::printf("a: value of class with inlined constructor: %d\n",
+                with_inline.val_);
+
+    some_class_with_kernel from_library{};
+    std::printf("a: value of class with constructor from library: %d\n",
+                from_library.val_);
+  }
+
+  // In main.cu
+  #include "kernel.cuh"
+
+  void non_inlined_function();
+
+  int main() {
+    some_class_with_kernel with_inline{1};
+    std::printf("a: value of class with inlined constructor: %d\n",
+                with_inline.val_);
+
+    non_inlined_function();
+  }
+
+Executing this binary will give us again:
+
+.. code:: bash
+
+  ./different_architectures/different_architectures
+  a: value of class with inlined constructor: 1610       <<<--- from main
+  a: value of class with inlined constructor: 1760       <<<--- from lib_a
+  a: value of class with constructor from library: 1760  <<<--- from lib_a
+
+  ./different_architectures/different_architectures_switched
+  a: value of class with inlined constructor: 1610       <<<--- from main
+  a: value of class with inlined constructor: 2510       <<<--- from lib_a
+  a: value of class with constructor from library: 2510  <<<--- from lib_b
+
+So there is not functional way we can solve this problem generically, because the moment a user actually uses any type
+of function that executes a kernel and puts that function into a shared library there is no guarantee which function
+is selected. The same happens if the user builds a type
+
+.. code:: cpp
+
+  class user_defined_with_kernel {
+    some_class_with_kernel val;
+
+    user_defined_with_kernel();
+    __forceinline__ user_defined_with_kernel(T input) : val(input)
+    {}
+  };
+
+  void function_that_uses_kernel_inside();
+
+If ``user_defined_with_kernel`` is ever baked into a library we would be back with the same exact problem,
+just one layer up. The user would need to know that ``some_class_with_kernel`` uses a kernel and then annotate *their*
+classes and functions appropriately. This is neither realistic nor feasible.
+
+Lets circle back to the previous statement: ``This is bad.`` Is it really though?
+
+Lets look at the prime example ``thrust::device_vector``, which uses a kernel for initialization. What happens if we
+accidentally run the kernel from another shared library compiled with different architectures? Worst case we are
+eating some performance regressions because the kernel will not utilize advanced features of a new architecture,
+but in the end the result of calling that kernel will not change the outcome.
+
+This is because the kernel call is consistent *within* each library. As long as the user facing API does not rely on
+specific internals of a kernel to be called -which it should not-, then any of the two libraries will do.
+
+Finally, the architectures that are passed around in ``__CUDA_ARCH_LIST__`` do *not* discriminate architecture families.
+There is currently not programmatic way to discriminate a library that has been compiled for ``SM90a`` from one that was
+compiled for ``SM90``. This is because the architecture specific macros are only available on device not on host.

--- a/docs/cub/developer/visibility/examples/device_kernel_visibility/CMakeLists.txt
+++ b/docs/cub/developer/visibility/examples/device_kernel_visibility/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(DeveloperGuideDeviceKernelVisibility CUDA CXX)
+
+add_executable(device_kernel_visibility main.cu)
+add_library(device_kernel_visibility_liba SHARED tu_a.cu)
+add_library(device_kernel_visibility_lib_b SHARED tu_b.cu)
+
+target_link_libraries(device_kernel_visibility PRIVATE
+  device_kernel_visibility_lib_a
+  device_kernel_visibility_lib_b)

--- a/docs/cub/developer/visibility/examples/device_kernel_visibility/kernel.cuh
+++ b/docs/cub/developer/visibility/examples/device_kernel_visibility/kernel.cuh
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdio>
+
+template <class T>
+__global__ void kernel(char ln, T* val)
+{
+  std::printf("%c: kernel: set val = 42\n", ln);
+  *val = 42;
+}

--- a/docs/cub/developer/visibility/examples/device_kernel_visibility/main.cu
+++ b/docs/cub/developer/visibility/examples/device_kernel_visibility/main.cu
@@ -1,0 +1,8 @@
+void a();
+void b();
+
+int main()
+{
+  a();
+  b();
+}

--- a/docs/cub/developer/visibility/examples/device_kernel_visibility/tu_a.cu
+++ b/docs/cub/developer/visibility/examples/device_kernel_visibility/tu_a.cu
@@ -1,0 +1,132 @@
+#include "kernel.cuh"
+
+void b_launch(void (*k)(char, size_t*), char c, size_t* d_out);
+
+void a_launch(void (*k)(char, int*), char c, int* d_out)
+{
+  void* ptr = reinterpret_cast<void*>(k);
+
+  std::printf("a: kernel stub address: %p\n", ptr);
+
+  cudaFunction_t func{};
+  if (cudaError_t error = cudaGetFuncBySymbol(&func, ptr))
+  {
+    std::printf("a: kernel NOT found in mapping: %s\n", cudaGetErrorString(error));
+  }
+  else
+  {
+    std::printf("a: kernel is in mapping: %s\n", cudaGetErrorString(error));
+  }
+
+  cudaMemset(d_out, 0, sizeof(int));
+  k<<<1, 1>>>(c, d_out);
+
+  if (cudaPeekAtLastError() != cudaSuccess)
+  {
+    std::printf("a: FAILED to launch kernel\n");
+  }
+  else
+  {
+    std::printf("a: launched kernel\n");
+  }
+
+  if (cudaStreamSynchronize(0) != cudaSuccess)
+  {
+    std::printf("a: FAILED to synchronize stream\n");
+  }
+  else
+  {
+    std::printf("a: synchronized stream\n");
+  }
+
+  int h_out{};
+  if (cudaMemcpy(&h_out, d_out, sizeof(int), cudaMemcpyDeviceToHost) != cudaSuccess)
+  {
+    std::printf("a: FAILED to copy from device to host\n");
+  }
+  else
+  {
+    std::printf("a: copied from device to host\n");
+  }
+
+  std::printf("a: out: %d\n", h_out);
+  if (h_out != 42)
+  {
+    std::printf("a: kernel was NOT actually launched: out != 42\n");
+  }
+  else
+  {
+    std::printf("a: kernel was launched: out == 42\n");
+  }
+
+  std::printf("\n");
+}
+
+void a()
+{
+  cudaGetLastError();
+
+  size_t* d_out{};
+  cudaMalloc(&d_out, sizeof(size_t));
+  cudaMemset(d_out, 0, sizeof(size_t));
+
+  void* ptr = reinterpret_cast<void*>(kernel<size_t>);
+
+  std::printf("a: kernel stub address: %p\n", ptr);
+
+  cudaFunction_t func{};
+  if (cudaError_t error = cudaGetFuncBySymbol(&func, ptr))
+  {
+    std::printf("a: kernel NOT found in mapping: %s\n", cudaGetErrorString(error));
+  }
+  else
+  {
+    std::printf("a: kernel is in mapping: %s\n", cudaGetErrorString(error));
+  }
+
+  kernel<<<1, 1>>>('a', d_out);
+
+  if (cudaPeekAtLastError() != cudaSuccess)
+  {
+    std::printf("b: FAILED to launch kernel\n");
+  }
+  else
+  {
+    std::printf("b: launched kernel\n");
+  }
+
+  if (cudaStreamSynchronize(0) != cudaSuccess)
+  {
+    std::printf("a: FAILED to synchronize stream\n");
+  }
+  else
+  {
+    std::printf("a: synchronized stream\n");
+  }
+
+  size_t h_out{};
+  if (cudaMemcpy(&h_out, d_out, sizeof(size_t), cudaMemcpyDeviceToHost) != cudaSuccess)
+  {
+    std::printf("a: FAILED to copy from device to host\n");
+  }
+  else
+  {
+    std::printf("a: copied from device to host\n");
+  }
+
+  std::printf("a: out: %d\n", static_cast<int>(h_out));
+  if (h_out != 42)
+  {
+    std::printf("a: kernel was NOT actually launched: out != 42\n");
+  }
+  else
+  {
+    std::printf("a: kernel was launched: out == 42\n");
+  }
+
+  cudaMemset(d_out, 0, sizeof(size_t));
+  std::printf("\n");
+
+  std::printf("a: defers launch to b\n");
+  b_launch(kernel<size_t>, 'b', d_out);
+}

--- a/docs/cub/developer/visibility/examples/device_kernel_visibility/tu_b.cu
+++ b/docs/cub/developer/visibility/examples/device_kernel_visibility/tu_b.cu
@@ -1,0 +1,132 @@
+#include "kernel.cuh"
+
+void a_launch(void (*k)(char, int*), char c, int* d_out);
+
+void b_launch(void (*k)(char, size_t*), char c, size_t* d_out)
+{
+  void* ptr = reinterpret_cast<void*>(k);
+
+  std::printf("b: kernel stub address: %p\n", ptr);
+
+  cudaFunction_t func{};
+  if (cudaError_t error = cudaGetFuncBySymbol(&func, ptr))
+  {
+    std::printf("b: kernel NOT found in mapping: %s\n", cudaGetErrorString(error));
+  }
+  else
+  {
+    std::printf("b: kernel is in mapping: %s\n", cudaGetErrorString(error));
+  }
+
+  k<<<1, 1>>>(c, d_out);
+
+  if (cudaPeekAtLastError() != cudaSuccess)
+  {
+    std::printf("b: FAILED to launch kernel\n");
+  }
+  else
+  {
+    std::printf("b: launched kernel\n");
+  }
+
+  if (cudaStreamSynchronize(0) != cudaSuccess)
+  {
+    std::printf("b: FAILED to synchronize stream\n");
+  }
+  else
+  {
+    std::printf("b: synchronized stream\n");
+  }
+
+  size_t h_out{};
+  if (cudaMemcpy(&h_out, d_out, sizeof(size_t), cudaMemcpyDeviceToHost) != cudaSuccess)
+  {
+    std::printf("b: FAILED to copy from device to host\n");
+  }
+  else
+  {
+    std::printf("b: copied from device to host\n");
+  }
+
+  std::printf("b: out: %d\n", static_cast<int>(h_out));
+  if (h_out != 42)
+  {
+    std::printf("b: kernel was NOT actually launched: out != 42\n");
+  }
+  else
+  {
+    std::printf("b: kernel was launched: out == 42\n");
+  }
+
+  std::printf("\n");
+}
+
+void b()
+{
+  cudaGetLastError();
+
+  int* d_out{};
+  cudaMalloc(&d_out, sizeof(int));
+  cudaMemset(d_out, 0, sizeof(int));
+
+  void* ptr = reinterpret_cast<void*>(kernel<int>);
+
+  std::printf("b: kernel stub address: %p\n", ptr);
+
+  cudaFunction_t func{};
+  if (cudaError_t error = cudaGetFuncBySymbol(&func, ptr))
+  {
+    std::printf("b: kernel NOT found in mapping: %s\n", cudaGetErrorString(error));
+  }
+  else
+  {
+    std::printf("b: kernel is in mapping: %s\n", cudaGetErrorString(error));
+  }
+
+  kernel<<<1, 1>>>('b', d_out);
+
+  if (cudaPeekAtLastError() != cudaSuccess)
+  {
+    std::printf("b: FAILED to launch kernel\n");
+  }
+  else
+  {
+    std::printf("b: launched kernel\n");
+  }
+
+  if (cudaStreamSynchronize(0) != cudaSuccess)
+  {
+    std::printf("b: FAILED to synchronize stream\n");
+  }
+  else
+  {
+    std::printf("b: synchronized stream\n");
+  }
+
+  int h_out{};
+  if (cudaMemcpy(&h_out, d_out, sizeof(int), cudaMemcpyDeviceToHost) != cudaSuccess)
+  {
+    std::printf("b: FAILED to copy from device to host\n");
+  }
+  else
+  {
+    std::printf("b: copied from device to host\n");
+  }
+
+  std::printf("b: out: %d\n", h_out);
+
+  if (h_out != 42)
+  {
+    std::printf("b: kernel was NOT actually launched: out != 42\n");
+  }
+  else
+  {
+    std::printf("b: kernel was launched: out == 42\n");
+  }
+
+  cudaMemset(d_out, 0, sizeof(int));
+  std::printf("\n");
+
+  std::printf("b: defers launch to a\n");
+  a_launch(kernel<int>, 'b', d_out);
+}

--- a/docs/cub/developer/visibility/examples/different_architectures/CMakeLists.txt
+++ b/docs/cub/developer/visibility/examples/different_architectures/CMakeLists.txt
@@ -1,0 +1,21 @@
+project(DeveloperGuideDifferentArchitectures CUDA CXX)
+
+add_library(different_architectures_lib_a SHARED tu_a.cu)
+set_target_properties(different_architectures_lib_a PROPERTIES CUDA_ARCHITECTURES "86;90a")
+
+add_library(different_architectures_lib_b SHARED tu_b.cu)
+set_target_properties(different_architectures_lib_b PROPERTIES CUDA_ARCHITECTURES "75;86;90a")
+
+add_executable(different_architectures main.cu)
+set_target_properties(different_architectures PROPERTIES CUDA_ARCHITECTURES "75;86")
+
+target_link_libraries(different_architectures PRIVATE
+  different_architectures_lib_a
+  different_architectures_lib_b)
+
+add_executable(different_architectures_switched main.cu kernel.cu)
+set_target_properties(different_architectures_switched PROPERTIES CUDA_ARCHITECTURES "75;86")
+
+target_link_libraries(different_architectures_switched PRIVATE
+  different_architectures_lib_b
+  different_architectures_lib_a)

--- a/docs/cub/developer/visibility/examples/different_architectures/kernel.cuh
+++ b/docs/cub/developer/visibility/examples/different_architectures/kernel.cuh
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+
+template <int... Archs>
+__attribute__((visibility("hidden"))) __host__ __device__ constexpr int sum_archs()
+{
+  return (Archs + ... + 0);
+}
+
+template <class T, auto Archs = sum_archs<__CUDA_ARCH_LIST__>()>
+__attribute__((visibility("hidden"))) __global__ void kernel(char ln, T* val)
+{
+  std::printf("%c: kernel: set val = %i\n", ln, sum_archs<__CUDA_ARCH_LIST__>());
+  *val = sum_archs<__CUDA_ARCH_LIST__>();
+}
+
+__attribute__((visibility("hidden"))) __forceinline__ int use_kernel()
+{
+  int* d_val{};
+  cudaMalloc(&d_val, sizeof(size_t));
+  kernel<<<1, 1>>>(d_val);
+  int ret;
+  if (cudaMemcpy(&ret, d_val, sizeof(size_t), cudaMemcpyDeviceToHost) != cudaSuccess)
+  {
+    std::printf("c: FAILED to copy from device to host\n");
+  }
+  return ret;
+}
+
+template <class T = int>
+struct some_class_with_kernel
+{
+  T val_;
+
+  some_class_with_kernel();
+  __forceinline__ some_class_with_kernel(T)
+  {
+    val_ = use_kernel();
+  }
+};

--- a/docs/cub/developer/visibility/examples/different_architectures/main.cu
+++ b/docs/cub/developer/visibility/examples/different_architectures/main.cu
@@ -1,0 +1,11 @@
+#include "kernel.cuh"
+
+void non_inlined_function();
+
+int main()
+{
+  some_class_with_kernel with_inline{1};
+  std::printf("a: value of class with inlined constructor: %d\n", with_inline.val_);
+
+  non_inlined_function();
+}

--- a/docs/cub/developer/visibility/examples/different_architectures/tu_a.cu
+++ b/docs/cub/developer/visibility/examples/different_architectures/tu_a.cu
@@ -1,0 +1,16 @@
+#include "kernel.cuh"
+
+template <class T>
+some_class_with_kernel<T>::some_class_with_kernel()
+{
+  val_ = use_kernel();
+}
+
+void non_inlined_function()
+{
+  some_class_with_kernel with_inline{1};
+  std::printf("a: value of class with inlined constructor: %d\n", with_inline.val_);
+
+  some_class_with_kernel from_library{};
+  std::printf("a: value of class with constructor from library: %d\n", from_library.val_);
+}

--- a/docs/cub/developer/visibility/examples/different_architectures/tu_b.cu
+++ b/docs/cub/developer/visibility/examples/different_architectures/tu_b.cu
@@ -1,0 +1,16 @@
+#include "kernel.cuh"
+
+template <class T>
+some_class_with_kernel<T>::some_class_with_kernel()
+{
+  val_ = use_kernel();
+}
+
+void non_inlined_function()
+{
+  some_class_with_kernel with_inline{1};
+  std::printf("a: value of class with inlined constructor: %d\n", with_inline.val_);
+
+  some_class_with_kernel from_library{};
+  std::printf("a: value of class with constructor from library: %d\n", from_library.val_);
+}

--- a/docs/cub/developer/visibility/examples/host_stub_visibility/CMakeLists.txt
+++ b/docs/cub/developer/visibility/examples/host_stub_visibility/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(DeveloperGuideHostStubVisibility CUDA CXX)
+
+add_executable(host_stub_visibility main.cu)
+add_library(host_stub_visibility_lib_a SHARED tu_a.cu)
+add_library(host_stub_visibility_lib_b SHARED tu_b.cu)
+
+target_link_libraries(host_stub_visibility PRIVATE
+  host_stub_visibility_lib_a
+  host_stub_visibility_lib_b)

--- a/docs/cub/developer/visibility/examples/host_stub_visibility/kernel.cuh
+++ b/docs/cub/developer/visibility/examples/host_stub_visibility/kernel.cuh
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdio>
+
+template <class T>
+__global__ void kernel(char ln, T* val)
+{
+  std::printf("%c: kernel: set val = 42\n", ln);
+  *val = 42;
+}

--- a/docs/cub/developer/visibility/examples/host_stub_visibility/main.cu
+++ b/docs/cub/developer/visibility/examples/host_stub_visibility/main.cu
@@ -1,0 +1,8 @@
+void a();
+void b();
+
+int main()
+{
+  a();
+  b();
+}

--- a/docs/cub/developer/visibility/examples/host_stub_visibility/tu_a.cu
+++ b/docs/cub/developer/visibility/examples/host_stub_visibility/tu_a.cu
@@ -1,0 +1,64 @@
+#include "kernel.cuh"
+
+void a()
+{
+  int* d_out{};
+  cudaMalloc(&d_out, sizeof(int));
+  cudaMemset(d_out, 0, sizeof(int));
+
+  void* ptr = reinterpret_cast<void*>(kernel<int>);
+
+  std::printf("a: kernel stub address: %p\n", ptr);
+
+  cudaFunction_t func{};
+  if (cudaError_t error = cudaGetFuncBySymbol(&func, ptr))
+  {
+    std::printf("a: kernel NOT found in mapping: %s\n", cudaGetErrorString(error));
+  }
+  else
+  {
+    std::printf("a: kernel is in mapping: %s\n", cudaGetErrorString(error));
+  }
+
+  kernel<<<1, 1>>>('a', d_out);
+
+  if (cudaPeekAtLastError() != cudaSuccess)
+  {
+    std::printf("b: FAILED to launch kernel\n");
+  }
+  else
+  {
+    std::printf("b: launched kernel\n");
+  }
+
+  if (cudaStreamSynchronize(0) != cudaSuccess)
+  {
+    std::printf("a: FAILED to synchronize stream\n");
+  }
+  else
+  {
+    std::printf("a: synchronized stream\n");
+  }
+
+  int h_out{};
+  if (cudaMemcpy(&h_out, d_out, sizeof(int), cudaMemcpyDeviceToHost) != cudaSuccess)
+  {
+    std::printf("a: FAILED to copy from device to host\n");
+  }
+  else
+  {
+    std::printf("a: copied from device to host\n");
+  }
+
+  std::printf("a: out: %d\n", h_out);
+  if (h_out != 42)
+  {
+    std::printf("a: kernel was NOT actually launched: out != 42\n");
+  }
+  else
+  {
+    std::printf("a: kernel was launched: out == 42\n");
+  }
+
+  std::printf("\n");
+}

--- a/docs/cub/developer/visibility/examples/host_stub_visibility/tu_b.cu
+++ b/docs/cub/developer/visibility/examples/host_stub_visibility/tu_b.cu
@@ -1,0 +1,65 @@
+#include "kernel.cuh"
+
+void b()
+{
+  int* d_out{};
+  cudaMalloc(&d_out, sizeof(int));
+  cudaMemset(d_out, 0, sizeof(int));
+
+  void* ptr = reinterpret_cast<void*>(kernel<int>);
+
+  std::printf("b: kernel stub address: %p\n", ptr);
+
+  cudaFunction_t func{};
+  if (cudaError_t error = cudaGetFuncBySymbol(&func, ptr))
+  {
+    std::printf("b: kernel NOT found in mapping: %s\n", cudaGetErrorString(error));
+  }
+  else
+  {
+    std::printf("b: kernel is in mapping: %s\n", cudaGetErrorString(error));
+  }
+
+  kernel<<<1, 1>>>('b', d_out);
+
+  if (cudaPeekAtLastError() != cudaSuccess)
+  {
+    std::printf("b: FAILED to launch kernel\n");
+  }
+  else
+  {
+    std::printf("b: launched kernel\n");
+  }
+
+  if (cudaStreamSynchronize(0) != cudaSuccess)
+  {
+    std::printf("b: FAILED to synchronize stream\n");
+  }
+  else
+  {
+    std::printf("b: synchronized stream\n");
+  }
+
+  int h_out{};
+  if (cudaMemcpy(&h_out, d_out, sizeof(int), cudaMemcpyDeviceToHost) != cudaSuccess)
+  {
+    std::printf("b: FAILED to copy from device to host\n");
+  }
+  else
+  {
+    std::printf("b: copied from device to host\n");
+  }
+
+  std::printf("b: out: %d\n", h_out);
+
+  if (h_out != 42)
+  {
+    std::printf("b: kernel was NOT actually launched: out != 42\n");
+  }
+  else
+  {
+    std::printf("b: kernel was launched: out == 42\n");
+  }
+
+  std::printf("\n");
+}

--- a/docs/cub/developer/visibility/host_stub_visibility.rst
+++ b/docs/cub/developer/visibility/host_stub_visibility.rst
@@ -1,0 +1,110 @@
+.. _cub-developer-guide-visibility-host-stub-visibility:
+
+
+Host Stub Visibility Issue
+---------------------------
+
+Consider the following simple TU:
+
+.. code:: cpp
+
+    template <class T>
+    __global__ void kernel(T *val) {
+        ::printf("kernel: set val = 42\n");
+        *val = 42;
+    }
+
+   int main() {
+     int *ptr{};
+     kernel<<<1, 1>>>(ptr);
+   }
+
+The cuda compiler frontend will turn this into:
+
+.. code:: cpp
+
+   template< class T>
+   static void __wrapper__device_stub_kernel(T *&ptr) {
+     ::cudaLaunchKernel(0, 0, 0, 0, 0, 0);
+   }
+
+   // stub host function
+   template< class T>
+   void kernel(T *ptr) {
+     __wrapper__device_stub_kernel<T>(ptr);
+   }
+
+   int main() {
+     int *ptr{};
+     (__cudaPushCallConfiguration(1, 1)) ? (void)0 : kernel(ptr);
+   }
+
+   static void __device_stub__Z6kernelIiEvPT_(int *__par0) {
+     __cudaLaunchPrologue(1);
+     __cudaSetupArgSimple(__par0, 0UL);
+     __cudaLaunch(((char *)((void ( *)(int *))kernel )));
+   }
+
+   template<> void __wrapper__device_stub_kernel(int *&__cuda_0) {
+     __device_stub__Z6kernelIiEvPT_( (int *&)__cuda_0);
+   }
+
+The CUDA runtime is going to use the address of ``template<> void kernel(T *ptr)`` (in the following ``h_kernel``)
+as a key in the host stub function (``h_kernel``) - device function (``d_kernel``) mapping. This works fine if
+there is only a single source of truth for the stub function ``h_kernel``.
+
+However, imagine that there are two shared libraries: ``lib_a`` and ``lib_b`` both using the same ``kernel`` instance.
+
+.. code-block:: cmake
+
+    project(HostStubVisibility CUDA CXX)
+
+    add_executable(host_stub_visibility main.cu)
+    add_library(lib_a SHARED tu_a.cu)
+    add_library(lib_b SHARED tu_b.cu)
+    target_link_libraries(host_stub_visibility PRIVATE lib_a lib_b)
+
+Each library will have it's own fatbinary: ``d_kernel_a`` and ``d_kernel_b``, but the the compiler
+generated host stub function ``h_kernel`` has weak external linkage, so after dynamic linkage, we'll end up having
+only one of them.
+
+=== ===================== ============
+lib host                  device
+=== ===================== ============
+a   0xh_kernel_a          0xd_kernel_a
+b   0xh_kernel_a <- issue 0xd_kernel_b
+=== ===================== ============
+
+Since there's a clash of stub function addresses, only one entry stored. When ``lib_b`` queries for the
+kernel using its address of ``h_kernel``, it's visible, although it might point to ``lib_a``'s fatbinary.
+The opposite case might happen as well, depending on loading order, linker etc and is undefined behavior.
+
+Launching ``d_kernel`` from ``lib_b`` is not possible and leads to random errors. For instance, there seems to be
+some per CUDART global state. When the ``__cudaPushCallConfiguration`` is called in ``lib_b``, it affects the state of
+``cudart_b``, but the launch happens through ``h_kernel``, which is in ``lib_a``.
+
+This sometimes leads to ``__global__ function call is not configured``. However, there might also be no error at all,
+and the kernel launch is silently skipped.
+
+A simple example program that exemplifies this can be found
+`on github <https://github.com/NVIDIA/cccl/tree/main/docs/cub/developer/visibility/examples/host_stub_visibility>`_
+
+.. code-block:: bash
+
+   :./host_stub_visibility/host_stub_visibility
+   a: kernel stub address: 0x7f43318a415d           <== same address as in B
+   a: kernel is in mapping: no error                <== kernel is found in the mapping
+   b: launched kernel
+   a: kernel: set val = 42
+   a: synchronized stream
+   a: copied from device to host
+   a: out: 42
+   a: kernel was launched: out == 42
+
+   b: kernel stub address: 0x7f43318a415d           <== same address as in A
+   b: kernel is in mapping: no error                <== kernel is found in the mapping
+   b: launched kernel
+   b: synchronized stream
+   b: copied from device to host
+   b: out: 0
+   b: kernel was NOT actually launched: out != 42   <== silent failure

--- a/docs/cub/developer_overview.rst
+++ b/docs/cub/developer_overview.rst
@@ -3,7 +3,7 @@ CUB Developer Overview
 
 .. toctree::
    :hidden:
-   :maxdepth: 1
+   :maxdepth: 2
 
    developer/thread_level
    developer/warp_level


### PR DESCRIPTION
Symbol visibility is a huge issue that we need to address.

The current way of doing so has considerable downsides, but also gurantees some form of safety. This tries to expand the internal developer guide a bit to describe the three different problems we have.

Personally I believe that there is not possibility for us as library authors to ever solve the problem of different architectures for all possible scenarios.

The moment a user puts any function or type that calls a kernel into a library the issue reappears and there is nothing we can do about it. 