### PR TITLE
Replace `_CCCL_HAS_CUDA_COMPILER()` with `_CCCL_CUDA_COMPILATION()`

### DIFF
--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -754,6 +754,6 @@ private:
 };
 CUB_NAMESPACE_END
 
-#if _CCCL_HAS_CUDA_COMPILER() && !_CCCL_COMPILER(NVRTC)
+#if _CCCL_CUDA_COMPILATION() && !_CCCL_COMPILER(NVRTC)
 #  include <cub/detail/launcher/cuda_runtime.cuh> // to complete the definition of TripleChevronFactory
-#endif // _CCCL_HAS_CUDA_COMPILER() && !_CCCL_COMPILER(NVRTC)
+#endif // _CCCL_CUDA_COMPILATION() && !_CCCL_COMPILER(NVRTC)

--- a/cudax/include/cuda/experimental/__container/async_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/async_buffer.cuh
@@ -21,9 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <cub/device/device_transform.cuh>
-#endif // _CCCL_HAS_CUDA_COMPILER()
+#endif // _CCCL_CUDA_COMPILATION()
 
 #include <cuda/__container/heterogeneous_iterator.h>
 #include <cuda/__container/uninitialized_async_buffer.h>
@@ -691,14 +691,13 @@ __fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::std::size_t __count, c
     }
     else
     {
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
       ::cuda::experimental::__ensure_current_device __guard(__stream);
       ::cub::DeviceTransform::Fill(__first, __count, __value, __stream.get());
-#else
-      static_assert(0,
-                    "CUDA compiler is required to initialize a buffer with "
-                    "elements larger than 4 bytes");
-#endif
+#else // ^^^ _CCCL_CUDA_COMPILATION() ^^^ / vvv !_CCCL_CUDA_COMPILATION() vvv
+      static_assert(sizeof(_Tp) <= 4,
+                    "CUDA compiler is required to initialize an async_buffer with elements larger than 4 bytes");
+#endif // ^^^ !_CCCL_CUDA_COMPILATION() ^^^
     }
   }
 }

--- a/libcudacxx/codegen/generators/header.h
+++ b/libcudacxx/codegen/generators/header.h
@@ -58,7 +58,7 @@ inline void FormatHeader(std::ostream& out)
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 extern "C" _CCCL_DEVICE void __atomic_cas_128b_unsupported_before_SM_90();
 extern "C" _CCCL_DEVICE void __atomic_exchange_128b_unsupported_before_SM_90();
@@ -71,7 +71,7 @@ extern "C" _CCCL_DEVICE void __atomic_ldst_128b_unsupported_before_SM_70();
 inline void FormatTail(std::ostream& out)
 {
   std::string tail = R"XXX(
-#endif // _CCCL_HAS_CUDA_COMPILER()
+#endif // _CCCL_CUDA_COMPILATION()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async.h
@@ -22,7 +22,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <cuda/__barrier/async_contract_fulfillment.h>
 #  include <cuda/__barrier/barrier.h>
@@ -174,6 +174,6 @@ _CCCL_END_NAMESPACE_CUDA
 
 #  include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CCCL_HAS_CUDA_COMPILER()
+#endif // _CCCL_CUDA_COMPILATION()
 
 #endif // _CUDA___MEMCPY_ASYNC_MEMCPY_ASYNC_H_

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated.h
@@ -41,7 +41,7 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 extern "C" _CCCL_DEVICE void __atomic_cas_128b_unsupported_before_SM_90();
 extern "C" _CCCL_DEVICE void __atomic_exchange_128b_unsupported_before_SM_90();
@@ -4425,7 +4425,7 @@ template <class _Type, class _Up, class _Sco>
   return __atomic_fetch_add_cuda(__ptr, -__op, __memorder, _Sco{});
 }
 
-#endif // _CCCL_HAS_CUDA_COMPILER()
+#endif // _CCCL_CUDA_COMPILATION()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/thrust/examples/include/host_device.h
+++ b/thrust/examples/include/host_device.h
@@ -18,7 +18,7 @@
 
 #include <cuda/__cccl_config>
 
-#if !_CCCL_HAS_CUDA_COMPILER()
+#if !_CCCL_CUDA_COMPILATION()
 
 #  ifndef __host__
 #    define __host__

--- a/thrust/thrust/random/detail/normal_distribution_base.h
+++ b/thrust/thrust/random/detail/normal_distribution_base.h
@@ -146,11 +146,12 @@ private:
 template <typename RealType>
 struct normal_distribution_base
 {
-#if _CCCL_HAS_CUDA_COMPILER() && !_CCCL_CUDA_COMPILER(NVHPC)
+#if _CCCL_CUDA_COMPILATION() && !_CCCL_CUDA_COMPILER(NVHPC)
   using type = normal_distribution_nvcc<RealType>;
-#else
+#else // ^^^ _CCCL_CUDA_COMPILATION() && !_CCCL_CUDA_COMPILER(NVHPC) ^^^ /
+      // vvv !_CCCL_CUDA_COMPILATION() || _CCCL_CUDA_COMPILER(NVHPC) vvv
   using type = normal_distribution_portable<RealType>;
-#endif
+#endif // ^^^ !_CCCL_CUDA_COMPILATION() || _CCCL_CUDA_COMPILER(NVHPC) ^^^
 };
 } // namespace random::detail
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/thrust/system/cuda/detail/adjacent_difference.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -215,4 +215,4 @@ THRUST_NAMESPACE_END
 //
 #  include <thrust/adjacent_difference.h>
 #  include <thrust/memory.h>
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/assign_value.h
+++ b/thrust/thrust/system/cuda/detail/assign_value.h
@@ -26,7 +26,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/detail/raw_pointer_cast.h>
 #  include <thrust/system/cuda/detail/cross_system.h>
@@ -121,4 +121,4 @@ _CCCL_HOST_DEVICE void assign_value(cross_system<System1, System2>& systems, Poi
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/copy.h
+++ b/thrust/thrust/system/cuda/detail/copy.h
@@ -48,9 +48,9 @@
 #include <thrust/system/cuda/detail/util.h>
 #include <thrust/type_traits/is_trivially_relocatable.h>
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <cub/device/dispatch/tuning/tuning_transform.cuh>
-#endif // _CCCL_HAS_CUDA_COMPILER()
+#endif // _CCCL_CUDA_COMPILATION()
 
 #include <cuda/__fwd/zip_iterator.h>
 #include <cuda/std/tuple>
@@ -131,7 +131,7 @@ OutputIt _CCCL_HOST non_trivial_cross_system_copy_n(
   return ret;
 }
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 // non-trivial copy D->H, only supported with NVCC compiler
 // because copy ctor must have  __device__ annotations, which is nvcc-only
 // feature
@@ -158,7 +158,7 @@ OutputIt _CCCL_HOST non_trivial_cross_system_copy_n(
   OutputIt ret = thrust::copy_n(host_s, temp_host.data(), num_items, result);
   return ret;
 }
-#endif // _CCCL_HAS_CUDA_COMPILER()
+#endif // _CCCL_CUDA_COMPILATION()
 
 template <class System1, class System2, class InputIt, class Size, class OutputIt>
 OutputIt _CCCL_HOST cross_system_copy_n(cross_system<System1, System2> systems, InputIt begin, Size n, OutputIt result)
@@ -188,7 +188,7 @@ OutputIt _CCCL_HOST cross_system_copy_n(cross_system<System1, System2> systems, 
   }
 }
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 template <class Derived, class InputIt, class OutputIt>
 OutputIt THRUST_RUNTIME_FUNCTION
 device_to_device(execution_policy<Derived>& policy, InputIt first, InputIt last, OutputIt result)
@@ -229,10 +229,10 @@ device_to_device(execution_policy<Derived>& policy, InputIt first, InputIt last,
       policy, first, last, result, ::cuda::proclaim_copyable_arguments(::cuda::std::identity{}));
   }
 }
-#endif // _CCCL_HAS_CUDA_COMPILER()
+#endif // _CCCL_CUDA_COMPILATION()
 } // namespace __copy
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class System, class InputIterator, class OutputIterator>
@@ -253,7 +253,7 @@ copy_n(execution_policy<System>& system, InputIterator first, Size n, OutputIter
                       (result = thrust::copy_n(cvt_to_seq(derived_cast(system)), first, n, result);));
   return result;
 }
-#endif // _CCCL_HAS_CUDA_COMPILER()
+#endif // _CCCL_CUDA_COMPILATION()
 
 template <class System1, class System2, class InputIterator, class OutputIterator>
 OutputIterator _CCCL_HOST

--- a/thrust/thrust/system/cuda/detail/copy_if.h
+++ b/thrust/thrust/system/cuda/detail/copy_if.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -248,4 +248,4 @@ OutputIterator _CCCL_HOST_DEVICE copy_if(
 THRUST_NAMESPACE_END
 
 #  include <thrust/copy.h>
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/core/agent_launcher.h
+++ b/thrust/thrust/system/cuda/detail/core/agent_launcher.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 #  include <thrust/system/cuda/detail/core/util.h>
 
@@ -277,4 +277,4 @@ struct AgentLauncher : Agent
 
 THRUST_NAMESPACE_END
 
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/count.h
+++ b/thrust/thrust/system/cuda/detail/count.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/config.h>
 
 #  include <thrust/iterator/transform_iterator.h>
@@ -72,4 +72,4 @@ count(execution_policy<Derived>& policy, InputIt first, InputIt last, Value cons
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/equal.h
+++ b/thrust/thrust/system/cuda/detail/equal.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/config.h>
 
 #  include <thrust/system/cuda/detail/mismatch.h>
@@ -59,4 +59,4 @@ bool _CCCL_HOST_DEVICE equal(execution_policy<Derived>& policy, InputIt1 first1,
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/extrema.h
+++ b/thrust/thrust/system/cuda/detail/extrema.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -470,4 +470,4 @@ minmax_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/fill.h
+++ b/thrust/thrust/system/cuda/detail/fill.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <cub/device/device_transform.cuh>
 
 #  include <thrust/fill.h>
@@ -96,4 +96,4 @@ fill(execution_policy<Derived>& policy, ForwardIterator first, ForwardIterator l
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/find.h
+++ b/thrust/thrust/system/cuda/detail/find.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/config.h>
 
 #  include <thrust/system/cuda/detail/execution_policy.h>
@@ -162,4 +162,4 @@ InputIt _CCCL_HOST_DEVICE find(execution_policy<Derived>& policy, InputIt first,
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/for_each.h
+++ b/thrust/thrust/system/cuda/detail/for_each.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/config.h>
 
 #  include <cub/device/device_for.cuh>
@@ -80,4 +80,4 @@ Input _CCCL_API _CCCL_FORCEINLINE for_each(execution_policy<Derived>& policy, In
 } // namespace cuda_cub
 
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/gather.h
+++ b/thrust/thrust/system/cuda/detail/gather.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/iterator/permutation_iterator.h>
 #  include <thrust/system/cuda/detail/transform.h>
 
@@ -86,4 +86,4 @@ ResultIt _CCCL_HOST_DEVICE gather_if(
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
 
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/generate.h
+++ b/thrust/thrust/system/cuda/detail/generate.h
@@ -12,7 +12,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <cub/device/device_transform.cuh>
 
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
@@ -56,4 +56,4 @@ void _CCCL_HOST_DEVICE generate(execution_policy<Derived>& policy, OutputIt firs
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/get_value.h
+++ b/thrust/thrust/system/cuda/detail/get_value.h
@@ -26,7 +26,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/config.h>
 
 #  include <thrust/detail/raw_pointer_cast.h>
@@ -62,4 +62,4 @@ _CCCL_HOST_DEVICE thrust::detail::it_value_t<Pointer> get_value(execution_policy
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
 
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/inner_product.h
+++ b/thrust/thrust/system/cuda/detail/inner_product.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/iterator/transform_iterator.h>
 #  include <thrust/iterator/zip_iterator.h>
 #  include <thrust/system/cuda/detail/reduce.h>
@@ -74,4 +74,4 @@ inner_product(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1
 } // namespace cuda_cub
 
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/iter_swap.h
+++ b/thrust/thrust/system/cuda/detail/iter_swap.h
@@ -26,7 +26,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -76,4 +76,4 @@ inline _CCCL_HOST_DEVICE void iter_swap(thrust::cuda::execution_policy<DerivedPo
 } // end iter_swap()
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -12,7 +12,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <cub/device/device_merge.cuh>
 
@@ -202,4 +202,4 @@ template <class Derived,
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/mismatch.h
+++ b/thrust/thrust/system/cuda/detail/mismatch.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/config.h>
 
 #  include <thrust/system/cuda/detail/execution_policy.h>
@@ -85,4 +85,4 @@ mismatch(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, Inp
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/parallel_for.h
+++ b/thrust/thrust/system/cuda/detail/parallel_for.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -76,4 +76,4 @@ void _CCCL_HOST_DEVICE parallel_for(execution_policy<Derived>& policy, F f, Size
 } // namespace cuda_cub
 
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/partition.h
+++ b/thrust/thrust/system/cuda/detail/partition.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -398,4 +398,4 @@ is_partitioned(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, P
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/per_device_resource.h
+++ b/thrust/thrust/system/cuda/detail/per_device_resource.h
@@ -37,7 +37,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -67,4 +67,4 @@ _CCCL_HOST MR* get_per_device_resource(execution_policy<DerivedPolicy>&)
 
 THRUST_NAMESPACE_END
 
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/reduce.h
+++ b/thrust/thrust/system/cuda/detail/reduce.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -771,4 +771,4 @@ THRUST_NAMESPACE_END
 #  include <thrust/memory.h>
 #  include <thrust/reduce.h>
 
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/thrust/system/cuda/detail/reduce_by_key.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -991,4 +991,4 @@ THRUST_NAMESPACE_END
 #  include <thrust/memory.h>
 #  include <thrust/reduce.h>
 
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/remove.h
+++ b/thrust/thrust/system/cuda/detail/remove.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/detail/copy_if.h>
 
 THRUST_NAMESPACE_BEGIN
@@ -102,4 +102,4 @@ remove_copy(execution_policy<Derived>& policy, InputIt first, InputIt last, Outp
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/replace.h
+++ b/thrust/thrust/system/cuda/detail/replace.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/detail/internal_functional.h>
 #  include <thrust/system/cuda/detail/transform.h>
 
@@ -118,4 +118,4 @@ OutputIt _CCCL_HOST_DEVICE replace_copy(
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/reverse.h
+++ b/thrust/thrust/system/cuda/detail/reverse.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/detail/execution_policy.h>
 
 THRUST_NAMESPACE_BEGIN
@@ -80,4 +80,4 @@ void _CCCL_HOST_DEVICE reverse(execution_policy<Derived>& policy, ItemsIt first,
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/scan.h
+++ b/thrust/thrust/system/cuda/detail/scan.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -337,4 +337,4 @@ THRUST_NAMESPACE_END
 
 #  include <thrust/scan.h>
 
-#endif // NVCC
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/thrust/system/cuda/detail/scan_by_key.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -409,4 +409,4 @@ THRUST_NAMESPACE_END
 
 #  include <thrust/scan.h>
 
-#endif // NVCC
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/scatter.h
+++ b/thrust/thrust/system/cuda/detail/scatter.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/iterator/permutation_iterator.h>
 #  include <thrust/system/cuda/detail/transform.h>
 
@@ -87,4 +87,4 @@ void _CCCL_HOST_DEVICE scatter_if(
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/set_operations.h
+++ b/thrust/thrust/system/cuda/detail/set_operations.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <cub/block/block_load.cuh>
 #  include <cub/iterator/cache_modified_input_iterator.cuh>
@@ -1719,4 +1719,4 @@ template <class Derived, class KeysIt1, class KeysIt2, class ItemsIt1, class Ite
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/sort.h
+++ b/thrust/thrust/system/cuda/detail/sort.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/config.h>
 
 #  include <cub/device/device_merge_sort.cuh>
@@ -470,4 +470,4 @@ stable_sort_by_key(execution_policy<Derived>& policy, KeysIt keys_first, KeysIt 
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/swap_ranges.h
+++ b/thrust/thrust/system/cuda/detail/swap_ranges.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/iterator/zip_iterator.h>
 #  include <thrust/system/cuda/detail/parallel_for.h>
@@ -96,4 +96,4 @@ swap_ranges(execution_policy<Derived>& policy, ItemsIt1 first1, ItemsIt1 last1, 
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/tabulate.h
+++ b/thrust/thrust/system/cuda/detail/tabulate.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/config.h>
 
 #  include <thrust/system/cuda/detail/transform.h>
@@ -59,4 +59,4 @@ void _CCCL_HOST_DEVICE tabulate(execution_policy<Derived>& policy, Iterator firs
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/transform.h
+++ b/thrust/thrust/system/cuda/detail/transform.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/config.h>
 
 #  include <cub/device/device_transform.cuh>
@@ -425,4 +425,4 @@ _CCCL_API _CCCL_FORCEINLINE OutputIt transform_if_n(
 } // namespace cuda_cub
 
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/transform_reduce.h
+++ b/thrust/thrust/system/cuda/detail/transform_reduce.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/config.h>
 
 #  include <cub/device/device_reduce.cuh>
@@ -136,4 +136,4 @@ T _CCCL_HOST_DEVICE transform_reduce(
 }
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/transform_scan.h
+++ b/thrust/thrust/system/cuda/detail/transform_scan.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/detail/type_traits.h>
 #  include <thrust/iterator/transform_iterator.h>
 #  include <thrust/system/cuda/detail/scan.h>
@@ -114,4 +114,4 @@ OutputIt _CCCL_HOST_DEVICE transform_exclusive_scan(
 } // namespace cuda_cub
 
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_copy.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/detail/execution_policy.h>
 #  include <thrust/system/cuda/detail/parallel_for.h>
 #  include <thrust/system/cuda/detail/transform.h>
@@ -111,4 +111,4 @@ uninitialized_copy(execution_policy<Derived>& policy, InputIt first, InputIt las
 } // namespace cuda_cub
 
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/uninitialized_fill.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_fill.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 #  include <thrust/system/cuda/detail/execution_policy.h>
 #  include <thrust/system/cuda/detail/fill.h>
 #  include <thrust/system/cuda/detail/parallel_for.h>
@@ -99,4 +99,4 @@ void _CCCL_HOST_DEVICE uninitialized_fill(execution_policy<Derived>& policy, Ite
 } // namespace cuda_cub
 
 THRUST_NAMESPACE_END
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/unique.h
+++ b/thrust/thrust/system/cuda/detail/unique.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -285,4 +285,4 @@ THRUST_NAMESPACE_END
 //
 #  include <thrust/memory.h>
 #  include <thrust/unique.h>
-#endif
+#endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/unique_by_key.h
+++ b/thrust/thrust/system/cuda/detail/unique_by_key.h
@@ -36,7 +36,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if _CCCL_HAS_CUDA_COMPILER()
+#if _CCCL_CUDA_COMPILATION()
 
 #  include <thrust/system/cuda/config.h>
 
@@ -304,4 +304,4 @@ THRUST_NAMESPACE_END
 #  include <thrust/memory.h>
 #  include <thrust/unique.h>
 
-#endif
+#endif // _CCCL_CUDA_COMPILATION()


### PR DESCRIPTION
In the past, we used to use `_CCCL_HAS_CUDA_COMPILER()` to check whether we are compiling a CUDA source file, which is not what `_CCCL_HAS_CUDA_COMPILER()` actually does. I've replaced the use with mostly `_CCCL_CUDA_COMPILATION()`.

Please, carefully check whether I didn't do a mistake :)