### PR TITLE
Fix thrust system dependend includes

### DIFF
--- a/thrust/thrust/execution_policy.h
+++ b/thrust/thrust/execution_policy.h
@@ -21,6 +21,14 @@
 
 //! \cond
 
+// Some build systems need a hint to know which files we actually include
+#if 0
+#  include <thrust/system/cpp/execution_policy.h>
+#  include <thrust/system/cuda/execution_policy.h>
+#  include <thrust/system/omp/execution_policy.h>
+#  include <thrust/system/tbb/execution_policy.h>
+#endif
+
 // #include the host system's execution_policy header
 #define __THRUST_HOST_SYSTEM_EXECUTION_POLICY_HEADER <__THRUST_HOST_SYSTEM_ROOT/execution_policy.h>
 #include __THRUST_HOST_SYSTEM_EXECUTION_POLICY_HEADER

--- a/thrust/thrust/iterator/detail/device_system_tag.h
+++ b/thrust/thrust/iterator/detail/device_system_tag.h
@@ -26,6 +26,14 @@
 #  pragma system_header
 #endif // no system header
 
+// Some build systems need a hint to know which files we actually include
+#if 0
+#  include <thrust/system/cpp/detail/execution_policy.h>
+#  include <thrust/system/cuda/detail/execution_policy.h>
+#  include <thrust/system/omp/detail/execution_policy.h>
+#  include <thrust/system/tbb/detail/execution_policy.h>
+#endif
+
 // #include the device system's execution_policy header
 #define __THRUST_DEVICE_SYSTEM_TAG_HEADER <__THRUST_DEVICE_SYSTEM_ROOT/detail/execution_policy.h>
 #include __THRUST_DEVICE_SYSTEM_TAG_HEADER

--- a/thrust/thrust/iterator/detail/host_system_tag.h
+++ b/thrust/thrust/iterator/detail/host_system_tag.h
@@ -26,6 +26,13 @@
 #  pragma system_header
 #endif // no system header
 
+// Some build systems need a hint to know which files we actually include
+#if 0
+#  include <thrust/system/cpp/detail/execution_policy.h>
+#  include <thrust/system/omp/detail/execution_policy.h>
+#  include <thrust/system/tbb/detail/execution_policy.h>
+#endif
+
 // #include the host system's execution_policy header
 #define __THRUST_HOST_SYSTEM_TAG_HEADER <__THRUST_HOST_SYSTEM_ROOT/detail/execution_policy.h>
 #include __THRUST_HOST_SYSTEM_TAG_HEADER

--- a/thrust/thrust/mr/device_memory_resource.h
+++ b/thrust/thrust/mr/device_memory_resource.h
@@ -26,6 +26,14 @@
 #  pragma system_header
 #endif // no system header
 
+// Some build systems need a hint to know which files we actually include
+#if 0
+#  include <thrust/system/cpp/memory_resource.h>
+#  include <thrust/system/cuda/memory_resource.h>
+#  include <thrust/system/omp/memory_resource.h>
+#  include <thrust/system/tbb/memory_resource.h>
+#endif
+
 // #include the device system's memory_resource header
 #define __THRUST_DEVICE_SYSTEM_MEMORY_HEADER <__THRUST_DEVICE_SYSTEM_ROOT/memory_resource.h>
 #include __THRUST_DEVICE_SYSTEM_MEMORY_HEADER

--- a/thrust/thrust/mr/host_memory_resource.h
+++ b/thrust/thrust/mr/host_memory_resource.h
@@ -26,6 +26,13 @@
 #  pragma system_header
 #endif // no system header
 
+// Some build systems need a hint to know which files we actually include
+#if 0
+#  include <thrust/system/cpp/memory_resource.h>
+#  include <thrust/system/omp/memory_resource.h>
+#  include <thrust/system/tbb/memory_resource.h>
+#endif
+
 // #include the host system's memory_resource header
 #define __THRUST_HOST_SYSTEM_MEMORY_HEADER <__THRUST_HOST_SYSTEM_ROOT/memory_resource.h>
 #include __THRUST_HOST_SYSTEM_MEMORY_HEADER

--- a/thrust/thrust/system/detail/adl/adjacent_difference.h
+++ b/thrust/thrust/system/detail/adl/adjacent_difference.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/adjacent_difference.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/adjacent_difference.h>
 #  include <thrust/system/cuda/detail/adjacent_difference.h>

--- a/thrust/thrust/system/detail/adl/assign_value.h
+++ b/thrust/thrust/system/detail/adl/assign_value.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/assign_value.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/assign_value.h>
 #  include <thrust/system/cuda/detail/assign_value.h>

--- a/thrust/thrust/system/detail/adl/binary_search.h
+++ b/thrust/thrust/system/detail/adl/binary_search.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/binary_search.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/binary_search.h>
 #  include <thrust/system/cuda/detail/binary_search.h>

--- a/thrust/thrust/system/detail/adl/copy.h
+++ b/thrust/thrust/system/detail/adl/copy.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/copy.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/copy.h>
 #  include <thrust/system/cuda/detail/copy.h>

--- a/thrust/thrust/system/detail/adl/copy_if.h
+++ b/thrust/thrust/system/detail/adl/copy_if.h
@@ -33,9 +33,7 @@
 #include <thrust/system/detail/generic/copy_if.h>
 #include <thrust/system/detail/sequential/copy_if.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/copy_if.h>
 #  include <thrust/system/cuda/detail/copy_if.h>

--- a/thrust/thrust/system/detail/adl/count.h
+++ b/thrust/thrust/system/detail/adl/count.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/count.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/count.h>
 #  include <thrust/system/cuda/detail/count.h>

--- a/thrust/thrust/system/detail/adl/equal.h
+++ b/thrust/thrust/system/detail/adl/equal.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/equal.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/equal.h>
 #  include <thrust/system/cuda/detail/equal.h>

--- a/thrust/thrust/system/detail/adl/extrema.h
+++ b/thrust/thrust/system/detail/adl/extrema.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/extrema.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/extrema.h>
 #  include <thrust/system/cuda/detail/extrema.h>

--- a/thrust/thrust/system/detail/adl/fill.h
+++ b/thrust/thrust/system/detail/adl/fill.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/fill.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/fill.h>
 #  include <thrust/system/cuda/detail/fill.h>

--- a/thrust/thrust/system/detail/adl/find.h
+++ b/thrust/thrust/system/detail/adl/find.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/find.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/find.h>
 #  include <thrust/system/cuda/detail/find.h>

--- a/thrust/thrust/system/detail/adl/for_each.h
+++ b/thrust/thrust/system/detail/adl/for_each.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/for_each.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/for_each.h>
 #  include <thrust/system/cuda/detail/for_each.h>

--- a/thrust/thrust/system/detail/adl/gather.h
+++ b/thrust/thrust/system/detail/adl/gather.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/gather.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/gather.h>
 #  include <thrust/system/cuda/detail/gather.h>

--- a/thrust/thrust/system/detail/adl/generate.h
+++ b/thrust/thrust/system/detail/adl/generate.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/generate.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/generate.h>
 #  include <thrust/system/cuda/detail/generate.h>

--- a/thrust/thrust/system/detail/adl/get_value.h
+++ b/thrust/thrust/system/detail/adl/get_value.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/get_value.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/get_value.h>
 #  include <thrust/system/cuda/detail/get_value.h>

--- a/thrust/thrust/system/detail/adl/inner_product.h
+++ b/thrust/thrust/system/detail/adl/inner_product.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/inner_product.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/inner_product.h>
 #  include <thrust/system/cuda/detail/inner_product.h>

--- a/thrust/thrust/system/detail/adl/iter_swap.h
+++ b/thrust/thrust/system/detail/adl/iter_swap.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/iter_swap.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/iter_swap.h>
 #  include <thrust/system/cuda/detail/iter_swap.h>

--- a/thrust/thrust/system/detail/adl/logical.h
+++ b/thrust/thrust/system/detail/adl/logical.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/logical.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/logical.h>
 #  include <thrust/system/cuda/detail/logical.h>

--- a/thrust/thrust/system/detail/adl/malloc_and_free.h
+++ b/thrust/thrust/system/detail/adl/malloc_and_free.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/malloc_and_free.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/malloc_and_free.h>
 #  include <thrust/system/cuda/detail/malloc_and_free.h>

--- a/thrust/thrust/system/detail/adl/merge.h
+++ b/thrust/thrust/system/detail/adl/merge.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/merge.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/merge.h>
 #  include <thrust/system/cuda/detail/merge.h>

--- a/thrust/thrust/system/detail/adl/mismatch.h
+++ b/thrust/thrust/system/detail/adl/mismatch.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/mismatch.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/mismatch.h>
 #  include <thrust/system/cuda/detail/mismatch.h>

--- a/thrust/thrust/system/detail/adl/partition.h
+++ b/thrust/thrust/system/detail/adl/partition.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/partition.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/partition.h>
 #  include <thrust/system/cuda/detail/partition.h>

--- a/thrust/thrust/system/detail/adl/per_device_resource.h
+++ b/thrust/thrust/system/detail/adl/per_device_resource.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/per_device_resource.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/per_device_resource.h>
 #  include <thrust/system/cuda/detail/per_device_resource.h>

--- a/thrust/thrust/system/detail/adl/reduce.h
+++ b/thrust/thrust/system/detail/adl/reduce.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/reduce.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/reduce.h>
 #  include <thrust/system/cuda/detail/reduce.h>

--- a/thrust/thrust/system/detail/adl/reduce_by_key.h
+++ b/thrust/thrust/system/detail/adl/reduce_by_key.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/reduce_by_key.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/reduce_by_key.h>
 #  include <thrust/system/cuda/detail/reduce_by_key.h>

--- a/thrust/thrust/system/detail/adl/remove.h
+++ b/thrust/thrust/system/detail/adl/remove.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/remove.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/remove.h>
 #  include <thrust/system/cuda/detail/remove.h>

--- a/thrust/thrust/system/detail/adl/replace.h
+++ b/thrust/thrust/system/detail/adl/replace.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/replace.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/replace.h>
 #  include <thrust/system/cuda/detail/replace.h>

--- a/thrust/thrust/system/detail/adl/reverse.h
+++ b/thrust/thrust/system/detail/adl/reverse.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/reverse.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/reverse.h>
 #  include <thrust/system/cuda/detail/reverse.h>

--- a/thrust/thrust/system/detail/adl/scan.h
+++ b/thrust/thrust/system/detail/adl/scan.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/scan.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/scan.h>
 #  include <thrust/system/cuda/detail/scan.h>

--- a/thrust/thrust/system/detail/adl/scan_by_key.h
+++ b/thrust/thrust/system/detail/adl/scan_by_key.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/scan_by_key.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/scan_by_key.h>
 #  include <thrust/system/cuda/detail/scan_by_key.h>

--- a/thrust/thrust/system/detail/adl/scatter.h
+++ b/thrust/thrust/system/detail/adl/scatter.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/scatter.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/scatter.h>
 #  include <thrust/system/cuda/detail/scatter.h>

--- a/thrust/thrust/system/detail/adl/sequence.h
+++ b/thrust/thrust/system/detail/adl/sequence.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/sequence.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/sequence.h>
 #  include <thrust/system/cuda/detail/sequence.h>

--- a/thrust/thrust/system/detail/adl/set_operations.h
+++ b/thrust/thrust/system/detail/adl/set_operations.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/set_operations.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/set_operations.h>
 #  include <thrust/system/cuda/detail/set_operations.h>

--- a/thrust/thrust/system/detail/adl/sort.h
+++ b/thrust/thrust/system/detail/adl/sort.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/sort.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/sort.h>
 #  include <thrust/system/cuda/detail/sort.h>

--- a/thrust/thrust/system/detail/adl/swap_ranges.h
+++ b/thrust/thrust/system/detail/adl/swap_ranges.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/swap_ranges.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/swap_ranges.h>
 #  include <thrust/system/cuda/detail/swap_ranges.h>

--- a/thrust/thrust/system/detail/adl/tabulate.h
+++ b/thrust/thrust/system/detail/adl/tabulate.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/tabulate.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/tabulate.h>
 #  include <thrust/system/cuda/detail/tabulate.h>

--- a/thrust/thrust/system/detail/adl/temporary_buffer.h
+++ b/thrust/thrust/system/detail/adl/temporary_buffer.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/temporary_buffer.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/temporary_buffer.h>
 #  include <thrust/system/cuda/detail/temporary_buffer.h>

--- a/thrust/thrust/system/detail/adl/transform.h
+++ b/thrust/thrust/system/detail/adl/transform.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/transform.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/transform.h>
 #  include <thrust/system/cuda/detail/transform.h>

--- a/thrust/thrust/system/detail/adl/transform_reduce.h
+++ b/thrust/thrust/system/detail/adl/transform_reduce.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/transform_reduce.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/transform_reduce.h>
 #  include <thrust/system/cuda/detail/transform_reduce.h>

--- a/thrust/thrust/system/detail/adl/transform_scan.h
+++ b/thrust/thrust/system/detail/adl/transform_scan.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/transform_scan.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/transform_scan.h>
 #  include <thrust/system/cuda/detail/transform_scan.h>

--- a/thrust/thrust/system/detail/adl/uninitialized_copy.h
+++ b/thrust/thrust/system/detail/adl/uninitialized_copy.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/uninitialized_copy.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/uninitialized_copy.h>
 #  include <thrust/system/cuda/detail/uninitialized_copy.h>

--- a/thrust/thrust/system/detail/adl/uninitialized_fill.h
+++ b/thrust/thrust/system/detail/adl/uninitialized_fill.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/uninitialized_fill.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/uninitialized_fill.h>
 #  include <thrust/system/cuda/detail/uninitialized_fill.h>

--- a/thrust/thrust/system/detail/adl/unique.h
+++ b/thrust/thrust/system/detail/adl/unique.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/unique.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/unique.h>
 #  include <thrust/system/cuda/detail/unique.h>

--- a/thrust/thrust/system/detail/adl/unique_by_key.h
+++ b/thrust/thrust/system/detail/adl/unique_by_key.h
@@ -32,9 +32,7 @@
 
 #include <thrust/system/detail/sequential/unique_by_key.h>
 
-// SCons can't see through the #defines below to figure out what this header
-// includes, so we fake it out by specifying all possible files we might end up
-// including inside an #if 0.
+// Some build systems need a hint to know which files we actually include
 #if 0
 #  include <thrust/system/cpp/detail/unique_by_key.h>
 #  include <thrust/system/cuda/detail/unique_by_key.h>

--- a/thrust/thrust/universal_allocator.h
+++ b/thrust/thrust/universal_allocator.h
@@ -31,6 +31,14 @@
 #  pragma system_header
 #endif // no system header
 
+// Some build systems need a hint to know which files we actually include
+#if 0
+#  include <thrust/system/cpp/memory.h>
+#  include <thrust/system/cuda/memory.h>
+#  include <thrust/system/omp/memory.h>
+#  include <thrust/system/tbb/memory.h>
+#endif
+
 // #include the device system's vector header
 #define __THRUST_DEVICE_SYSTEM_MEMORY_HEADER <__THRUST_DEVICE_SYSTEM_ROOT/memory.h>
 #include __THRUST_DEVICE_SYSTEM_MEMORY_HEADER

--- a/thrust/thrust/universal_vector.h
+++ b/thrust/thrust/universal_vector.h
@@ -30,7 +30,16 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/universal_allocator.h>
+
+// Some build systems need a hint to know which files we actually include
+#if 0
+#  include <thrust/system/cpp/vector.h>
+#  include <thrust/system/cuda/vector.h>
+#  include <thrust/system/omp/vector.h>
+#  include <thrust/system/tbb/vector.h>
+#endif
 
 // #include the device system's vector header
 #define __THRUST_DEVICE_SYSTEM_VECTOR_HEADER <__THRUST_DEVICE_SYSTEM_ROOT/vector.h>


### PR DESCRIPTION
Some build systems have issues with our preprocessor based includes, so give them a hint.

Fixes [BUG]: some thrust headers need include file hints #6308
