### PR TITLE
Unpin CCCL version used for RAPIDS testing

### DIFF
--- a/.github/workflows/build-rapids.yml
+++ b/.github/workflows/build-rapids.yml
@@ -85,10 +85,8 @@ jobs:
           role-duration-seconds: 43200 # 12h
       - name: Run command # Do not change this step's name, it is checked in parse-job-times.py
         env:
-          # TODO: Temporarily hardcoding the override while RAPIDS gets updated
-          # for the various breaking changes in cudax between 3.0/3.1/3.2
-          CCCL_TAG: branch/3.1.x
-          CCCL_VERSION: 3.1.0
+          CCCL_TAG: ${{ inputs.override_cccl_tag }}
+          CCCL_VERSION: ${{ inputs.override_cccl_version }}
           CI: true
           RAPIDS_LIBS: ${{ matrix.libs }}
           # Uncomment any of these to customize the git repo and branch for a RAPIDS lib:


### PR DESCRIPTION
## Summary
Unpins CCCL version used for RAPIDS testing. Reverts part of https://github.com/NVIDIA/cccl/pull/5973/.

Removes hardcoded `CCCL_TAG` and `CCCL_VERSION` values, allowing the workflow to use override inputs as intended.