### PR TITLE
Fix `__compressed_movable_box`

### DIFF
--- a/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/compressed_movable_box.h
@@ -205,6 +205,11 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage
   __storage __storage_{};
   bool __engaged_{};
 
+  _CCCL_API constexpr __compressed_box_storage(bool __engaged) noexcept
+      : __storage_()
+      , __engaged_(__engaged)
+  {}
+
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
   _CCCL_REQUIRES(is_default_constructible_v<_Tp2>)
@@ -252,6 +257,11 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_storage<_Index, _Tp, true>
   };
   __storage __storage_{};
   bool __engaged_{};
+
+  _CCCL_API constexpr __compressed_box_storage(bool __engaged) noexcept
+      : __storage_()
+      , __engaged_(__engaged)
+  {}
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp2 = _Tp)
@@ -319,14 +329,16 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_base<_Index, _Tp, __compresse
   }
 };
 
+//! @brief We only need to do something for types that require the engaged state
 template <class _Tp>
 inline constexpr __smf_availability __compressed_box_copy_construct_available =
-  copy_constructible<_Tp> && is_trivially_copy_constructible_v<_Tp> ? __smf_availability::__trivial
-  : copy_constructible<_Tp>
+  (is_copy_constructible_v<_Tp> && __compressed_box_choose<_Tp>() != __compressed_box_specialization::__with_engaged)
+    ? __smf_availability::__trivial
+  : is_copy_constructible_v<_Tp>
     ? __smf_availability::__available
     : __smf_availability::__deleted;
 
-//! @brief Nothing to do for trivially copy constructible types
+//! @brief Nothing to do for copy constructible types
 template <size_t _Index, class _Tp, __smf_availability = __compressed_box_copy_construct_available<_Tp>>
 struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_copy_base : __compressed_box_base<_Index, _Tp>
 {
@@ -340,16 +352,12 @@ __compressed_box_copy_base<_Index, _Tp, __smf_availability::__available> : __com
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__compressed_box_copy_base, __compressed_box_base, _Index, _Tp);
 
-  // This ctor shouldn't need to initialize the base explicitly, but g++ 9 considers it to be uninitialized
-  // during constexpr evaluation if it isn't initialized explicitly. This can be replaced with the pattern
-  // below, in __compressed_box_move_base, once g++ 9 falls off our support matrix.
   _CCCL_API _CCCL_CONSTEXPR_CXX20
   __compressed_box_copy_base(const __compressed_box_copy_base& __other) noexcept(is_nothrow_copy_constructible_v<_Tp>)
-      : __base()
+      : __base(__other.__engaged())
   {
     if (__other.__engaged())
     {
-      this->__set_engaged(__other.__engaged());
       this->__construct(__other.__get());
     }
   }
@@ -371,14 +379,16 @@ __compressed_box_copy_base<_Index, _Tp, __smf_availability::__deleted> : __compr
   _CCCL_HIDE_FROM_ABI __compressed_box_copy_base& operator=(__compressed_box_copy_base&&)      = default;
 };
 
+//! @brief We only need to do something for types that require the engaged state
 template <class _Tp>
 inline constexpr __smf_availability __compressed_box_move_construct_available =
-  is_trivially_move_constructible_v<_Tp> ? __smf_availability::__trivial
+  (is_move_constructible_v<_Tp> && __compressed_box_choose<_Tp>() != __compressed_box_specialization::__with_engaged)
+    ? __smf_availability::__trivial
   : is_move_constructible_v<_Tp>
     ? __smf_availability::__available
     : __smf_availability::__deleted;
 
-//! @brief Nothing to do for trivially move constructible types
+//! @brief Nothing to do for move constructible types
 template <size_t _Index, class _Tp, __smf_availability = __compressed_box_move_construct_available<_Tp>>
 struct _CCCL_DECLSPEC_EMPTY_BASES __compressed_box_move_base : __compressed_box_copy_base<_Index, _Tp>
 {
@@ -392,17 +402,13 @@ __compressed_box_move_base<_Index, _Tp, __smf_availability::__available> : __com
 {
   _LIBCUDACXX_DELEGATE_CONSTRUCTORS(__compressed_box_move_base, __compressed_box_copy_base, _Index, _Tp);
 
-  // This ctor shouldn't need to initialize the base explicitly, but g++ 9 considers it to be uninitialized
-  // during constexpr evaluation if it isn't initialized explicitly. This can be replaced with the pattern
-  // below, in __compressed_box_move_base, once g++ 9 falls off our support matrix.
   _CCCL_HIDE_FROM_ABI __compressed_box_move_base(const __compressed_box_move_base&) = default;
   _CCCL_API _CCCL_CONSTEXPR_CXX20
   __compressed_box_move_base(__compressed_box_move_base&& __other) noexcept(is_nothrow_move_constructible_v<_Tp>)
-      : __base()
+      : __base(__other.__engaged())
   {
     if (__other.__engaged())
     {
-      this->__set_engaged(__other.__engaged());
       this->__construct(::cuda::std::move(__other.__get()));
     }
   }

--- a/libcudacxx/test/libcudacxx/libcxx/iterators/compressed_movable_box/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/iterators/compressed_movable_box/ctor.copy.pass.cpp
@@ -76,6 +76,14 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
     test<NotTriviallyCopyConstructible<MayThrow>>(1337);
   }
 
+  { // not default constructible
+    test<NotDefaultConstructible>(1337);
+  }
+
+  { // not copy assignable not default constructible
+    test<NotCopyAssignableNotDefaultConstructible<42>>(1337);
+  }
+
   { // not copy constructible
     static_assert(!cuda::std::is_copy_constructible_v<box<NotCopyConstructible<42>>>);
     static_assert(!cuda::std::is_copy_constructible_v<box<NotCopyConstructibleEmpty>>);

--- a/libcudacxx/test/libcudacxx/libcxx/iterators/compressed_movable_box/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/iterators/compressed_movable_box/ctor.move.pass.cpp
@@ -75,6 +75,14 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
     test<NotTriviallyCopyConstructible<MayThrow>>(1337);
   }
 
+  { // not default constructible
+    test<NotDefaultConstructible>(1337);
+  }
+
+  { // not copy assignable not default constructible
+    test<NotMoveAssignableNotDefaultConstructible<42>>(1337);
+  }
+
   return true;
 }
 

--- a/libcudacxx/test/libcudacxx/libcxx/iterators/compressed_movable_box/types.h
+++ b/libcudacxx/test/libcudacxx/libcxx/iterators/compressed_movable_box/types.h
@@ -238,6 +238,23 @@ struct NotCopyAssignable
 };
 
 template <int Val>
+struct NotCopyAssignableNotDefaultConstructible
+{
+  int val_ = Val;
+
+  __host__ __device__ constexpr NotCopyAssignableNotDefaultConstructible(const int val) noexcept
+      : val_(val)
+  {}
+  __host__ __device__ constexpr NotCopyAssignableNotDefaultConstructible(
+    const NotCopyAssignableNotDefaultConstructible& other) noexcept(Val != MayThrow)
+      : val_(other.val_)
+  {}
+  NotCopyAssignableNotDefaultConstructible(NotCopyAssignableNotDefaultConstructible&&)                 = default;
+  NotCopyAssignableNotDefaultConstructible& operator=(const NotCopyAssignableNotDefaultConstructible&) = delete;
+  NotCopyAssignableNotDefaultConstructible& operator=(NotCopyAssignableNotDefaultConstructible&&)      = default;
+};
+
+template <int Val>
 struct NotCopyAssignableEmpty
 {
   __host__ __device__ constexpr NotCopyAssignableEmpty(const int val) noexcept {}
@@ -337,6 +354,23 @@ struct NotMoveAssignable
   NotMoveAssignable(NotMoveAssignable&&)                 = default;
   NotMoveAssignable& operator=(const NotMoveAssignable&) = delete;
   NotMoveAssignable& operator=(NotMoveAssignable&&)      = default;
+};
+
+template <int Val>
+struct NotMoveAssignableNotDefaultConstructible
+{
+  int val_ = Val;
+
+  __host__ __device__ constexpr NotMoveAssignableNotDefaultConstructible(const int val) noexcept
+      : val_(val)
+  {}
+  __host__ __device__ constexpr NotMoveAssignableNotDefaultConstructible(
+    const NotMoveAssignableNotDefaultConstructible& other) noexcept(Val != MayThrow)
+      : val_(other.val_)
+  {}
+  NotMoveAssignableNotDefaultConstructible(NotMoveAssignableNotDefaultConstructible&&)                 = default;
+  NotMoveAssignableNotDefaultConstructible& operator=(const NotMoveAssignableNotDefaultConstructible&) = delete;
+  NotMoveAssignableNotDefaultConstructible& operator=(NotMoveAssignableNotDefaultConstructible&&)      = default;
 };
 
 template <int Val>


### PR DESCRIPTION
The implementation is derived from optional, which is always default constructible.

However, this is not the case here. We must only synthesize the copy / move constructors if we are in the engaged state and then we can use a special constructor to first set the enageged flag and then manually put the payload in.