### PR TITLE
Cache modify iterators locally in agent_merge.cuh

### DIFF
--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -144,11 +144,11 @@ __launch_bounds__(
   auto& temp_storage = vsmem_helper_t::get_temp_storage(shared_temp_storage, global_temp_storage);
   MergeAgent{
     temp_storage.Alias(),
-    try_make_cache_modified_iterator<MergePolicy::LOAD_MODIFIER>(keys1),
-    try_make_cache_modified_iterator<MergePolicy::LOAD_MODIFIER>(items1),
+    keys1,
+    items1,
     num_keys1,
-    try_make_cache_modified_iterator<MergePolicy::LOAD_MODIFIER>(keys2),
-    try_make_cache_modified_iterator<MergePolicy::LOAD_MODIFIER>(items2),
+    keys2,
+    items2,
     num_keys2,
     keys_result,
     items_result,


### PR DESCRIPTION
This avoids needing to specify the cache modifier in two places and eases integration of #6077

No relevant SASS changes on sm86 and sm120 for `cub.cpp17.test.device_merge.lid_0`. Just a few symbol changes and constants like:
```diff
<         /*0110*/                   HFMA2 R8, -RZ, RZ, 0, 6.258487701416015625e-06 ;           /* 0x00000069ff087431 */
---
>         /*0110*/                   HFMA2 R8, -RZ, RZ, 0, 5.900859832763671875e-06 ;           /* 0x00000063ff087431 */
```