### PR TITLE
Fix wrongly rewritten license headers in Thrust OMP/TBB backend

### DIFF
--- a/thrust/thrust/system/omp/detail/adjacent_difference.h
+++ b/thrust/thrust/system/omp/detail/adjacent_difference.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/assign_value.h
+++ b/thrust/thrust/system/omp/detail/assign_value.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/binary_search.h
+++ b/thrust/thrust/system/omp/detail/binary_search.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/copy.h
+++ b/thrust/thrust/system/omp/detail/copy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/copy_if.h
+++ b/thrust/thrust/system/omp/detail/copy_if.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/count.h
+++ b/thrust/thrust/system/omp/detail/count.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/default_decomposition.h
+++ b/thrust/thrust/system/omp/detail/default_decomposition.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file default_decomposition.h

--- a/thrust/thrust/system/omp/detail/equal.h
+++ b/thrust/thrust/system/omp/detail/equal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/execution_policy.h
+++ b/thrust/thrust/system/omp/detail/execution_policy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2025, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/extrema.h
+++ b/thrust/thrust/system/omp/detail/extrema.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/fill.h
+++ b/thrust/thrust/system/omp/detail/fill.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/find.h
+++ b/thrust/thrust/system/omp/detail/find.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file find.h

--- a/thrust/thrust/system/omp/detail/for_each.h
+++ b/thrust/thrust/system/omp/detail/for_each.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file for_each.h

--- a/thrust/thrust/system/omp/detail/gather.h
+++ b/thrust/thrust/system/omp/detail/gather.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/generate.h
+++ b/thrust/thrust/system/omp/detail/generate.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/get_value.h
+++ b/thrust/thrust/system/omp/detail/get_value.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/inner_product.h
+++ b/thrust/thrust/system/omp/detail/inner_product.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/iter_swap.h
+++ b/thrust/thrust/system/omp/detail/iter_swap.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/logical.h
+++ b/thrust/thrust/system/omp/detail/logical.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/malloc_and_free.h
+++ b/thrust/thrust/system/omp/detail/malloc_and_free.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/merge.h
+++ b/thrust/thrust/system/omp/detail/merge.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/mismatch.h
+++ b/thrust/thrust/system/omp/detail/mismatch.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/partition.h
+++ b/thrust/thrust/system/omp/detail/partition.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file reduce.h

--- a/thrust/thrust/system/omp/detail/per_device_resource.h
+++ b/thrust/thrust/system/omp/detail/per_device_resource.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2018, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2018, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/pragma_omp.h
+++ b/thrust/thrust/system/omp/detail/pragma_omp.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/reduce.h
+++ b/thrust/thrust/system/omp/detail/reduce.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file reduce.h

--- a/thrust/thrust/system/omp/detail/reduce_by_key.h
+++ b/thrust/thrust/system/omp/detail/reduce_by_key.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file reduce.h

--- a/thrust/thrust/system/omp/detail/reduce_intervals.h
+++ b/thrust/thrust/system/omp/detail/reduce_intervals.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file reduce_intervals.h

--- a/thrust/thrust/system/omp/detail/remove.h
+++ b/thrust/thrust/system/omp/detail/remove.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/replace.h
+++ b/thrust/thrust/system/omp/detail/replace.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/reverse.h
+++ b/thrust/thrust/system/omp/detail/reverse.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/scan.h
+++ b/thrust/thrust/system/omp/detail/scan.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/scan_by_key.h
+++ b/thrust/thrust/system/omp/detail/scan_by_key.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/scatter.h
+++ b/thrust/thrust/system/omp/detail/scatter.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/sequence.h
+++ b/thrust/thrust/system/omp/detail/sequence.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/set_operations.h
+++ b/thrust/thrust/system/omp/detail/set_operations.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/sort.h
+++ b/thrust/thrust/system/omp/detail/sort.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/swap_ranges.h
+++ b/thrust/thrust/system/omp/detail/swap_ranges.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/tabulate.h
+++ b/thrust/thrust/system/omp/detail/tabulate.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/temporary_buffer.h
+++ b/thrust/thrust/system/omp/detail/temporary_buffer.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/transform.h
+++ b/thrust/thrust/system/omp/detail/transform.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/transform_reduce.h
+++ b/thrust/thrust/system/omp/detail/transform_reduce.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/transform_scan.h
+++ b/thrust/thrust/system/omp/detail/transform_scan.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/omp/detail/uninitialized_copy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/uninitialized_fill.h
+++ b/thrust/thrust/system/omp/detail/uninitialized_fill.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/unique.h
+++ b/thrust/thrust/system/omp/detail/unique.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/omp/detail/unique_by_key.h
+++ b/thrust/thrust/system/omp/detail/unique_by_key.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/adjacent_difference.h
+++ b/thrust/thrust/system/tbb/detail/adjacent_difference.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/assign_value.h
+++ b/thrust/thrust/system/tbb/detail/assign_value.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/binary_search.h
+++ b/thrust/thrust/system/tbb/detail/binary_search.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/copy.h
+++ b/thrust/thrust/system/tbb/detail/copy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/copy_if.h
+++ b/thrust/thrust/system/tbb/detail/copy_if.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/copy_if.inl
+++ b/thrust/thrust/system/tbb/detail/copy_if.inl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/count.h
+++ b/thrust/thrust/system/tbb/detail/count.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/equal.h
+++ b/thrust/thrust/system/tbb/detail/equal.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/execution_policy.h
+++ b/thrust/thrust/system/tbb/detail/execution_policy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2025, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 

--- a/thrust/thrust/system/tbb/detail/extrema.h
+++ b/thrust/thrust/system/tbb/detail/extrema.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/fill.h
+++ b/thrust/thrust/system/tbb/detail/fill.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/find.h
+++ b/thrust/thrust/system/tbb/detail/find.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/for_each.h
+++ b/thrust/thrust/system/tbb/detail/for_each.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/gather.h
+++ b/thrust/thrust/system/tbb/detail/gather.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/generate.h
+++ b/thrust/thrust/system/tbb/detail/generate.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/get_value.h
+++ b/thrust/thrust/system/tbb/detail/get_value.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/inner_product.h
+++ b/thrust/thrust/system/tbb/detail/inner_product.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/iter_swap.h
+++ b/thrust/thrust/system/tbb/detail/iter_swap.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/logical.h
+++ b/thrust/thrust/system/tbb/detail/logical.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/malloc_and_free.h
+++ b/thrust/thrust/system/tbb/detail/malloc_and_free.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/memory.inl
+++ b/thrust/thrust/system/tbb/detail/memory.inl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2018, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2018, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/merge.h
+++ b/thrust/thrust/system/tbb/detail/merge.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2021, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/mismatch.h
+++ b/thrust/thrust/system/tbb/detail/mismatch.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/partition.h
+++ b/thrust/thrust/system/tbb/detail/partition.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/per_device_resource.h
+++ b/thrust/thrust/system/tbb/detail/per_device_resource.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2018, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2018, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/reduce.h
+++ b/thrust/thrust/system/tbb/detail/reduce.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file reduce.h

--- a/thrust/thrust/system/tbb/detail/reduce_by_key.h
+++ b/thrust/thrust/system/tbb/detail/reduce_by_key.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/reduce_by_key.inl
+++ b/thrust/thrust/system/tbb/detail/reduce_by_key.inl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/reduce_intervals.h
+++ b/thrust/thrust/system/tbb/detail/reduce_intervals.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/remove.h
+++ b/thrust/thrust/system/tbb/detail/remove.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/remove.inl
+++ b/thrust/thrust/system/tbb/detail/remove.inl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/replace.h
+++ b/thrust/thrust/system/tbb/detail/replace.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/reverse.h
+++ b/thrust/thrust/system/tbb/detail/reverse.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/scan.h
+++ b/thrust/thrust/system/tbb/detail/scan.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file scan.h

--- a/thrust/thrust/system/tbb/detail/scan_by_key.h
+++ b/thrust/thrust/system/tbb/detail/scan_by_key.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/scatter.h
+++ b/thrust/thrust/system/tbb/detail/scatter.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/sequence.h
+++ b/thrust/thrust/system/tbb/detail/sequence.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/set_operations.h
+++ b/thrust/thrust/system/tbb/detail/set_operations.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/sort.h
+++ b/thrust/thrust/system/tbb/detail/sort.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/swap_ranges.h
+++ b/thrust/thrust/system/tbb/detail/swap_ranges.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/tabulate.h
+++ b/thrust/thrust/system/tbb/detail/tabulate.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/temporary_buffer.h
+++ b/thrust/thrust/system/tbb/detail/temporary_buffer.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/transform.h
+++ b/thrust/thrust/system/tbb/detail/transform.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/transform_reduce.h
+++ b/thrust/thrust/system/tbb/detail/transform_reduce.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/transform_scan.h
+++ b/thrust/thrust/system/tbb/detail/transform_scan.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/tbb/detail/uninitialized_copy.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/uninitialized_fill.h
+++ b/thrust/thrust/system/tbb/detail/uninitialized_fill.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/unique.h
+++ b/thrust/thrust/system/tbb/detail/unique.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/unique.inl
+++ b/thrust/thrust/system/tbb/detail/unique.inl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/unique_by_key.h
+++ b/thrust/thrust/system/tbb/detail/unique_by_key.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/detail/unique_by_key.inl
+++ b/thrust/thrust/system/tbb/detail/unique_by_key.inl
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once

--- a/thrust/thrust/system/tbb/memory.h
+++ b/thrust/thrust/system/tbb/memory.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2018, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2018, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file thrust/system/tbb/memory.h

--- a/thrust/thrust/system/tbb/memory_resource.h
+++ b/thrust/thrust/system/tbb/memory_resource.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2018-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2018-2020, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file tbb/memory_resource.h

--- a/thrust/thrust/system/tbb/pointer.h
+++ b/thrust/thrust/system/tbb/pointer.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2020, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2020, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file thrust/system/tbb/memory.h

--- a/thrust/thrust/system/tbb/vector.h
+++ b/thrust/thrust/system/tbb/vector.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2008-2013, NVIDIA Corporation. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
 /*! \file thrust/system/tbb/vector.h


### PR DESCRIPTION
In #6394 and #6372 I rewrote some license headers to SPDX, but picked the wrong license. The original files were Apache 2.0 (without LLVM EXCEPTION). Also, I wrongly added `& AFFILIATES` to the copyright text. This PR reverts the license and spelling of the copyright to were it was before the two PRs mentioned before.