### PR TITLE
Refactor `agent_histogram.cuh` Part 2

### DIFF
--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -637,9 +637,9 @@ struct AgentHistogram
     OffsetT num_row_pixels, OffsetT num_rows, OffsetT row_stride_samples, int tiles_per_row, GridQueue<int> tile_queue)
   {
     // Check whether all row starting offsets are vec-aligned (in single-channel) or pixel-aligned (in multi-channel)
-    static constexpr int vec_mask   = AlignBytes<VecT>::ALIGN_BYTES - 1;
-    static constexpr int pixel_mask = AlignBytes<PixelT>::ALIGN_BYTES - 1;
-    const size_t row_bytes          = sizeof(SampleT) * row_stride_samples;
+    constexpr int vec_mask   = AlignBytes<VecT>::ALIGN_BYTES - 1;
+    constexpr int pixel_mask = AlignBytes<PixelT>::ALIGN_BYTES - 1;
+    const size_t row_bytes   = sizeof(SampleT) * row_stride_samples;
 
     const bool vec_aligned_rows =
       (NumChannels == 1) && (samples_per_thread % vec_size == 0) && // Single channel


### PR DESCRIPTION
These are SASS changing refactorings. This is a follow-up to #6141.

Benchmark of `cub.bench.histogram.even.base` on B200 of (showing only changes larger than 2%)
```c++
PYTHONPATH=./_deps/nvbench-src/scripts ./_deps/nvbench-src/scripts/nvbench_compare.py --threshold-diff 0.02 base.json new.json
['base.json', 'new.json']
# base

## [0] NVIDIA B200

|  SampleT{ct}  |  CounterT{ct}  |  OffsetT{ct}  |  Elements{io}  |  Bins  |  Entropy  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------------|----------------|---------------|----------------|--------|-----------|------------|-------------|------------|-------------|-----------|---------|----------|
|      I8       |      I32       |      I32      |      2^16      |  128   |   0.201   |   8.926 us |      11.46% |   8.722 us |      10.55% | -0.204 us |  -2.28% |   SAME   |
|      I8       |      I32       |      I32      |      2^16      |  128   |     1     |   8.952 us |      11.37% |   8.639 us |      10.19% | -0.313 us |  -3.50% |   SAME   |
|      I32      |      I32       |      I32      |      2^16      |  2048  |     1     |  15.596 us |       6.38% |  16.064 us |       4.39% |  0.468 us |   3.00% |   SAME   |
|      I64      |      I32       |      I32      |      2^20      |   32   |     1     |  12.386 us |       4.04% |  12.710 us |       6.54% |  0.323 us |   2.61% |   SAME   |
|      F64      |      I32       |      I32      |      2^16      |   32   |   0.201   |   9.950 us |       6.87% |  10.178 us |       3.16% |  0.228 us |   2.29% |   SAME   |
|      F64      |      I32       |      I32      |      2^16      |  128   |   0.201   |   9.685 us |       9.00% |  10.129 us |       3.83% |  0.444 us |   4.59% |   SLOW   |
|      F64      |      I32       |      I32      |      2^16      |  128   |     1     |   9.184 us |      11.27% |   9.485 us |      10.39% |  0.301 us |   3.28% |   SAME   |
|      F64      |      I32       |      I32      |      2^20      |  128   |     1     |  11.085 us |       9.32% |  11.528 us |       8.49% |  0.443 us |   4.00% |   SAME   |
```
The hickup on the small problem size is fine and probably noise.