### PR TITLE
Ensure that `detect_wrong_difference` is a valid output iterator

### DIFF
--- a/thrust/testing/cpp/adjacent_difference.cu
+++ b/thrust/testing/cpp/adjacent_difference.cu
@@ -7,6 +7,12 @@
 
 struct detect_wrong_difference
 {
+  using difference_type   = void;
+  using value_type        = long long;
+  using pointer           = void;
+  using reference         = detect_wrong_difference;
+  using iterator_category = ::cuda::std::output_iterator_tag;
+
   bool* flag;
 
   _CCCL_HOST_DEVICE detect_wrong_difference operator++() const


### PR DESCRIPTION
We were missing some iterator traits for `detect_wrong_difference` which would break some internal checks for iterator traits

Fixes [BUG]: no type named 'value_type' in 'thrust::iterator_traits<...>
Fixes #2822
