### PR TITLE
Ensure that we can instantiate `zip_function` with a type that is not non-const invocable

### DIFF
--- a/libcudacxx/include/cuda/__iterator/zip_function.h
+++ b/libcudacxx/include/cuda/__iterator/zip_function.h
@@ -76,7 +76,8 @@ public:
   //! @brief Applies a tuple to the stored functor
   //! @param __tuple The tuple of arguments to be passed
   _CCCL_EXEC_CHECK_DISABLE
-  template <class _Tuple>
+  _CCCL_TEMPLATE(class _Tuple)
+  _CCCL_REQUIRES(::cuda::std::__can_apply<const _Fn&, _Tuple>)
   [[nodiscard]] _CCCL_API constexpr decltype(auto) operator()(_Tuple&& __tuple) const
     noexcept(__is_nothrow_invocable<const _Fn&, _Tuple>)
   {
@@ -85,7 +86,8 @@ public:
 
   //! @brief Applies a tuple to the stored functor
   _CCCL_EXEC_CHECK_DISABLE
-  template <class _Tuple>
+  _CCCL_TEMPLATE(class _Tuple)
+  _CCCL_REQUIRES(::cuda::std::__can_apply<_Fn&, _Tuple>)
   [[nodiscard]] _CCCL_API constexpr decltype(auto)
   operator()(_Tuple&& __tuple) noexcept(__is_nothrow_invocable<_Fn&, _Tuple>)
   {

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_like.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_like.h
@@ -68,14 +68,13 @@ inline constexpr bool __tuple_like_impl<::cuda::std::ranges::subrange<_Ip, _Sp, 
 template <class... _Tp>
 inline constexpr bool __tuple_like_impl<__tuple_types<_Tp...>> = true;
 
-#if _CCCL_STD_VER >= 2014
 template <class _Tp>
 _CCCL_CONCEPT __tuple_like = __tuple_like_impl<remove_cvref_t<_Tp>>;
 
+// Not on line 74 because of __COUNTER__ missing in NVRTC
 template <class _Tp>
 _CCCL_CONCEPT __pair_like = _CCCL_REQUIRES_EXPR((_Tp)) //
   (requires(__tuple_like_impl<remove_cvref_t<_Tp>>), requires(tuple_size<remove_cvref_t<_Tp>>::value == 2));
-#endif // _CCCL_STD_VER >= 2014
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
+++ b/libcudacxx/include/cuda/std/detail/libcxx/include/tuple
@@ -1334,6 +1334,18 @@ _CCCL_API inline _CCCL_CONSTEXPR_CXX20 __pair_base<_T1, _T2, _IsRef>::__pair_bas
     return __VA_ARGS__;                  \
   }
 
+template <class _Fn, class _Tuple>
+inline constexpr bool __can_apply_impl = false;
+
+template <class _Fn, class... _Types>
+inline constexpr bool __can_apply_impl<_Fn, __tuple_types<_Types...>> = is_invocable_v<_Fn, _Types...>;
+
+template <class _Fn, class _Tuple, bool = __tuple_like<_Tuple>>
+inline constexpr bool __can_apply = false;
+
+template <class _Fn, class _Tuple>
+inline constexpr bool __can_apply<_Fn, _Tuple, true> = __can_apply_impl<_Fn, __make_tuple_types_t<_Tuple>>;
+
 template <class _Fn, class _Tuple, size_t... _Id>
 _CCCL_API constexpr decltype(auto) __apply_tuple_impl(_Fn&& __f, _Tuple&& __t, __tuple_indices<_Id...>)
   _LIBCUDACXX_NOEXCEPT_RETURN(

--- a/libcudacxx/test/libcudacxx/cuda/functional/zip_function/call.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/zip_function/call.pass.cpp
@@ -164,6 +164,13 @@ __host__ __device__ constexpr bool test()
     test<true>(fn, cuda::std::pair{1, 3.14});
     test<false>(fn, cuda::std::tuple{1});
   }
+
+  { // Ensure that we can instantiate a zip_function that is not invocable
+    static_assert(!cuda::std::is_invocable_v<const zip_function<Mutable>, cuda::std::tuple<int, double, foo>>);
+    static_assert(!cuda::std::is_invocable_v<const zip_function<Mutable>, cuda::std::pair<int, double>>);
+    static_assert(!cuda::std::is_invocable_v<const zip_function<Mutable>, cuda::std::tuple<int>>);
+  }
+
   return true;
 };
 


### PR DESCRIPTION
I did not constraint the call operators properly, so when the compiler tried to build the overload set for an
instantiation of a `const zip_function` that holds a function with only a mutable call operator it would fail.
