### PR TITLE
Add `_CCCL_DECLSPEC_EMPTY_BASES` to mdspan features

### DIFF
--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -175,8 +175,8 @@ constexpr size_t __count_dynamic_v = (size_t{0} + ... + static_cast<size_t>(_Val
 // The position of a dynamic value is indicated through a tag value.
 // We manually implement EBCO because MSVC and some odler compiler fail hard with [[no_unique_address]]
 template <class _TDynamic, class _TStatic, _TStatic _DynTag, _TStatic... _Values>
-struct __maybe_static_array
-    : private __possibly_empty_array<_TDynamic, __count_dynamic_v<_TStatic, _DynTag, _Values...>>
+struct _CCCL_DECLSPEC_EMPTY_BASES
+__maybe_static_array : private __possibly_empty_array<_TDynamic, __count_dynamic_v<_TStatic, _DynTag, _Values...>>
 {
   static_assert(is_convertible_v<_TStatic, _TDynamic>,
                 "__maybe_static_array: _TStatic must be convertible to _TDynamic");

--- a/libcudacxx/include/cuda/std/__mdspan/layout_left.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_left.h
@@ -47,7 +47,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 // Helper for lightweight test checking that one did pass a layout policy as LayoutPolicy template argument
 template <class _Extents>
-class layout_left::mapping : private __mdspan_ebco<_Extents>
+class _CCCL_DECLSPEC_EMPTY_BASES layout_left::mapping : private __mdspan_ebco<_Extents>
 {
 public:
   static_assert(__is_cuda_std_extents_v<_Extents>,
@@ -298,8 +298,8 @@ public:
 
 #if _CCCL_STD_VER <= 2017
   template <class _OtherExtents, class _Extents2 = _Extents>
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator!=(const mapping& __lhs, const mapping<_OtherExtents>& __rhs) noexcept
+  [[nodiscard]]
+  _CCCL_API friend constexpr auto operator!=(const mapping& __lhs, const mapping<_OtherExtents>& __rhs) noexcept
     _CCCL_TRAILING_REQUIRES(bool)((_OtherExtents::rank() == _Extents2::rank()))
   {
     return __lhs.extents() != __rhs.extents();

--- a/libcudacxx/include/cuda/std/__mdspan/layout_right.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_right.h
@@ -47,7 +47,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Extents>
-class layout_right::mapping : private __mdspan_ebco<_Extents>
+class _CCCL_DECLSPEC_EMPTY_BASES layout_right::mapping : private __mdspan_ebco<_Extents>
 {
 public:
   static_assert(__is_cuda_std_extents_v<_Extents>,
@@ -291,8 +291,8 @@ public:
 
 #if _CCCL_STD_VER <= 2017
   template <class _OtherExtents, class _Extents2 = _Extents>
-  [[nodiscard]] _CCCL_API friend constexpr auto
-  operator!=(const mapping& __lhs, const mapping<_OtherExtents>& __rhs) noexcept
+  [[nodiscard]]
+  _CCCL_API friend constexpr auto operator!=(const mapping& __lhs, const mapping<_OtherExtents>& __rhs) noexcept
     _CCCL_TRAILING_REQUIRES(bool)((_OtherExtents::rank() == _Extents2::rank()))
   {
     return __lhs.extents() != __rhs.extents();

--- a/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
+++ b/libcudacxx/include/cuda/std/__mdspan/layout_stride.h
@@ -71,7 +71,7 @@ struct __constraints
 } // namespace __layout_stride_detail
 
 template <class _Extents>
-class layout_stride::mapping
+class _CCCL_DECLSPEC_EMPTY_BASES layout_stride::mapping
     : private __mdspan_ebco<_Extents,
                             __mdspan_detail::__possibly_empty_array<typename _Extents::index_type, _Extents::rank()>>
 {


### PR DESCRIPTION
We were seeing some test failures on windows where we could have data corruption between host and device.

This is due to missing `_CCCL_DECLSPEC_EMPTY_BASES` in layout_stride

To be safe add it to the others too

Addresses parts of nvbug5327816