### PR TITLE
Remove fully qualified ::cuda::std:: from examples

### DIFF
--- a/thrust/examples/constant_iterator.cu
+++ b/thrust/examples/constant_iterator.cu
@@ -12,8 +12,7 @@ int main()
   thrust::device_vector<int> data{3, 7, 2, 5};
 
   // add 10 to all values in data
-  thrust::transform(
-    data.begin(), data.end(), thrust::constant_iterator<int>(10), data.begin(), cuda::std::plus<int>());
+  thrust::transform(data.begin(), data.end(), thrust::constant_iterator<int>(10), data.begin(), cuda::std::plus<int>());
 
   // data is now [13, 17, 12, 15]
 

--- a/thrust/examples/constant_iterator.cu
+++ b/thrust/examples/constant_iterator.cu
@@ -13,7 +13,7 @@ int main()
 
   // add 10 to all values in data
   thrust::transform(
-    data.begin(), data.end(), thrust::constant_iterator<int>(10), data.begin(), ::cuda::std::plus<int>());
+    data.begin(), data.end(), thrust::constant_iterator<int>(10), data.begin(), cuda::std::plus<int>());
 
   // data is now [13, 17, 12, 15]
 

--- a/thrust/examples/counting_iterator.cu
+++ b/thrust/examples/counting_iterator.cu
@@ -23,7 +23,7 @@ int main()
   // compute indices of nonzero elements
   using IndexIterator = thrust::device_vector<int>::iterator;
 
-  IndexIterator indices_end = thrust::copy_if(first, last, stencil.begin(), indices.begin(), ::cuda::std::identity{});
+  IndexIterator indices_end = thrust::copy_if(first, last, stencil.begin(), indices.begin(), cuda::std::identity{});
   // indices now contains [1,2,5,7]
 
   // print result

--- a/thrust/examples/cuda/async_reduce.cu
+++ b/thrust/examples/cuda/async_reduce.cu
@@ -42,9 +42,9 @@ int main()
 
   // launch a CUDA kernel with only 1 thread on our stream
 #ifdef THRUST_EXAMPLE_DEVICE_SIDE
-  reduce_kernel<<<1, 1, 0, s>>>(data.begin(), data.end(), 0, ::cuda::std::plus<int>(), result.data());
+  reduce_kernel<<<1, 1, 0, s>>>(data.begin(), data.end(), 0, cuda::std::plus<int>(), result.data());
 #else
-  result[0] = thrust::reduce(thrust::cuda::par, data.begin(), data.end(), 0, ::cuda::std::plus<int>());
+  result[0] = thrust::reduce(thrust::cuda::par, data.begin(), data.end(), 0, cuda::std::plus<int>());
 #endif
 
   // wait for the stream to finish
@@ -63,7 +63,7 @@ int main()
   auto begin        = data.begin();
   auto end          = data.end();
   unsigned int init = 0;
-  auto binary_op    = ::cuda::std::plus<unsigned int>();
+  auto binary_op    = cuda::std::plus<unsigned int>();
 
   // std::async captures the algorithm parameters by value
   // use std::launch::async to ensure the creation of a new thread

--- a/thrust/examples/cuda/range_view.cu
+++ b/thrust/examples/cuda/range_view.cu
@@ -7,8 +7,6 @@
 
 #include <iostream>
 
-#include "../include/host_device.h"
-
 // This example demonstrates the use of a view: a non-owning wrapper for an
 // iterator range which presents a container-like interface to the user.
 //
@@ -40,7 +38,7 @@ public:
 
   __host__ __device__ difference_type size() const
   {
-    return ::cuda::std::distance(first, last);
+    return cuda::std::distance(first, last);
   }
 
   __host__ __device__ reference operator[](difference_type n)
@@ -196,7 +194,7 @@ int main()
     make_range_view(thrust::make_transform_iterator(X.cbegin(), f1()), thrust::make_transform_iterator(X.cend(), f1())),
 
     // range view of normal_iterators
-    make_range_view(Y.begin(), ::cuda::std::distance(Y.begin(), Y.end())),
+    make_range_view(Y.begin(), cuda::std::distance(Y.begin(), Y.end())),
 
     // range view of naked pointers
     make_range_view(Z.data().get(), 4));

--- a/thrust/examples/expand.cu
+++ b/thrust/examples/expand.cu
@@ -22,7 +22,7 @@ OutputIterator expand(InputIterator1 first1, InputIterator1 last1, InputIterator
 {
   using difference_type = typename cuda::std::iterator_traits<InputIterator1>::difference_type;
 
-  difference_type input_size  = ::cuda::std::distance(first1, last1);
+  difference_type input_size  = cuda::std::distance(first1, last1);
   difference_type output_size = thrust::reduce(first1, last1);
 
   // scan the counts to obtain output offsets for each input element
@@ -46,7 +46,7 @@ OutputIterator expand(InputIterator1 first1, InputIterator1 last1, InputIterator
   thrust::gather(output_indices.begin(), output_indices.end(), first2, output);
 
   // return output + output_size
-  ::cuda::std::advance(output, output_size);
+  cuda::std::advance(output, output_size);
   return output;
 }
 

--- a/thrust/examples/histogram.cu
+++ b/thrust/examples/histogram.cu
@@ -119,8 +119,8 @@ void sparse_histogram(const Vector1& input, Vector2& histogram_values, Vector3& 
     data.end() - 1,
     data.begin() + 1,
     IndexType(1),
-    ::cuda::std::plus<IndexType>(),
-    ::cuda::std::not_equal_to<ValueType>());
+    cuda::std::plus<IndexType>(),
+    cuda::std::not_equal_to<ValueType>());
 
   // resize histogram storage
   histogram_values.resize(num_bins);

--- a/thrust/examples/minimal_custom_backend.cu
+++ b/thrust/examples/minimal_custom_backend.cu
@@ -44,16 +44,16 @@ int main()
   my_system sys;
 
   // To invoke our version of for_each, pass sys as the first parameter
-  thrust::for_each(sys, vec.begin(), vec.end(), ::cuda::std::negate{});
+  thrust::for_each(sys, vec.begin(), vec.end(), cuda::std::negate{});
 
   // Other algorithms that Thrust implements with thrust::for_each will also
   // cause our version of for_each to be invoked when we pass an instance of my_system as the first parameter.
   // Even though we did not define a special version of transform, Thrust dispatches the version it knows
   // for thrust::device_execution_policy, which my_system inherits.
-  thrust::transform(sys, vec.begin(), vec.end(), vec.begin(), ::cuda::std::identity{});
+  thrust::transform(sys, vec.begin(), vec.end(), vec.begin(), cuda::std::identity{});
 
   // Invocations without my_system are handled normally.
-  thrust::for_each(vec.begin(), vec.end(), ::cuda::std::negate{});
+  thrust::for_each(vec.begin(), vec.end(), cuda::std::negate{});
 
   return 0;
 }

--- a/thrust/examples/monte_carlo.cu
+++ b/thrust/examples/monte_carlo.cu
@@ -66,11 +66,7 @@ int main()
   int M = 30000;
 
   float estimate = thrust::transform_reduce(
-    thrust::counting_iterator<int>(0),
-    thrust::counting_iterator<int>(M),
-    estimate_pi(),
-    0.0f,
-    cuda::std::plus<float>());
+    thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(M), estimate_pi(), 0.0f, cuda::std::plus<float>());
   estimate /= M;
 
   std::cout << std::setprecision(3);

--- a/thrust/examples/monte_carlo.cu
+++ b/thrust/examples/monte_carlo.cu
@@ -70,7 +70,7 @@ int main()
     thrust::counting_iterator<int>(M),
     estimate_pi(),
     0.0f,
-    ::cuda::std::plus<float>());
+    cuda::std::plus<float>());
   estimate /= M;
 
   std::cout << std::setprecision(3);

--- a/thrust/examples/monte_carlo_disjoint_sequences.cu
+++ b/thrust/examples/monte_carlo_disjoint_sequences.cu
@@ -77,7 +77,7 @@ int main()
     thrust::counting_iterator<int>(M),
     estimate_pi(),
     0.0f,
-    ::cuda::std::plus<float>());
+    cuda::std::plus<float>());
   estimate /= M;
 
   std::cout << "pi is around " << estimate << std::endl;

--- a/thrust/examples/monte_carlo_disjoint_sequences.cu
+++ b/thrust/examples/monte_carlo_disjoint_sequences.cu
@@ -73,11 +73,7 @@ int main()
   int M = 30000;
 
   float estimate = thrust::transform_reduce(
-    thrust::counting_iterator<int>(0),
-    thrust::counting_iterator<int>(M),
-    estimate_pi(),
-    0.0f,
-    cuda::std::plus<float>());
+    thrust::counting_iterator<int>(0), thrust::counting_iterator<int>(M), estimate_pi(), 0.0f, cuda::std::plus<float>());
   estimate /= M;
 
   std::cout << "pi is around " << estimate << std::endl;

--- a/thrust/examples/norm.cu
+++ b/thrust/examples/norm.cu
@@ -34,7 +34,7 @@ int main()
 
   // setup arguments
   square<float> unary_op;
-  ::cuda::std::plus<float> binary_op;
+  cuda::std::plus<float> binary_op;
   float init = 0;
 
   // compute norm

--- a/thrust/examples/saxpy.cu
+++ b/thrust/examples/saxpy.cu
@@ -44,10 +44,10 @@ void saxpy_slow(float A, thrust::device_vector<float>& X, thrust::device_vector<
   thrust::fill(temp.begin(), temp.end(), A);
 
   // temp <- A * X
-  thrust::transform(X.begin(), X.end(), temp.begin(), temp.begin(), ::cuda::std::multiplies<float>());
+  thrust::transform(X.begin(), X.end(), temp.begin(), temp.begin(), cuda::std::multiplies<float>());
 
   // Y <- A * X + Y
-  thrust::transform(temp.begin(), temp.end(), Y.begin(), Y.begin(), ::cuda::std::plus<float>());
+  thrust::transform(temp.begin(), temp.end(), Y.begin(), Y.begin(), cuda::std::plus<float>());
 }
 
 int main()

--- a/thrust/examples/scan_by_key.cu
+++ b/thrust/examples/scan_by_key.cu
@@ -5,7 +5,7 @@
 #include <iostream>
 
 // BinaryPredicate for the head flag segment representation
-// equivalent to ::cuda::std::not_fn(thrust::project2nd<int,int>()));
+// equivalent to cuda::std::not_fn(thrust::project2nd<int,int>()));
 template <typename HeadFlagType>
 struct head_flag_predicate
 {

--- a/thrust/examples/sort.cu
+++ b/thrust/examples/sort.cu
@@ -139,7 +139,7 @@ int main()
     thrust::device_vector<int> keys(N);
     initialize(keys);
     print(keys);
-    thrust::sort(keys.begin(), keys.end(), ::cuda::std::greater<int>());
+    thrust::sort(keys.begin(), keys.end(), cuda::std::greater<int>());
     print(keys);
   }
 
@@ -186,7 +186,7 @@ int main()
     thrust::device_vector<int> values(N);
     initialize(keys, values);
     print(keys, values);
-    thrust::sort_by_key(keys.begin(), keys.end(), values.begin(), ::cuda::std::greater<int>());
+    thrust::sort_by_key(keys.begin(), keys.end(), values.begin(), cuda::std::greater<int>());
     print(keys, values);
   }
 

--- a/thrust/examples/sparse_vector.cu
+++ b/thrust/examples/sparse_vector.cu
@@ -64,8 +64,8 @@ void sum_sparse_vectors(
       temp_index.end() - 1,
       temp_index.begin() + 1,
       size_t(0),
-      ::cuda::std::plus<size_t>(),
-      ::cuda::std::not_equal_to<IndexType>())
+      cuda::std::plus<size_t>(),
+      cuda::std::not_equal_to<IndexType>())
     + 1;
 
   // allocate space for output
@@ -79,8 +79,8 @@ void sum_sparse_vectors(
     temp_value.begin(),
     C_index.begin(),
     C_value.begin(),
-    ::cuda::std::equal_to<IndexType>(),
-    ::cuda::std::plus<ValueType>());
+    cuda::std::equal_to<IndexType>(),
+    cuda::std::plus<ValueType>());
 }
 
 int main()

--- a/thrust/examples/sum.cu
+++ b/thrust/examples/sum.cu
@@ -25,7 +25,7 @@ int main()
   int init = 0;
 
   // binary operation used to reduce values
-  ::cuda::std::plus<int> binary_op;
+  cuda::std::plus<int> binary_op;
 
   // compute sum on the device
   int sum = thrust::reduce(d_vec.begin(), d_vec.end(), init, binary_op);

--- a/thrust/examples/sum_rows.cu
+++ b/thrust/examples/sum_rows.cu
@@ -49,8 +49,8 @@ int main()
     array.begin(),
     row_indices.begin(),
     row_sums.begin(),
-    ::cuda::std::equal_to<int>(),
-    ::cuda::std::plus<int>());
+    cuda::std::equal_to<int>(),
+    cuda::std::plus<int>());
 
   // print data
   for (int i = 0; i < R; i++)

--- a/thrust/examples/transform_input_output_iterator.cu
+++ b/thrust/examples/transform_input_output_iterator.cu
@@ -90,7 +90,7 @@ int main()
     C.begin(), ValueToScaledInteger{C_scale}, ScaledIntegerToValue{C_scale});
 
   // Sum A and B as ScaledIntegers, storing the scaled result in C
-  thrust::transform(A_begin, A_end, B_begin, C_begin, ::cuda::std::plus<ScaledInteger>{});
+  thrust::transform(A_begin, A_end, B_begin, C_begin, cuda::std::plus<ScaledInteger>{});
 
   thrust::host_vector<int> A_h(A);
   thrust::host_vector<int> B_h(B);

--- a/thrust/examples/transform_iterator.cu
+++ b/thrust/examples/transform_iterator.cu
@@ -110,10 +110,10 @@ int main()
 
   ////
   // combine transform_iterator with another transform_iterator
-  using NegatedClampedCountingIterator = thrust::transform_iterator<::cuda::std::negate<int>, ClampedCountingIterator>;
+  using NegatedClampedCountingIterator = thrust::transform_iterator<cuda::std::negate<int>, ClampedCountingIterator>;
 
-  NegatedClampedCountingIterator ncs_begin = thrust::make_transform_iterator(cs_begin, ::cuda::std::negate<int>());
-  NegatedClampedCountingIterator ncs_end   = thrust::make_transform_iterator(cs_end, ::cuda::std::negate<int>());
+  NegatedClampedCountingIterator ncs_begin = thrust::make_transform_iterator(cs_begin, cuda::std::negate<int>());
+  NegatedClampedCountingIterator ncs_end   = thrust::make_transform_iterator(cs_end, cuda::std::negate<int>());
 
   print_range("negated sequence ", ncs_begin, ncs_end);
 

--- a/thrust/examples/word_count.cu
+++ b/thrust/examples/word_count.cu
@@ -41,7 +41,7 @@ int word_count(const thrust::device_vector<char>& input)
     input.end() - 1, // sequence of left characters
     input.begin() + 1, // sequence of right characters
     0, // initialize sum to 0
-    ::cuda::std::plus<int>(), // sum values together
+    cuda::std::plus<int>(), // sum values together
     is_word_start()); // how to compare the left and right characters
 
   // if the first character is alphabetical, then it also begins a word


### PR DESCRIPTION
This PR removes fully qualified `::cuda::std::` names from Thrust examples, replacing them with the simpler qualified form `cuda::std::`.

**Changes:**
- Replaced `::cuda::std::` with `cuda::std::` in 19 example files
- Removed legacy `#include "../include/host_device.h"`

Closes #4479