### PR TITLE
[cudax] Fix managed resource test

### DIFF
--- a/cudax/test/memory_resource/managed_memory_resource.cu
+++ b/cudax/test/memory_resource/managed_memory_resource.cu
@@ -227,13 +227,21 @@ C2H_CCCLRT_TEST_LIST("managed_memory_resource comparison", "[memory_resource]", 
     CHECK(!(first != second));
   }
 
-#if _CCCL_CTK_BELOW(13, 0)
-  { // comparison against a plain managed_memory_resource with a different pool
-    managed_resource second = get_resource<managed_resource>();
+  if constexpr (cuda::std::is_same_v<managed_resource, cudax::legacy_managed_memory_resource>)
+  { // comparison against a plain legacy_managed_memory_resource with a different flags
+    managed_resource second = cudax::legacy_managed_memory_resource{cudaMemAttachHost};
     CHECK((first != second));
     CHECK(!(first == second));
   }
-#endif // _CCCL_CTK_BELOW(13, 0)
+#if _CCCL_CTK_AT_LEAST(13, 0)
+  else
+  {
+    // comparison against a managed_memory_pool_ref with a different pool
+    cudax::managed_memory_pool second{};
+    CHECK((first != second));
+    CHECK(!(first == second));
+  }
+#endif // _CCCL_CTK_AT_LEAST(13, 0)
 
   { // comparison against a managed_memory_resource wrapped inside a synchronous_resource_ref<device_accessible>
     managed_resource second = get_resource<managed_resource>();


### PR DESCRIPTION
Recent test changes made the test fail because the `legacy_managed_memory_resource` argument is no longer provided