### PR TITLE
[libcu++] Implement `cuda::ffs`

### DIFF
--- a/docs/libcudacxx/extended_api/bit.rst
+++ b/docs/libcudacxx/extended_api/bit.rst
@@ -11,6 +11,7 @@ Bit
    bit/bit_reverse
    bit/bitfield_insert
    bit/bitfield_extract
+   bit/ffs
 
 .. list-table::
    :widths: 25 45 30 30
@@ -40,3 +41,8 @@ Bit
      - Extract a bitfield
      - CCCL 3.0.0
      - CUDA 13.0
+
+   * - :ref:`ffs <libcudacxx-extended-api-bit-ffs>`
+     - Find first set bit
+     - CCCL 3.2.0
+     - CUDA 13.2

--- a/docs/libcudacxx/extended_api/bit/ffs.rst
+++ b/docs/libcudacxx/extended_api/bit/ffs.rst
@@ -1,0 +1,68 @@
+.. _libcudacxx-extended-api-bit-ffs:
+
+``cuda::ffs``
+=============
+
+Defined in the ``<cuda/bit>`` header.
+
+.. code:: cpp
+
+   namespace cuda {
+
+   template <class T>
+   [[nodiscard]] __host__ __device__ constexpr
+   int ffs(T value) noexcept;
+
+   } // namespace cuda
+
+The function finds the first (least significant) set bit in ``value`` and returns its 1-based index. If ``value`` is 0, returns 0.
+
+**Parameters**
+
+- ``value``: Input value
+
+**Return value**
+
+- The 1-based index of the first set bit, or 0 if ``value`` is 0
+
+**Constraints**
+
+- ``T`` must be an unsigned integer type. Supported types include all standard unsigned integer types and ``__uint128_t`` when available.
+
+**Relationship with other functions**
+
+- For non-zero values: ``ffs(x) == countr_zero(x) + 1``
+
+**Performance considerations**
+
+The function performs the following operations:
+
+- Device:
+
+  - ``uint8_t``, ``uint16_t``, ``uint32_t``: ``BREV``, ``FLO``, ``IADD3``
+
+- Host:
+
+  - GCC/Clang: ``__builtin_ffs`` / ``__builtin_ffsll``
+  - MSVC: ``_BitScanForward`` / ``_BitScanForward64``
+
+Example
+-------
+
+.. code:: cpp
+
+    #include <cuda/bit>
+    #include <cuda/std/cassert>
+
+    __global__ void ffs_kernel() {
+        assert(cuda::ffs(0u) == 0);
+        assert(cuda::ffs(1u) == 1);
+        assert(cuda::ffs(0b1100u) == 3);
+        assert(cuda::ffs(0x80000000u) == 32);
+    }
+
+    int main() {
+        ffs_kernel<<<1, 1>>>();
+        cudaDeviceSynchronize();
+        return 0;
+    }

--- a/libcudacxx/include/cuda/__bit/ffs.h
+++ b/libcudacxx/include/cuda/__bit/ffs.h
@@ -1,0 +1,175 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___BIT_FFS_H
+#define _CUDA___BIT_FFS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_unsigned_integer.h>
+#include <cuda/std/__type_traits/remove_cv.h>
+#include <cuda/std/cstdint>
+
+#include <nv/target>
+
+#if _CCCL_COMPILER(MSVC)
+#  include <intrin.h>
+#endif // _CCCL_COMPILER(MSVC)
+
+#include <cuda/std/__cccl/prologue.h>
+
+#if _CCCL_HAS_BUILTIN(__builtin_ffs) || _CCCL_COMPILER(GCC)
+#  define _CCCL_BUILTIN_FFS(...)   __builtin_ffs(__VA_ARGS__)
+#  define _CCCL_BUILTIN_FFSLL(...) __builtin_ffsll(__VA_ARGS__)
+#endif // _CCCL_HAS_BUILTIN(__builtin_ffs) || _CCCL_COMPILER(GCC)
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+namespace __detail
+{
+// Generic constexpr implementation - used for constexpr evaluation and as fallback
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_DEVICE constexpr int __ffs_constexpr_impl(_Tp __v) noexcept
+{
+  static_assert(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>, "_Tp must be unsigned");
+  if (__v == 0)
+  {
+    return 0;
+  }
+  int __pos = 1;
+  while ((__v & 1) == 0)
+  {
+    __v >>= 1;
+    ++__pos;
+  }
+  return __pos;
+}
+
+#if _CCCL_CUDA_COMPILATION()
+// Device-specific implementations using CUDA intrinsics
+[[nodiscard]] _CCCL_DEVICE_API inline int __ffs_device32(::cuda::std::uint32_t __v) noexcept
+{
+  return ::__ffs(static_cast<int>(__v));
+}
+
+[[nodiscard]] _CCCL_DEVICE_API inline int __ffs_device64(::cuda::std::uint64_t __v) noexcept
+{
+  return ::__ffsll(static_cast<long long>(__v));
+}
+
+#  if _CCCL_HAS_INT128()
+[[nodiscard]] _CCCL_DEVICE_API inline int __ffs_device128(__uint128_t __v) noexcept
+{
+  const auto __lo = static_cast<::cuda::std::uint64_t>(__v);
+  if (const int __result = ::cuda::__detail::__ffs_device64(__lo))
+  {
+    return __result;
+  }
+  const auto __hi = static_cast<::cuda::std::uint64_t>(__v >> 64);
+  if (const int __result = ::cuda::__detail::__ffs_device64(__hi))
+  {
+    return __result + 64;
+  }
+  return 0;
+}
+#  endif // _CCCL_HAS_INT128()
+
+#endif // _CCCL_CUDA_COMPILATION()
+} // namespace __detail
+
+template <class _Tp, ::cuda::std::enable_if_t<::cuda::std::__cccl_is_cv_unsigned_integer_v<_Tp>, int> = 0>
+[[nodiscard]] _CCCL_API constexpr int ffs(_Tp __v) noexcept
+{
+  using _Unsigned = ::cuda::std::remove_cv_t<_Tp>;
+
+  _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+  {
+#if _CCCL_HAS_INT128()
+    if constexpr (sizeof(_Unsigned) == sizeof(__uint128_t))
+    {
+      NV_IF_ELSE_TARGET(
+        NV_IS_HOST,
+        (
+          // Host path for 128-bit: split into two 64-bit parts
+          const auto __lo = static_cast<::cuda::std::uint64_t>(__v);
+          const auto __hi = static_cast<::cuda::std::uint64_t>(static_cast<__uint128_t>(__v) >> 64);
+#  if defined(_CCCL_BUILTIN_FFSLL)
+          if (const int __result = _CCCL_BUILTIN_FFSLL(static_cast<long long>(__lo))) {
+            return __result;
+          } if (const int __result = _CCCL_BUILTIN_FFSLL(static_cast<long long>(__hi))) {
+            return __result + 64;
+          } return 0;
+#  else
+          if (const int __result = ::cuda::__detail::__ffs_constexpr_impl(__lo)) {
+            return __result;
+          } if (const int __result = ::cuda::__detail::__ffs_constexpr_impl(__hi)) { return __result + 64; } return 0;
+#  endif
+          ),
+        (return ::cuda::__detail::__ffs_device128(static_cast<__uint128_t>(__v));))
+    }
+#endif // _CCCL_HAS_INT128()
+
+    if constexpr (sizeof(_Unsigned) <= sizeof(::cuda::std::uint32_t))
+    {
+      NV_IF_ELSE_TARGET(
+        NV_IS_HOST,
+        (
+          // Host path for 32-bit
+          const auto __v32 = static_cast<::cuda::std::uint32_t>(__v);
+#if defined(_CCCL_BUILTIN_FFS)
+          return _CCCL_BUILTIN_FFS(static_cast<int>(__v32));
+#elif _CCCL_COMPILER(MSVC)
+          unsigned long __where{};
+          const unsigned char __res = ::_BitScanForward(&__where, __v32);
+          return __res ? static_cast<int>(__where) + 1 : 0;
+#else
+          return ::cuda::__detail::__ffs_constexpr_impl(__v32);
+#endif
+          ),
+        (return ::cuda::__detail::__ffs_device32(static_cast<::cuda::std::uint32_t>(__v));))
+    }
+    else if constexpr (sizeof(_Unsigned) <= sizeof(::cuda::std::uint64_t))
+    {
+      NV_IF_ELSE_TARGET(
+        NV_IS_HOST,
+        (
+          // Host path for 64-bit
+          const auto __v64 = static_cast<::cuda::std::uint64_t>(__v);
+#if defined(_CCCL_BUILTIN_FFSLL)
+          return _CCCL_BUILTIN_FFSLL(static_cast<long long>(__v64));
+#elif _CCCL_COMPILER(MSVC)
+          unsigned long __where{};
+          const unsigned char __res = ::_BitScanForward64(&__where, __v64);
+          return __res ? static_cast<int>(__where) + 1 : 0;
+#else
+          return ::cuda::__detail::__ffs_constexpr_impl(__v64);
+#endif
+          ),
+        (return ::cuda::__detail::__ffs_device64(static_cast<::cuda::std::uint64_t>(__v));))
+    }
+  }
+
+  return ::cuda::__detail::__ffs_constexpr_impl(static_cast<_Unsigned>(__v));
+}
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___BIT_FFS_H

--- a/libcudacxx/include/cuda/bit
+++ b/libcudacxx/include/cuda/bit
@@ -24,6 +24,7 @@
 #include <cuda/__bit/bit_reverse.h>
 #include <cuda/__bit/bitfield.h>
 #include <cuda/__bit/bitmask.h>
+#include <cuda/__bit/ffs.h>
 #include <cuda/std/bit>
 
 #endif // _CUDA_BIT

--- a/libcudacxx/include/cuda/pipeline
+++ b/libcudacxx/include/cuda/pipeline
@@ -28,6 +28,7 @@
 #include <cuda/__ptx/instructions/get_sreg.h>
 #include <cuda/atomic>
 #include <cuda/barrier>
+#include <cuda/bit>
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__bit/popcount.h>
 #include <cuda/std/__chrono/duration.h>
@@ -111,7 +112,7 @@ public:
       NV_IS_DEVICE,
       const uint32_t __match_mask =
         ::__match_any_sync(::__activemask(), reinterpret_cast<uintptr_t>(__shared_state_get_refcount()));
-      const uint32_t __elected_id = ::__ffs(__match_mask) - 1;
+      const uint32_t __elected_id = ::cuda::ffs(__match_mask) - 1;
       __elected                   = (::cuda::ptx::get_sreg_laneid() == __elected_id);
       __sub_count                 = ::cuda::std::popcount(__match_mask);
       , __elected = true;
@@ -133,11 +134,6 @@ public:
     }
     __active = false;
     return __released;
-  }
-
-  _CCCL_API inline bool __is_active() const
-  {
-    return __active;
   }
 
   _CCCL_API inline void producer_acquire()
@@ -305,7 +301,7 @@ make_pipeline(const _Group& __group, pipeline_shared_state<_Scope, _Stages_count
       NV_IS_DEVICE,
       const uint32_t __match_mask =
         ::__match_any_sync(::__activemask(), reinterpret_cast<uintptr_t>(&__shared_state->__refcount));
-      const uint32_t __elected_id = ::__ffs(__match_mask) - 1;
+      const uint32_t __elected_id = ::cuda::ffs(__match_mask) - 1;
       __elected                   = (::cuda::ptx::get_sreg_laneid() == __elected_id);
       __add_count                 = ::cuda::std::popcount(__match_mask);
       , __elected = true;
@@ -473,15 +469,15 @@ _CCCL_API inline pipeline<thread_scope_thread> make_pipeline()
 }
 
 template <uint8_t _Prior>
-_CCCL_API inline void pipeline_consumer_wait_prior([[maybe_unused]] pipeline<thread_scope_thread>& __pipeline)
+_CCCL_API inline void pipeline_consumer_wait_prior(pipeline<thread_scope_thread>& __pipeline)
 {
   NV_IF_TARGET(NV_PROVIDES_SM_80, ::cuda::device::__pipeline_consumer_wait<_Prior>(__pipeline);
                __pipeline.__tail = __pipeline.__head - _Prior;)
 }
 
 template <thread_scope _Scope>
-_CCCL_API inline void pipeline_producer_commit([[maybe_unused]] pipeline<thread_scope_thread>& __pipeline,
-                                               [[maybe_unused]] barrier<_Scope>& __barrier)
+_CCCL_API inline void
+pipeline_producer_commit([[maybe_unused]] pipeline<thread_scope_thread>& __pipeline, barrier<_Scope>& __barrier)
 {
   NV_IF_TARGET(NV_PROVIDES_SM_80,
                ((void) __memcpy_completion_impl::__defer(
@@ -492,11 +488,6 @@ template <typename _Group, class _Tp, typename _Size, thread_scope _Scope>
 _CCCL_API inline async_contract_fulfillment __memcpy_async_pipeline(
   _Group const& __group, _Tp* __destination, _Tp const* __source, _Size __size, pipeline<_Scope>& __pipeline)
 {
-  if constexpr (_Scope != thread_scope_thread)
-  {
-    _CCCL_ASSERT(__pipeline.__is_active(), "The pipeline used for memcpy_async must be active (not quitted)");
-  }
-
   // 1. Set the completion mechanisms that can be used.
   //
   //    Do not (yet) allow async_bulk_group completion. Do not allow

--- a/libcudacxx/test/libcudacxx/cuda/bit/ffs.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/bit/ffs.pass.cpp
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// int ffs(T x) noexcept;
+//
+// Returns: The 1-based index of the first (least significant) set bit, or 0 if x == 0.
+
+#include <cuda/bit>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+
+#include "literal.h"
+#include "test_macros.h"
+
+using namespace test_integer_literals;
+
+template <typename T>
+__host__ __device__ constexpr bool constexpr_test()
+{
+  assert(cuda::ffs(T(0)) == 0);
+  assert(cuda::ffs(T(1)) == 1);
+  assert(cuda::ffs(T(2)) == 2);
+  assert(cuda::ffs(T(3)) == 1);
+  assert(cuda::ffs(T(4)) == 3);
+  assert(cuda::ffs(T(5)) == 1);
+  assert(cuda::ffs(T(6)) == 2);
+  assert(cuda::ffs(T(7)) == 1);
+  assert(cuda::ffs(T(8)) == 4);
+  assert(cuda::ffs(T(9)) == 1);
+  assert(cuda::ffs(T(127)) == 1);
+  assert(cuda::ffs(T(128)) == 8);
+
+  // Test relationship with countr_zero: ffs(x) == countr_zero(x) + 1 for x != 0
+  assert(cuda::ffs(T(1)) == cuda::std::countr_zero(T(1)) + 1);
+  assert(cuda::ffs(T(2)) == cuda::std::countr_zero(T(2)) + 1);
+  assert(cuda::ffs(T(4)) == cuda::std::countr_zero(T(4)) + 1);
+  assert(cuda::ffs(T(8)) == cuda::std::countr_zero(T(8)) + 1);
+
+  // Test MSB for different sizes (compile-time)
+  if constexpr (sizeof(T) >= 4)
+  {
+    assert(cuda::ffs(T(0x80000000u)) == 32);
+  }
+  if constexpr (sizeof(T) >= 8)
+  {
+    assert(cuda::ffs(T(0x8000000000000000ull)) == 64);
+  }
+
+  return true;
+}
+
+template <typename T>
+__host__ __device__ inline void assert_ffs(T val, int expected)
+{
+  volatile auto v = val;
+  assert(cuda::ffs(v) == expected);
+}
+
+template <typename T>
+__host__ __device__ void runtime_test()
+{
+  static_assert(cuda::std::is_same_v<int, decltype(cuda::ffs(T(0)))>, "");
+  static_assert(noexcept(cuda::ffs(T(0))), "");
+
+  assert_ffs(T(0), 0);
+  assert_ffs(T(1), 1);
+  assert_ffs(T(121), 1);
+  assert_ffs(T(122), 2);
+  assert_ffs(T(124), 3);
+
+  if constexpr (sizeof(T) > 1)
+  {
+    assert_ffs(T(128), 8);
+    assert_ffs(T(256), 9);
+    assert_ffs(T(512), 10);
+    assert_ffs(T(1024), 11);
+  }
+
+  if constexpr (sizeof(T) >= 4)
+  {
+    assert_ffs(T(0x80000000u), 32);
+  }
+
+  if constexpr (sizeof(T) >= 8)
+  {
+    assert_ffs(T(0x8000000000000000ull), 64);
+  }
+}
+
+int main(int, char**)
+{
+  static_assert(constexpr_test<unsigned char>(), "");
+  static_assert(constexpr_test<unsigned short>(), "");
+  static_assert(constexpr_test<unsigned>(), "");
+  static_assert(constexpr_test<unsigned long>(), "");
+  static_assert(constexpr_test<unsigned long long>(), "");
+
+#if _CCCL_HAS_INT128()
+  static_assert(constexpr_test<__uint128_t>(), "");
+#endif // _CCCL_HAS_INT128()
+
+  runtime_test<unsigned char>();
+  runtime_test<unsigned short>();
+  runtime_test<unsigned>();
+  runtime_test<unsigned long>();
+  runtime_test<unsigned long long>();
+
+#if _CCCL_HAS_INT128()
+  runtime_test<__uint128_t>();
+
+  // Additional 128-bit tests with literals
+  assert_ffs(0_u128, 0);
+  assert_ffs(1_u128, 1);
+  assert_ffs(0x8000000000000000_u128, 64);
+  assert_ffs((1_u128 << 64), 65);
+  assert_ffs((1_u128 << 65), 66);
+  assert_ffs((1_u128 << 100), 101);
+  assert_ffs((1_u128 << 127), 128);
+#endif // _CCCL_HAS_INT128()
+
+  return 0;
+}


### PR DESCRIPTION
Implement type-safe `cuda::std::ffs` function as replacement for `__ffs` intrinsic.

* Returns 1-based index of first set bit (0 for no bits set)
* Works on all platforms and integer types
* Handles `x == 0` correctly (returns 0)

Fixes #6108