### PR TITLE
Fix transform.cu size_t/int issue.

### DIFF
--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -209,7 +209,7 @@ struct transform_kernel_source
   }
 
 private:
-  static auto is_pointer_aligned(const indirect_iterator_t& it, int alignment)
+  static auto is_pointer_aligned(const indirect_iterator_t& it, ::cuda::std::size_t alignment)
   {
     return it.value_size != 0 && ::cuda::is_aligned(*static_cast<char**>(it.ptr), alignment);
   }


### PR DESCRIPTION
This PR does two things:

1. Ensures we build with `/WX` (warning-as-error) in our default Windows CI configuration (MSVC, CMake Visual Studio generator).
2. Fixes a size_t/int warning in transform.cu that causes the build to fail due to `/WX`.