### PR TITLE
Fix invalid reference type of `cuda::strided_iterator`

### DIFF
--- a/libcudacxx/include/cuda/__iterator/strided_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/strided_iterator.h
@@ -92,7 +92,7 @@ public:
 
   // Those are technically not to spec, but pre-ranges iterator_traits do not work properly with iterators that do not
   // define all 5 aliases, see https://en.cppreference.com/w/cpp/iterator/iterator_traits.html
-  using reference = value_type;
+  using reference = ::cuda::std::iter_reference_t<_Iter>;
   using pointer   = void;
 
   //! @brief value-initializes both the base iterator and stride

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/iterator_traits.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/iterator_traits.compile.pass.cpp
@@ -31,6 +31,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
     static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, cuda::std::iter_reference_t<int*>>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
   }
@@ -42,6 +43,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::same_as<typename IterTraits::value_type, int>);
     static_assert(cuda::std::is_signed_v<typename IterTraits::difference_type>);
     static_assert(cuda::std::same_as<typename IterTraits::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::same_as<typename IterTraits::reference, cuda::std::iter_reference_t<int*>>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::__has_random_access_traversal<Iter>);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/member_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/member_typedefs.compile.pass.cpp
@@ -27,6 +27,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::same_as<Iter::value_type, int>);
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::same_as<Iter::reference, cuda::std::iter_reference_t<int*>>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::is_trivially_copyable_v<Iter>);
   }
@@ -38,6 +39,7 @@ __host__ __device__ void test()
     static_assert(cuda::std::same_as<Iter::value_type, int>);
     static_assert(cuda::std::is_signed_v<Iter::difference_type>);
     static_assert(cuda::std::same_as<Iter::difference_type, cuda::std::iter_difference_t<int*>>);
+    static_assert(cuda::std::same_as<Iter::reference, cuda::std::iter_reference_t<int*>>);
     static_assert(cuda::std::random_access_iterator<Iter>);
     static_assert(cuda::std::is_trivially_copyable_v<Iter>);
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/star.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/star.pass.cpp
@@ -28,6 +28,8 @@ __host__ __device__ constexpr void test(Stride stride)
 
     ++iter;
     assert(*iter == 3);
+    *iter = 5;
+    assert(buffer[iter.stride()] == 5);
     assert(cuda::std::addressof(*iter) == buffer + iter.stride());
     static_assert(noexcept(*iter));
     static_assert(cuda::std::is_same_v<decltype(*iter), cuda::std::iter_reference_t<int*>>);

--- a/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/strided_iterator/subscript.pass.cpp
@@ -29,6 +29,9 @@ __host__ __device__ constexpr void test(Stride stride)
     ++iter;
     assert(iter[2] == *(buffer + 3 * iter.stride()));
     assert(cuda::std::addressof(iter[2]) == buffer + 3 * iter.stride());
+
+    iter[3] = 5;
+    assert(buffer[4 * iter.stride()] == 5);
     static_assert(noexcept(iter[2]));
     static_assert(cuda::std::is_same_v<decltype(iter[2]), cuda::std::iter_reference_t<int*>>);
   }


### PR DESCRIPTION
Fixes #6500
