### PR TITLE
GCC only recognizes `unused-local-typedefs`

### DIFF
--- a/cmake/CCCLBuildCompilerTargets.cmake
+++ b/cmake/CCCLBuildCompilerTargets.cmake
@@ -172,7 +172,7 @@ function(cccl_build_compiler_targets)
     append_option_if_available("-Woverloaded-virtual" cxx_compile_options)
     append_option_if_available("-Wcast-qual" cxx_compile_options)
     append_option_if_available("-Wpointer-arith" cxx_compile_options)
-    append_option_if_available("-Wunused-local-typedef" cxx_compile_options)
+    append_option_if_available("-Wunused-local-typedefs" cxx_compile_options)
     append_option_if_available("-Wvla" cxx_compile_options)
 
     # Disable GNU extensions (flag is clang only)

--- a/libcudacxx/include/cuda/__utility/__basic_any/virtcall.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/virtcall.h
@@ -32,7 +32,7 @@
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedefs")
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -1464,7 +1464,7 @@ class Configuration(object):
             if "nvcc" not in self.config.available_features:
                 # The '#define static_assert' provided by libc++ in C++03 mode
                 # causes an unused local typedef whenever it is used.
-                self.cxx.addWarningFlagIfSupported("-Wno-unused-local-typedef")
+                self.cxx.addWarningFlagIfSupported("-Wno-unused-local-typedefs")
 
     def configure_sanitizer(self):
         san = self.get_lit_conf("use_sanitizer", "").strip()


### PR DESCRIPTION
Clang recognizes both. Update this flag so that gcc can use it as well.