### PR TITLE
`cuda::align_up/down` workaround for memory space

### DIFF
--- a/docs/libcudacxx/extended_api/memory/align_down.rst
+++ b/docs/libcudacxx/extended_api/memory/align_down.rst
@@ -29,6 +29,8 @@ The function returns the original pointer or closest pointer smaller than ``ptr`
 **Performance considerations**
 
 - The function is optimized for compile-time values of ``alignment``.
+- The function does not perform any operations if ``alignment == alignof(T)``.
+- The function is translated to a single ``LOP3.LUT`` instruction for other values of ``alignment``.
 - The returned pointer is decorated with ``__builtin_assume_aligned`` to help the compiler generate better code.
 - The returned pointer maintains the same memory space, for example shared memory, as the input pointer.
 

--- a/docs/libcudacxx/extended_api/memory/align_up.rst
+++ b/docs/libcudacxx/extended_api/memory/align_up.rst
@@ -29,13 +29,15 @@ The function returns the original pointer or closest pointer larger than ``ptr``
 **Performance considerations**
 
 - The function is optimized for compile-time values of ``alignment``.
+- The function does not perform any operations if ``alignment == alignof(T)``.
+- The function is translated to ``LOP3.LUT`` + ``IADD.64`` instructions for other values of ``alignment``.
 - The returned pointer is decorated with ``__builtin_assume_aligned`` to help the compiler generate better code.
 - The returned pointer maintains the same memory space, for example shared memory, as the input pointer.
 
 Example
 -------
 
-.. code:: cuda
+.. code:: cudas
 
     #include <cuda/memory>
 

--- a/libcudacxx/include/cuda/__memory/align_up.h
+++ b/libcudacxx/include/cuda/__memory/align_up.h
@@ -22,9 +22,10 @@
 #endif // no system header
 
 #include <cuda/__cmath/pow2.h>
+#include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__memory/runtime_assume_aligned.h>
 #include <cuda/std/__type_traits/is_void.h>
-#include <cuda/std/cstddef>
+#include <cuda/std/__type_traits/remove_cv.h>
 #include <cuda/std/cstdint>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -34,18 +35,25 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 template <typename _Tp>
 [[nodiscard]] _CCCL_API inline _Tp* align_up(_Tp* __ptr, ::cuda::std::size_t __alignment) noexcept
 {
+  using ::cuda::std::uintptr_t;
   _CCCL_ASSERT(::cuda::is_power_of_two(__alignment), "alignment must be a power of two");
   if constexpr (!::cuda::std::is_void_v<_Tp>)
   {
     _CCCL_ASSERT(__alignment >= alignof(_Tp), "wrong alignment");
-    _CCCL_ASSERT(reinterpret_cast<::cuda::std::uintptr_t>(__ptr) % alignof(_Tp) == 0, "ptr is not aligned");
+    _CCCL_ASSERT(reinterpret_cast<uintptr_t>(__ptr) % alignof(_Tp) == 0, "ptr is not aligned");
     if (__alignment == alignof(_Tp))
     {
       return __ptr;
     }
   }
-  auto __tmp = static_cast<::cuda::std::uintptr_t>(__alignment - 1);
-  auto __ret = reinterpret_cast<_Tp*>((reinterpret_cast<::cuda::std::uintptr_t>(__ptr) + __tmp) & ~__tmp);
+  // all code below is translated to LOP3.LUT + IADD.64 instructions
+  using _Up                = ::cuda::std::remove_cv_t<_Tp>;
+  const auto __char_ptr    = reinterpret_cast<char*>(const_cast<_Up*>(__ptr));
+  const auto __tmp         = static_cast<uintptr_t>(__alignment - 1);
+  const auto __aligned_ptr = reinterpret_cast<char*>((reinterpret_cast<uintptr_t>(__ptr) + __tmp) & ~__tmp);
+  // __aligned_ptr and __ptr must be pointers (not values) to apply the optimization
+  const auto __diff = static_cast<::cuda::std::size_t>(__aligned_ptr - __char_ptr);
+  const auto __ret  = reinterpret_cast<_Tp*>(__char_ptr + __diff);
   return ::cuda::std::__runtime_assume_aligned(__ret, __alignment);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_down.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_down.pass.cpp
@@ -12,32 +12,42 @@
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
 
-template <typename T, typename U>
+template <typename T>
+__host__ __device__ void test_impl()
+{
+  if constexpr (alignof(T) <= 2)
+  {
+    uintptr_t ptr_int = 10;
+    auto ptr          = reinterpret_cast<T>(ptr_int);
+    assert(cuda::align_down(ptr, 1) == ptr);
+    assert(cuda::align_down(ptr, 2) == ptr);
+    assert(cuda::align_down(ptr, 4) == reinterpret_cast<T>(8));
+    assert(cuda::align_down(ptr, 8) == reinterpret_cast<T>(8));
+  }
+  uintptr_t ptr_int2 = 12;
+  auto ptr2          = reinterpret_cast<T>(ptr_int2);
+  assert(cuda::align_down(ptr2, 8) == reinterpret_cast<T>(8));
+  size_t align = 8;
+  assert(cuda::align_down(ptr2, align) == reinterpret_cast<T>(8)); // run-time alignment
+}
+
+template <typename T>
 __host__ __device__ void test()
 {
-  uintptr_t ptr_int = 10;
-  auto ptr          = reinterpret_cast<T>(ptr_int);
-  assert(cuda::align_down(ptr, 1) == ptr);
-  assert(cuda::align_down(ptr, 2) == ptr);
-  assert(cuda::align_down(ptr, 4) == reinterpret_cast<T>(8));
-  assert(cuda::align_down(ptr, 8) == reinterpret_cast<T>(8));
-  uintptr_t ptr_int2 = 12;
-  auto ptr2          = reinterpret_cast<U>(ptr_int2);
-  assert(cuda::align_down(ptr2, 8) == reinterpret_cast<U>(8));
-  size_t align = 8;
-  assert(cuda::align_down(ptr2, align) == reinterpret_cast<U>(8)); // run-time alignment
+  test_impl<T*>();
+  test_impl<const T*>();
+  test_impl<volatile T*>();
+  test_impl<const volatile T*>();
 }
 
 __host__ __device__ bool test()
 {
-  test<char*, int*>();
-  test<const char*, const int*>();
-  test<volatile char*, volatile int*>();
-  test<const volatile char*, const volatile int*>();
-  test<void*, void*>();
+  test<char>();
+  test<short>();
+  test<int>();
+  test<void>();
   return true;
 }
-
 __global__ void test_kernel()
 {
   __shared__ int smem_value[4];

--- a/libcudacxx/test/libcudacxx/cuda/memory/align_up.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/align_up.pass.cpp
@@ -12,27 +12,38 @@
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
 
-template <typename T, typename U>
+template <typename T>
+__host__ __device__ void test_impl()
+{
+  if constexpr (alignof(T) <= 2)
+  {
+    uintptr_t ptr_int = 10;
+    auto ptr          = reinterpret_cast<T>(ptr_int);
+    assert(cuda::align_up(ptr, 1) == ptr);
+    assert(cuda::align_up(ptr, 2) == ptr);
+    assert(cuda::align_up(ptr, 4) == reinterpret_cast<T>(12));
+    assert(cuda::align_up(ptr, 8) == reinterpret_cast<T>(16));
+  }
+  uintptr_t ptr_int2 = 12;
+  auto ptr2          = reinterpret_cast<T>(ptr_int2);
+  assert(cuda::align_up(ptr2, 8) == reinterpret_cast<T>(16));
+}
+
+template <typename T>
 __host__ __device__ void test()
 {
-  uintptr_t ptr_int = 10;
-  auto ptr          = reinterpret_cast<T>(ptr_int);
-  assert(cuda::align_up(ptr, 1) == ptr);
-  assert(cuda::align_up(ptr, 2) == ptr);
-  assert(cuda::align_up(ptr, 4) == reinterpret_cast<T>(12));
-  assert(cuda::align_up(ptr, 8) == reinterpret_cast<T>(16));
-  uintptr_t ptr_int2 = 12;
-  auto ptr2          = reinterpret_cast<U>(ptr_int2);
-  assert(cuda::align_up(ptr2, 8) == reinterpret_cast<U>(16));
+  test_impl<T*>();
+  test_impl<const T*>();
+  test_impl<volatile T*>();
+  test_impl<const volatile T*>();
 }
 
 __host__ __device__ bool test()
 {
-  test<char*, int*>();
-  test<const char*, const int*>();
-  test<volatile char*, volatile int*>();
-  test<const volatile char*, const volatile int*>();
-  test<void*, void*>();
+  test<char>();
+  test<short>();
+  test<int>();
+  test<void>();
   return true;
 }
 


### PR DESCRIPTION
Address #6528

Ensure that `align_down` and `align_up` return pointers in the same memory space of the input, while keeping optimal code.
Took me a while, but I was able to find the right pattern that the compiler is able to optimize for both functions.

Kept the opportunity to improve related documentation and unit test.