### PR TITLE
[DO NOT MERGE] Fix Host `isnan`, `isinf`, etc.  handling in some `math.h` implementations

### DIFF
--- a/libcudacxx/include/cuda/std/__cmath/isfinite.h
+++ b/libcudacxx/include/cuda/std/__cmath/isfinite.h
@@ -46,11 +46,7 @@ template <class _Tp>
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-#if defined(isfinite)
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::isfinite(__x);), (return isfinite(__x);));
-#else // ^^^ macro ^^^ / vvv function vvv
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::isfinite(__x);), (return ::isfinite(__x);));
-#endif // function
+    return isfinite(__x);
   }
   return !::cuda::std::isnan(__x) && !::cuda::std::isinf(__x);
 }
@@ -62,11 +58,7 @@ template <class _Tp>
 #else // ^^^ _CCCL_BUILTIN_ISFINITE ^^^ / vvv !_CCCL_BUILTIN_ISFINITE vvv
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-#  if defined(isfinite)
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::isfinite(__x);), (return isfinite(__x);));
-#  else // ^^^ macro ^^^ / vvv function vvv
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::isfinite(__x);), (return ::isfinite(__x);));
-#  endif // function
+    return isfinite(__x);
   }
 #  if _CCCL_HAS_CONSTEXPR_BIT_CAST()
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mask_of_v<float>) != __fp_exp_mask_of_v<float>;
@@ -83,7 +75,7 @@ template <class _Tp>
 #else // ^^^ _CCCL_BUILTIN_ISFINITE ^^^ / vvv !_CCCL_BUILTIN_ISFINITE vvv
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    return ::isfinite(__x);
+    return isfinite(__x);
   }
 #  if _CCCL_HAS_CONSTEXPR_BIT_CAST()
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mask_of_v<double>) != __fp_exp_mask_of_v<double>;

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -47,11 +47,7 @@ template <class _Tp>
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-#if defined(isinf)
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::isinf(__x);), (return isinf(__x);));
-#else // ^^^ macro ^^^ / vvv function vvv
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::isinf(__x);), (return ::isinf(__x);));
-#endif // function
+    return isinf(__x);
   }
   if (::cuda::std::isnan(__x))
   {
@@ -74,11 +70,7 @@ template <class _Tp>
 #elif _CCCL_HAS_CONSTEXPR_BIT_CAST()
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-#  if defined(isinf)
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::isinf(__x);), (return isinf(__x);));
-#  else // ^^^ macro ^^^ / vvv function vvv
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::isinf(__x);), (return ::isinf(__x);));
-#  endif // function
+    return isinf(__x);
   }
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<float>) == __fp_exp_mask_of_v<float>;
 #else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
@@ -100,7 +92,7 @@ template <class _Tp>
 #elif _CCCL_HAS_CONSTEXPR_BIT_CAST()
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-    return ::isinf(__x);
+    return isinf(__x);
   }
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<double>) == __fp_exp_mask_of_v<double>;
 #else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv

--- a/libcudacxx/include/cuda/std/__cmath/isnan.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnan.h
@@ -45,11 +45,7 @@ template <class _Tp>
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   if (!::cuda::std::__cccl_default_is_constant_evaluated())
   {
-#if defined(isnan)
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::isnan(__x);), (return isnan(__x);));
-#else // ^^^ macro ^^^ / vvv function vvv
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::isnan(__x);), (return ::isnan(__x);));
-#endif // function
+    return isnan(__x);
   }
   return __x != __x;
 }

--- a/libcudacxx/include/cuda/std/__cmath/traits.h
+++ b/libcudacxx/include/cuda/std/__cmath/traits.h
@@ -64,11 +64,7 @@ template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 #  if defined(_CCCL_BUILTIN_ISGREATER)
   return _CCCL_BUILTIN_ISGREATER(__x, __y);
 #  else // ^^^ _CCCL_BUILTIN_ISGREATER ^^^ / vvv !_CCCL_BUILTIN_ISGREATER vvv
-#    if defined(isgreater)
   return isgreater(__x, __y);
-#    else // ^^^ macro ^^^ / vvv function vvv
-  return ::isgreater(__x, __y);
-#    endif // function
 #  endif // !_CCCL_BUILTIN_ISGREATER
 }
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -105,11 +101,7 @@ template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 #  if defined(_CCCL_BUILTIN_ISGREATEREQUAL)
   return _CCCL_BUILTIN_ISGREATEREQUAL(__x, __y);
 #  else // ^^^ _CCCL_BUILTIN_ISGREATEREQUAL ^^^ / vvv !_CCCL_BUILTIN_ISGREATEREQUAL vvv
-#    if defined(isgreaterequal)
   return isgreaterequal(__x, __y);
-#    else // ^^^ macro ^^^ / vvv function vvv
-  return ::isgreaterequal(__x, __y);
-#    endif // function
 #  endif // !_CCCL_BUILTIN_ISGREATEREQUAL
 }
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -146,11 +138,7 @@ template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 #  if defined(_CCCL_BUILTIN_ISLESS)
   return _CCCL_BUILTIN_ISLESS(__x, __y);
 #  else // ^^^ _CCCL_BUILTIN_ISLESS ^^^ / vvv !_CCCL_BUILTIN_ISLESS vvv
-#    if defined(isless)
   return isless(__x, __y);
-#    else // ^^^ macro ^^^ / vvv function vvv
-  return ::isless(__x, __y);
-#    endif // function
 #  endif // !_CCCL_BUILTIN_ISLESS
 }
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -187,11 +175,7 @@ template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 #  if defined(_CCCL_BUILTIN_ISLESSEQUAL)
   return _CCCL_BUILTIN_ISLESSEQUAL(__x, __y);
 #  else // ^^^ _CCCL_BUILTIN_ISLESSEQUAL ^^^ / vvv !_CCCL_BUILTIN_ISLESSEQUAL vvv
-#    if defined(islessequal)
   return islessequal(__x, __y);
-#    else // ^^^ macro ^^^ / vvv function vvv
-  return ::islessequal(__x, __y);
-#    endif // function
 #  endif // !_CCCL_BUILTIN_ISLESSEQUAL
 }
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -228,11 +212,7 @@ template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 #  if defined(_CCCL_BUILTIN_ISLESSGREATER)
   return _CCCL_BUILTIN_ISLESSGREATER(__x, __y);
 #  else // ^^^ _CCCL_BUILTIN_ISLESSGREATER ^^^ / vvv !_CCCL_BUILTIN_ISLESSGREATER vvv
-#    if defined(islessgreater)
   return islessgreater(__x, __y);
-#    else // ^^^ macro ^^^ / vvv function vvv
-  return ::islessgreater(__x, __y);
-#    endif // function
 #  endif // !_CCCL_BUILTIN_ISLESSGREATER
 }
 #endif // !_CCCL_COMPILER(NVRTC)


### PR DESCRIPTION
## Description

`isnan`, `isinf` and other utilities in  `math.h`  can be implemented as a macro or a function, depending on the implementation. 
Most x86 implementations provide it as a function. Some Arm64 implementations provide it as a macro.

This PR adds the host fallback with `isnan` instead of `::isnan` when the utility is implemented as a macro.