### PR TITLE
Improve `cudax::dynamic_shared_memory` implementation

### DIFF
--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -12,6 +12,13 @@
 #define _CUDAX__LAUNCH_CONFIGURATION_CUH
 
 #include <cuda/__driver/driver_api.h>
+#include <cuda/__numeric/overflow_cast.h>
+#include <cuda/__ptx/instructions/get_sreg.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__type_traits/is_const.h>
+#include <cuda/std/__type_traits/is_reference.h>
+#include <cuda/std/__type_traits/is_unbounded_array.h>
+#include <cuda/std/__type_traits/rank.h>
 #include <cuda/std/span>
 #include <cuda/std/tuple>
 
@@ -32,17 +39,7 @@ struct launch_option
 {
   static constexpr bool needs_attribute_space = false;
   static constexpr bool is_relevant_on_device = false;
-
-protected:
-  [[nodiscard]] cudaError_t apply(CUlaunchConfig&, CUfunction) const noexcept
-  {
-    return cudaSuccess;
-  }
 };
-
-template <typename Dimensions, typename... Options>
-cudaError_t apply_kernel_config(
-  const kernel_config<Dimensions, Options...>& config, CUlaunchConfig& cuda_config, CUfunction kernel) noexcept;
 
 // Might need to go to the main namespace?
 enum class launch_option_kind
@@ -128,36 +125,68 @@ struct cooperative_launch : public __detail::launch_option
   static constexpr bool needs_attribute_space        = true;
   static constexpr bool is_relevant_on_device        = true;
   static constexpr __detail::launch_option_kind kind = __detail::launch_option_kind::cooperative_launch;
-
-  constexpr cooperative_launch() = default;
-
-  template <typename Dimensions, typename... Options>
-  friend cudaError_t __detail::apply_kernel_config(
-    const kernel_config<Dimensions, Options...>& config, CUlaunchConfig& cuda_config, CUfunction kernel) noexcept;
-
-private:
-  [[nodiscard]] cudaError_t apply(CUlaunchConfig& config, CUfunction) const noexcept
-  {
-    CUlaunchAttribute attr;
-    attr.id                = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
-    attr.value.cooperative = true;
-
-    config.attrs[config.numAttrs++] = attr;
-
-    return cudaSuccess;
-  }
 };
+
+[[nodiscard]] _CCCL_API inline cudaError_t
+__apply_launch_option(const cooperative_launch&, CUlaunchConfig& config, CUfunction) noexcept
+{
+  CUlaunchAttribute attr;
+  attr.id                = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
+  attr.value.cooperative = true;
+
+  config.attrs[config.numAttrs++] = attr;
+
+  return cudaSuccess;
+}
+
+template <class _Tp>
+class __dyn_smem_option_base
+{
+protected:
+  using value_type = _Tp;
+  using view_type  = _Tp&;
+};
+
+template <class _Tp>
+class __dyn_smem_option_base<_Tp[]>
+{
+protected:
+  using value_type = _Tp;
+  using view_type  = ::cuda::std::span<_Tp>;
+
+  ::cuda::std::size_t __n_;
+
+  _CCCL_HOST_API constexpr __dyn_smem_option_base(::cuda::std::size_t __n) noexcept
+      : __n_{__n}
+  {}
+};
+
+template <class _Tp, ::cuda::std::size_t _Np>
+class __dyn_smem_option_base<_Tp[_Np]>
+{
+protected:
+  using value_type = _Tp;
+  using view_type  = ::cuda::std::span<_Tp, _Np>;
+
+  static constexpr ::cuda::std::size_t __n_ = _Np;
+};
+
+enum class non_portable_t : unsigned char
+{
+};
+inline constexpr non_portable_t non_portable{};
+
+inline constexpr ::cuda::std::size_t __max_portable_dyn_smem_size = 48 * 1024;
 
 /**
  * @brief Launch option specifying dynamic shared memory configuration
  *
  * This launch option causes the launch to allocate amount of shared memory sufficient
  * to store the specified number of object of the specified type.
- * This type can be constructed directly or with dynamic_shared_memory helper function.
+ * This type can be constructed with dynamic_shared_memory helper function.
  *
  * When launch configuration contains this option, that configuration can be then
- * passed to dynamic_smem_span or dynamic_smem_ref function to get a span/reference
- * to that shared memory allocation that is appropriately typed.
+ * passed to dynamic_shared_memory_view to get the view_type over the dynamic shared memory.
  * It is also possible to obtain that memory through the original
  * extern __shared__ variable[] declaration.
  *
@@ -174,13 +203,13 @@ private:
  * template <typename Configuration>
  * __global__ void kernel(Configuration conf)
  * {
- *     auto dynamic_shared = cudax::dynamic_smem_span(conf);
+ *     auto dynamic_shared = cudax::dynamic_shared_memory_view(conf);
  *     dynamic_shared[0] = 1;
  * }
  *
  * void kernel_launch(cuda::stream_ref stream) {
  *     auto dims = cudax::make_hierarchy(cudax::block<128>(), cudax::grid(4));
- *     auto conf = cudax::make_configuration(dims, dynamic_shared_memory<int, 128>());
+ *     auto conf = cudax::make_configuration(dims, dynamic_shared_memory<int[128]>());
  *
  *     cudax::launch(stream, conf, kernel);
  * }
@@ -197,96 +226,151 @@ private:
  * @tparam NonPortableSize
  *  Needs to be enabled to exceed the portable limit of 48kB of shared memory per block
  */
-template <typename Content, std::size_t Extent = 1, bool NonPortableSize = false>
-struct dynamic_shared_memory_option : public __detail::launch_option
+template <class _Tp>
+class _CCCL_DECLSPEC_EMPTY_BASES dynamic_shared_memory
+    : __dyn_smem_option_base<_Tp>
+    , public __detail::launch_option
 {
-  using content_type                                 = Content;
-  static constexpr std::size_t extent                = Extent;
+  using __base_type = __dyn_smem_option_base<_Tp>;
+
+  static_assert(::cuda::std::rank_v<_Tp> <= 1,
+                "multidimensional arrays cannot be used with dynamic shared memory option");
+  static_assert(!::cuda::std::is_const_v<typename __base_type::value_type>, "the value type cannot be const");
+  static_assert(!::cuda::std::is_reference_v<typename __base_type::value_type>, "the value type cannot be a reference");
+
+public:
+  bool __non_portable_{}; //!< \c true if the object was created with non_portable flag.
+
+  using typename __base_type::value_type; //!< Value type of the dynamic shared memory elements.
+  using typename __base_type::view_type; //!< The view type returned by the
+                                         //!< cuda::device::dynamic_shared_memory_view(config).
+
   static constexpr bool is_relevant_on_device        = true;
   static constexpr __detail::launch_option_kind kind = __detail::launch_option_kind::dynamic_shared_memory;
-  const std::size_t size;
 
-  constexpr dynamic_shared_memory_option(std::size_t set_size) noexcept
-      : size(set_size)
+  _CCCL_HIDE_FROM_ABI constexpr dynamic_shared_memory() noexcept = default;
+
+  _CCCL_HOST_API constexpr dynamic_shared_memory(non_portable_t) noexcept
+      : __non_portable_{true}
   {}
 
-  template <typename Dimensions, typename... Options>
-  friend cudaError_t __detail::apply_kernel_config(
-    const kernel_config<Dimensions, Options...>& config, CUlaunchConfig& cuda_config, CUfunction kernel) noexcept;
-
-private:
-  [[nodiscard]] cudaError_t apply(CUlaunchConfig& config, CUfunction kernel) const noexcept
+  _CCCL_TEMPLATE(class _Tp2 = _Tp)
+  _CCCL_REQUIRES((!::cuda::std::is_unbounded_array_v<_Tp2>) )
+  _CCCL_HOST_API constexpr dynamic_shared_memory() noexcept
   {
-    cudaError_t status = cudaSuccess;
+    static_assert(sizeof(_Tp2) <= __max_portable_dyn_smem_size, "portable dynamic shared memory limit exceeded");
+  }
 
-    int max_dynamic_shared_size{};
-    status = ::cuda::__driver::__functionGetAttributeNoThrow(
-      max_dynamic_shared_size, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, kernel);
-    if (status != cudaSuccess)
+  _CCCL_TEMPLATE(class _Tp2 = _Tp)
+  _CCCL_REQUIRES((!::cuda::std::is_unbounded_array_v<_Tp2>) )
+  _CCCL_HOST_API constexpr dynamic_shared_memory(non_portable_t) noexcept
+      : __non_portable_{true}
+  {}
+
+  _CCCL_TEMPLATE(class _Tp2 = _Tp)
+  _CCCL_REQUIRES(::cuda::std::is_unbounded_array_v<_Tp2>)
+  _CCCL_HOST_API constexpr dynamic_shared_memory(::cuda::std::size_t __n)
+      : __base_type{__n}
+  {
+    if (__n * sizeof(value_type) > __max_portable_dyn_smem_size)
     {
-      return status;
+      ::cuda::std::__throw_invalid_argument("portable dynamic shared memory limit exceeded");
     }
+  }
 
-    int size_needed = static_cast<int>(size * sizeof(Content));
+  _CCCL_TEMPLATE(class _Tp2 = _Tp)
+  _CCCL_REQUIRES(::cuda::std::is_unbounded_array_v<_Tp2>)
+  _CCCL_HOST_API constexpr dynamic_shared_memory(::cuda::std::size_t __n, non_portable_t) noexcept
+      : __base_type{__n}
+      , __non_portable_{true}
+  {}
 
-    if ((size_needed > max_dynamic_shared_size) && NonPortableSize)
+  //! @brief Gets the size of the dynamic shared memory in bytes.
+  [[nodiscard]] _CCCL_API constexpr ::cuda::std::size_t size_bytes() const noexcept
+  {
+    if constexpr (::cuda::std::is_unbounded_array_v<_Tp>)
     {
-      // TODO since 12.6 there is a per launch option available, we should switch once compatibility is not an issue
-      // TODO should we validate the max amount with device props or just pass it through and rely on driver error?
-      status = ::cuda::__driver::__functionSetAttributeNoThrow(
-        kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, size_needed);
-      if (status != cudaSuccess)
+      if (!::cuda::std::__cccl_default_is_constant_evaluated())
       {
-        return status;
+        NV_IF_TARGET(NV_IS_DEVICE, (return ::cuda::ptx::get_sreg_dynamic_smem_size();))
       }
+      return __base_type::__n_ * sizeof(value_type);
     }
+    else
+    {
+      return sizeof(_Tp);
+    }
+  }
 
-    config.sharedMemBytes = static_cast<unsigned>(size_needed);
-    return cudaSuccess;
+  [[nodiscard]] _CCCL_API constexpr view_type __make_view(value_type* __ptr) const noexcept
+  {
+    if constexpr (::cuda::std::rank_v<_Tp> == 0)
+    {
+      return *__ptr;
+    }
+    else
+    {
+      return view_type{__ptr, __base_type::__n_};
+    }
   }
 };
 
-/**
- * @brief Creates an instance of dynamic_shared_memory_option with a statically known size
- *
- * Type and size need to specified using template arguments.
- *
- * @tparam Content
- *  Type intended to be stored in dynamic shared memory
- *
- * @tparam Extent
- *  Statically specified number of Content objects in dynamic shared memory
- *
- * @tparam NonPortableSize
- *  Needs to be enabled to exceed the portable limit of 48kB of shared memory per block
- */
-template <typename Content, std::size_t Extent = 1, bool NonPortableSize = false>
-constexpr dynamic_shared_memory_option<Content, Extent, NonPortableSize> dynamic_shared_memory() noexcept
+template <class _Tp>
+[[nodiscard]] ::cudaError_t __apply_launch_option(
+  const dynamic_shared_memory<_Tp>& __opt, ::CUlaunchConfig& __config, ::CUfunction __kernel) noexcept
 {
-  static_assert(Extent != ::cuda::std::dynamic_extent, "Size needs to be provided when dynamic_extent is specified");
+  ::cudaError_t __status = ::cudaSuccess;
 
-  return dynamic_shared_memory_option<Content, Extent, NonPortableSize>(Extent);
-}
+  // Since CUDA 12.4, querying CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES requires the function to be loaded.
+  if (::cuda::__driver::__getVersion() >= 12040)
+  {
+    __status = ::cuda::__driver::__functionLoadNoThrow(__kernel);
+    if (__status != ::cudaSuccess)
+    {
+      return __status;
+    }
+  }
 
-/**
- * @brief Creates an instance of dynamic_shared_memory_option with a dynamic size
- *
- * Type stored needs to be specified using template argument, while size is a function argument
- *
- * @param count
- *  Number of Content elements in dynamic shared memory
- *
- * @tparam Content
- *  Type intended to be stored in dynamic shared memory
- *
- * @tparam NonPortableSize
- *  Needs to be enabled to exceed the portable limit of 48kB of shared memory per block
- */
-template <typename Content, bool NonPortableSize = false>
-constexpr dynamic_shared_memory_option<Content, ::cuda::std::dynamic_extent, NonPortableSize>
-dynamic_shared_memory(std::size_t count) noexcept
-{
-  return dynamic_shared_memory_option<Content, ::cuda::std::dynamic_extent, NonPortableSize>(count);
+  int __static_smem_size{};
+  __status = ::cuda::__driver::__functionGetAttributeNoThrow(
+    __static_smem_size, ::CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, __kernel);
+  if (__status != ::cudaSuccess)
+  {
+    return __status;
+  }
+
+  int __max_dyn_smem_size{};
+  __status = ::cuda::__driver::__functionGetAttributeNoThrow(
+    __max_dyn_smem_size, ::CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, __kernel);
+  if (__status != ::cudaSuccess)
+  {
+    return __status;
+  }
+
+  const auto __dyn_smem_size = ::cuda::overflow_cast<int>(__opt.size_bytes());
+  if (__dyn_smem_size.overflow)
+  {
+    return ::cudaErrorInvalidValue;
+  }
+
+  const int __smem_size = __static_smem_size + __dyn_smem_size.value;
+  if (static_cast<::cuda::std::size_t>(__smem_size) > __max_portable_dyn_smem_size && !__opt.__non_portable_)
+  {
+    return ::cudaErrorInvalidValue;
+  }
+
+  if (__max_dyn_smem_size < __dyn_smem_size.value)
+  {
+    __status = ::cuda::__driver::__functionSetAttributeNoThrow(
+      __kernel, ::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, __dyn_smem_size.value);
+    if (__status != ::cudaSuccess)
+    {
+      return __status;
+    }
+  }
+
+  __config.sharedMemBytes = static_cast<unsigned>(__dyn_smem_size.value);
+  return ::cudaSuccess;
 }
 
 /**
@@ -299,30 +383,26 @@ dynamic_shared_memory(std::size_t count) noexcept
 struct launch_priority : public __detail::launch_option
 {
   static constexpr bool needs_attribute_space        = true;
-  static constexpr bool is_relevant_on_dpevice       = false;
+  static constexpr bool is_relevant_on_device        = false;
   static constexpr __detail::launch_option_kind kind = __detail::launch_option_kind::launch_priority;
   int priority;
 
   launch_priority(int p) noexcept
       : priority(p)
   {}
-
-  template <typename Dimensions, typename... Options>
-  friend cudaError_t __detail::apply_kernel_config(
-    const kernel_config<Dimensions, Options...>& config, CUlaunchConfig& cuda_config, CUfunction kernel) noexcept;
-
-private:
-  [[nodiscard]] cudaError_t apply(CUlaunchConfig& config, CUfunction) const noexcept
-  {
-    CUlaunchAttribute attr;
-    attr.id             = CU_LAUNCH_ATTRIBUTE_PRIORITY;
-    attr.value.priority = priority;
-
-    config.attrs[config.numAttrs++] = attr;
-
-    return cudaSuccess;
-  }
 };
+
+[[nodiscard]] _CCCL_HOST_API inline cudaError_t
+__apply_launch_option(const launch_priority& __opt, CUlaunchConfig& config, CUfunction) noexcept
+{
+  CUlaunchAttribute attr;
+  attr.id             = CU_LAUNCH_ATTRIBUTE_PRIORITY;
+  attr.value.priority = __opt.priority;
+
+  config.attrs[config.numAttrs++] = attr;
+
+  return cudaSuccess;
+}
 
 template <typename... _OptionsToFilter>
 struct __filter_options
@@ -628,62 +708,27 @@ template <typename Dimensions, typename... Options>
       (void) (... && [&](cudaError_t call_status) {
         status = call_status;
         return call_status == cudaSuccess;
-      }(config_options.apply(cuda_config, kernel)));
+      }(::cuda::experimental::__apply_launch_option(config_options, cuda_config, kernel)));
     },
     config.options);
 
   return status;
 }
-
-// Needs to be a char casted to the appropriate type, if it would be a template
-//  different instantiations would clash the extern symbol
-[[nodiscard]] _CCCL_DEVICE static char* get_smem_ptr() noexcept
-{
-  extern __shared__ char dynamic_smem[];
-
-  return &dynamic_smem[0];
-}
 } // namespace __detail
 
-// Might consider cutting this one due to being a potential trap with missing & in auto& var = dynamic_smem_ref(...);
-/**
- * @brief Returns a reference to shared memory variable in dynamic shared memory
- *
- * This function returns a reference to a variable placed in dynamic shared memory.
- * It accepts a kernel_config containing a dynamic_shared_memory_option.
- * Its only usable when dynamic shared memory option is holding a single object.
- */
-template <typename Dimensions, typename... Options>
-_CCCL_DEVICE auto& dynamic_smem_ref(const kernel_config<Dimensions, Options...>& config) noexcept
+namespace device
 {
-  auto& option = __detail::find_option_in_tuple<__detail::launch_option_kind::dynamic_shared_memory>(config.options);
-  using option_type = ::cuda::std::remove_reference_t<decltype(option)>;
-  static_assert(!::cuda::std::is_same_v<option_type, __detail::option_not_found>,
-                "Dynamic shared memory option not found in the kernel configuration");
-  static_assert(option_type::extent == 1, "Usable only on dynamic shared memory with a single element");
-
-  return *reinterpret_cast<typename option_type::content_type*>(__detail::get_smem_ptr());
-}
-
-/**
- * @brief Returns a cuda::std::span object referring to dynamic shared memory region
- *
- * This function returns a std::std::span object referring to the dynamic shared memory region
- * configured when launching the kernel.
- * It accepts a kernel_config containing a dynamic_shared_memory_option.
- * It is typed and sized according to the launch option provided as input.
- */
-template <typename Dimensions, typename... Options>
-_CCCL_DEVICE auto dynamic_smem_span(const kernel_config<Dimensions, Options...>& config) noexcept
+template <class _Dims, class... _Opts>
+_CCCL_DEVICE_API decltype(auto) dynamic_shared_memory_view(const kernel_config<_Dims, _Opts...>& __config) noexcept
 {
-  auto& option = __detail::find_option_in_tuple<__detail::launch_option_kind::dynamic_shared_memory>(config.options);
-  using option_type = ::cuda::std::remove_reference_t<decltype(option)>;
-  static_assert(!::cuda::std::is_same_v<option_type, __detail::option_not_found>,
+  auto& __opt = __detail::find_option_in_tuple<__detail::launch_option_kind::dynamic_shared_memory>(__config.options);
+  using _Opt  = ::cuda::std::remove_reference_t<decltype(__opt)>;
+  static_assert(!::cuda::std::is_same_v<_Opt, __detail::option_not_found>,
                 "Dynamic shared memory option not found in the kernel configuration");
-
-  return cuda::std::span<typename option_type::content_type, option_type::extent>(
-    reinterpret_cast<typename option_type::content_type*>(__detail::get_smem_ptr()), option.size);
+  extern __shared__ unsigned char __cccl_device_dyn_smem[];
+  return __opt.__make_view(reinterpret_cast<typename _Opt::value_type*>(__cccl_device_dyn_smem));
 }
+} // namespace device
 } // namespace cuda::experimental
 #endif // _CCCL_STD_VER >= 2017
 

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -74,6 +74,10 @@ foreach (cudax_target IN LISTS cudax_TARGETS)
     launch/configuration.cu
   )
 
+  cudax_add_catch2_test(test_target launch_config_dynamic_smem ${cudax_target}
+    launch/dynamic_shared_memory.cu
+  )
+
   cudax_add_catch2_test(test_target execution ${cudax_target}
     execution/env.cu
     execution/policies/policies.cu

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -143,10 +143,10 @@ auto configuration_test(
   SECTION("Priority and dynamic smem")
   {
     CUlaunchAttribute attrs[2];
-    const int priority = 42;
-    const int num_ints = 128;
+    constexpr int priority = 42;
+    constexpr int num_ints = 128;
     auto config =
-      cudax::make_config(dims, cudax::launch_priority(priority), cudax::dynamic_shared_memory<int>(num_ints));
+      cudax::make_config(dims, cudax::launch_priority(priority), cudax::dynamic_shared_memory<int[num_ints]>());
     expectedConfig.sharedMemBytes          = num_ints * sizeof(int);
     expectedConfig.numAttrs                = 1 + HasCluster;
     expectedConfig.attrs                   = &attrs[0];
@@ -168,7 +168,7 @@ auto configuration_test(
       int arr[13 * 1024];
     };
     CUlaunchAttribute attrs[1];
-    auto config                   = cudax::make_config(dims, cudax::dynamic_shared_memory<S, 1, true>());
+    auto config                   = cudax::make_config(dims, cudax::dynamic_shared_memory<S>(cudax::non_portable));
     expectedConfig.sharedMemBytes = sizeof(S);
     expectedConfig.numAttrs       = HasCluster;
     expectedConfig.attrs          = &attrs[0];

--- a/cudax/test/launch/dynamic_shared_memory.cu
+++ b/cudax/test/launch/dynamic_shared_memory.cu
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/devices>
+#include <cuda/std/cstddef>
+#include <cuda/std/functional>
+#include <cuda/std/span>
+#include <cuda/std/type_traits>
+#include <cuda/stream>
+
+#include <cuda/experimental/hierarchy.cuh>
+#include <cuda/experimental/launch.cuh>
+
+#include <testing.cuh>
+
+template <class T, class View>
+struct TestKernel
+{
+  template <class Config>
+  __device__ void operator()(const Config& config)
+  {
+    static_assert(cuda::std::is_same_v<View, decltype(cudax::device::dynamic_shared_memory_view(config))>);
+    static_assert(noexcept(cudax::device::dynamic_shared_memory_view(config)));
+
+    write_smem(cudax::device::dynamic_shared_memory_view(config));
+  }
+
+  __device__ void write_smem(T& view)
+  {
+    view = T{};
+    CUDAX_REQUIRE(view == T{});
+  }
+
+  template <cuda::std::size_t N>
+  __device__ void write_smem(cuda::std::span<T, N> view)
+  {
+    for (cuda::std::size_t i = 0; i < view.size(); ++i)
+    {
+      view[i] = T{};
+      CUDAX_REQUIRE(view[i] == T{});
+    }
+  }
+};
+
+template <class T, class View, class Opt>
+void test_opt_and_launch(cuda::stream_ref stream, Opt opt)
+{
+  static_assert(cuda::std::is_same_v<T, typename Opt::value_type>);
+  static_assert(cuda::std::is_same_v<View, typename Opt::view_type>);
+
+  const auto config = cudax::make_config(cudax::block_dims<1, 1>(), cudax::grid_dims<1, 1>(), opt);
+  cudax::launch(stream, config, TestKernel<T, View>{});
+  stream.sync();
+}
+
+template <class T>
+void test_ref(cuda::stream_ref stream)
+{
+  static_assert(noexcept(cudax::dynamic_shared_memory<T>()));
+  test_opt_and_launch<T, T&>(stream, cudax::dynamic_shared_memory<T>());
+}
+
+void test_ref(cuda::stream_ref stream)
+{
+  test_ref<int>(stream);
+  test_ref<float>(stream);
+  test_ref<double*>(stream);
+  test_ref<void (*)()>(stream);
+}
+
+template <class T, cuda::std::size_t N>
+void test_span(cuda::stream_ref stream)
+{
+  static_assert(!noexcept(cudax::dynamic_shared_memory<T[]>(N)));
+  test_opt_and_launch<T, cuda::std::span<T>>(stream, cudax::dynamic_shared_memory<T[]>(N));
+
+  static_assert(noexcept(cudax::dynamic_shared_memory<T[N]>()));
+  test_opt_and_launch<T, cuda::std::span<T, N>>(stream, cudax::dynamic_shared_memory<T[N]>());
+}
+
+void test_span(cuda::stream_ref stream)
+{
+  test_span<int, 1>(stream);
+  test_span<int, 256>(stream);
+  test_span<float, 1>(stream);
+  test_span<float, 256>(stream);
+  test_span<double*, 1>(stream);
+  test_span<double*, 256>(stream);
+  test_span<void (*)(), 1>(stream);
+  test_span<void (*)(), 256>(stream);
+}
+
+C2H_TEST("Dynamic shared memory option", "[launch]")
+{
+  cuda::device_ref device = cuda::devices[0];
+  cuda::stream stream{device};
+
+  test_ref(stream);
+  test_span(stream);
+}

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -88,7 +88,7 @@ struct dynamic_smem_single
   template <typename Config>
   __device__ void operator()(Config config)
   {
-    auto& dynamic_smem = cudax::dynamic_smem_ref(config);
+    decltype(auto) dynamic_smem = cudax::device::dynamic_shared_memory_view(config);
     static_assert(::cuda::std::is_same_v<SmemType&, decltype(dynamic_smem)>);
     CUDAX_REQUIRE(::cuda::device::is_object_from(dynamic_smem, ::cuda::device::address_space::shared));
     kernel_run_proof = true;
@@ -101,7 +101,7 @@ struct dynamic_smem_span
   template <typename Config>
   __device__ void operator()(Config config, int size)
   {
-    auto dynamic_smem = cudax::dynamic_smem_span(config);
+    auto dynamic_smem = cudax::device::dynamic_shared_memory_view(config);
     static_assert(decltype(dynamic_smem)::extent == Extent);
     static_assert(::cuda::std::is_same_v<SmemType&, decltype(dynamic_smem[1])>);
     CUDAX_REQUIRE(dynamic_smem.size() == size);
@@ -273,7 +273,7 @@ void launch_smoke_test(StreamOrPathBuilder& dst)
       // Dynamic span
       {
         const int size = 2;
-        auto config    = input_config.add(cudax::dynamic_shared_memory<my_dynamic_smem_t>(size));
+        auto config    = input_config.add(cudax::dynamic_shared_memory<my_dynamic_smem_t[]>(size));
         cudax::launch(dst, config, dynamic_smem_span<my_dynamic_smem_t, ::cuda::std::dynamic_extent>(), size);
         check_kernel_run(dst);
       }
@@ -281,7 +281,7 @@ void launch_smoke_test(StreamOrPathBuilder& dst)
       // Static span
       {
         constexpr int size = 3;
-        auto config        = input_config.add(cudax::dynamic_shared_memory<my_dynamic_smem_t, size>());
+        auto config        = input_config.add(cudax::dynamic_shared_memory<my_dynamic_smem_t[size]>());
         cudax::launch(dst, config, dynamic_smem_span<my_dynamic_smem_t, size>(), size);
         check_kernel_run(dst);
       }

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -748,6 +748,13 @@ __functionGetAttributeNoThrow(int& __value, ::CUfunction_attribute __attr, ::CUf
   return static_cast<::cudaError_t>(__driver_fn(&__value, __attr, __kernel));
 }
 
+[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __functionLoadNoThrow(::CUfunction __kernel) noexcept
+{
+  static auto __driver_fn = reinterpret_cast<::CUresult(CUDAAPI*)(::CUfunction)>(
+    ::cuda::__driver::__get_driver_entry_point("cuFuncLoad", 12, 4));
+  return static_cast<::cudaError_t>(__driver_fn(__kernel));
+}
+
 [[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
 __functionSetAttributeNoThrow(::CUfunction __kernel, ::CUfunction_attribute __attr, int __value)
 {


### PR DESCRIPTION
Some time ago, I had an idea that we could copy the syntax of `new` or `std::make_unique` when creating the dynamic shared memory launch option and do:
```cpp
auto opt1 = cuda::dynamic_shared_memory<int>();
auto opt2 = cuda::dynamic_shared_memory<int[]>();
auto opt3 = cuda::dynamic_shared_memory<int[10]>();
```
In dependance of the type passed to the function, a `dynamic_shared_memory_option::view_type` type alias is set. The mappings are:
```cpp
T    -> T&
T[]  -> cuda::std::span<T>
T[N] -> cuda::std::span<T, N>
```
The view type is then returned from the `cuda::device::dynamic_shared_memory_view(config)` call on device.

I was also considering supporting multidimensional arrays as `T[N0][N1]` or allowing `cuda::std::extents` to be passed to the factory function resulting in a `cuda::std::mdspan` type, but I don't think it will be used.