### PR TITLE
Move the `throw_meow_error` functions into their own header and drop the `stdexcept` include

### DIFF
--- a/cudax/include/cuda/experimental/__cufile/driver.cuh
+++ b/cudax/include/cuda/experimental/__cufile/driver.cuh
@@ -19,9 +19,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__exception/throw_error.h>
 #include <cuda/std/__type_traits/always_false.h>
 #include <cuda/std/__type_traits/is_same.h>
-#include <cuda/std/detail/libcxx/include/stdexcept>
 
 #include <cuda/experimental/__cufile/driver_attributes.cuh>
 #include <cuda/experimental/__cufile/exception.cuh>

--- a/cudax/include/cuda/experimental/__memory_resource/legacy_managed_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/legacy_managed_memory_resource.cuh
@@ -30,7 +30,7 @@
 #include <cuda/__memory_resource/resource.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__cuda/api_wrapper.h>
-#include <cuda/std/detail/libcxx/include/stdexcept>
+#include <cuda/std/__exception/throw_error.h>
 
 #include <cuda/experimental/__memory_resource/any_resource.cuh>
 #include <cuda/experimental/__stream/internal_streams.cuh>

--- a/cudax/include/cuda/experimental/__memory_resource/legacy_pinned_memory_resource.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/legacy_pinned_memory_resource.cuh
@@ -29,7 +29,7 @@
 #include <cuda/__memory_resource/properties.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__cuda/api_wrapper.h>
-#include <cuda/std/detail/libcxx/include/stdexcept>
+#include <cuda/std/__exception/throw_error.h>
 
 #include <cuda/experimental/__memory_resource/memory_resource_base.cuh>
 #include <cuda/experimental/__stream/internal_streams.cuh>

--- a/cudax/include/cuda/experimental/__memory_resource/managed_memory_pool.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/managed_memory_pool.cuh
@@ -26,7 +26,7 @@
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/std/__concepts/concept_macros.h>
 #  include <cuda/std/__cuda/api_wrapper.h>
-#  include <cuda/std/detail/libcxx/include/stdexcept>
+#  include <cuda/std/__exception/throw_error.h>
 
 #  include <cuda/experimental/__memory_resource/memory_resource_base.cuh>
 

--- a/cudax/include/cuda/experimental/__memory_resource/pinned_memory_pool.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/pinned_memory_pool.cuh
@@ -29,7 +29,7 @@
 #include <cuda/__memory_resource/properties.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__cuda/api_wrapper.h>
-#include <cuda/std/detail/libcxx/include/stdexcept>
+#include <cuda/std/__exception/throw_error.h>
 
 #include <cuda/experimental/__memory_resource/memory_resource_base.cuh>
 

--- a/libcudacxx/include/cuda/std/__exception/throw_error.h
+++ b/libcudacxx/include/cuda/std/__exception/throw_error.h
@@ -1,0 +1,120 @@
+// -*- C++ -*-
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___EXCEPTION_THROW_ERROR_H
+#define _CUDA_STD___EXCEPTION_THROW_ERROR_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__exception/terminate.h>
+
+#if _CCCL_HAS_EXCEPTIONS()
+#  include <stdexcept>
+#endif // _LIBCUDACXX_HAS_STRING
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+[[noreturn]] _CCCL_API inline void __throw_runtime_error([[maybe_unused]] const char* __msg)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::std::runtime_error(__msg);), (::cuda::std::terminate();))
+#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+  ::cuda::std::terminate();
+#endif // !_CCCL_HAS_EXCEPTIONS()
+}
+
+[[noreturn]] _CCCL_API inline void __throw_logic_error([[maybe_unused]] const char* __msg)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::std::logic_error(__msg);), (::cuda::std::terminate();))
+#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+  ::cuda::std::terminate();
+#endif // !_CCCL_HAS_EXCEPTIONS()
+}
+
+[[noreturn]] _CCCL_API inline void __throw_domain_error([[maybe_unused]] const char* __msg)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::std::domain_error(__msg);), (::cuda::std::terminate();))
+#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+  ::cuda::std::terminate();
+#endif // !_CCCL_HAS_EXCEPTIONS()
+}
+
+[[noreturn]] _CCCL_API inline void __throw_invalid_argument([[maybe_unused]] const char* __msg)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::std::invalid_argument(__msg);), (::cuda::std::terminate();))
+#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+  ::cuda::std::terminate();
+#endif // !_CCCL_HAS_EXCEPTIONS()
+}
+
+[[noreturn]] _CCCL_API inline void __throw_length_error([[maybe_unused]] const char* __msg)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::std::length_error(__msg);), (::cuda::std::terminate();))
+#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+  ::cuda::std::terminate();
+#endif // !_CCCL_HAS_EXCEPTIONS()
+}
+
+[[noreturn]] _CCCL_API inline void __throw_out_of_range([[maybe_unused]] const char* __msg)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::std::out_of_range(__msg);), (::cuda::std::terminate();))
+#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+  ::cuda::std::terminate();
+#endif // !_CCCL_HAS_EXCEPTIONS()
+}
+
+[[noreturn]] _CCCL_API inline void __throw_range_error([[maybe_unused]] const char* __msg)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::std::range_error(__msg);), (::cuda::std::terminate();))
+#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+  ::cuda::std::terminate();
+#endif // !_CCCL_HAS_EXCEPTIONS()
+}
+
+[[noreturn]] _CCCL_API inline void __throw_overflow_error([[maybe_unused]] const char* __msg)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::std::overflow_error(__msg);), (::cuda::std::terminate();))
+#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+  ::cuda::std::terminate();
+#endif // !_CCCL_HAS_EXCEPTIONS()
+}
+
+[[noreturn]] _CCCL_API inline void __throw_underflow_error([[maybe_unused]] const char* __msg)
+{
+#if _CCCL_HAS_EXCEPTIONS()
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::std::underflow_error(__msg);), (::cuda::std::terminate();))
+#else // ^^^ _CCCL_HAS_EXCEPTIONS() ^^^ / vvv !_CCCL_HAS_EXCEPTIONS() vvv
+  ::cuda::std::terminate();
+#endif // !_CCCL_HAS_EXCEPTIONS()
+}
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___EXCEPTION_THROW_ERROR_H

--- a/libcudacxx/include/cuda/std/__string/string_view.h
+++ b/libcudacxx/include/cuda/std/__string/string_view.h
@@ -23,10 +23,10 @@
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 #  include <cuda/std/compare>
 #endif
+#include <cuda/std/__exception/throw_error.h>
 #include <cuda/std/__string/char_traits.h>
 #include <cuda/std/__type_traits/is_constant_evaluated.h>
 #include <cuda/std/cstddef>
-#include <cuda/std/detail/libcxx/include/stdexcept>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -170,16 +170,16 @@ public:
 
 #if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator<=>(__string_view const& __lhs, __string_view const& __rhs) noexcept
+  [[nodiscard]]
+  _CCCL_API friend constexpr auto operator<=>(__string_view const& __lhs, __string_view const& __rhs) noexcept
   {
     return __lhs.compare(__rhs) <=> 0;
   }
 
 #else // ^^^ _LIBCUDACXX_HAS_SPACESHIP_OPERATOR() ^^^ / vvv !_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
 
-  [[nodiscard]] _CCCL_API friend constexpr bool
-  operator!=(__string_view const& __lhs, __string_view const& __rhs) noexcept
+  [[nodiscard]]
+  _CCCL_API friend constexpr bool operator!=(__string_view const& __lhs, __string_view const& __rhs) noexcept
   {
     return !(__lhs == __rhs);
   }

--- a/libcudacxx/include/cuda/std/array
+++ b/libcudacxx/include/cuda/std/array
@@ -25,6 +25,7 @@
 #include <cuda/std/__algorithm/lexicographical_compare.h>
 #include <cuda/std/__algorithm/swap_ranges.h>
 #include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__exception/throw_error.h>
 #include <cuda/std/__iterator/reverse_iterator.h>
 #include <cuda/std/__tuple_dir/sfinae_helpers.h>
 #include <cuda/std/__type_traits/conditional.h>
@@ -41,7 +42,6 @@
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/__utility/unreachable.h>
 #include <cuda/std/cstdint>
-#include <cuda/std/detail/libcxx/include/stdexcept>
 #include <cuda/std/limits>
 
 // standard-mandated includes

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -26,13 +26,13 @@
 #include <cuda/std/__algorithm/fill.h>
 #include <cuda/std/__algorithm/find.h>
 #include <cuda/std/__bit/reference.h>
+#include <cuda/std/__exception/throw_error.h>
 #include <cuda/std/__functional/hash.h>
 #include <cuda/std/__functional/unary_function.h>
 #include <cuda/std/__string/char_traits.h>
 #include <cuda/std/__type_traits/is_char_like_type.h>
 #include <cuda/std/climits>
 #include <cuda/std/cstddef>
-#include <cuda/std/detail/libcxx/include/stdexcept>
 #include <cuda/std/string_view>
 #include <cuda/std/version>
 

--- a/libcudacxx/include/cuda/std/inplace_vector
+++ b/libcudacxx/include/cuda/std/inplace_vector
@@ -31,6 +31,7 @@
 #include <cuda/std/__algorithm/rotate.h>
 #include <cuda/std/__algorithm/swap_ranges.h>
 #include <cuda/std/__exception/terminate.h>
+#include <cuda/std/__exception/throw_error.h>
 #include <cuda/std/__iterator/advance.h>
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__iterator/distance.h>
@@ -65,7 +66,6 @@
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/cstdint>
-#include <cuda/std/detail/libcxx/include/stdexcept>
 #include <cuda/std/initializer_list>
 #include <cuda/std/limits>
 

--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__concepts/convertible_to.h>
 #include <cuda/std/__concepts/equality_comparable.h>
+#include <cuda/std/__exception/throw_error.h>
 #include <cuda/std/__fwd/array.h>
 #include <cuda/std/__fwd/span.h>
 #include <cuda/std/__fwd/string.h>
@@ -53,7 +54,6 @@
 #include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/array>
 #include <cuda/std/cstddef>
-#include <cuda/std/detail/libcxx/include/stdexcept>
 #include <cuda/std/initializer_list>
 #include <cuda/std/version>
 

--- a/libcudacxx/include/cuda/std/string_view
+++ b/libcudacxx/include/cuda/std/string_view
@@ -22,6 +22,7 @@
 
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__exception/throw_error.h>
 #include <cuda/std/__functional/hash.h>
 #include <cuda/std/__functional/unary_function.h>
 #include <cuda/std/__fwd/allocator.h>
@@ -54,7 +55,6 @@
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/__utility/declval.h>
-#include <cuda/std/detail/libcxx/include/stdexcept>
 #include <cuda/std/limits>
 #include <cuda/std/version>
 

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -29,10 +29,10 @@
 #include <thrust/detail/preprocessor.h>
 
 #include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__exception/throw_error.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_unsigned.h>
 #include <cuda/std/cstdint>
-#include <cuda/std/detail/libcxx/include/stdexcept>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 


### PR DESCRIPTION
We want this to be an internal header