### PR TITLE
Fix exception handling macros in exceptions.h

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/exceptions.h
+++ b/libcudacxx/include/cuda/std/__cccl/exceptions.h
@@ -58,9 +58,9 @@
     if constexpr (true) \
     {
 #  define _CCCL_THROW(...) ::cuda::std::terminate()
-#  define _CCCL_CATCH(...)                                                 \
-    }                                                                      \
-    else if constexpr (__VA_ARGS__ = ::stdexec::__catch_any_lvalue; false) \
+#  define _CCCL_CATCH(...)                                               \
+    }                                                                    \
+    else if constexpr (__VA_ARGS__ = ::__cccl_catch_any_lvalue{}; false) \
     {
 #  define _CCCL_CATCH_ALL    \
     }                        \


### PR DESCRIPTION
## Description

the current `try`/`catch` portability macros (`_CCCL_TRY`, et. al.) generate invalid code if there is a `_CCCL_CATCH_ALL` block following a `_CCCL_CATCH` block.

the new macros, taken from stdexec, do not have that problem. however, the following code will now be a hard error when compiling with exceptions disabled:

```c++
_CCCL_TRY {
}
_CCCL_CATCH(std::exception& e) {
}
```

all uses of `_CCCL_TRY` _must_ end with either a `_CCCL_CATCH_ALL` or the new macro `_CCCL_CATCH_FALLTHROUGH`. this is the correct way to write the above.

```c++
_CCCL_TRY {
}
_CCCL_CATCH(std::exception& e) {
}
_CCCL_CATCH_FALLTHROUGH
```





## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
