### PR TITLE
Disable test for compressed_movable_box

### DIFF
--- a/libcudacxx/test/libcudacxx/libcxx/iterators/compressed_movable_box/assign.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/iterators/compressed_movable_box/assign.move.pass.cpp
@@ -162,10 +162,11 @@ int main(int, char**)
 {
   test();
 #if TEST_STD_VER >= 2020
-#  if !TEST_COMPILER(MSVC)
+#  if !TEST_COMPILER(GCC, ==, 10) && !TEST_COMPILER(MSVC)
+  // GCC: internal compiler error: in cxx_eval_store_expression, at cp/constexpr.c:5137
   // MSVC: error: read of an uninitialized symbol
   static_assert(test());
-#  endif // !TEST_COMPILER(MSVC)
+#  endif // !TEST_COMPILER(GCC, ==, 10) && !TEST_COMPILER(MSVC)
 #endif // TEST_STD_VER >= 2020
 
   return 0;


### PR DESCRIPTION
This test segfaults GCC 10 in C++20 under constexpr.

The type it fails for is a move-constructible but not move-assignable and also empty type

I am not worried about real life occurances of such a type
