### PR TITLE
c.parallel: enable dynamic policies in merge_sort.

### DIFF
--- a/c/parallel/include/cccl/c/merge_sort.h
+++ b/c/parallel/include/cccl/c/merge_sort.h
@@ -33,6 +33,7 @@ typedef struct cccl_device_merge_sort_build_result_t
   CUkernel block_sort_kernel;
   CUkernel partition_kernel;
   CUkernel merge_kernel;
+  void* runtime_policy;
 } cccl_device_merge_sort_build_result_t;
 
 CCCL_C_API CUresult cccl_device_merge_sort_build(

--- a/c/parallel/src/merge_sort.cu
+++ b/c/parallel/src/merge_sort.cu
@@ -19,6 +19,7 @@
 #include "kernels/operators.h"
 #include "util/context.h"
 #include "util/indirect_arg.h"
+#include "util/runtime_policy.h"
 #include "util/tuning.h"
 #include "util/types.h"
 #include <cccl/c/merge_sort.h>
@@ -40,37 +41,22 @@ namespace merge_sort
 {
 struct merge_sort_runtime_tuning_policy
 {
-  int block_size;
-  int items_per_thread;
-  int items_per_tile;
-  merge_sort_runtime_tuning_policy MergeSort() const
+  cub::detail::RuntimeMergeSortAgentPolicy merge_sort;
+
+  auto MergeSort() const
   {
-    return *this;
+    return merge_sort;
   }
 
-  using MergeSortPolicy = merge_sort_runtime_tuning_policy;
-};
+  using MergeSortPolicy = cub::detail::RuntimeMergeSortAgentPolicy;
+  using MaxPolicy       = merge_sort_runtime_tuning_policy;
 
-struct merge_sort_tuning_t
-{
-  int cc;
-  int block_size;
-  int items_per_thread;
-};
-
-template <typename Tuning, int N>
-Tuning find_tuning(int cc, const Tuning (&tunings)[N])
-{
-  for (const Tuning& tuning : tunings)
+  template <typename F>
+  cudaError_t Invoke(int, F& op)
   {
-    if (cc >= tuning.cc)
-    {
-      return tuning;
-    }
+    return op.template Invoke<merge_sort_runtime_tuning_policy>(*this);
   }
-
-  return tunings[N - 1];
-}
+};
 
 enum class merge_sort_iterator_t
 {
@@ -119,19 +105,6 @@ std::string get_iterator_name(cccl_iterator_t iterator, merge_sort_iterator_t wh
 
     return iterator_t;
   }
-}
-
-merge_sort_runtime_tuning_policy get_policy(int cc, int key_size)
-{
-  merge_sort_tuning_t chain[]            = {{60, 256, nominal_4b_items_to_items(17, static_cast<int>(key_size))},
-                                            {35, 256, nominal_4b_items_to_items(11, static_cast<int>(key_size))}};
-  auto [_, block_size, items_per_thread] = find_tuning(cc, chain);
-  // TODO: we hardcode this value in order to make sure that the merge_sort test does not fail due to the memory op
-  // assertions. This currently happens when we pass in items and keys of type uint8_t or int16_t, and for the custom
-  // types test as well. This will be fixed after https://github.com/NVIDIA/cccl/issues/3570 is resolved.
-  items_per_thread = 1;
-
-  return {block_size, items_per_thread, block_size * items_per_thread};
 }
 
 std::string get_merge_sort_kernel_name(
@@ -197,21 +170,6 @@ std::string get_partition_kernel_name(cccl_iterator_t output_keys_it)
     key_t);
 }
 
-template <auto* GetPolicy>
-struct dynamic_merge_sort_policy_t
-{
-  using MaxPolicy = dynamic_merge_sort_policy_t;
-
-  template <typename F>
-  cudaError_t Invoke(int device_ptx_version, F& op)
-  {
-    return op.template Invoke<merge_sort_runtime_tuning_policy>(
-      GetPolicy(device_ptx_version, static_cast<int>(key_size)));
-  }
-
-  uint64_t key_size;
-};
-
 struct merge_sort_kernel_source
 {
   cccl_device_merge_sort_build_result_t& build;
@@ -259,20 +217,13 @@ struct dynamic_vsmem_helper_t
   template <typename PolicyT, typename... Ts>
   static int BlockThreads(PolicyT policy)
   {
-    return policy.block_size;
+    return policy.BlockThreads();
   }
 
   template <typename PolicyT, typename... Ts>
   static int ItemsPerTile(PolicyT policy)
   {
-    return policy.items_per_tile;
-  }
-
-private:
-  merge_sort_runtime_tuning_policy fallback_policy = {64, 1, 64};
-  bool uses_fallback_policy() const
-  {
-    return false;
+    return policy.ItemsPerTile();
   }
 };
 } // namespace merge_sort
@@ -297,8 +248,7 @@ CUresult cccl_device_merge_sort_build_ex(
   {
     const char* name = "test";
 
-    const int cc      = cc_major * 10 + cc_minor;
-    const auto policy = merge_sort::get_policy(cc, static_cast<int>(output_keys_it.value_type.size));
+    const int cc = cc_major * 10 + cc_minor;
 
     const auto input_keys_it_value_t   = cccl_type_enum_to_name(input_keys_it.value_type.type);
     const auto input_items_it_value_t  = cccl_type_enum_to_name(input_items_it.value_type.type);
@@ -338,29 +288,59 @@ struct __align__({1}) storage_t {{
 struct __align__({3}) items_storage_t {{
   char data[{2}];
 }};
+{4}
+{5}
+{6}
 {7}
 {8}
-{9}
-{10}
-struct agent_policy_t {{
-  static constexpr int ITEMS_PER_TILE = {6};
-  static constexpr int ITEMS_PER_THREAD = {5};
-  static constexpr int BLOCK_THREADS = {4};
-  static constexpr cub::BlockLoadAlgorithm LOAD_ALGORITHM = cub::BLOCK_LOAD_WARP_TRANSPOSE;
-  static constexpr cub::CacheLoadModifier LOAD_MODIFIER = cub::LOAD_LDG;
-  static constexpr cub::BlockStoreAlgorithm STORE_ALGORITHM = cub::BLOCK_STORE_WARP_TRANSPOSE;
-}};
+)XXX";
+
+    const std::string src = std::format(
+      src_template,
+      input_keys_it.value_type.size, // 0
+      input_keys_it.value_type.alignment, // 1
+      input_items_it.value_type.size, // 2
+      input_items_it.value_type.alignment, // 3
+      input_keys_iterator_src, // 4
+      input_items_iterator_src, // 5
+      output_keys_iterator_src, // 6
+      output_items_iterator_src, // 7
+      op_src); // 8
+
+    const std::string ptx_arch = std::format("-arch=compute_{}{}", cc_major, cc_minor);
+
+    std::vector<const char*> ptx_args = {
+      ptx_arch.c_str(), cub_path, thrust_path, libcudacxx_path, ctk_path, "-rdc=true"};
+
+    cccl::detail::extend_args_with_build_config(ptx_args, config);
+
+    std::string policy_hub_expr =
+      std::format("cub::detail::merge_sort::policy_hub<{}>",
+                  get_iterator_name(input_keys_it, merge_sort::merge_sort_iterator_t::input_keys));
+
+    nlohmann::json runtime_policy = get_policy(
+      std::format("cub::detail::merge_sort::MakeMergeSortPolicyWrapper({}::MaxPolicy::ActivePolicy{{}})",
+                  policy_hub_expr),
+      "#include <cub/device/dispatch/tuning/tuning_merge_sort.cuh>\n" + src,
+      ptx_args);
+
+    using cub::detail::RuntimeMergeSortAgentPolicy;
+    auto [ms_policy, ms_policy_str] = RuntimeMergeSortAgentPolicy::from_json(runtime_policy, "MergeSortPolicy");
+
+    std::string final_src = std::format(
+      R"XXX(
+{0}
 struct device_merge_sort_policy {{
   struct ActivePolicy {{
-    using MergeSortPolicy = agent_policy_t;
+    {1}
   }};
 }};
 struct device_merge_sort_vsmem_helper {{
   template<typename ActivePolicyT, typename KeyInputIteratorT, typename ValueInputIteratorT, typename... Ts>
   struct MergeSortVSMemHelperT {{
-    using policy_t = agent_policy_t;
-    using block_sort_agent_t = cub::detail::merge_sort::AgentBlockSort<agent_policy_t, KeyInputIteratorT, ValueInputIteratorT, Ts...>;
-    using merge_agent_t = cub::detail::merge_sort::AgentMerge<agent_policy_t, Ts...>;
+    using policy_t = device_merge_sort_policy::ActivePolicy::MergeSortPolicy;
+    using block_sort_agent_t = cub::detail::merge_sort::AgentBlockSort<policy_t, KeyInputIteratorT, ValueInputIteratorT, Ts...>;
+    using merge_agent_t = cub::detail::merge_sort::AgentMerge<policy_t, Ts...>;
   }};
   template <typename AgentT>
   struct VSmemHelperT {{
@@ -377,27 +357,13 @@ struct device_merge_sort_vsmem_helper {{
     }}
   }};
 }};
-{11};
-)XXX";
-
-    const std::string src = std::format(
-      src_template,
-      input_keys_it.value_type.size, // 0
-      input_keys_it.value_type.alignment, // 1
-      input_items_it.value_type.size, // 2
-      input_items_it.value_type.alignment, // 3
-      policy.block_size, // 4
-      policy.items_per_thread, // 5
-      policy.items_per_tile, // 6
-      input_keys_iterator_src, // 7
-      input_items_iterator_src, // 8
-      output_keys_iterator_src, // 9
-      output_items_iterator_src, // 10
-      op_src); // 11
+)XXX",
+      src,
+      ms_policy_str);
 
 #if false // CCCL_DEBUGGING_SWITCH
     fflush(stderr);
-    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", src.c_str());
+    printf("\nCODE4NVRTC BEGIN\n%sCODE4NVRTC END\n", final_src.c_str());
     fflush(stdout);
 #endif
 
@@ -432,7 +398,7 @@ struct device_merge_sort_vsmem_helper {{
 
     nvrtc_link_result result =
       begin_linking_nvrtc_program(num_lto_args, lopts)
-        ->add_program(nvrtc_translation_unit{src.c_str(), name})
+        ->add_program(nvrtc_translation_unit{final_src.c_str(), name})
         ->add_expression({block_sort_kernel_name})
         ->add_expression({partition_kernel_name})
         ->add_expression({merge_kernel_name})
@@ -450,11 +416,12 @@ struct device_merge_sort_vsmem_helper {{
     check(cuLibraryGetKernel(&build_ptr->partition_kernel, build_ptr->library, partition_kernel_lowered_name.c_str()));
     check(cuLibraryGetKernel(&build_ptr->merge_kernel, build_ptr->library, merge_kernel_lowered_name.c_str()));
 
-    build_ptr->cc         = cc;
-    build_ptr->cubin      = (void*) result.data.release();
-    build_ptr->cubin_size = result.size;
-    build_ptr->key_type   = input_keys_it.value_type;
-    build_ptr->item_type  = input_items_it.value_type;
+    build_ptr->cc             = cc;
+    build_ptr->cubin          = (void*) result.data.release();
+    build_ptr->cubin_size     = result.size;
+    build_ptr->key_type       = input_keys_it.value_type;
+    build_ptr->item_type      = input_items_it.value_type;
+    build_ptr->runtime_policy = new merge_sort::merge_sort_runtime_tuning_policy{ms_policy};
   }
   catch (const std::exception& exc)
   {
@@ -504,7 +471,7 @@ CUresult cccl_device_merge_sort(
       indirect_arg_t,
       OffsetT,
       indirect_arg_t,
-      merge_sort::dynamic_merge_sort_policy_t<&merge_sort::get_policy>,
+      merge_sort::merge_sort_runtime_tuning_policy,
       merge_sort::merge_sort_kernel_source,
       cub::detail::CudaDriverLauncherFactory,
       merge_sort::dynamic_vsmem_helper_t,
@@ -520,7 +487,7 @@ CUresult cccl_device_merge_sort(
                                 stream,
                                 {build},
                                 cub::detail::CudaDriverLauncherFactory{cu_device, build.cc},
-                                {d_out_keys.value_type.size});
+                                *reinterpret_cast<merge_sort::merge_sort_runtime_tuning_policy*>(build.runtime_policy));
 
     error = static_cast<CUresult>(exec_status);
   }
@@ -581,6 +548,7 @@ CUresult cccl_device_merge_sort_cleanup(cccl_device_merge_sort_build_result_t* b
     }
 
     std::unique_ptr<char[]> cubin(reinterpret_cast<char*>(build_ptr->cubin));
+    std::unique_ptr<char[]> policy(reinterpret_cast<char*>(build_ptr->runtime_policy));
     check(cuLibraryUnload(build_ptr->library));
   }
   catch (const std::exception& exc)

--- a/cub/cub/agent/agent_merge_sort.cuh
+++ b/cub/cub/agent/agent_merge_sort.cuh
@@ -66,6 +66,27 @@ struct AgentMergeSortPolicy
   static constexpr cub::BlockStoreAlgorithm STORE_ALGORITHM = _STORE_ALGORITHM;
 };
 
+#if defined(CUB_DEFINE_RUNTIME_POLICIES) || defined(CUB_ENABLE_POLICY_PTX_JSON)
+namespace detail
+{
+// Only define this when needed.
+// Because of overload woes, this depends on C++20 concepts. util_device.h checks that concepts are available when
+// either runtime policies or PTX JSON information are enabled, so if they are, this is always valid. The generic
+// version is always defined, and that's the only one needed for regular CUB operations.
+//
+// TODO: enable this unconditionally once concepts are always available
+CUB_DETAIL_POLICY_WRAPPER_DEFINE(
+  MergeSortAgentPolicy,
+  (GenericAgentPolicy),
+  (BLOCK_THREADS, BlockThreads, int),
+  (ITEMS_PER_THREAD, ItemsPerThread, int),
+  (ITEMS_PER_TILE, ItemsPerTile, int),
+  (LOAD_ALGORITHM, LoadAlgorithm, cub::BlockLoadAlgorithm),
+  (LOAD_MODIFIER, LoadModifier, cub::CacheLoadModifier),
+  (STORE_ALGORITHM, StoreAlgorithm, cub::BlockStoreAlgorithm))
+} // namespace detail
+#endif // defined(CUB_DEFINE_RUNTIME_POLICIES
+
 namespace detail::merge_sort
 {
 

--- a/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_merge_sort.cuh
@@ -62,6 +62,14 @@ struct MergeSortPolicyWrapper<StaticPolicyT, ::cuda::std::void_t<decltype(Static
   {}
 
   CUB_DEFINE_SUB_POLICY_GETTER(MergeSort);
+
+#if defined(CUB_ENABLE_POLICY_PTX_JSON)
+  _CCCL_DEVICE static constexpr auto EncodedPolicy()
+  {
+    using namespace ptx_json;
+    return object<key<"MergeSortPolicy">() = MergeSort().EncodedPolicy()>();
+  }
+#endif
 };
 
 template <typename PolicyT>


### PR DESCRIPTION
## Description

Reuse CUB policies for merge_sort in c.parallel.

Resolves #5190 

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
