### PR TITLE
Allow `__builtin_bitreverse` with clang-cuda

### DIFF
--- a/libcudacxx/include/cuda/__bit/bit_reverse.h
+++ b/libcudacxx/include/cuda/__bit/bit_reverse.h
@@ -27,6 +27,30 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_CHECK_BUILTIN(builtin_bitreverse8)
+#  define _CCCL_BUILTIN_BITREVERSE8(...) __builtin_bitreverse8(__VA_ARGS__)
+#endif
+
+#if _CCCL_CHECK_BUILTIN(builtin_bitreverse16)
+#  define _CCCL_BUILTIN_BITREVERSE16(...) __builtin_bitreverse16(__VA_ARGS__)
+#endif
+
+#if _CCCL_CHECK_BUILTIN(builtin_bitreverse32)
+#  define _CCCL_BUILTIN_BITREVERSE32(...) __builtin_bitreverse32(__VA_ARGS__)
+#endif
+
+#if _CCCL_CHECK_BUILTIN(builtin_bitreverse64)
+#  define _CCCL_BUILTIN_BITREVERSE64(...) __builtin_bitreverse64(__VA_ARGS__)
+#endif
+
+// nvcc doesn't allow clang's bitreverse builtin
+#if _CCCL_CUDA_COMPILER(NVCC)
+#  undef _CCCL_BUILTIN_BITREVERSE8
+#  undef _CCCL_BUILTIN_BITREVERSE16
+#  undef _CCCL_BUILTIN_BITREVERSE32
+#  undef _CCCL_BUILTIN_BITREVERSE64
+#endif // _CCCL_CUDA_COMPILER(NVCC)
+
 _CCCL_BEGIN_NAMESPACE_CUDA
 
 #if defined(_CCCL_BUILTIN_BITREVERSE32)
@@ -37,20 +61,22 @@ template <typename _Tp>
 #  if _CCCL_HAS_INT128()
   if constexpr (sizeof(_Tp) == sizeof(__uint128_t))
   {
-    auto __high = static_cast<__uint128_t>(_CCCL_BUILTIN_BITREVERSE64(static_cast<uint64_t>(__value))) << 64;
-    auto __low  = static_cast<__uint128_t>(_CCCL_BUILTIN_BITREVERSE64(static_cast<uint64_t>(__value >> 64)));
+    auto __high = static_cast<__uint128_t>(_CCCL_BUILTIN_BITREVERSE64(static_cast<::cuda::std::uint64_t>(__value)))
+               << 64;
+    auto __low =
+      static_cast<__uint128_t>(_CCCL_BUILTIN_BITREVERSE64(static_cast<::cuda::std::uint64_t>(__value >> 64)));
     return __high | __low;
   }
 #  endif // _CCCL_HAS_INT128()
-  if constexpr (sizeof(_Tp) == sizeof(uint64_t))
+  if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint64_t))
   {
     return _CCCL_BUILTIN_BITREVERSE64(__value);
   }
-  else if constexpr (sizeof(_Tp) == sizeof(uint32_t))
+  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint32_t))
   {
     return _CCCL_BUILTIN_BITREVERSE32(__value);
   }
-  else if constexpr (sizeof(_Tp) == sizeof(uint16_t))
+  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint16_t))
   {
     return _CCCL_BUILTIN_BITREVERSE16(__value);
   }
@@ -70,26 +96,28 @@ template <typename _Tp>
 #  if _CCCL_HAS_INT128()
   if constexpr (sizeof(_Tp) == sizeof(__uint128_t))
   {
-    auto __high = static_cast<__uint128_t>(::cuda::__bit_reverse_device(static_cast<uint64_t>(__value))) << 64;
-    auto __low  = static_cast<__uint128_t>(::cuda::__bit_reverse_device(static_cast<uint64_t>(__value >> 64)));
+    auto __high = static_cast<__uint128_t>(::cuda::__bit_reverse_device(static_cast<::cuda::std::uint64_t>(__value)))
+               << 64;
+    auto __low =
+      static_cast<__uint128_t>(::cuda::__bit_reverse_device(static_cast<::cuda::std::uint64_t>(__value >> 64)));
     return __high | __low;
   }
 #  endif // _CCCL_HAS_INT128()
-  if constexpr (sizeof(_Tp) == sizeof(uint64_t))
+  if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint64_t))
   {
     NV_IF_TARGET(NV_IS_DEVICE, (return ::__brevll(__value);))
   }
-  else if constexpr (sizeof(_Tp) == sizeof(uint32_t))
+  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint32_t))
   {
     NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(__value);))
   }
-  else if constexpr (sizeof(_Tp) == sizeof(uint16_t))
+  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint16_t))
   {
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(static_cast<uint32_t>(__value) << 16);))
+    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(static_cast<::cuda::std::uint32_t>(__value) << 16);))
   }
   else
   {
-    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(static_cast<uint32_t>(__value) << 24);))
+    NV_IF_TARGET(NV_IS_DEVICE, (return ::__brev(static_cast<::cuda::std::uint32_t>(__value) << 24);))
   }
   _CCCL_UNREACHABLE();
 }
@@ -102,12 +130,12 @@ template <typename _Tp>
 #if _CCCL_HAS_INT128()
   if constexpr (sizeof(_Tp) == sizeof(__uint128_t))
   {
-    constexpr auto __c1 = __uint128_t{0x5555555555555555} << 64 | uint64_t{0x5555555555555555};
-    constexpr auto __c2 = __uint128_t{0x3333333333333333} << 64 | uint64_t{0x3333333333333333};
-    constexpr auto __c3 = __uint128_t{0x0F0F0F0F0F0F0F0F} << 64 | uint64_t{0x0F0F0F0F0F0F0F0F};
-    constexpr auto __c4 = __uint128_t{0x00FF00FF00FF00FF} << 64 | uint64_t{0x00FF00FF00FF00FF};
-    constexpr auto __c5 = __uint128_t{0x0000FFFF0000FFFF} << 64 | uint64_t{0x0000FFFF0000FFFF};
-    constexpr auto __c6 = __uint128_t{0x00000000FFFFFFFF} << 64 | uint64_t{0x00000000FFFFFFFF};
+    constexpr auto __c1 = __uint128_t{0x5555555555555555} << 64 | ::cuda::std::uint64_t{0x5555555555555555};
+    constexpr auto __c2 = __uint128_t{0x3333333333333333} << 64 | ::cuda::std::uint64_t{0x3333333333333333};
+    constexpr auto __c3 = __uint128_t{0x0F0F0F0F0F0F0F0F} << 64 | ::cuda::std::uint64_t{0x0F0F0F0F0F0F0F0F};
+    constexpr auto __c4 = __uint128_t{0x00FF00FF00FF00FF} << 64 | ::cuda::std::uint64_t{0x00FF00FF00FF00FF};
+    constexpr auto __c5 = __uint128_t{0x0000FFFF0000FFFF} << 64 | ::cuda::std::uint64_t{0x0000FFFF0000FFFF};
+    constexpr auto __c6 = __uint128_t{0x00000000FFFFFFFF} << 64 | ::cuda::std::uint64_t{0x00000000FFFFFFFF};
     __value             = ((__value >> 1) & __c1) | ((__value & __c1) << 1);
     __value             = ((__value >> 2) & __c2) | ((__value & __c2) << 2);
     __value             = ((__value >> 4) & __c3) | ((__value & __c3) << 4);
@@ -117,7 +145,7 @@ template <typename _Tp>
     return (__value >> 64) | (__value << 64);
   }
 #endif // _CCCL_HAS_INT128()
-  if constexpr (sizeof(_Tp) == sizeof(uint64_t))
+  if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint64_t))
   {
     __value = ((__value >> 1) & 0x5555555555555555) | ((__value & 0x5555555555555555) << 1);
     __value = ((__value >> 2) & 0x3333333333333333) | ((__value & 0x3333333333333333) << 2);
@@ -126,7 +154,7 @@ template <typename _Tp>
     __value = ((__value >> 16) & 0x0000FFFF0000FFFF) | ((__value & 0x0000FFFF0000FFFF) << 16);
     return (__value >> 32) | (__value << 32);
   }
-  else if constexpr (sizeof(_Tp) == sizeof(uint32_t))
+  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint32_t))
   {
     __value = ((__value >> 1) & 0x55555555) | ((__value & 0x55555555) << 1);
     __value = ((__value >> 2) & 0x33333333) | ((__value & 0x33333333) << 2);
@@ -134,7 +162,7 @@ template <typename _Tp>
     __value = ((__value >> 8) & 0x00FF00FF) | ((__value & 0x00FF00FF) << 8);
     return (__value >> 16) | (__value << 16);
   }
-  else if constexpr (sizeof(_Tp) == sizeof(uint16_t))
+  else if constexpr (sizeof(_Tp) == sizeof(::cuda::std::uint16_t))
   {
     __value = ((__value >> 1) & 0x5555) | ((__value & 0x5555) << 1);
     __value = ((__value >> 2) & 0x3333) | ((__value & 0x3333) << 2);

--- a/libcudacxx/include/cuda/std/__cccl/builtin.h
+++ b/libcudacxx/include/cuda/std/__cccl/builtin.h
@@ -159,22 +159,6 @@
 #  undef _CCCL_BUITLIN_CTZG
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 
-#if _CCCL_CHECK_BUILTIN(builtin_bitreverse8) && !_CCCL_HAS_CUDA_COMPILER()
-#  define _CCCL_BUILTIN_BITREVERSE8(...) __builtin_bitreverse8(__VA_ARGS__)
-#endif
-
-#if _CCCL_CHECK_BUILTIN(builtin_bitreverse16) && !_CCCL_HAS_CUDA_COMPILER()
-#  define _CCCL_BUILTIN_BITREVERSE16(...) __builtin_bitreverse16(__VA_ARGS__)
-#endif
-
-#if _CCCL_CHECK_BUILTIN(builtin_bitreverse32) && !_CCCL_HAS_CUDA_COMPILER()
-#  define _CCCL_BUILTIN_BITREVERSE32(...) __builtin_bitreverse32(__VA_ARGS__)
-#endif
-
-#if _CCCL_CHECK_BUILTIN(builtin_bitreverse64) && !_CCCL_HAS_CUDA_COMPILER()
-#  define _CCCL_BUILTIN_BITREVERSE64(...) __builtin_bitreverse64(__VA_ARGS__)
-#endif
-
 #if _CCCL_HAS_BUILTIN(__builtin_COLUMN) || _CCCL_COMPILER(MSVC, >=, 19, 27)
 #  define _CCCL_BUILTIN_COLUMN() __builtin_COLUMN()
 #else // ^^^ _CCCL_HAS_BUILTIN(__builtin_COLUMN) ^^^ / vvv !_CCCL_HAS_BUILTIN(__builtin_COLUMN) vvv


### PR DESCRIPTION
The builtins don't work with nvcc unfortunatelly, but we can still make them work with clang-cuda.