### PR TITLE
Fix using `char` as the index type of `tabulate_output_iterator`

### DIFF
--- a/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
@@ -31,6 +31,7 @@
 #include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
 #include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_signed.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
@@ -136,6 +137,8 @@ private:
   {
     return __store_.template __get<1>();
   }
+
+  static_assert(::cuda::std::is_signed_v<_Index>, "tabulate_output_iterator: _Index must be a signed integer");
 
 public:
   using iterator_concept  = ::cuda::std::random_access_iterator_tag;

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/iterator_traits.compile.pass.cpp
@@ -37,11 +37,11 @@ __host__ __device__ void test()
   }
 
   {
-    using Iter       = cuda::tabulate_output_iterator<basic_functor, char>;
+    using Iter       = cuda::tabulate_output_iterator<basic_functor, signed char>;
     using IterTraits = Traits<Iter>;
     static_assert(cuda::std::same_as<typename IterTraits::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<typename IterTraits::value_type, void>);
-    static_assert(cuda::std::same_as<typename IterTraits::difference_type, char>);
+    static_assert(cuda::std::same_as<typename IterTraits::difference_type, signed char>);
 #if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
     static_assert(cuda::std::output_iterator<Iter, int>);
 #endif // !_CCCL_ARCH(ARM64)

--- a/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/tabulate_output_iterator/member_typedefs.compile.pass.cpp
@@ -33,11 +33,11 @@ __host__ __device__ void test()
   }
 
   {
-    using Iter = cuda::tabulate_output_iterator<basic_functor, char>;
+    using Iter = cuda::tabulate_output_iterator<basic_functor, signed char>;
     static_assert(cuda::std::same_as<Iter::iterator_concept, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::iterator_category, cuda::std::random_access_iterator_tag>);
     static_assert(cuda::std::same_as<Iter::value_type, void>);
-    static_assert(cuda::std::same_as<Iter::difference_type, char>);
+    static_assert(cuda::std::same_as<Iter::difference_type, signed char>);
 #if !_CCCL_ARCH(ARM64) // There are some compiler issues on arm compilers
     static_assert(cuda::std::output_iterator<Iter, int>);
 #endif // !_CCCL_ARCH(ARM64)


### PR DESCRIPTION
If a user compiles with `-funsigned-char` this will break.

Rather use the explicit `signed char`

Fixes #6256
