### PR TITLE
Fix `is_sufficiently_aligned` with `const void*`

### DIFF
--- a/libcudacxx/include/cuda/std/__memory/is_sufficiently_aligned.h
+++ b/libcudacxx/include/cuda/std/__memory/is_sufficiently_aligned.h
@@ -23,9 +23,9 @@
 #endif // no system header
 
 #include <cuda/__cmath/pow2.h>
+#include <cuda/std/__type_traits/is_void.h>
 #include <cuda/std/cstddef> // size_t
 #include <cuda/std/cstdint> // uintptr_t
-#include <cuda/std/type_traits> // is_void_v
 
 #include <cuda/std/__cccl/prologue.h>
 


### PR DESCRIPTION
## Description

`alignof(_ElementType)` fails when `_ElementType* == const void` or (just `void`)
