### PR TITLE
Expose `cuda::multiply_half_high`

### DIFF
--- a/docs/libcudacxx/extended_api/math.rst
+++ b/docs/libcudacxx/extended_api/math.rst
@@ -17,6 +17,7 @@ Math
    math/neg
    math/uabs
    math/fast_mod_div
+   math/multiply_half_high
 
 .. list-table::
    :widths: 25 45 30 30
@@ -91,3 +92,9 @@ Math
      - Fast Modulo/Division
      - CCCL 3.1.0
      - CUDA 13.1
+
+   * - :ref:`multiply_half_high <libcudacxx-extended-api-math-multiply-half-high>`
+     - Half high of the product
+     - CCCL 3.2.0
+     - CUDA 13.2
+     

--- a/docs/libcudacxx/extended_api/math.rst
+++ b/docs/libcudacxx/extended_api/math.rst
@@ -97,4 +97,3 @@ Math
      - Half high of the product
      - CCCL 3.2.0
      - CUDA 13.2
-     

--- a/docs/libcudacxx/extended_api/math/multiply_high_half.rst
+++ b/docs/libcudacxx/extended_api/math/multiply_high_half.rst
@@ -1,0 +1,68 @@
+.. _libcudacxx-extended-api-math-multiply-high-half:
+
+``cuda::multiply_half_high``
+============================
+
+Defined in ``<cuda/cmath>`` header.
+
+.. code:: cuda
+
+   namespace cuda {
+
+   template <typename T>
+   [[nodiscard]] constexpr
+   T multiply_half_high(T lhs, T rhs) noexcept;
+
+   } // namespace cuda
+
+Computes the high half of the product of two non-negative integers ``lhs`` and ``rhs``.
+
+**Parameters**
+
+- ``lhs``: First multiplicand.
+- ``rhs``: Second multiplicand.
+
+**Return value**
+
+Upper half of ``lhs * rhs`` returned as ``T``.
+
+**Constraints**
+
+- ``T`` is an integer type.
+
+**Preconditions**
+
+- ``lhs >= 0`` when ``T`` is signed.
+- ``rhs >= 0`` when ``T`` is signed.
+
+**Remarks**
+
+- Uses ``__umulhi`` or ``__umul64hi`` instructions on device when available.
+- Uses a double-width intermediate type when possible.
+- Relies on a manual decomposition fallback when 128-bit intermediates are unavailable.
+
+Example
+-------
+
+.. code:: cuda
+
+   #include <cuda/cmath>
+   #include <cuda/std/cassert>
+   #include <cuda/std/cstdint>
+
+   __global__ void multiply_high_kernel()
+   {
+       uint32_t lhs = 0xABCD1234;
+       uint32_t rhs = 1 << 16;
+       uint32_t high_half = cuda::multiply_half_high(lhs, rhs);
+       assert(high_half == 0xAB);
+   }
+
+   int main()
+   {
+       multiply_high_kernel<<<1, 1>>>();
+       cudaDeviceSynchronize();
+       return 0;
+   }
+
+`See it on Godbolt 🔗 <https://godbolt.org/z/dPPzsEaGM>`_

--- a/docs/libcudacxx/extended_api/math/multiply_high_half.rst
+++ b/docs/libcudacxx/extended_api/math/multiply_high_half.rst
@@ -52,8 +52,8 @@ Example
 
    __global__ void multiply_high_kernel()
    {
-       uint32_t lhs = 0xABCD1234;
-       uint32_t rhs = 1 << 16;
+       uint32_t lhs       = 0xABCD1234;
+       uint32_t rhs       = 1 << 16; // 2^16
        uint32_t high_half = cuda::multiply_half_high(lhs, rhs);
        assert(high_half == 0xAB);
    }

--- a/libcudacxx/include/cuda/__cmath/multiply_high.h
+++ b/libcudacxx/include/cuda/__cmath/multiply_high.h
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___CMATH_MULTIPLY_HIGH_HALF_H
+#define _CUDA___CMATH_MULTIPLY_HIGH_HALF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/is_constant_evaluated.h>
+#include <cuda/std/__type_traits/is_integer.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/make_nbit_int.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
+#include <cuda/std/__type_traits/num_bits.h>
+#include <cuda/std/cstdint>
+
+#if _CCCL_COMPILER(MSVC)
+#  include <intrin.h>
+#endif // _CCCL_COMPILER(MSVC)
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+/***********************************************************************************************************************
+ * Extract higher bits after multiplication
+ **********************************************************************************************************************/
+
+template <typename _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __multiply_half_high_fallback(_Tp __lhs, _Tp __rhs)
+{
+  constexpr int __shift = ::cuda::std::__num_bits_v<_Tp> / 2;
+  auto __x_high         = __lhs >> __shift;
+  auto __x_low          = __lhs;
+  auto __y_high         = __rhs >> __shift;
+  auto __y_low          = __rhs;
+  auto __p0             = __x_low * __y_low;
+  auto __p1             = __x_low * __y_high;
+  auto __p2             = __x_high * __y_low;
+  auto __p3             = __x_high * __y_high;
+  auto __mid            = __p1 + __p2;
+  auto __carry          = static_cast<_Tp>(__mid < __p1);
+  auto __po_half        = __p0 >> __shift;
+  __mid                 = __mid + __po_half;
+  __carry += (__mid < __po_half);
+  return __p3 + (__mid >> __shift) + (__carry << __shift);
+}
+
+_CCCL_TEMPLATE(typename _Tp)
+_CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
+[[nodiscard]]
+_CCCL_API constexpr _Tp multiply_half_high(_Tp __lhs, _Tp __rhs)
+{
+  if constexpr (::cuda::std::is_signed_v<_Tp>)
+  {
+    _CCCL_ASSERT(__lhs >= 0, "__lhs must be non-negative");
+    _CCCL_ASSERT(__rhs >= 0, "__rhs must be non-negative");
+  }
+  using ::cuda::std::uint32_t;
+  using ::cuda::std::uint64_t;
+  using _Up         = ::cuda::std::make_unsigned_t<_Tp>;
+  const auto __lhs1 = static_cast<_Up>(__lhs);
+  const auto __rhs1 = static_cast<_Up>(__rhs);
+  if (!::cuda::std::__cccl_default_is_constant_evaluated())
+  {
+    if constexpr (sizeof(_Tp) <= sizeof(uint32_t))
+    {
+      NV_IF_TARGET(NV_IS_DEVICE, (return ::__umulhi(__lhs1, __rhs1);));
+    }
+    else if constexpr (sizeof(_Tp) == sizeof(uint64_t))
+    {
+      NV_IF_TARGET(NV_IS_DEVICE, (return ::__umul64hi(__lhs1, __rhs1);));
+#if _CCCL_COMPILER(MSVC)
+      NV_IF_TARGET(NV_IS_HOST, (return ::__umulh(__lhs1, __rhs1);));
+#endif // _CCCL_COMPILER(MSVC)
+    }
+  }
+  if constexpr (sizeof(_Tp) < sizeof(uint64_t) || (sizeof(_Tp) == sizeof(uint64_t) && _CCCL_HAS_INT128()))
+  {
+    using __larger_t      = ::cuda::std::__make_nbit_uint_t<::cuda::std::__num_bits_v<_Tp> * 2>;
+    constexpr auto __bits = ::cuda::std::__num_bits_v<_Tp>;
+    auto __ret            = (static_cast<__larger_t>(__lhs1) * __rhs1) >> __bits;
+    return static_cast<_Tp>(__ret);
+  }
+  else // sizeof(_Tp) >= sizeof(uint64_t) && !_CCCL_HAS_INT128()
+  {
+    return ::cuda::__multiply_half_high_fallback(__lhs1, __rhs1);
+  }
+}
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___CMATH_MULTIPLY_HIGH_HALF_H

--- a/libcudacxx/include/cuda/cmath
+++ b/libcudacxx/include/cuda/cmath
@@ -26,6 +26,7 @@
 #include <cuda/__cmath/ilog.h>
 #include <cuda/__cmath/ipow.h>
 #include <cuda/__cmath/isqrt.h>
+#include <cuda/__cmath/multiply_high_half.h>
 #include <cuda/__cmath/neg.h>
 #include <cuda/__cmath/pow2.h>
 #include <cuda/__cmath/round_down.h>

--- a/libcudacxx/test/libcudacxx/cuda/cmath/multiply_high_half.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/multiply_high_half.pass.cpp
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/cmath>
+#include <cuda/std/cassert>
+#include <cuda/std/climits>
+#include <cuda/std/cstdint>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+
+template <typename T>
+__host__ __device__ constexpr void test_type()
+{
+  static_assert(cuda::std::is_same_v<T, decltype(cuda::multiply_half_high(T{}, T{}))>);
+  static_assert(noexcept(cuda::multiply_half_high(T{}, T{})));
+  constexpr int bits       = static_cast<int>(sizeof(T) * CHAR_BIT);
+  constexpr auto max_value = cuda::std::numeric_limits<T>::max();
+  using U                  = cuda::std::make_unsigned_t<T>;
+
+  // trivial cases
+  assert(cuda::multiply_half_high(T{0}, T{0}) == T{0});
+  assert(cuda::multiply_half_high(max_value, T{0}) == T{0});
+  assert(cuda::multiply_half_high(max_value, T{1}) == T{0});
+  assert(cuda::multiply_half_high(T{0}, max_value) == T{0});
+  assert(cuda::multiply_half_high(T{1}, max_value) == T{0});
+
+  // non-trivial cases
+  constexpr auto mask1 = T{T{0x7B} << (bits - 8)};
+  assert(cuda::multiply_half_high(mask1, T{16}) == T{0x7});
+  assert(cuda::multiply_half_high(T{16}, mask1) == T{0x7});
+
+  constexpr auto mask2 = static_cast<U>(-1);
+  assert(cuda::multiply_half_high(mask2, U{64}) == mask2 >> (bits - 6));
+  assert(cuda::multiply_half_high(U{64}, mask2) == mask2 >> (bits - 6));
+
+  if constexpr (sizeof(T) >= 2)
+  {
+    constexpr auto mask3 = static_cast<T>(0x7BCD);
+    assert(cuda::multiply_half_high(mask3, T{4096}) == (mask3 >> (bits - 12)));
+    assert(cuda::multiply_half_high(T{4096}, mask3) == (mask3 >> (bits - 12)));
+  }
+  if constexpr (sizeof(T) >= 4)
+  {
+    constexpr auto mask3 = static_cast<T>(0x7ABCABCD);
+    assert(cuda::multiply_half_high(mask3, T{1 << 24}) == mask3 >> (bits - 24));
+    assert(cuda::multiply_half_high(T{1 << 24}, mask3) == mask3 >> (bits - 24));
+  }
+  if constexpr (sizeof(T) >= 8)
+  {
+    constexpr auto mask3 = static_cast<T>(0x7ABCABCD12345678);
+    assert(cuda::multiply_half_high(mask3, T{1} << 48) == mask3 >> (bits - 48));
+    assert(cuda::multiply_half_high(T{1} << 48, mask3) == mask3 >> (bits - 48));
+  }
+#if _CCCL_HAS_INT128()
+  if constexpr (sizeof(T) == 16)
+  {
+    using namespace test_integer_literals;
+    constexpr auto mask4 = T{0x7ABCABCD12345678_i128};
+    assert(cuda::multiply_half_high(mask4, T{1} << 96) == mask4 >> (bits - 96));
+    assert(cuda::multiply_half_high(T{1} << 96, mask4) == mask4 >> (bits - 96));
+  }
+#endif // _CCCL_HAS_INT128()
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test_type<unsigned char>();
+  test_type<unsigned short>();
+  test_type<unsigned int>();
+  test_type<unsigned long>();
+  test_type<unsigned long long>();
+
+  test_type<signed char>();
+  test_type<short>();
+  test_type<int>();
+  test_type<long>();
+  test_type<long long>();
+
+#if _CCCL_HAS_INT128()
+  test_type<__uint128_t>();
+  test_type<__int128_t>();
+#endif // _CCCL_HAS_INT128()
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}


### PR DESCRIPTION
## Description

Motivated by [Add a philox PRNG engine to thrust](https://github.com/NVIDIA/cccl/pull/6109) #6109.

Multiply and keep the high half of the result is a common primitive in random generator, cryptography, and modulo arithmetic.
We already use the functionality in `fast_mod_div`.
This PR exposes the functionality, improving a few aspects, and adding a fast windows path for 64-bit operands.