### PR TITLE
Implement a way to provide a stream through the execution policy

### DIFF
--- a/libcudacxx/include/cuda/__execution/policy.h
+++ b/libcudacxx/include/cuda/__execution/policy.h
@@ -23,6 +23,8 @@
 #if _CCCL_HAS_BACKEND_CUDA()
 
 #  include <cuda/__fwd/execution_policy.h>
+#  include <cuda/__stream/get_stream.h>
+#  include <cuda/__stream/stream_ref.h>
 #  include <cuda/std/__execution/policy.h>
 #  include <cuda/std/__type_traits/is_execution_policy.h>
 
@@ -30,10 +32,112 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
+template <bool _HasStream>
+struct __policy_stream_holder
+{
+  ::cuda::stream_ref __stream_;
+
+  _CCCL_API constexpr __policy_stream_holder(::cuda::stream_ref __stream) noexcept
+      : __stream_(__stream)
+  {}
+};
+
+template <>
+struct __policy_stream_holder<false>
+{
+  _CCCL_HIDE_FROM_ABI __policy_stream_holder() = default;
+
+  //! @brief Dummy constructor to simplify implementation of the cuda policy
+  _CCCL_HOST_API constexpr __policy_stream_holder(::cuda::stream_ref) noexcept {}
+};
+
 template <uint32_t _Policy>
 struct _CCCL_DECLSPEC_EMPTY_BASES __execution_policy_base<_Policy, __execution_backend::__cuda>
     : __execution_policy_base<_Policy, __execution_backend::__none>
-{};
+    , protected __policy_stream_holder<__cuda_policy_with_stream<_Policy>>
+{
+private:
+  template <uint32_t, __execution_backend>
+  friend struct __execution_policy_base;
+
+  using __stream_holder = __policy_stream_holder<__cuda_policy_with_stream<_Policy>>;
+
+  template <uint32_t _OtherPolicy>
+  _CCCL_HOST_API constexpr __execution_policy_base(
+    const __execution_policy_base<_OtherPolicy, __execution_backend::__cuda>& __policy) noexcept
+      : __stream_holder(__policy.query(::cuda::get_stream))
+  {}
+
+  template <uint32_t _OtherPolicy>
+  _CCCL_HOST_API constexpr __execution_policy_base(
+    const __execution_policy_base<_OtherPolicy, __execution_backend::__cuda>&, ::cuda::stream_ref __stream) noexcept
+      : __stream_holder(__stream)
+  {}
+
+public:
+  _CCCL_HIDE_FROM_ABI constexpr __execution_policy_base() noexcept = default;
+
+  //! @brief Convert to a policy that holds a stream
+  //! @note This cannot be merged with the other case where we already have a stream as this needs to be const qualified
+  _CCCL_TEMPLATE(bool _WithStream = __cuda_policy_with_stream<_Policy>)
+  _CCCL_REQUIRES((!_WithStream))
+  [[nodiscard]] _CCCL_HOST_API auto set_stream(::cuda::stream_ref __stream) const noexcept
+  {
+    constexpr uint32_t __new_policy = __set_cuda_backend_option<_Policy, __cuda_backend_options::__with_stream>;
+    return __execution_policy_base<__new_policy>{*this, __stream};
+  }
+
+  //! @brief Set the current stream
+  _CCCL_TEMPLATE(bool _WithStream = __cuda_policy_with_stream<_Policy>)
+  _CCCL_REQUIRES(_WithStream)
+  [[nodiscard]] _CCCL_HOST_API __execution_policy_base& set_stream(::cuda::stream_ref __stream) noexcept
+  {
+    this->__stream_ = __stream;
+    return *this;
+  }
+
+  //! @brief Return the stream stored in the holder or a default stream
+  [[nodiscard]] _CCCL_HOST_API ::cuda::stream_ref query(const ::cuda::get_stream_t&) const noexcept
+  {
+    if constexpr (__cuda_policy_with_stream<_Policy>)
+    {
+      return this->__stream_;
+    }
+    else
+    {
+      return ::cuda::stream_ref{cudaStreamPerThread};
+    }
+  }
+
+  template <uint32_t _OtherPolicy, __execution_backend _OtherBackend>
+  [[nodiscard]] _CCCL_API friend constexpr bool operator==(
+    const __execution_policy_base& __lhs, const __execution_policy_base<_OtherPolicy, _OtherBackend>& __rhs) noexcept
+  {
+    if constexpr (_Policy != _OtherPolicy)
+    {
+      return false;
+    }
+
+    if constexpr (__cuda_policy_with_stream<_Policy>)
+    {
+      if (__lhs.query(::cuda::get_stream) != __rhs.query(::cuda::get_stream))
+      {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+#  if _CCCL_STD_VER <= 2017
+  template <uint32_t _OtherPolicy, __execution_backend _OtherBackend>
+  [[nodiscard]] _CCCL_API friend constexpr bool operator!=(
+    const __execution_policy_base& __lhs, const __execution_policy_base<_OtherPolicy, _OtherBackend>& __rhs) noexcept
+  {
+    return !(__lhs == __rhs);
+  }
+#  endif // _CCCL_STD_VER <= 2017
+};
 
 _CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
 

--- a/libcudacxx/include/cuda/__fwd/execution_policy.h
+++ b/libcudacxx/include/cuda/__fwd/execution_policy.h
@@ -28,6 +28,11 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
+enum __cuda_backend_options : uint16_t
+{
+  __with_stream = 1 << 0, ///> Determines whether the policy holds a stream
+};
+
 //! @brief Sets the execution backend to cuda
 template <uint32_t _Policy>
 [[nodiscard]] _CCCL_API constexpr uint32_t __with_cuda_backend() noexcept
@@ -37,6 +42,21 @@ template <uint32_t _Policy>
     (_Policy & __backend_mask) | (static_cast<uint32_t>(__execution_backend::__cuda) << 8);
   return __new_policy;
 }
+
+//! @brief Backend specific options of the CUDA backend
+template <uint32_t _Policy>
+inline constexpr __cuda_backend_options __policy_to_cuda_backend_options =
+  static_cast<__cuda_backend_options>((_Policy & uint32_t{0xFFFF0000}) >> 16);
+
+//! @brief Sets a backend specific optio
+template <uint32_t _Policy, __cuda_backend_options __option>
+inline constexpr uint32_t __set_cuda_backend_option =
+  _Policy | static_cast<uint32_t>(static_cast<uint32_t>(__option) << 16);
+
+//! @brief Detects whether a given policy holds a user provided stream
+template <uint32_t _Policy>
+inline constexpr bool __cuda_policy_with_stream =
+  __policy_to_cuda_backend_options<_Policy> & __cuda_backend_options::__with_stream;
 
 _CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
@@ -27,10 +27,12 @@
 
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
 #  include <cuda/std/__algorithm/for_each_n.h>
 #  include <cuda/std/__exception/cuda_error.h>
 #  include <cuda/std/__exception/terminate.h>
+#  include <cuda/std/__execution/env.h>
 #  include <cuda/std/__execution/policy.h>
 #  include <cuda/std/__iterator/iterator_traits.h>
 #  include <cuda/std/__pstl/dispatch.h>
@@ -54,7 +56,8 @@ struct __pstl_dispatch<__pstl_algorithm::__for_each_n, __execution_backend::__cu
   __par_impl([[maybe_unused]] _Policy __policy, _Iter __first, _Size __orig_n, _Fn __func) noexcept
   {
     const auto __count = ::cuda::std::__convert_to_integral(__orig_n);
-    ::cuda::stream_ref __stream{cudaStreamPerThread};
+
+    auto __stream = __policy.query(::cuda::get_stream);
 
     _CCCL_TRY_CUDA_API(
       ::cub::DeviceFor::ForEachN,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
@@ -32,6 +32,7 @@ _CCCL_DIAG_POP
 
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/__stream/get_stream.h>
 #  include <cuda/std/__exception/cuda_error.h>
 #  include <cuda/std/__execution/env.h>
 #  include <cuda/std/__execution/policy.h>
@@ -61,9 +62,14 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
   {
     // Allocate memory for result
     _Tp* __device_ret_ptr = nullptr;
+    auto __stream         = __policy.query(::cuda::get_stream);
 
     _CCCL_TRY_CUDA_API(
-      ::cudaMalloc, "__pstl_cuda_reduce: allocation failed", reinterpret_cast<void**>(&__device_ret_ptr), sizeof(_Tp));
+      ::cudaMallocAsync,
+      "__pstl_cuda_reduce: allocation failed",
+      reinterpret_cast<void**>(&__device_ret_ptr),
+      sizeof(_Tp),
+      __stream.get());
 
     const auto __count = ::cuda::std::distance(__first, __last);
     _Tp __ret;
@@ -79,14 +85,17 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
       ::cuda::std::move(__policy));
 
     _CCCL_TRY_CUDA_API(
-      ::cudaMemcpy,
+      ::cudaMemcpyAsync,
       "__pstl_cuda_reduce: copy of result from device to host failed",
       ::cuda::std::addressof(__ret),
       __device_ret_ptr,
       sizeof(_Tp),
-      ::cudaMemcpyDeviceToHost);
+      ::cudaMemcpyDeviceToHost,
+      __stream.get());
 
-    _CCCL_TRY_CUDA_API(::cudaFree, "__pstl_cuda_reduce: deallocate failed", __device_ret_ptr);
+    _CCCL_TRY_CUDA_API(::cudaFreeAsync, "__pstl_cuda_reduce: deallocate failed", __device_ret_ptr, __stream.get());
+
+    __stream.sync();
 
     return __ret;
   }

--- a/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_stream.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_stream.pass.cpp
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/memory_resource>
+#include <cuda/std/__pstl/for_each.h>
+#include <cuda/std/execution>
+#include <cuda/std/memory>
+#include <cuda/std/type_traits>
+#include <cuda/stream>
+
+#include <nv/target>
+
+template <class Policy>
+void test(Policy pol)
+{
+  namespace execution = cuda::std::execution;
+  static_assert(!execution::__queryable_with<execution::sequenced_policy, ::cuda::get_stream_t>);
+  static_assert(!execution::__queryable_with<execution::parallel_policy, ::cuda::get_stream_t>);
+  static_assert(!execution::__queryable_with<execution::parallel_unsequenced_policy, ::cuda::get_stream_t>);
+  static_assert(!execution::__queryable_with<execution::unsequenced_policy, ::cuda::get_stream_t>);
+
+  { // Ensure that the plain policy returns a well defined stream
+    cuda::stream_ref expected_stream{cudaStreamPerThread};
+    assert(cuda::get_stream(pol) == expected_stream);
+  }
+
+  { // Ensure that we can attach a stream to an execution policy
+    cuda::stream stream{cuda::device_ref{0}};
+    auto pol_with_stream = pol.set_stream(stream);
+    assert(cuda::get_stream(pol_with_stream) == stream);
+
+    using stream_policy_t = decltype(pol_with_stream);
+    static_assert(noexcept(pol.set_stream(stream)));
+    static_assert(cuda::std::is_execution_policy_v<stream_policy_t>);
+    static_assert(cuda::std::is_base_of_v<cuda::std::execution::__policy_stream_holder<true>, stream_policy_t>);
+  }
+
+  { // Ensure that attaching a stream multiple times just overwrites the old stream
+    cuda::stream stream{cuda::device_ref{0}};
+    auto pol_with_stream = pol.set_stream(stream);
+    assert(cuda::get_stream(pol_with_stream) == stream);
+
+    using stream_policy_t = decltype(pol_with_stream);
+    cuda::stream other_stream{cuda::device_ref{0}};
+    decltype(auto) pol_with_other_stream = pol_with_stream.set_stream(other_stream);
+    static_assert(cuda::std::is_same_v<decltype(pol_with_other_stream), stream_policy_t&>);
+    assert(::cuda::get_stream(pol_with_stream) == other_stream);
+    assert(::cuda::get_stream(pol_with_other_stream) == other_stream);
+    assert(cuda::std::addressof(pol_with_stream) == cuda::std::addressof(pol_with_other_stream));
+  }
+}
+
+void test()
+{
+  namespace execution = cuda::std::execution;
+  static_assert(!execution::__queryable_with<execution::sequenced_policy, ::cuda::get_stream_t>);
+  static_assert(!execution::__queryable_with<execution::parallel_policy, ::cuda::get_stream_t>);
+  static_assert(!execution::__queryable_with<execution::parallel_unsequenced_policy, ::cuda::get_stream_t>);
+  static_assert(!execution::__queryable_with<execution::unsequenced_policy, ::cuda::get_stream_t>);
+
+  test(cuda::execution::__cub_par_unseq);
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, (test();))
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each.cu
@@ -21,6 +21,7 @@
 #include <cuda/std/__pstl/for_each.h>
 #include <cuda/std/execution>
 #include <cuda/std/functional>
+#include <cuda/stream>
 
 #include <testing.cuh>
 #include <utility.cuh>
@@ -40,10 +41,24 @@ struct mark_present_for_each
 
 C2H_TEST("cuda::std::for_each", "[parallel algorithm]")
 {
-  thrust::device_vector<bool> res(size, false);
-  mark_present_for_each fn{thrust::raw_pointer_cast(res.data())};
+  SECTION("with default stream")
+  {
+    thrust::device_vector<bool> res(size, false);
+    mark_present_for_each fn{thrust::raw_pointer_cast(res.data())};
 
-  const auto policy = cuda::execution::__cub_par_unseq;
-  cuda::std::for_each(policy, cuda::counting_iterator{0}, cuda::counting_iterator{size}, fn);
-  CHECK(thrust::all_of(res.begin(), res.end(), cuda::std::identity{}));
+    const auto policy = cuda::execution::__cub_par_unseq;
+    cuda::std::for_each(policy, cuda::counting_iterator{0}, cuda::counting_iterator{size}, fn);
+    CHECK(thrust::all_of(res.begin(), res.end(), cuda::std::identity{}));
+  }
+
+  SECTION("with unique stream")
+  {
+    ::cuda::stream stream{::cuda::device_ref{0}};
+    thrust::device_vector<bool> res(size, false);
+    mark_present_for_each fn{thrust::raw_pointer_cast(res.data())};
+
+    const auto policy = cuda::execution::__cub_par_unseq.set_stream(stream);
+    cuda::std::for_each(policy, cuda::counting_iterator{0}, cuda::counting_iterator{size}, fn);
+    CHECK(thrust::all_of(res.begin(), res.end(), cuda::std::identity{}));
+  }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each_n.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each_n.cu
@@ -21,6 +21,7 @@
 #include <cuda/std/__pstl/for_each_n.h>
 #include <cuda/std/execution>
 #include <cuda/std/functional>
+#include <cuda/stream>
 
 #include <testing.cuh>
 #include <utility.cuh>
@@ -40,10 +41,24 @@ struct mark_present_for_each
 
 C2H_TEST("cuda::std::for_each_n", "[parallel algorithm]")
 {
-  thrust::device_vector<bool> res(size, false);
-  mark_present_for_each fn{thrust::raw_pointer_cast(res.data())};
+  SECTION("with default stream")
+  {
+    thrust::device_vector<bool> res(size, false);
+    mark_present_for_each fn{thrust::raw_pointer_cast(res.data())};
 
-  const auto policy = cuda::execution::__cub_par_unseq;
-  cuda::std::for_each_n(policy, cuda::counting_iterator{0}, size, fn);
-  CHECK(thrust::all_of(res.begin(), res.end(), cuda::std::identity{}));
+    const auto policy = cuda::execution::__cub_par_unseq;
+    cuda::std::for_each_n(policy, cuda::counting_iterator{0}, size, fn);
+    CHECK(thrust::all_of(res.begin(), res.end(), cuda::std::identity{}));
+  }
+
+  SECTION("with unique stream")
+  {
+    ::cuda::stream stream{::cuda::device_ref{0}};
+    thrust::device_vector<bool> res(size, false);
+    mark_present_for_each fn{thrust::raw_pointer_cast(res.data())};
+
+    const auto policy = cuda::execution::__cub_par_unseq.set_stream(stream);
+    cuda::std::for_each_n(policy, cuda::counting_iterator{0}, size, fn);
+    CHECK(thrust::all_of(res.begin(), res.end(), cuda::std::identity{}));
+  }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/pstl_reduce.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/pstl_reduce.cu
@@ -25,6 +25,7 @@
 #include <cuda/std/__pstl/reduce.h>
 #include <cuda/std/execution>
 #include <cuda/std/functional>
+#include <cuda/stream>
 
 #include <testing.cuh>
 #include <utility.cuh>
@@ -35,32 +36,70 @@ inline constexpr int size = 100;
 
 C2H_TEST("cuda::std::reduce(Iter, Iter)", "[parallel algorithm]")
 {
-  thrust::device_vector<int> data(size);
-  thrust::sequence(data.begin(), data.end(), 1);
+  SECTION("with default stream")
+  {
+    thrust::device_vector<int> data(size);
+    thrust::sequence(data.begin(), data.end(), 1);
 
-  const auto policy  = cuda::execution::__cub_par_unseq;
-  decltype(auto) res = cuda::std::reduce(policy, data.begin(), data.end());
+    const auto policy  = cuda::execution::__cub_par_unseq;
+    decltype(auto) res = cuda::std::reduce(policy, data.begin(), data.end());
 #if !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
-  static_assert(cuda::std::is_same_v<decltype(res), int>);
+    static_assert(cuda::std::is_same_v<decltype(res), int>);
 #endif // !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
 
-  constexpr int expected = size * (size + 1) / 2;
-  CHECK(res == expected);
+    constexpr int expected = size * (size + 1) / 2;
+    CHECK(res == expected);
+  }
+
+  SECTION("with provided stream")
+  {
+    thrust::device_vector<int> data(size);
+    thrust::sequence(data.begin(), data.end(), 1);
+
+    ::cuda::stream stream{::cuda::device_ref{0}};
+    const auto policy  = cuda::execution::__cub_par_unseq.set_stream(stream);
+    decltype(auto) res = cuda::std::reduce(policy, data.begin(), data.end());
+#if !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
+    static_assert(cuda::std::is_same_v<decltype(res), int>);
+#endif // !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
+
+    constexpr int expected = size * (size + 1) / 2;
+    CHECK(res == expected);
+  }
 }
 
 C2H_TEST("cuda::std::reduce(Iter, Iter, Tp)", "[parallel algorithm]")
 {
-  thrust::device_vector<int> data(size);
-  thrust::sequence(data.begin(), data.end(), 1);
+  SECTION("with default stream")
+  {
+    thrust::device_vector<int> data(size);
+    thrust::sequence(data.begin(), data.end(), 1);
 
-  const auto policy  = cuda::execution::__cub_par_unseq;
-  decltype(auto) res = cuda::std::reduce(policy, data.begin(), data.end(), 42);
+    const auto policy  = cuda::execution::__cub_par_unseq;
+    decltype(auto) res = cuda::std::reduce(policy, data.begin(), data.end(), 42);
 #if !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
-  static_assert(cuda::std::is_same_v<decltype(res), int>);
+    static_assert(cuda::std::is_same_v<decltype(res), int>);
 #endif // !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
 
-  constexpr int expected = size * (size + 1) / 2 + 42;
-  CHECK(res == expected);
+    constexpr int expected = size * (size + 1) / 2 + 42;
+    CHECK(res == expected);
+  }
+
+  SECTION("with provided stream")
+  {
+    thrust::device_vector<int> data(size);
+    thrust::sequence(data.begin(), data.end(), 1);
+
+    ::cuda::stream stream{::cuda::device_ref{0}};
+    const auto policy  = cuda::execution::__cub_par_unseq.set_stream(stream);
+    decltype(auto) res = cuda::std::reduce(policy, data.begin(), data.end(), 42);
+#if !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
+    static_assert(cuda::std::is_same_v<decltype(res), int>);
+#endif // !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
+
+    constexpr int expected = size * (size + 1) / 2 + 42;
+    CHECK(res == expected);
+  }
 }
 
 struct plus_two
@@ -73,15 +112,34 @@ struct plus_two
 
 C2H_TEST("cuda::std::reduce(Iter, Iter, Tp, Fn)", "[parallel algorithm]")
 {
-  thrust::device_vector<int> data(size);
-  thrust::sequence(data.begin(), data.end(), 1);
+  SECTION("with default stream")
+  {
+    thrust::device_vector<int> data(size);
+    thrust::sequence(data.begin(), data.end(), 1);
 
-  const auto policy  = cuda::execution::__cub_par_unseq;
-  decltype(auto) res = cuda::std::reduce(policy, data.begin(), data.end(), 42, plus_two{});
+    const auto policy  = cuda::execution::__cub_par_unseq;
+    decltype(auto) res = cuda::std::reduce(policy, data.begin(), data.end(), 42, plus_two{});
 #if !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
-  static_assert(cuda::std::is_same_v<decltype(res), int>);
+    static_assert(cuda::std::is_same_v<decltype(res), int>);
 #endif // !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
 
-  constexpr int expected = size * (size + 1) / 2 + 42 + size * 2;
-  CHECK(res == expected);
+    constexpr int expected = size * (size + 1) / 2 + 42 + size * 2;
+    CHECK(res == expected);
+  }
+
+  SECTION("with provided stream")
+  {
+    thrust::device_vector<int> data(size);
+    thrust::sequence(data.begin(), data.end(), 1);
+
+    ::cuda::stream stream{::cuda::device_ref{0}};
+    const auto policy  = cuda::execution::__cub_par_unseq.set_stream(stream);
+    decltype(auto) res = cuda::std::reduce(policy, data.begin(), data.end(), 42, plus_two{});
+#if !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
+    static_assert(cuda::std::is_same_v<decltype(res), int>);
+#endif // !TEST_CUDA_COMPILER(NVCC, <, 12, 5)
+
+    constexpr int expected = size * (size + 1) / 2 + 42 + size * 2;
+    CHECK(res == expected);
+  }
 }


### PR DESCRIPTION
This implements a specialization of our execution policies for the cuda backend that provides a stream.

It also adds an policy wrapper that can be used to store a user provided stream