### PR TITLE
Add noexcept to deallocate in type erased wrappers

### DIFF
--- a/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/any_resource.cuh
@@ -117,7 +117,7 @@ struct __ibasic_resource : __basic_interface<__ibasic_resource>
 
   _CCCL_PUBLIC_HOST_API void
 
-  deallocate_sync(void* __pv, size_t __bytes, size_t __alignment = alignof(::cuda::std::max_align_t))
+  deallocate_sync(void* __pv, size_t __bytes, size_t __alignment = alignof(::cuda::std::max_align_t)) noexcept
   {
     return ::cuda::__virtcall<&__ibasic_resource::deallocate_sync>(this, __pv, __bytes, __alignment);
   }
@@ -140,12 +140,13 @@ struct __ibasic_async_resource : __basic_interface<__ibasic_async_resource>
       this, __stream, __bytes, alignof(::cuda::std::max_align_t));
   }
 
-  _CCCL_PUBLIC_HOST_API void deallocate(::cuda::stream_ref __stream, void* __pv, size_t __bytes, size_t __alignment)
+  _CCCL_PUBLIC_HOST_API void
+  deallocate(::cuda::stream_ref __stream, void* __pv, size_t __bytes, size_t __alignment) noexcept
   {
     return ::cuda::__virtcall<&__deallocate_async<__ibasic_async_resource>>(this, __stream, __pv, __bytes, __alignment);
   }
 
-  _CCCL_PUBLIC_HOST_API void deallocate(::cuda::stream_ref __stream, void* __pv, size_t __bytes)
+  _CCCL_PUBLIC_HOST_API void deallocate(::cuda::stream_ref __stream, void* __pv, size_t __bytes) noexcept
   {
     return ::cuda::__virtcall<&__deallocate_async<__ibasic_async_resource>>(
       this, __stream, __pv, __bytes, alignof(::cuda::std::max_align_t));


### PR DESCRIPTION
`deallocate_sync` is marked noexcept, but `deallocate` is not, it was probably just missed