### PR TITLE
Fix Random CI failures for Deterministic Device Reduce (RFA) with different policies

### DIFF
--- a/cub/test/catch2_test_device_reduce_deterministic.cu
+++ b/cub/test/catch2_test_device_reduce_deterministic.cu
@@ -190,7 +190,7 @@ C2H_TEST("Deterministic Device reduce works with float and double and is determi
   h_expected[0] = std::accumulate(h_input.begin(), h_input.end(), type{}, cuda::std::plus<type>());
 
   // device RFA result should be approximately equal to host result
-  REQUIRE_APPROX_EQ_EPSILON(h_expected, d_output_p1, type{0.01});
+  REQUIRE_APPROX_EQ_EPSILON(h_expected, d_output_p1, type{0.05});
 
   // Both device RFA results should be strictly equal, as RFA is deterministic
   REQUIRE(d_output_p1 == d_output_p2);


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes https://github.com/NVIDIA/cccl/issues/6463

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
