### PR TITLE
Do not use `pair` for two element zip iterators

### DIFF
--- a/libcudacxx/include/cuda/__iterator/zip_common.h
+++ b/libcudacxx/include/cuda/__iterator/zip_common.h
@@ -35,16 +35,6 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-_CCCL_TEMPLATE(class... _Iterators)
-_CCCL_REQUIRES((sizeof...(_Iterators) != 2))
-[[nodiscard]] _CCCL_API constexpr auto __tuple_or_pair_impl() noexcept -> ::cuda::std::tuple<_Iterators...>;
-
-template <class _Tp, class _Up>
-[[nodiscard]] _CCCL_API constexpr auto __tuple_or_pair_impl() noexcept -> ::cuda::std::pair<_Tp, _Up>;
-
-template <class... _Iterators>
-using __tuple_or_pair = decltype(::cuda::__tuple_or_pair_impl<_Iterators...>());
-
 template <class... _Iterators>
 struct __zip_iter_constraints
 {
@@ -106,7 +96,7 @@ template <class... _Iterators>
 struct __zip_op_star
 {
   template <class... _Iterators>
-  using reference = __tuple_or_pair<::cuda::std::iter_reference_t<_Iterators>...>;
+  using reference = ::cuda::std::tuple<::cuda::std::iter_reference_t<_Iterators>...>;
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Iterators>
@@ -140,7 +130,7 @@ struct __zip_op_decrement
 struct __zip_iter_move
 {
   template <class... _Iterators>
-  using __iter_move_ret = __tuple_or_pair<::cuda::std::iter_rvalue_reference_t<_Iterators>...>;
+  using __iter_move_ret = ::cuda::std::tuple<::cuda::std::iter_rvalue_reference_t<_Iterators>...>;
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Iterators>

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -42,7 +42,6 @@
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/integer_sequence.h>
 #include <cuda/std/__utility/move.h>
-#include <cuda/std/__utility/pair.h>
 #include <cuda/std/tuple>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -123,7 +122,7 @@ using __zv_iter_category_base =
 template <class... _Iterators>
 class zip_iterator : public __zv_iter_category_base<_Iterators...>
 {
-  __tuple_or_pair<_Iterators...> __current_;
+  ::cuda::std::tuple<_Iterators...> __current_;
 
   template <class...>
   friend class zip_iterator;
@@ -131,8 +130,8 @@ class zip_iterator : public __zv_iter_category_base<_Iterators...>
   template <class _Fn>
   _CCCL_API static constexpr auto
   __zip_apply(const _Fn& __fun,
-              const __tuple_or_pair<_Iterators...>& __tuple1,
-              const __tuple_or_pair<_Iterators...>& __tuple2) //
+              const ::cuda::std::tuple<_Iterators...>& __tuple1,
+              const ::cuda::std::tuple<_Iterators...>& __tuple2) //
     noexcept(noexcept(__fun(__tuple1, __tuple2, ::cuda::std::make_index_sequence<sizeof...(_Iterators)>())))
   {
     return __fun(__tuple1, __tuple2, ::cuda::std::make_index_sequence<sizeof...(_Iterators)>());
@@ -143,8 +142,8 @@ public:
   _CCCL_HIDE_FROM_ABI zip_iterator() = default;
 
   //! @brief Constructs a @c zip_iterator from a tuple of iterators
-  //! @param __iters A tuple or pair of iterators
-  _CCCL_API constexpr explicit zip_iterator(__tuple_or_pair<_Iterators...> __iters)
+  //! @param __iters A tuple of iterators
+  _CCCL_API constexpr explicit zip_iterator(::cuda::std::tuple<_Iterators...> __iters)
       : __current_(::cuda::std::move(__iters))
   {}
 
@@ -163,8 +162,8 @@ public:
   {}
 
   using iterator_concept = decltype(__get_zip_iterator_concept<_Iterators...>());
-  using value_type       = __tuple_or_pair<::cuda::std::iter_value_t<_Iterators>...>;
-  using reference        = __tuple_or_pair<::cuda::std::iter_reference_t<_Iterators>...>;
+  using value_type       = ::cuda::std::tuple<::cuda::std::iter_value_t<_Iterators>...>;
+  using reference        = ::cuda::std::tuple<::cuda::std::iter_reference_t<_Iterators>...>;
   using difference_type  = ::cuda::std::common_type_t<::cuda::std::iter_difference_t<_Iterators>...>;
 
   // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
@@ -360,8 +359,8 @@ public:
     _CCCL_EXEC_CHECK_DISABLE
     template <size_t _Zero, size_t... _Indices>
     [[nodiscard]] _CCCL_API constexpr difference_type
-    operator()(const __tuple_or_pair<_Iterators...>& __iters1,
-               const __tuple_or_pair<_Iterators...>& __iters2,
+    operator()(const ::cuda::std::tuple<_Iterators...>& __iters1,
+               const ::cuda::std::tuple<_Iterators...>& __iters2,
                ::cuda::std::index_sequence<_Zero, _Indices...>) const //
       noexcept(noexcept(((::cuda::std::get<_Indices>(__iters1) - ::cuda::std::get<_Indices>(__iters2)) && ...)))
     {
@@ -391,8 +390,8 @@ public:
   {
     _CCCL_EXEC_CHECK_DISABLE
     template <size_t... _Indices>
-    _CCCL_API constexpr bool operator()(const __tuple_or_pair<_Iterators...>& __iters1,
-                                        const __tuple_or_pair<_Iterators...>& __iters2,
+    _CCCL_API constexpr bool operator()(const ::cuda::std::tuple<_Iterators...>& __iters1,
+                                        const ::cuda::std::tuple<_Iterators...>& __iters2,
                                         ::cuda::std::index_sequence<_Indices...>) const
       noexcept(noexcept(((::cuda::std::get<_Indices>(__iters1) == ::cuda::std::get<_Indices>(__iters2)) || ...)))
     {
@@ -490,8 +489,8 @@ public:
   struct __zip_op_iter_swap
   {
     template <size_t... _Indices>
-    _CCCL_API constexpr void operator()(const __tuple_or_pair<_Iterators...>& __iters1,
-                                        const __tuple_or_pair<_Iterators...>& __iters2,
+    _CCCL_API constexpr void operator()(const ::cuda::std::tuple<_Iterators...>& __iters1,
+                                        const ::cuda::std::tuple<_Iterators...>& __iters2,
                                         ::cuda::std::index_sequence<_Indices...>) const
       noexcept(__zip_iter_constraints<_Iterators...>::__all_noexcept_swappable)
     {
@@ -508,12 +507,12 @@ public:
     return __zip_apply(__zip_op_iter_swap{}, __lhs.__current_, __rhs.__current_);
   }
 
-  [[nodiscard]] _CCCL_API constexpr __tuple_or_pair<_Iterators...>& __iterators() noexcept
+  [[nodiscard]] _CCCL_API constexpr ::cuda::std::tuple<_Iterators...>& __iterators() noexcept
   {
     return __current_;
   }
 
-  [[nodiscard]] _CCCL_API constexpr const __tuple_or_pair<_Iterators...>& __iterators() const noexcept
+  [[nodiscard]] _CCCL_API constexpr const ::cuda::std::tuple<_Iterators...>& __iterators() const noexcept
   {
     return __current_;
   }
@@ -521,9 +520,6 @@ public:
 
 template <class... _Iterators>
 _CCCL_HOST_DEVICE zip_iterator(::cuda::std::tuple<_Iterators...>) -> zip_iterator<_Iterators...>;
-
-template <class _Iterator1, class _Iterator2>
-_CCCL_HOST_DEVICE zip_iterator(::cuda::std::pair<_Iterator1, _Iterator2>) -> zip_iterator<_Iterator1, _Iterator2>;
 
 template <class... _Iterators>
 _CCCL_HOST_DEVICE zip_iterator(_Iterators...) -> zip_iterator<_Iterators...>;

--- a/libcudacxx/include/cuda/__iterator/zip_transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_transform_iterator.h
@@ -41,7 +41,6 @@
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/integer_sequence.h>
 #include <cuda/std/__utility/move.h>
-#include <cuda/std/__utility/pair.h>
 #include <cuda/std/tuple>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -154,7 +153,7 @@ template <class _Fn, class... _Iterators>
 class zip_transform_iterator
 {
   ::cuda::std::ranges::__movable_box<_Fn> __func_;
-  __tuple_or_pair<_Iterators...> __current_;
+  ::cuda::std::tuple<_Iterators...> __current_;
 
   template <class, class...>
   friend class zip_transform_iterator;
@@ -162,8 +161,8 @@ class zip_transform_iterator
   template <class _Op>
   _CCCL_API static constexpr auto
   __zip_apply(const _Op& __op,
-              const __tuple_or_pair<_Iterators...>& __tuple1,
-              const __tuple_or_pair<_Iterators...>& __tuple2) //
+              const ::cuda::std::tuple<_Iterators...>& __tuple1,
+              const ::cuda::std::tuple<_Iterators...>& __tuple2) //
     noexcept(noexcept(__op(__tuple1, __tuple2, ::cuda::std::make_index_sequence<sizeof...(_Iterators)>())))
   {
     return __op(__tuple1, __tuple2, ::cuda::std::make_index_sequence<sizeof...(_Iterators)>());
@@ -191,19 +190,10 @@ public:
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
   //! @brief Constructs a @c zip_transform_iterator from a tuple of iterators
-  //! @param __iters A tuple or pair of iterators
-  _CCCL_API constexpr explicit zip_transform_iterator(_Fn __fun, __tuple_or_pair<_Iterators...> __iters)
-      : __func_(::cuda::std::in_place, ::cuda::std::move(__fun))
-      , __current_(::cuda::std::move(__iters))
-  {}
-
-  //! @brief Constructs a @c zip_transform_iterator from a tuple of iterators
   //! @param __iters A tuple of iterators
-  _CCCL_TEMPLATE(size_t _NumIterators = sizeof...(_Iterators))
-  _CCCL_REQUIRES((_NumIterators == 2))
   _CCCL_API constexpr explicit zip_transform_iterator(_Fn __fun, ::cuda::std::tuple<_Iterators...> __iters)
       : __func_(::cuda::std::in_place, ::cuda::std::move(__fun))
-      , __current_(::cuda::std::get<0>(::cuda::std::move(__iters)), ::cuda::std::get<1>(::cuda::std::move(__iters)))
+      , __current_(::cuda::std::move(__iters))
   {}
 
   //! @brief Constructs a @c zip_transform_iterator from variadic set of iterators
@@ -226,7 +216,7 @@ public:
 
   // Internal helper functions to extract internals for device dispatch, must be a tuple for cub_transform_many
   [[nodiscard]] _CCCL_API constexpr ::cuda::std::tuple<_Iterators...>
-  __base() && noexcept(::cuda::std::is_nothrow_move_constructible_v<__tuple_or_pair<_Iterators...>>)
+  __base() && noexcept(::cuda::std::is_nothrow_move_constructible_v<::cuda::std::tuple<_Iterators...>>)
   {
     return ::cuda::std::move(__current_);
   }
@@ -425,8 +415,8 @@ public:
     _CCCL_EXEC_CHECK_DISABLE
     template <size_t _Zero, size_t... _Indices>
     [[nodiscard]] _CCCL_API constexpr difference_type
-    operator()(const __tuple_or_pair<_Iterators...>& __iters1,
-               const __tuple_or_pair<_Iterators...>& __iters2,
+    operator()(const ::cuda::std::tuple<_Iterators...>& __iters1,
+               const ::cuda::std::tuple<_Iterators...>& __iters2,
                ::cuda::std::index_sequence<_Zero, _Indices...>) const //
       noexcept(noexcept(((::cuda::std::get<_Indices>(__iters1) - ::cuda::std::get<_Indices>(__iters2)) && ...)))
     {
@@ -456,8 +446,8 @@ public:
   {
     _CCCL_EXEC_CHECK_DISABLE
     template <size_t... _Indices>
-    _CCCL_API constexpr bool operator()(const __tuple_or_pair<_Iterators...>& __iters1,
-                                        const __tuple_or_pair<_Iterators...>& __iters2,
+    _CCCL_API constexpr bool operator()(const ::cuda::std::tuple<_Iterators...>& __iters1,
+                                        const ::cuda::std::tuple<_Iterators...>& __iters2,
                                         ::cuda::std::index_sequence<_Indices...>) const
       noexcept(noexcept(((::cuda::std::get<_Indices>(__iters1) == ::cuda::std::get<_Indices>(__iters2)) || ...)))
     {
@@ -547,10 +537,6 @@ public:
 template <class _Fn, class... _Iterators>
 _CCCL_HOST_DEVICE zip_transform_iterator(_Fn, ::cuda::std::tuple<_Iterators...>)
   -> zip_transform_iterator<_Fn, _Iterators...>;
-
-template <class _Fn, class _Iterator1, class _Iterator2>
-_CCCL_HOST_DEVICE zip_transform_iterator(_Fn, ::cuda::std::pair<_Iterator1, _Iterator2>)
-  -> zip_transform_iterator<_Fn, _Iterator1, _Iterator2>;
 
 template <class _Fn, class... _Iterators>
 _CCCL_HOST_DEVICE zip_transform_iterator(_Fn, _Iterators...) -> zip_transform_iterator<_Fn, _Iterators...>;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/ctor.other.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/ctor.other.pass.cpp
@@ -51,7 +51,7 @@ __host__ __device__ constexpr bool test()
     }
 
     { // pair
-      cuda::zip_iterator iter{cuda::std::pair{buffer + 1, static_cast<const int*>(buffer + 3)}};
+      cuda::zip_iterator iter{cuda::std::tuple{buffer + 1, static_cast<const int*>(buffer + 3)}};
       static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_iterator<int*, const int*>>);
       assert(cuda::std::get<0>(*iter) == *(buffer + 1));
       assert(cuda::std::get<1>(*iter) == *(buffer + 3));
@@ -98,7 +98,7 @@ __host__ __device__ constexpr bool test()
     }
 
     { // pair
-      cuda::zip_iterator<int*, const int*> iter{cuda::std::pair{buffer + 1, buffer + 3}};
+      cuda::zip_iterator<int*, const int*> iter{cuda::std::tuple{buffer + 1, buffer + 3}};
       assert(cuda::std::get<0>(*iter) == *(buffer + 1));
       assert(cuda::std::get<1>(*iter) == *(buffer + 3));
     }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/deref.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/deref.pass.cpp
@@ -39,7 +39,7 @@ __host__ __device__ constexpr bool test()
     auto [x, y] = *iter;
     assert(cuda::std::addressof(x) == cuda::std::addressof(a[0]));
     assert(cuda::std::addressof(y) == cuda::std::addressof(b[0]));
-    static_assert(cuda::std::is_same_v<decltype(*iter), cuda::std::pair<int&, double&>>);
+    static_assert(cuda::std::is_same_v<decltype(*iter), cuda::std::tuple<int&, double&>>);
 
     x = 5;
     y = 0.1;
@@ -59,7 +59,7 @@ __host__ __device__ constexpr bool test()
     cuda::zip_iterator iter{a, cuda::std::as_const(b)};
     assert(cuda::std::addressof(cuda::std::get<0>(*iter)) == cuda::std::addressof(a[0]));
     assert(cuda::std::addressof(cuda::std::get<1>(*iter)) == cuda::std::addressof(b[0]));
-    static_assert(cuda::std::is_same_v<decltype(*iter), cuda::std::pair<int&, const double&>>);
+    static_assert(cuda::std::is_same_v<decltype(*iter), cuda::std::tuple<int&, const double&>>);
   }
 
   return true;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/iterator_traits.compile.pass.cpp
@@ -44,7 +44,7 @@ __host__ __device__ void test()
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::is_same_v<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::is_same_v<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
-    static_assert(cuda::std::is_same_v<typename IterTraits::value_type, cuda::std::pair<int, Foo>>);
+    static_assert(cuda::std::is_same_v<typename IterTraits::value_type, cuda::std::tuple<int, Foo>>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
   }
@@ -91,7 +91,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::is_same_v<typename IterTraits::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::is_same_v<typename IterTraits::difference_type, cuda::std::ptrdiff_t>);
     static_assert(
-      cuda::std::is_same_v<typename IterTraits::value_type, cuda::std::pair<int, cuda::std::pair<Foo, int>>>);
+      cuda::std::is_same_v<typename IterTraits::value_type, cuda::std::tuple<int, cuda::std::tuple<Foo, int>>>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/member_types.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/member_types.compile.pass.cpp
@@ -63,7 +63,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::is_same_v<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::is_same_v<Iter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
-    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::pair<int, Foo>>);
+    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int, Foo>>);
     static_assert(HasIterCategory<Iter>);
     static_assert(cuda::std::random_access_iterator<Iter>);
   }
@@ -112,7 +112,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::is_same_v<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::is_same_v<Iter::iterator_category, cuda::std::input_iterator_tag>);
     static_assert(cuda::std::is_same_v<Iter::difference_type, cuda::std::ptrdiff_t>);
-    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::pair<int, cuda::std::pair<Foo, int>>>);
+    static_assert(cuda::std::is_same_v<Iter::value_type, cuda::std::tuple<int, cuda::std::tuple<Foo, int>>>);
     static_assert(HasIterCategory<Iter>);
     static_assert(cuda::std::random_access_iterator<Iter>);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/subscript.pass.cpp
@@ -42,7 +42,7 @@ __host__ __device__ constexpr bool test()
     auto [x, y] = iter[0];
     assert(cuda::std::addressof(x) == cuda::std::addressof(a[0]));
     assert(cuda::std::addressof(y) == cuda::std::addressof(b[0]));
-    static_assert(cuda::std::is_same_v<decltype(iter[0]), cuda::std::pair<int&, double&>>);
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), cuda::std::tuple<int&, double&>>);
 
     x = 5;
     y = 0.1;
@@ -62,7 +62,7 @@ __host__ __device__ constexpr bool test()
     cuda::zip_iterator iter{a, cuda::std::as_const(b)};
     assert(cuda::std::addressof(cuda::std::get<0>(iter[0])) == cuda::std::addressof(a[0]));
     assert(cuda::std::addressof(cuda::std::get<1>(iter[0])) == cuda::std::addressof(b[0]));
-    static_assert(cuda::std::is_same_v<decltype(iter[0]), cuda::std::pair<int&, const double&>>);
+    static_assert(cuda::std::is_same_v<decltype(iter[0]), cuda::std::tuple<int&, const double&>>);
   }
 
   { // not all random_access_iterator

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/ctor.other.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/ctor.other.pass.cpp
@@ -49,7 +49,7 @@ __host__ __device__ constexpr bool test()
     }
 
     { // pair
-      cuda::zip_transform_iterator iter{Plus{}, cuda::std::pair{buffer + 1, static_cast<const int*>(buffer + 3)}};
+      cuda::zip_transform_iterator iter{Plus{}, cuda::std::tuple{buffer + 1, static_cast<const int*>(buffer + 3)}};
       static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_transform_iterator<Plus, int*, const int*>>);
       assert(*iter == Plus{}(buffer[1], buffer[3]));
     }
@@ -90,7 +90,7 @@ __host__ __device__ constexpr bool test()
     }
 
     { // pair
-      cuda::zip_transform_iterator<Plus, int*, const int*> iter{Plus{}, cuda::std::pair{buffer + 1, buffer + 3}};
+      cuda::zip_transform_iterator<Plus, int*, const int*> iter{Plus{}, cuda::std::tuple{buffer + 1, buffer + 3}};
       assert(*iter == Plus{}(buffer[1], buffer[3]));
     }
 


### PR DESCRIPTION
The standard tried to be clever with `zip_view` and used the simpler `pair` for 2 element zip_views

Turns out that is a bad choice as it breaks a lot of cases where a user just expects a `tuple` because they do not know the number of elements prior.

In thrust we use this a lot, so bite the bullet and always use a tuple

This should also fix some issues we have in the MatX build currently