### PR TITLE
Fix `__is_primary_std_template` for libc++

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_primary_template.h
@@ -84,11 +84,13 @@ template <class _Iter>
 struct __is_primary_std_template : bool_constant<__is_primary_std_template_impl<_Iter, is_pointer_v<_Iter>>>
 {};
 #  elif defined(_LIBCPP_VERSION)
+
 // libc++ uses the same mechanism than we do with __primary_template
 template <class _Traits>
 using __test_for_primary_std_template = enable_if_t<_IsSame<_Traits, typename _Traits::__primary_template>::value>;
 template <class _Iter>
-using __is_primary_std_template = _IsValidExpansion<__test_for_primary_template, ::std::iterator_traits<_Iter>>;
+using __is_primary_std_template = _IsValidExpansion<__test_for_primary_std_template, ::std::iterator_traits<_Iter>>;
+
 #  elif defined(_MSVC_STL_VERSION) || defined(_IS_WRS)
 // On MSVC we must check for the base class because `_From_primary` is only defined in C++20
 template <class _Iter, bool>


### PR DESCRIPTION
We were using the wrong check, so that we would check for a specialization of `::cuda::std::iterator_traits` instead of `::std::iterator_traits`

Fixes #6238