### PR TITLE
Fix missing monostate_include

### DIFF
--- a/libcudacxx/include/cuda/std/variant
+++ b/libcudacxx/include/cuda/std/variant
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__utility/monostate.h>
 #include <cuda/std/__variant/bad_variant_access.h>
 #include <cuda/std/__variant/comparison.h>
 #include <cuda/std/__variant/get.h>

--- a/libcudacxx/test/libcudacxx/std/utilities/variant/variant.synopsis/monostate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/variant/variant.synopsis/monostate.pass.cpp
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/variant>
+
+// struct monostate {};
+
+#include <cuda/std/type_traits>
+#include <cuda/std/variant>
+
+#include "test_macros.h"
+
+int main(int, char**)
+{
+  using M = cuda::std::monostate;
+  static_assert(cuda::std::is_trivially_default_constructible<M>::value, "");
+  static_assert(cuda::std::is_trivially_copy_constructible<M>::value, "");
+  static_assert(cuda::std::is_trivially_copy_assignable<M>::value, "");
+  static_assert(cuda::std::is_trivially_destructible<M>::value, "");
+  [[maybe_unused]] constexpr M m{};
+
+  return 0;
+}


### PR DESCRIPTION
We just modularized `<variant>` which accidentally dropped the monostate include

Add a test that we actually include it through variant
