### PR TITLE
Fix title in docs/python/index.rst

### DIFF
--- a/docs/python/index.rst
+++ b/docs/python/index.rst
@@ -1,5 +1,4 @@
 CCCL Python Libraries
-
 ======================
 
 Welcome to the CCCL Python libraries! This collection provides Pythonic interfaces to


### PR DESCRIPTION
## Description

An erroneously introduced newline has caused the `python/inded` page not to have a title:

<img width="903" height="633" alt="Screenshot from 2025-10-09 06-36-11" src="https://github.com/user-attachments/assets/9d90b4ed-6f14-4394-a575-75fd7037bb9d" />

Which has also broken the sidebar, removing the "CCCL Python Libraries" level:

<img width="272" height="333" alt="Screenshot from 2025-10-09 06-38-30" src="https://github.com/user-attachments/assets/8970de7e-898b-4fed-ac75-6e632330e177" />

This PR fixes these issues.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
