### PR TITLE
Add launch bounds to block_reduce_kernel

### DIFF
--- a/cub/test/catch2_test_block_reduce.cu
+++ b/cub/test/catch2_test_block_reduce.cu
@@ -15,8 +15,8 @@ template <cub::BlockReduceAlgorithm Algorithm,
           int BlockDimZ,
           class T,
           class ActionT>
-__launch_bounds__(BlockDimX * BlockDimY * BlockDimZ)
-__global__ void block_reduce_kernel(T* in, T* out, int valid_items, ActionT action)
+__launch_bounds__(BlockDimX* BlockDimY* BlockDimZ) __global__
+  void block_reduce_kernel(T* in, T* out, int valid_items, ActionT action)
 {
   using block_reduce_t = cub::BlockReduce<T, BlockDimX, Algorithm, BlockDimY, BlockDimZ>;
   using storage_t      = typename block_reduce_t::TempStorage;


### PR DESCRIPTION
This prevents out-of-resources launch failures in unoptimized builds.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #6532 <!-- Link issue here -->

Set `__launch_bounds__` for the kernel, to avoid launch failures caused by the kernel using too many registers in unoptimized builds.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [n/a] The documentation is up to date with these changes.
