### PR TITLE
Fix `iter_move` constraints for MSVC

### DIFF
--- a/libcudacxx/include/cuda/std/__iterator/iter_swap.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_swap.h
@@ -26,6 +26,7 @@
 #include <cuda/std/__iterator/iter_move.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__iterator/readable_traits.h>
+#include <cuda/std/__type_traits/add_lvalue_reference.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/forward.h>
 #include <cuda/std/__utility/move.h>
@@ -33,82 +34,99 @@
 #include <cuda/std/__cccl/prologue.h>
 
 // [iter.cust.swap]
-
 _CCCL_BEGIN_NAMESPACE_RANGES
 _CCCL_BEGIN_NAMESPACE_CPO(__iter_swap)
 template <class _I1, class _I2>
 void iter_swap(_I1, _I2) = delete;
 
-#if _CCCL_HAS_CONCEPTS()
 template <class _T1, class _T2>
-concept __unqualified_iter_swap =
-  (__class_or_enum<remove_cvref_t<_T1>> || __class_or_enum<remove_cvref_t<_T2>>)
-  && requires(_T1&& __x, _T2&& __y) { iter_swap(::cuda::std::forward<_T1>(__x), ::cuda::std::forward<_T2>(__y)); };
+_CCCL_CONCEPT __unqualified_iter_swap = _CCCL_REQUIRES_EXPR((_T1, _T2), _T1&& __x, _T2&& __y)(
+  requires(__class_or_enum<remove_cvref_t<_T1>> || __class_or_enum<remove_cvref_t<_T2>>),
+  ((void) iter_swap(::cuda::std::forward<_T1>(__x), ::cuda::std::forward<_T2>(__y))));
+
+#if _CCCL_HAS_NOEXCEPT_MANGLING() // older GCC cannot use noexcept inside a requires clause
+template <class _T1, class _T2>
+_CCCL_CONCEPT __noexcept_unqualified_iter_swap = _CCCL_REQUIRES_EXPR((_T1, _T2), _T1&& __x, _T2&& __y)(
+  requires(__unqualified_iter_swap<_T1, _T2>),
+  noexcept(iter_swap(::cuda::std::forward<_T1>(__x), ::cuda::std::forward<_T2>(__y))));
+#else // ^^^ _CCCL_HAS_NOEXCEPT_MANGLING() ^^^ / vvv !_CCCL_HAS_NOEXCEPT_MANGLING() vvv
+template <class _T1, class _T2, bool = __unqualified_iter_swap<_T1, _T2>>
+inline constexpr bool __noexcept_unqualified_iter_swap = false;
 
 template <class _T1, class _T2>
-concept __readable_swappable = !__unqualified_iter_swap<_T1, _T2> && indirectly_readable<_T1>
-                            && indirectly_readable<_T2> && swappable_with<iter_reference_t<_T1>, iter_reference_t<_T2>>;
+inline constexpr bool __noexcept_unqualified_iter_swap<_T1, _T2, true> =
+  noexcept(iter_swap(::cuda::std::declval<_T1>(), ::cuda::std::declval<_T2>()));
+#endif // !_CCCL_HAS_NOEXCEPT_MANGLING()
 
 template <class _T1, class _T2>
-concept __moveable_storable = !__unqualified_iter_swap<_T1, _T2> && !__readable_swappable<_T1, _T2>
-                           && indirectly_movable_storable<_T1, _T2> && indirectly_movable_storable<_T2, _T1>;
-#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
+_CCCL_CONCEPT __readable_swappable = _CCCL_REQUIRES_EXPR((_T1, _T2))(
+  requires(!__unqualified_iter_swap<_T1, _T2>),
+  requires(indirectly_readable<_T1>),
+  requires(indirectly_readable<_T2>),
+  requires(__can_reference<iter_reference_t<_T1>>),
+  requires(__can_reference<iter_reference_t<_T2>>),
+  requires(swappable_with<iter_reference_t<_T1>, iter_reference_t<_T2>>));
+
+#if _CCCL_HAS_NOEXCEPT_MANGLING() // older GCC cannot use noexcept inside a requires clause
 template <class _T1, class _T2>
-_CCCL_CONCEPT_FRAGMENT(
-  __unqualified_iter_swap_,
-  requires(_T1&& __x, _T2&& __y)(requires(__class_or_enum<remove_cvref_t<_T1>> || __class_or_enum<remove_cvref_t<_T2>>),
-                                 ((void) iter_swap(::cuda::std::forward<_T1>(__x), ::cuda::std::forward<_T2>(__y)))));
+_CCCL_CONCEPT __noexcept_readable_swappable = _CCCL_REQUIRES_EXPR((_T1, _T2), _T1&& __x, _T2&& __y) //
+  (requires(__readable_swappable<_T1, _T2>),
+   noexcept(::cuda::std::ranges::swap(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y))));
+#else // ^^^ _CCCL_HAS_NOEXCEPT_MANGLING() ^^^ / vvv !_CCCL_HAS_NOEXCEPT_MANGLING() vvv
+template <class _T1, class _T2, bool = __readable_swappable<_T1, _T2>>
+inline constexpr bool __noexcept_readable_swappable = false;
 
 template <class _T1, class _T2>
-_CCCL_CONCEPT __unqualified_iter_swap = _CCCL_FRAGMENT(__unqualified_iter_swap_, _T1, _T2);
+inline constexpr bool __noexcept_readable_swappable<_T1, _T2, true> =
+  noexcept(::cuda::std::ranges::swap(*::cuda::std::declval<_T1>(), *::cuda::std::declval<_T2>()));
+#endif // !_CCCL_HAS_NOEXCEPT_MANGLING()
 
 template <class _T1, class _T2>
-_CCCL_CONCEPT_FRAGMENT(
-  __readable_swappable_,
-  requires()(requires(!__unqualified_iter_swap<_T1, _T2>),
-             requires(indirectly_readable<_T1>),
-             requires(indirectly_readable<_T2>),
-             requires(swappable_with<iter_reference_t<_T1>, iter_reference_t<_T2>>)));
+_CCCL_CONCEPT __movable_storable = _CCCL_REQUIRES_EXPR((_T1, _T2))(
+  requires(!__unqualified_iter_swap<_T1, _T2>),
+  requires(!__readable_swappable<_T1, _T2>),
+  requires(indirectly_movable_storable<_T1, _T2>),
+  requires(indirectly_movable_storable<_T2, _T1>));
+
+#if _CCCL_HAS_NOEXCEPT_MANGLING() // older GCC cannot use noexcept inside a requires clause
+template <class _T1, class _T2>
+_CCCL_CONCEPT __noexcept_movable_storable =
+  _CCCL_REQUIRES_EXPR((_T1, _T2), _T1&& __x, _T2&& __y, iter_value_t<_T2> __old)(
+    requires(__movable_storable<_T1, _T2>),
+    noexcept(iter_value_t<_T2>(::cuda::std::ranges::iter_move(__y))),
+    noexcept(*__y = ::cuda::std::ranges::iter_move(__x)),
+    noexcept(*::cuda::std::forward<_T1>(__x) = ::cuda::std::move(__old)));
+#else // ^^^ _CCCL_HAS_NOEXCEPT_MANGLING() ^^^ / vvv !_CCCL_HAS_NOEXCEPT_MANGLING() vvv
+template <class _T1, class _T2, bool = __movable_storable<_T1, _T2>>
+inline constexpr bool __noexcept_movable_storable = false;
 
 template <class _T1, class _T2>
-_CCCL_CONCEPT __readable_swappable = _CCCL_FRAGMENT(__readable_swappable_, _T1, _T2);
-
-template <class _T1, class _T2>
-_CCCL_CONCEPT_FRAGMENT(
-  __moveable_storable_,
-  requires()(requires(!__unqualified_iter_swap<_T1, _T2>),
-             requires(!__readable_swappable<_T1, _T2>),
-             requires(indirectly_movable_storable<_T1, _T2>),
-             requires(indirectly_movable_storable<_T2, _T1>)));
-
-template <class _T1, class _T2>
-_CCCL_CONCEPT __moveable_storable = _CCCL_FRAGMENT(__moveable_storable_, _T1, _T2);
-#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
+inline constexpr bool __noexcept_movable_storable<_T1, _T2, true> =
+  noexcept(iter_value_t<_T2>(::cuda::std::ranges::iter_move(::cuda::std::declval<add_lvalue_reference_t<_T2>>())))
+  && noexcept(*::cuda::std::declval<add_lvalue_reference_t<_T2>>() =
+                ::cuda::std::ranges::iter_move(::cuda::std::declval<add_lvalue_reference_t<_T1>>()))
+  && noexcept(*::cuda::std::declval<_T1>() = ::cuda::std::declval<iter_value_t<_T2>>());
+#endif // !_CCCL_HAS_NOEXCEPT_MANGLING()
 
 struct __fn
 {
   _CCCL_TEMPLATE(class _T1, class _T2)
   _CCCL_REQUIRES(__unqualified_iter_swap<_T1, _T2>)
-  _CCCL_API constexpr void operator()(_T1&& __x, _T2&& __y) const
-    noexcept(noexcept(iter_swap(::cuda::std::forward<_T1>(__x), ::cuda::std::forward<_T2>(__y))))
+  _CCCL_API constexpr void operator()(_T1&& __x, _T2&& __y) const noexcept(__noexcept_unqualified_iter_swap<_T1, _T2>)
   {
     (void) iter_swap(::cuda::std::forward<_T1>(__x), ::cuda::std::forward<_T2>(__y));
   }
 
   _CCCL_TEMPLATE(class _T1, class _T2)
   _CCCL_REQUIRES(__readable_swappable<_T1, _T2>)
-  _CCCL_API constexpr void operator()(_T1&& __x, _T2&& __y) const
-    noexcept(noexcept(::cuda::std::ranges::swap(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y))))
+  _CCCL_API constexpr void operator()(_T1&& __x, _T2&& __y) const noexcept(__noexcept_readable_swappable<_T1, _T2>)
   {
     ::cuda::std::ranges::swap(*::cuda::std::forward<_T1>(__x), *::cuda::std::forward<_T2>(__y));
   }
 
   _CCCL_TEMPLATE(class _T1, class _T2)
-  _CCCL_REQUIRES(__moveable_storable<_T2, _T1>)
-  _CCCL_API constexpr void operator()(_T1&& __x, _T2&& __y) const
-    noexcept(noexcept(iter_value_t<_T2>(::cuda::std::ranges::iter_move(__y)))
-             && noexcept(*__y = ::cuda::std::ranges::iter_move(__x))
-             && noexcept(*::cuda::std::forward<_T1>(__x) = declval<iter_value_t<_T2>>()))
+  _CCCL_REQUIRES(__movable_storable<_T2, _T1>)
+  _CCCL_API constexpr void operator()(_T1&& __x, _T2&& __y) const noexcept(__noexcept_movable_storable<_T1, _T2>)
   {
     iter_value_t<_T2> __old(::cuda::std::ranges::iter_move(__y));
     *__y                            = ::cuda::std::ranges::iter_move(__x);


### PR DESCRIPTION
Seems like we have issues in cases where the iterator prooduces a PR value that does not bind to an lvalue reference.

Investigate workarounds for this