### PR TITLE
Do not include API references into toc tree

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "nbsphinx",
     # "rst_processor",  # Disabled - breathe handles embed:rst natively
     "auto_api_generator",  # Automatically generate API reference pages from Doxygen XML
+    "sphinx_remove_toctrees",
 ]
 
 # Breathe configuration for Doxygen integration
@@ -236,6 +237,9 @@ copybutton_prompt_text = ">>> |$ |# "
 autosummary_imported_members = False
 autosummary_generate = True
 autoclass_content = "class"
+
+# Set the path of  the global toc file
+remove_from_toctrees = ["libcudacxx/api", "cub/api/*", "cudax/api/*", "thrust/api/*"]
 
 
 def setup(app):

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,7 @@ nvidia-sphinx-theme>=0.0.8
 myst-parser>=4.0.1
 sphinx-copybutton>=0.5.2
 sphinx-design>=0.6.1
+sphinx-remove-toctrees>=1.0.0
 nbsphinx>=0.9.0
 numpydoc>=1.5.0
 numpy>=1.24.0  # Required for type annotations in Python modules


### PR DESCRIPTION
This reduces our docs size by about 200MB
