### PR TITLE
Cleanup includes in thrust

### DIFF
--- a/c2h/include/c2h/vector.h
+++ b/c2h/include/c2h/vector.h
@@ -5,6 +5,8 @@
 
 #include <thrust/detail/vector_base.h>
 
+#include <cuda/std/type_traits>
+
 #include <memory>
 
 #include <catch2/catch_tostring.hpp>

--- a/thrust/thrust/advance.h
+++ b/thrust/thrust/advance.h
@@ -26,7 +26,10 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/iterator>
+#include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__iterator/next.h>
+#include <cuda/std/__iterator/prev.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/allocate_unique.h
+++ b/thrust/thrust/allocate_unique.h
@@ -20,7 +20,9 @@
 #include <thrust/detail/type_deduction.h>
 
 #include <cuda/std/__cccl/memory_wrapper.h>
-#include <cuda/std/utility>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/__utility/swap.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/detail/alignment.h
+++ b/thrust/thrust/detail/alignment.h
@@ -29,9 +29,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/cmath>
+#include <cuda/__cmath/ceil_div.h>
+#include <cuda/std/__type_traits/alignment_of.h>
 #include <cuda/std/cstddef> // For `std::size_t` and `std::max_align_t`.
-#include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail

--- a/thrust/thrust/detail/allocator/allocator_traits.h
+++ b/thrust/thrust/detail/allocator/allocator_traits.h
@@ -39,8 +39,13 @@
 #include <thrust/detail/type_traits/pointer_traits.h>
 
 #include <cuda/std/__cccl/memory_wrapper.h>
+#include <cuda/std/__type_traits/add_lvalue_reference.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_empty.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
+#include <cuda/std/__type_traits/type_identity.h>
+#include <cuda/std/__type_traits/void_t.h>
 #include <cuda/std/limits>
-#include <cuda/std/type_traits>
 
 #include <new>
 

--- a/thrust/thrust/detail/allocator/copy_construct_range.h
+++ b/thrust/thrust/detail/allocator/copy_construct_range.h
@@ -26,18 +26,20 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/advance.h>
 #include <thrust/detail/allocator/allocator_traits.h>
 #include <thrust/detail/copy.h>
 #include <thrust/detail/execution_policy.h>
 #include <thrust/detail/type_traits/pointer_traits.h>
-#include <thrust/distance.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/tuple.h>
 
 #include <cuda/std/__cccl/memory_wrapper.h>
+#include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__iterator/distance.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_trivially_copy_constructible.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -64,7 +66,7 @@ struct copy_construct_with_allocator
 template <typename Allocator, typename T>
 inline constexpr bool needs_copy_construct_via_allocator =
   allocator_traits_detail::has_member_construct2<Allocator, T, T>::value
-  || !::cuda::std::is_trivially_copy_constructible<T>::value;
+  || !::cuda::std::is_trivially_copy_constructible_v<T>;
 
 // we know that std::allocator::construct's only effect is to call T's
 // copy constructor, so we needn't consider or use its construct() member for copy construction

--- a/thrust/thrust/detail/allocator_aware_execution_policy.h
+++ b/thrust/thrust/detail/allocator_aware_execution_policy.h
@@ -28,7 +28,9 @@
 #include <thrust/detail/alignment.h>
 #include <thrust/detail/execute_with_allocator_fwd.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_reference.h>
+#include <cuda/std/__utility/move.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -83,8 +85,7 @@ struct allocator_aware_execution_policy
   // perfect forwarding doesn't help, because a const reference has to be turned
   // into a value by copying for the purpose of storing it in execute_with_allocator
   _CCCL_EXEC_CHECK_DISABLE
-  template <typename Allocator,
-            typename ::cuda::std::enable_if<!::cuda::std::is_lvalue_reference<Allocator>::value>::type* = nullptr>
+  template <typename Allocator, ::cuda::std::enable_if_t<!::cuda::std::is_lvalue_reference_v<Allocator>>* = nullptr>
   _CCCL_HOST_DEVICE typename execute_with_allocator_type<Allocator>::type operator()(Allocator&& alloc) const
   {
     return typename execute_with_allocator_type<Allocator>::type(::cuda::std::move(alloc));

--- a/thrust/thrust/detail/contiguous_storage.h
+++ b/thrust/thrust/detail/contiguous_storage.h
@@ -30,7 +30,8 @@
 #include <thrust/detail/execution_policy.h>
 #include <thrust/iterator/detail/normal_iterator.h>
 
-#include <cuda/std/utility>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/__utility/swap.h>
 
 #include <stdexcept>
 

--- a/thrust/thrust/detail/contiguous_storage.inl
+++ b/thrust/thrust/detail/contiguous_storage.inl
@@ -32,7 +32,8 @@
 #include <thrust/detail/allocator/value_initialize_range.h>
 #include <thrust/detail/contiguous_storage.h>
 
-#include <cuda/std/utility> // for use of std::swap in the WAR below
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/__utility/swap.h>
 
 #include <nv/target>
 

--- a/thrust/thrust/detail/functional/actor.h
+++ b/thrust/thrust/detail/functional/actor.h
@@ -37,8 +37,10 @@
 #include <thrust/detail/type_deduction.h>
 #include <thrust/tuple.h>
 
-#include <cuda/std/type_traits>
-#include <cuda/std/utility>
+#include <cuda/std/__type_traits/decay.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__utility/declval.h>
+#include <cuda/std/__utility/move.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail::functional

--- a/thrust/thrust/detail/functional/operators.h
+++ b/thrust/thrust/detail/functional/operators.h
@@ -37,7 +37,8 @@
 #include <thrust/functional.h>
 #include <thrust/tuple.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__type_traits/enable_if.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail::functional

--- a/thrust/thrust/detail/internal_functional.h
+++ b/thrust/thrust/detail/internal_functional.h
@@ -44,7 +44,13 @@
 #include <cuda/__iterator/transform_output_iterator.h>
 #include <cuda/std/__cccl/memory_wrapper.h> // for ::new
 #include <cuda/std/__new/device_new.h>
-#include <cuda/std/type_traits>
+#include <cuda/std/__tuple_dir/get.h>
+#include <cuda/std/__tuple_dir/tuple_element.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_const.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_reference.h>
+#include <cuda/std/__type_traits/type_identity.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -240,7 +246,7 @@ struct device_destroy_functor
 
 template <typename System, typename T>
 struct destroy_functor
-    : thrust::detail::eval_if<::cuda::std::is_convertible<System, thrust::host_system_tag>::value,
+    : thrust::detail::eval_if<::cuda::std::is_convertible_v<System, thrust::host_system_tag>,
                               ::cuda::std::type_identity<host_destroy_functor<T>>,
                               ::cuda::std::type_identity<device_destroy_functor<T>>>
 {};

--- a/thrust/thrust/detail/memory_algorithms.h
+++ b/thrust/thrust/detail/memory_algorithms.h
@@ -23,11 +23,10 @@
 
 #include <cuda/std/__cccl/memory_wrapper.h>
 #include <cuda/std/__memory/addressof.h>
-#include <cuda/std/utility>
+#include <cuda/std/__new/device_new.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
 
 #include <nv/target>
-
-#include <new>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/detail/pointer.h
+++ b/thrust/thrust/detail/pointer.h
@@ -37,8 +37,13 @@
 #include <thrust/iterator/iterator_adaptor.h>
 #include <thrust/iterator/iterator_traversal_tags.h>
 
+#include <cuda/std/__type_traits/is_reference.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_void.h>
+#include <cuda/std/__type_traits/remove_cv.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/cstddef>
-#include <cuda/std/type_traits>
 
 #if !_CCCL_COMPILER(NVRTC)
 #  include <ostream>

--- a/thrust/thrust/detail/random_bijection.h
+++ b/thrust/thrust/detail/random_bijection.h
@@ -23,8 +23,10 @@
 
 #include <thrust/random.h>
 
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__utility/forward.h>
 #include <cuda/std/cstdint>
-#include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail

--- a/thrust/thrust/detail/raw_reference_cast.h
+++ b/thrust/thrust/detail/raw_reference_cast.h
@@ -31,7 +31,12 @@
 #include <thrust/detail/type_traits/has_nested_type.h>
 #include <thrust/tuple.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__tuple_dir/apply.h>
+#include <cuda/std/__type_traits/add_lvalue_reference.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/remove_cv.h>
+#include <cuda/std/__type_traits/type_identity.h>
+#include <cuda/std/__utility/forward.h>
 
 // the order of declarations and definitions in this file is totally goofy
 // this header defines raw_reference_cast, which has a few overloads towards the bottom of the file

--- a/thrust/thrust/detail/reference.h
+++ b/thrust/thrust/detail/reference.h
@@ -35,7 +35,10 @@
 #include <thrust/system/detail/generic/memory.h>
 #include <thrust/system/detail/generic/select_system.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__utility/move.h>
 
 #include <ostream>
 

--- a/thrust/thrust/detail/temporary_array.h
+++ b/thrust/thrust/detail/temporary_array.h
@@ -47,7 +47,8 @@ THRUST_NAMESPACE_END
 #include <thrust/iterator/iterator_traits.h>
 
 #include <cuda/std/__cccl/memory_wrapper.h>
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/type_identity.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail

--- a/thrust/thrust/detail/temporary_array.inl
+++ b/thrust/thrust/detail/temporary_array.inl
@@ -28,8 +28,10 @@
 
 #include <thrust/detail/temporary_array.h>
 #include <thrust/detail/type_traits.h>
-#include <thrust/distance.h>
 #include <thrust/system/detail/generic/select_system.h>
+
+#include <cuda/std/__iterator/distance.h>
+#include <cuda/std/__type_traits/is_trivially_copy_constructible.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/detail/type_deduction.h
+++ b/thrust/thrust/detail/type_deduction.h
@@ -19,8 +19,7 @@
 
 #include <thrust/detail/preprocessor.h>
 
-#include <cuda/std/type_traits>
-#include <cuda/std/utility>
+#include <cuda/std/__utility/forward.h>
 
 ///////////////////////////////////////////////////////////////////////////////
 

--- a/thrust/thrust/detail/type_traits.h
+++ b/thrust/thrust/detail/type_traits.h
@@ -31,7 +31,14 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__type_traits/conjunction.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/is_arithmetic.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/type_identity.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -65,7 +72,7 @@ template <typename T>
 inline constexpr bool is_proxy_reference_v = false;
 
 template <typename Boolean>
-struct not_ : public integral_constant<bool, !Boolean::value>
+struct not_ : public ::cuda::std::integral_constant<bool, !Boolean::value>
 {}; // end not_
 
 template <bool, typename Then, typename Else>

--- a/thrust/thrust/detail/type_traits/has_member_function.h
+++ b/thrust/thrust/detail/type_traits/has_member_function.h
@@ -28,20 +28,23 @@
 
 #include <thrust/detail/type_traits.h>
 
-#include <cuda/std/utility> // for std::declval
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_void.h>
+#include <cuda/std/__utility/declval.h>
 
-#define __THRUST_DEFINE_HAS_MEMBER_FUNCTION(trait_name, member_function_name)                                       \
-  template <typename T, typename Signature, typename = void>                                                        \
-  struct trait_name : thrust::false_type                                                                            \
-  {};                                                                                                               \
-                                                                                                                    \
-  template <typename T, typename ResultT, typename... Args>                                                         \
-  struct trait_name<                                                                                                \
-    T,                                                                                                              \
-    ResultT(Args...),                                                                                               \
-    ::cuda::std::enable_if_t<                                                                                       \
-      ::cuda::std::is_same<ResultT, void>::value                                                                    \
-      || ::cuda::std::                                                                                              \
-        is_convertible<ResultT, decltype(std::declval<T>().member_function_name(std::declval<Args>()...))>::value>> \
-      : thrust::true_type                                                                                           \
+#define __THRUST_DEFINE_HAS_MEMBER_FUNCTION(trait_name, member_function_name)                                          \
+  template <typename T, typename Signature, typename = void>                                                           \
+  struct trait_name : thrust::false_type                                                                               \
+  {};                                                                                                                  \
+                                                                                                                       \
+  template <typename T, typename ResultT, typename... Args>                                                            \
+  struct trait_name<                                                                                                   \
+    T,                                                                                                                 \
+    ResultT(Args...),                                                                                                  \
+    ::cuda::std::enable_if_t<::cuda::std::is_void_v<ResultT>                                                           \
+                             || ::cuda::std::is_convertible_v<ResultT,                                                 \
+                                                              decltype(::cuda::std::declval<T>().member_function_name( \
+                                                                ::cuda::std::declval<Args>()...))>>>                   \
+      : thrust::true_type                                                                                              \
   {};

--- a/thrust/thrust/detail/type_traits/iterator/is_output_iterator.h
+++ b/thrust/thrust/detail/type_traits/iterator/is_output_iterator.h
@@ -29,7 +29,9 @@
 #include <thrust/iterator/detail/any_assign.h>
 #include <thrust/iterator/iterator_traits.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_void.h>
+#include <cuda/std/__type_traits/void_t.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/detail/type_traits/minimum_type.h
+++ b/thrust/thrust/detail/type_traits/minimum_type.h
@@ -26,7 +26,9 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_same.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/detail/type_traits/pointer_traits.h
+++ b/thrust/thrust/detail/type_traits/pointer_traits.h
@@ -31,8 +31,14 @@
 #include <thrust/detail/type_traits/is_thrust_pointer.h>
 #include <thrust/iterator/iterator_traits.h>
 
+#include <cuda/std/__type_traits/add_lvalue_reference.h>
+#include <cuda/std/__type_traits/conjunction.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_void.h>
+#include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/cstddef>
-#include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -116,10 +122,10 @@ template <template <typename, typename, typename, typename...> class Ptr,
           typename Tag,
           typename... PtrTail,
           typename T>
-struct rebind_pointer<Ptr<OldT, Tag, typename ::cuda::std::add_lvalue_reference<OldT>::type, PtrTail...>, T>
+struct rebind_pointer<Ptr<OldT, Tag, ::cuda::std::add_lvalue_reference_t<OldT>, PtrTail...>, T>
 {
   //  static_assert(::cuda::std::is_same<OldT, Tag>::value, "2");
-  using type = Ptr<T, Tag, typename ::cuda::std::add_lvalue_reference<T>::type, PtrTail...>;
+  using type = Ptr<T, Tag, ::cuda::std::add_lvalue_reference_t<T>, PtrTail...>;
 };
 
 // Rebind `thrust::pointer`-like things with native reference types and templated
@@ -130,12 +136,10 @@ template <template <typename, typename, typename, typename...> class Ptr,
           template <typename...> class DerivedPtr,
           typename... DerivedPtrTail,
           typename T>
-struct rebind_pointer<
-  Ptr<OldT, Tag, typename ::cuda::std::add_lvalue_reference<OldT>::type, DerivedPtr<OldT, DerivedPtrTail...>>,
-  T>
+struct rebind_pointer<Ptr<OldT, Tag, ::cuda::std::add_lvalue_reference_t<OldT>, DerivedPtr<OldT, DerivedPtrTail...>>, T>
 {
   //  static_assert(::cuda::std::is_same<OldT, Tag>::value, "3");
-  using type = Ptr<T, Tag, typename ::cuda::std::add_lvalue_reference<T>::type, DerivedPtr<T, DerivedPtrTail...>>;
+  using type = Ptr<T, Tag, ::cuda::std::add_lvalue_reference_t<T>, DerivedPtr<T, DerivedPtrTail...>>;
 };
 
 namespace pointer_traits_detail
@@ -159,7 +163,7 @@ struct capture_address
 // metafunction to compute the type of pointer_to's parameter below
 template <typename T>
 struct pointer_to_param
-    : thrust::detail::eval_if<::cuda::std::is_void<T>::value,
+    : thrust::detail::eval_if<::cuda::std::is_void_v<T>,
                               ::cuda::std::type_identity<capture_address<T>>,
                               ::cuda::std::add_lvalue_reference<T>>
 {};

--- a/thrust/thrust/detail/vector_base.h
+++ b/thrust/thrust/detail/vector_base.h
@@ -37,9 +37,11 @@
 #include <thrust/iterator/iterator_traits.h>
 
 #include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__iterator/reverse_iterator.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/__utility/swap.h>
 #include <cuda/std/initializer_list>
-#include <cuda/std/iterator>
-#include <cuda/std/utility>
 
 #include <vector>
 

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -26,19 +26,27 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/advance.h>
 #include <thrust/detail/copy.h>
 #include <thrust/detail/overlapped_copy.h>
 #include <thrust/detail/temporary_array.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/detail/vector_base.h>
-#include <thrust/distance.h>
 #include <thrust/equal.h>
 #include <thrust/iterator/iterator_traits.h>
 
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
-#include <cuda/std/type_traits>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__iterator/distance.h>
+#include <cuda/std/__iterator/next.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_trivially_constructible.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/initializer_list>
 
 #include <stdexcept>
 

--- a/thrust/thrust/device_vector.h
+++ b/thrust/thrust/device_vector.h
@@ -33,8 +33,8 @@
 #include <thrust/detail/vector_base.h>
 #include <thrust/device_allocator.h>
 
+#include <cuda/std/__utility/move.h>
 #include <cuda/std/initializer_list>
-#include <cuda/std/utility>
 
 #include <vector>
 

--- a/thrust/thrust/distance.h
+++ b/thrust/thrust/distance.h
@@ -26,7 +26,8 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/iterator>
+#include <cuda/std/__iterator/distance.h>
+#include <cuda/std/__iterator/iterator_traits.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/functional.h
+++ b/thrust/thrust/functional.h
@@ -32,8 +32,14 @@
 
 #include <thrust/detail/functional/actor.h>
 
-#include <cuda/functional>
-#include <cuda/std/functional>
+#include <cuda/__functional/maximum.h>
+#include <cuda/__functional/minimum.h>
+#include <cuda/std/__functional/not_fn.h>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__type_traits/decay.h>
+#include <cuda/std/__type_traits/is_constructible.h>
+#include <cuda/std/__type_traits/is_move_constructible.h>
+#include <cuda/std/__utility/forward.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -33,8 +33,8 @@
 #include <thrust/detail/vector_base.h>
 
 #include <cuda/std/__cccl/memory_wrapper.h>
+#include <cuda/std/__utility/move.h>
 #include <cuda/std/initializer_list>
-#include <cuda/std/utility>
 
 #include <vector>
 

--- a/thrust/thrust/iterator/constant_iterator.h
+++ b/thrust/thrust/iterator/constant_iterator.h
@@ -32,8 +32,8 @@
 #include <thrust/iterator/iterator_adaptor.h>
 #include <thrust/iterator/iterator_facade.h>
 
+#include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/cstdint>
-#include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -46,9 +46,12 @@
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/strided_iterator.h>
 
+#include <cuda/__type_traits/is_floating_point.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/cstddef>
-#include <cuda/std/type_traits>
-#include <cuda/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -64,7 +67,7 @@ using counting_iterator_difference_type =
 template <typename Incrementable, typename System, typename Traversal, typename Difference, typename StrideHolder>
 struct make_counting_iterator_base
 {
-  using system = typename eval_if<::cuda::std::is_same<System, use_default>::value,
+  using system = typename eval_if<::cuda::std::is_same_v<System, use_default>,
                                   ::cuda::std::type_identity<any_system_tag>,
                                   ::cuda::std::type_identity<System>>::type;
 
@@ -281,7 +284,7 @@ private:
   _CCCL_HOST_DEVICE difference_type distance_to(
     counting_iterator<Incrementable, OtherSystem, OtherTraversal, OtherDifference, StrideHolder> const& y) const
   {
-    if constexpr (::cuda::std::is_integral<Incrementable>::value)
+    if constexpr (::cuda::std::is_integral_v<Incrementable>)
     {
       return static_cast<difference_type>(y.base()) - static_cast<difference_type>(this->base());
     }

--- a/thrust/thrust/iterator/detail/iterator_adaptor_base.h
+++ b/thrust/thrust/iterator/detail/iterator_adaptor_base.h
@@ -31,7 +31,10 @@
 #include <thrust/iterator/iterator_facade.h>
 #include <thrust/iterator/iterator_traits.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/add_lvalue_reference.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/type_identity.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/iterator/detail/iterator_facade_category.h
+++ b/thrust/thrust/iterator/detail/iterator_facade_category.h
@@ -35,8 +35,11 @@
 #include <thrust/iterator/iterator_categories.h>
 #include <thrust/iterator/iterator_traversal_tags.h>
 
-#include <cuda/std/iterator>
-#include <cuda/std/type_traits>
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/type_identity.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/iterator/detail/minimum_system.h
+++ b/thrust/thrust/iterator/detail/minimum_system.h
@@ -29,8 +29,6 @@
 #include <thrust/detail/type_traits/is_metafunction_defined.h>
 #include <thrust/detail/type_traits/minimum_type.h>
 
-#include <cuda/std/type_traits>
-
 THRUST_NAMESPACE_BEGIN
 namespace detail
 {

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -31,8 +31,9 @@
 #include <thrust/pair.h>
 #include <thrust/tuple.h>
 
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__utility/move.h>
 #include <cuda/std/tuple>
-#include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/iterator/iterator_categories.h
+++ b/thrust/thrust/iterator/iterator_categories.h
@@ -42,7 +42,7 @@
 #include <thrust/iterator/detail/iterator_category_with_system_and_traversal.h>
 #include <thrust/iterator/iterator_traversal_tags.h>
 
-#include <cuda/std/iterator>
+#include <cuda/std/__iterator/iterator_traits.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/iterator/reverse_iterator.h
+++ b/thrust/thrust/iterator/reverse_iterator.h
@@ -40,7 +40,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/iterator>
+#include <cuda/std/__iterator/reverse_iterator.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/iterator/shuffle_iterator.h
+++ b/thrust/thrust/iterator/shuffle_iterator.h
@@ -33,7 +33,12 @@
 #include <thrust/iterator/iterator_adaptor.h>
 #include <thrust/iterator/iterator_traits.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_constructible.h>
+#include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/iterator/transform_iterator.h
+++ b/thrust/thrust/iterator/transform_iterator.h
@@ -47,9 +47,13 @@
 #include <thrust/iterator/iterator_adaptor.h>
 #include <thrust/iterator/iterator_traits.h>
 
+#include <cuda/std/__functional/identity.h>
 #include <cuda/std/__memory/construct_at.h>
-#include <cuda/std/functional>
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/is_copy_assignable.h>
+#include <cuda/std/__type_traits/is_copy_constructible.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__type_traits/remove_reference.h>
+#include <cuda/std/__utility/declval.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -38,7 +38,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/advance.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/iterator/detail/minimum_system.h>
 #include <thrust/iterator/detail/tuple_of_iterator_references.h>
@@ -46,6 +45,13 @@
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/type_traits/integer_sequence.h>
 
+#include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_constructible.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__utility/declval.h>
+#include <cuda/std/__utility/forward.h>
 #include <cuda/std/tuple>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/mr/validator.h
+++ b/thrust/thrust/mr/validator.h
@@ -29,7 +29,7 @@
 #include <thrust/detail/config/memory_resource.h>
 #include <thrust/mr/memory_resource.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/is_base_of.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace mr
@@ -37,7 +37,7 @@ namespace mr
 template <typename MR>
 struct validator
 {
-  static_assert(::cuda::std::is_base_of<memory_resource<typename MR::pointer>, MR>::value,
+  static_assert(::cuda::std::is_base_of_v<memory_resource<typename MR::pointer>, MR>,
                 "a type used as a memory resource must derive from memory_resource");
 };
 

--- a/thrust/thrust/pair.h
+++ b/thrust/thrust/pair.h
@@ -30,7 +30,10 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/utility>
+#include <cuda/std/__tuple_dir/get.h>
+#include <cuda/std/__tuple_dir/tuple_element.h>
+#include <cuda/std/__tuple_dir/tuple_size.h>
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/random/detail/normal_distribution_base.h
+++ b/thrust/thrust/random/detail/normal_distribution_base.h
@@ -35,7 +35,9 @@
 #include <thrust/pair.h>
 #include <thrust/random/uniform_real_distribution.h>
 
-#include <cuda/std/cmath>
+#include <cuda/std/__cmath/logarithms.h>
+#include <cuda/std/__cmath/roots.h>
+#include <cuda/std/__cmath/trigonometric_functions.h>
 #include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/random/detail/uniform_real_distribution.inl
+++ b/thrust/thrust/random/detail/uniform_real_distribution.inl
@@ -28,7 +28,7 @@
 
 #include <thrust/random/uniform_real_distribution.h>
 
-#include <cuda/std/cmath>
+#include <cuda/std/__cmath/lerp.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/random/detail/xor_combine_engine_max.h
+++ b/thrust/thrust/random/detail/xor_combine_engine_max.h
@@ -32,7 +32,6 @@
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/cstddef>
 #include <cuda/std/limits>
-#include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 namespace random::detail

--- a/thrust/thrust/random/xor_combine_engine.h
+++ b/thrust/thrust/random/xor_combine_engine.h
@@ -36,8 +36,8 @@
 #include <thrust/random/detail/random_core_access.h>
 #include <thrust/random/detail/xor_combine_engine_max.h>
 
+#include <cuda/std/__type_traits/type_identity.h>
 #include <cuda/std/cstddef> // for size_t
-#include <cuda/std/type_traits>
 
 #include <iostream>
 

--- a/thrust/thrust/swap.h
+++ b/thrust/thrust/swap.h
@@ -31,7 +31,7 @@
 #endif // no system header
 #include <thrust/detail/execution_policy.h>
 
-#include <cuda/std/utility>
+#include <cuda/std/__utility/swap.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cpp/pointer.h
+++ b/thrust/thrust/system/cpp/pointer.h
@@ -32,7 +32,7 @@
 #include <thrust/detail/reference.h>
 #include <thrust/system/cpp/detail/execution_policy.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/add_lvalue_reference.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::cpp

--- a/thrust/thrust/system/cuda/detail/adjacent_difference.h
+++ b/thrust/thrust/system/cuda/detail/adjacent_difference.h
@@ -53,8 +53,11 @@
 #  include <thrust/type_traits/is_contiguous_iterator.h>
 #  include <thrust/type_traits/unwrap_contiguous_iterator.h>
 
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__type_traits/is_pointer.h>
+#  include <cuda/std/__type_traits/is_same.h>
 #  include <cuda/std/cstdint>
-#  include <cuda/std/type_traits>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -151,8 +154,8 @@ adjacent_difference(execution_policy<Derived>& policy, InputIt first, InputIt la
   using OutputValueT = thrust::detail::it_value_t<UnwrapOutputIt>;
 
   constexpr bool can_compare_iterators =
-    ::cuda::std::is_pointer<UnwrapInputIt>::value && ::cuda::std::is_pointer<UnwrapOutputIt>::value
-    && std::is_same<InputValueT, OutputValueT>::value;
+    ::cuda::std::is_pointer_v<UnwrapInputIt> && ::cuda::std::is_pointer_v<UnwrapOutputIt>
+    && std::is_same_v<InputValueT, OutputValueT>;
 
   auto first_unwrap  = thrust::try_unwrap_contiguous_iterator(first);
   auto result_unwrap = thrust::try_unwrap_contiguous_iterator(result);

--- a/thrust/thrust/system/cuda/detail/copy_if.h
+++ b/thrust/thrust/system/cuda/detail/copy_if.h
@@ -45,17 +45,17 @@
 #  include <cub/util_temporary_storage.cuh>
 #  include <cub/util_type.cuh>
 
-#  include <thrust/advance.h>
 #  include <thrust/detail/alignment.h>
 #  include <thrust/detail/function.h>
 #  include <thrust/detail/temporary_array.h>
-#  include <thrust/distance.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/core/util.h>
 #  include <thrust/system/cuda/detail/dispatch.h>
 #  include <thrust/system/cuda/detail/execution_policy.h>
 #  include <thrust/system/cuda/detail/util.h>
 
+#  include <cuda/std/__iterator/advance.h>
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/detail/core/util.h
+++ b/thrust/thrust/system/cuda/detail/core/util.h
@@ -39,7 +39,11 @@
 
 #include <thrust/system/cuda/detail/util.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/type_identity.h>
+#include <cuda/std/__type_traits/void_t.h>
+#include <cuda/std/cstdint>
 
 #include <nv/target>
 

--- a/thrust/thrust/system/cuda/detail/count.h
+++ b/thrust/thrust/system/cuda/detail/count.h
@@ -39,10 +39,12 @@
 #if _CCCL_HAS_CUDA_COMPILER()
 #  include <thrust/system/cuda/config.h>
 
-#  include <thrust/distance.h>
 #  include <thrust/iterator/transform_iterator.h>
 #  include <thrust/system/cuda/detail/reduce.h>
 #  include <thrust/system/cuda/detail/util.h>
+
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/dispatch.h
+++ b/thrust/thrust/system/cuda/detail/dispatch.h
@@ -34,7 +34,6 @@
 #include <cuda/std/__type_traits/is_unsigned.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
-#include <cuda/std/type_traits>
 
 #include <string>
 

--- a/thrust/thrust/system/cuda/detail/extrema.h
+++ b/thrust/thrust/system/cuda/detail/extrema.h
@@ -43,7 +43,6 @@
 #  include <cub/util_math.cuh>
 
 #  include <thrust/detail/temporary_array.h>
-#  include <thrust/distance.h>
 #  include <thrust/extrema.h>
 #  include <thrust/iterator/counting_iterator.h>
 #  include <thrust/iterator/transform_iterator.h>
@@ -51,8 +50,9 @@
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/reduce.h>
 
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/cstdint>
-#  include <cuda/std/iterator>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/for_each.h
+++ b/thrust/thrust/system/cuda/detail/for_each.h
@@ -42,10 +42,11 @@
 #  include <cub/device/device_for.cuh>
 
 #  include <thrust/detail/function.h>
-#  include <thrust/distance.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/parallel_for.h>
 #  include <thrust/system/cuda/detail/util.h>
+
+#  include <cuda/std/__iterator/distance.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/generate.h
+++ b/thrust/thrust/system/cuda/detail/generate.h
@@ -18,7 +18,8 @@
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/dispatch.h>
 
-#  include <cuda/std/iterator>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/tuple>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/inner_product.h
+++ b/thrust/thrust/system/cuda/detail/inner_product.h
@@ -37,11 +37,13 @@
 #endif // no system header
 
 #if _CCCL_HAS_CUDA_COMPILER()
-#  include <thrust/distance.h>
 #  include <thrust/iterator/transform_iterator.h>
 #  include <thrust/iterator/zip_iterator.h>
 #  include <thrust/system/cuda/detail/reduce.h>
 #  include <thrust/zip_function.h>
+
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -17,12 +17,13 @@
 #  include <cub/device/device_merge.cuh>
 
 #  include <thrust/detail/temporary_array.h>
-#  include <thrust/distance.h>
 #  include <thrust/iterator/iterator_traits.h>
 #  include <thrust/pair.h>
 #  include <thrust/system/cuda/detail/dispatch.h>
 #  include <thrust/system/cuda/detail/util.h>
 
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/detail/partition.h
+++ b/thrust/thrust/system/cuda/detail/partition.h
@@ -45,7 +45,6 @@
 #  include <cub/util_math.cuh>
 
 #  include <thrust/detail/temporary_array.h>
-#  include <thrust/distance.h>
 #  include <thrust/pair.h>
 #  include <thrust/partition.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
@@ -55,6 +54,7 @@
 #  include <thrust/system/cuda/detail/uninitialized_copy.h>
 #  include <thrust/system/cuda/detail/util.h>
 
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/detail/reduce.h
+++ b/thrust/thrust/system/cuda/detail/reduce.h
@@ -48,7 +48,6 @@
 #  include <thrust/detail/alignment.h>
 #  include <thrust/detail/raw_reference_cast.h>
 #  include <thrust/detail/temporary_array.h>
-#  include <thrust/distance.h>
 #  include <thrust/functional.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/core/agent_launcher.h>
@@ -58,6 +57,13 @@
 #  include <thrust/system/cuda/detail/make_unsigned_special.h>
 #  include <thrust/system/cuda/detail/util.h>
 
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__memory/is_sufficiently_aligned.h>
+#  include <cuda/std/__type_traits/conditional.h>
+#  include <cuda/std/__type_traits/is_arithmetic.h>
+#  include <cuda/std/__type_traits/is_pointer.h>
+#  include <cuda/std/__type_traits/remove_cv.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
@@ -214,9 +220,9 @@ struct ReduceAgent
     ITEMS_PER_TILE     = ptx_plan::ITEMS_PER_TILE,
     VECTOR_LOAD_LENGTH = ptx_plan::VECTOR_LOAD_LENGTH,
 
-    ATTEMPT_VECTORIZATION = (VECTOR_LOAD_LENGTH > 1) && (ITEMS_PER_THREAD % VECTOR_LOAD_LENGTH == 0)
-                         && ::cuda::std::is_pointer<InputIt>::value
-                         && ::cuda::std::is_arithmetic<typename ::cuda::std::remove_cv<T>>::value
+    ATTEMPT_VECTORIZATION =
+      (VECTOR_LOAD_LENGTH > 1) && (ITEMS_PER_THREAD % VECTOR_LOAD_LENGTH == 0)
+      && ::cuda::std::is_pointer_v<InputIt> && ::cuda::std::is_arithmetic_v<::cuda::std::remove_cv_t<T>>
   };
 
   struct impl

--- a/thrust/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/thrust/system/cuda/detail/reduce_by_key.h
@@ -50,7 +50,6 @@
 #  include <thrust/detail/temporary_array.h>
 #  include <thrust/detail/type_traits.h>
 #  include <thrust/detail/type_traits/iterator/is_output_iterator.h>
-#  include <thrust/distance.h>
 #  include <thrust/functional.h>
 #  include <thrust/pair.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
@@ -61,8 +60,12 @@
 
 #  include <cuda/std/__algorithm/max.h>
 #  include <cuda/std/__algorithm/min.h>
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__type_traits/conditional.h>
+#  include <cuda/std/__type_traits/is_arithmetic.h>
+#  include <cuda/std/__type_traits/is_same.h>
 #  include <cuda/std/cstdint>
-#  include <cuda/std/iterator>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -207,8 +210,8 @@ struct ReduceByKeyAgent
 
     // Whether or not the scan operation has a zero-valued identity value
     // (true if we're performing addition on a primitive type)
-    HAS_IDENTITY_ZERO = ::cuda::std::is_same<ReductionOp, ::cuda::std::plus<value_type>>::value
-                     && ::cuda::std::is_arithmetic<value_type>::value
+    HAS_IDENTITY_ZERO =
+      ::cuda::std::is_same_v<ReductionOp, ::cuda::std::plus<value_type>> && ::cuda::std::is_arithmetic_v<value_type>
   };
 
   struct impl

--- a/thrust/thrust/system/cuda/detail/reverse.h
+++ b/thrust/thrust/system/cuda/detail/reverse.h
@@ -50,12 +50,12 @@ void _CCCL_HOST_DEVICE reverse(execution_policy<Derived>& policy, ItemsIt first,
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
 
-#  include <thrust/advance.h>
-#  include <thrust/distance.h>
 #  include <thrust/system/cuda/detail/copy.h>
 #  include <thrust/system/cuda/detail/swap_ranges.h>
 
-#  include <cuda/std/iterator>
+#  include <cuda/std/__iterator/advance.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/reverse_iterator.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/scan.h
+++ b/thrust/thrust/system/cuda/detail/scan.h
@@ -44,11 +44,13 @@
 
 #  include <thrust/detail/temporary_array.h>
 #  include <thrust/detail/type_traits.h>
-#  include <thrust/distance.h>
 #  include <thrust/iterator/iterator_traits.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/dispatch.h>
 
+#  include <cuda/std/__functional/invoke.h>
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/detail/scan_by_key.h
+++ b/thrust/thrust/system/cuda/detail/scan_by_key.h
@@ -44,7 +44,6 @@
 #  include <cub/util_type.cuh>
 
 #  include <thrust/detail/temporary_array.h>
-#  include <thrust/distance.h>
 #  include <thrust/functional.h>
 #  include <thrust/iterator/iterator_traits.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
@@ -54,6 +53,8 @@
 #  include <thrust/type_traits/is_contiguous_iterator.h>
 #  include <thrust/type_traits/unwrap_contiguous_iterator.h>
 
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/detail/scatter.h
+++ b/thrust/thrust/system/cuda/detail/scatter.h
@@ -40,7 +40,8 @@
 #  include <thrust/iterator/permutation_iterator.h>
 #  include <thrust/system/cuda/detail/transform.h>
 
-#  include <cuda/std/functional>
+#  include <cuda/__functional/address_stability.h>
+#  include <cuda/std/__functional/identity.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/set_operations.h
+++ b/thrust/thrust/system/cuda/detail/set_operations.h
@@ -43,7 +43,6 @@
 
 #  include <thrust/detail/alignment.h>
 #  include <thrust/detail/temporary_array.h>
-#  include <thrust/distance.h>
 #  include <thrust/extrema.h>
 #  include <thrust/pair.h>
 #  include <thrust/set_operations.h>
@@ -56,6 +55,8 @@
 #  include <cuda/std/__algorithm/max.h>
 #  include <cuda/std/__algorithm/min.h>
 #  include <cuda/std/__bit/popcount.h>
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/detail/sort.h
+++ b/thrust/thrust/system/cuda/detail/sort.h
@@ -45,7 +45,6 @@
 #  include <thrust/detail/alignment.h>
 #  include <thrust/detail/temporary_array.h>
 #  include <thrust/detail/trivial_sequence.h>
-#  include <thrust/distance.h>
 #  include <thrust/extrema.h>
 #  include <thrust/sequence.h>
 #  include <thrust/sort.h>
@@ -56,7 +55,13 @@
 #  include <thrust/system/cuda/detail/util.h>
 #  include <thrust/type_traits/is_contiguous_iterator.h>
 
-#  include <cuda/cmath>
+#  include <cuda/__cmath/round_up.h>
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__type_traits/enable_if.h>
+#  include <cuda/std/__type_traits/integral_constant.h>
+#  include <cuda/std/__type_traits/is_arithmetic.h>
+#  include <cuda/std/__type_traits/is_same.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
@@ -303,19 +308,19 @@ namespace __smart_sort
 template <class Key, class CompareOp>
 using can_use_primitive_sort = ::cuda::std::integral_constant<
   bool,
-  (::cuda::std::is_arithmetic<Key>::value
+  (::cuda::std::is_arithmetic_v<Key>
 #  if _CCCL_HAS_NVFP16() && !defined(__CUDA_NO_HALF_OPERATORS__) && !defined(__CUDA_NO_HALF_CONVERSIONS__)
-   || ::cuda::std::is_same<Key, __half>::value
+   || ::cuda::std::is_same_v<Key, __half>
 #  endif // _CCCL_HAS_NVFP16() && !defined(__CUDA_NO_HALF_OPERATORS__) && !defined(__CUDA_NO_HALF_CONVERSIONS__)
 #  if _CCCL_HAS_NVBF16() && !defined(__CUDA_NO_BFLOAT16_CONVERSIONS__) && !defined(__CUDA_NO_BFLOAT16_OPERATORS__)
-   || ::cuda::std::is_same<Key, __nv_bfloat16>::value
+   || ::cuda::std::is_same_v<Key, __nv_bfloat16>
 #  endif // _CCCL_HAS_NVBF16() && !defined(__CUDA_NO_BFLOAT16_CONVERSIONS__) &&
          // !defined(__CUDA_NO_BFLOAT16_OPERATORS__)
    )
-    && (::cuda::std::is_same<CompareOp, ::cuda::std::less<Key>>::value
-        || ::cuda::std::is_same<CompareOp, ::cuda::std::less<void>>::value
-        || ::cuda::std::is_same<CompareOp, ::cuda::std::greater<Key>>::value
-        || ::cuda::std::is_same<CompareOp, ::cuda::std::greater<void>>::value)>;
+    && (::cuda::std::is_same_v<CompareOp, ::cuda::std::less<Key>>
+        || ::cuda::std::is_same_v<CompareOp, ::cuda::std::less<void>>
+        || ::cuda::std::is_same_v<CompareOp, ::cuda::std::greater<Key>>
+        || ::cuda::std::is_same_v<CompareOp, ::cuda::std::greater<void>>)>;
 
 template <
   class SORT_ITEMS,

--- a/thrust/thrust/system/cuda/detail/swap_ranges.h
+++ b/thrust/thrust/system/cuda/detail/swap_ranges.h
@@ -43,9 +43,10 @@
 #  include <thrust/system/cuda/detail/transform.h>
 #  include <thrust/type_traits/is_trivially_relocatable.h>
 
-#  include <cuda/functional>
-#  include <cuda/std/__algorithm_>
-#  include <cuda/std/iterator>
+#  include <cuda/__functional/address_stability.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iter_swap.h>
+#  include <cuda/std/__utility/swap.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/tabulate.h
+++ b/thrust/thrust/system/cuda/detail/tabulate.h
@@ -43,7 +43,8 @@
 #  include <thrust/system/cuda/execution_policy.h>
 
 #  include <cuda/__functional/address_stability.h>
-#  include <cuda/std/iterator>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/incrementable_traits.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/cuda/detail/transform_reduce.h
+++ b/thrust/thrust/system/cuda/detail/transform_reduce.h
@@ -45,7 +45,6 @@
 #  include <thrust/detail/alignment.h>
 #  include <thrust/detail/raw_reference_cast.h>
 #  include <thrust/detail/temporary_array.h>
-#  include <thrust/distance.h>
 #  include <thrust/functional.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/core/agent_launcher.h>
@@ -55,6 +54,7 @@
 #  include <thrust/system/cuda/detail/make_unsigned_special.h>
 #  include <thrust/system/cuda/detail/util.h>
 
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/detail/transform_scan.h
+++ b/thrust/thrust/system/cuda/detail/transform_scan.h
@@ -38,11 +38,11 @@
 
 #if _CCCL_HAS_CUDA_COMPILER()
 #  include <thrust/detail/type_traits.h>
-#  include <thrust/distance.h>
 #  include <thrust/iterator/transform_iterator.h>
 #  include <thrust/system/cuda/detail/scan.h>
 
-#  include <cuda/std/type_traits>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__type_traits/remove_cvref.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/uninitialized_copy.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_copy.h
@@ -43,8 +43,11 @@
 #  include <thrust/system/cuda/detail/util.h>
 #  include <thrust/type_traits/is_trivially_relocatable.h>
 
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/incrementable_traits.h>
 #  include <cuda/std/__new/device_new.h>
-#  include <cuda/std/iterator>
+#  include <cuda/std/__type_traits/is_trivially_copy_assignable.h>
+#  include <cuda/std/__type_traits/is_trivially_copy_constructible.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/uninitialized_fill.h
+++ b/thrust/thrust/system/cuda/detail/uninitialized_fill.h
@@ -37,13 +37,15 @@
 #endif // no system header
 
 #if _CCCL_HAS_CUDA_COMPILER()
-#  include <thrust/distance.h>
 #  include <thrust/system/cuda/detail/execution_policy.h>
 #  include <thrust/system/cuda/detail/fill.h>
 #  include <thrust/system/cuda/detail/parallel_for.h>
 #  include <thrust/system/cuda/detail/util.h>
 
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/__new/device_new.h>
+#  include <cuda/std/__type_traits/is_trivially_assignable.h>
+#  include <cuda/std/__type_traits/is_trivially_constructible.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/cuda/detail/unique.h
+++ b/thrust/thrust/system/cuda/detail/unique.h
@@ -43,9 +43,7 @@
 #  include <cub/device/device_select.cuh>
 #  include <cub/util_math.cuh>
 
-#  include <thrust/advance.h>
 #  include <thrust/count.h>
-#  include <thrust/distance.h>
 #  include <thrust/functional.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/core/agent_launcher.h>
@@ -53,6 +51,10 @@
 #  include <thrust/system/cuda/detail/get_value.h>
 #  include <thrust/system/cuda/detail/util.h>
 
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/advance.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/next.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/detail/unique_by_key.h
+++ b/thrust/thrust/system/cuda/detail/unique_by_key.h
@@ -45,7 +45,6 @@
 
 #  include <thrust/detail/alignment.h>
 #  include <thrust/detail/temporary_array.h>
-#  include <thrust/distance.h>
 #  include <thrust/functional.h>
 #  include <thrust/pair.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
@@ -54,6 +53,8 @@
 #  include <thrust/system/cuda/detail/get_value.h>
 #  include <thrust/system/cuda/detail/util.h>
 
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/cuda/pointer.h
+++ b/thrust/thrust/system/cuda/pointer.h
@@ -33,7 +33,7 @@
 #include <thrust/detail/reference.h>
 #include <thrust/system/cuda/detail/execution_policy.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/add_lvalue_reference.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub

--- a/thrust/thrust/system/detail/generic/binary_search.inl
+++ b/thrust/thrust/system/detail/generic/binary_search.inl
@@ -29,12 +29,14 @@
 #include <thrust/detail/function.h>
 #include <thrust/detail/temporary_array.h>
 #include <thrust/detail/type_traits.h>
-#include <thrust/distance.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/system/detail/generic/scalar/binary_search.h>
 #include <thrust/system/detail/generic/select_system.h>
+
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__iterator/distance.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -182,19 +184,6 @@ _CCCL_HOST_DEVICE OutputType binary_search(
 
   return output;
 }
-
-// this functor differs from ::cuda::std::less<T>
-// because it allows the types of lhs & rhs to differ
-// which is required by the binary search functions
-// XXX use C++14 ::cuda::std::less<> when it's ready
-struct binary_search_less
-{
-  template <typename T1, typename T2>
-  _CCCL_HOST_DEVICE bool operator()(const T1& lhs, const T2& rhs) const
-  {
-    return lhs < rhs;
-  }
-};
 } // end namespace detail
 
 //////////////////////
@@ -206,7 +195,7 @@ _CCCL_HOST_DEVICE ForwardIterator
 lower_bound(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator begin, ForwardIterator end, const T& value)
 {
   namespace p = thrust::placeholders;
-  return thrust::lower_bound(exec, begin, end, value, detail::binary_search_less());
+  return thrust::lower_bound(exec, begin, end, value, ::cuda::std::less<>{});
 }
 
 template <typename DerivedPolicy, typename ForwardIterator, typename T, typename StrictWeakOrdering>
@@ -227,7 +216,7 @@ _CCCL_HOST_DEVICE ForwardIterator
 upper_bound(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator begin, ForwardIterator end, const T& value)
 {
   namespace p = thrust::placeholders;
-  return thrust::upper_bound(exec, begin, end, value, detail::binary_search_less());
+  return thrust::upper_bound(exec, begin, end, value, ::cuda::std::less<>{});
 }
 
 template <typename DerivedPolicy, typename ForwardIterator, typename T, typename StrictWeakOrdering>
@@ -247,7 +236,7 @@ template <typename DerivedPolicy, typename ForwardIterator, typename T>
 _CCCL_HOST_DEVICE bool
 binary_search(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator begin, ForwardIterator end, const T& value)
 {
-  return thrust::binary_search(exec, begin, end, value, detail::binary_search_less());
+  return thrust::binary_search(exec, begin, end, value, ::cuda::std::less<>{});
 }
 
 template <typename DerivedPolicy, typename ForwardIterator, typename T, typename StrictWeakOrdering>
@@ -275,7 +264,7 @@ _CCCL_HOST_DEVICE OutputIterator lower_bound(
   OutputIterator output)
 {
   namespace p = thrust::placeholders;
-  return thrust::lower_bound(exec, begin, end, values_begin, values_end, output, detail::binary_search_less());
+  return thrust::lower_bound(exec, begin, end, values_begin, values_end, output, ::cuda::std::less<>{});
 }
 
 template <typename DerivedPolicy,
@@ -305,7 +294,7 @@ _CCCL_HOST_DEVICE OutputIterator upper_bound(
   OutputIterator output)
 {
   namespace p = thrust::placeholders;
-  return thrust::upper_bound(exec, begin, end, values_begin, values_end, output, detail::binary_search_less());
+  return thrust::upper_bound(exec, begin, end, values_begin, values_end, output, ::cuda::std::less<>{});
 }
 
 template <typename DerivedPolicy,
@@ -335,7 +324,7 @@ _CCCL_HOST_DEVICE OutputIterator binary_search(
   OutputIterator output)
 {
   namespace p = thrust::placeholders;
-  return thrust::binary_search(exec, begin, end, values_begin, values_end, output, detail::binary_search_less());
+  return thrust::binary_search(exec, begin, end, values_begin, values_end, output, ::cuda::std::less<>{});
 }
 
 template <typename DerivedPolicy,
@@ -362,7 +351,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
   ForwardIterator last,
   const LessThanComparable& value)
 {
-  return thrust::equal_range(exec, first, last, value, detail::binary_search_less());
+  return thrust::equal_range(exec, first, last, value, ::cuda::std::less<>{});
 }
 
 template <typename DerivedPolicy, typename ForwardIterator, typename T, typename StrictWeakOrdering>

--- a/thrust/thrust/system/detail/generic/copy_if.inl
+++ b/thrust/thrust/system/detail/generic/copy_if.inl
@@ -29,7 +29,6 @@
 #include <thrust/detail/internal_functional.h>
 #include <thrust/detail/temporary_array.h>
 #include <thrust/detail/type_traits.h>
-#include <thrust/distance.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/scan.h>
@@ -37,6 +36,9 @@
 #include <thrust/system/detail/generic/copy_if.h>
 #include <thrust/transform.h>
 
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__iterator/distance.h>
+#include <cuda/std/__type_traits/make_unsigned.h>
 #include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/system/detail/generic/equal.inl
+++ b/thrust/thrust/system/detail/generic/equal.inl
@@ -29,7 +29,7 @@
 #include <thrust/mismatch.h>
 #include <thrust/system/detail/generic/equal.h>
 
-#include <cuda/std/functional>
+#include <cuda/std/__functional/operations.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/system/detail/generic/extrema.inl
+++ b/thrust/thrust/system/detail/generic/extrema.inl
@@ -14,10 +14,6 @@
  *  limitations under the License.
  */
 
-/*! \file distance.h
- *  \brief Device implementations for distance.
- */
-
 #pragma once
 
 #include <thrust/detail/config.h>

--- a/thrust/thrust/system/detail/generic/generate.inl
+++ b/thrust/thrust/system/detail/generic/generate.inl
@@ -28,7 +28,8 @@
 
 #include <thrust/for_each.h>
 
-#include <cuda/std/utility>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/move.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/system/detail/generic/partition.inl
+++ b/thrust/thrust/system/detail/generic/partition.inl
@@ -25,7 +25,7 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/advance.h>
+
 #include <thrust/count.h>
 #include <thrust/detail/internal_functional.h>
 #include <thrust/detail/temporary_array.h>
@@ -36,6 +36,9 @@
 #include <thrust/remove.h>
 #include <thrust/sort.h>
 #include <thrust/system/detail/generic/partition.h>
+
+#include <cuda/std/__functional/not_fn.h>
+#include <cuda/std/__iterator/advance.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/system/detail/generic/reduce_by_key.inl
+++ b/thrust/thrust/system/detail/generic/reduce_by_key.inl
@@ -36,7 +36,9 @@
 #include <thrust/scatter.h>
 #include <thrust/transform.h>
 
-#include <cuda/std/iterator>
+#include <cuda/std/__functional/not_fn.h>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
@@ -169,11 +171,9 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   OutputIterator2 values_output,
   BinaryPredicate binary_pred)
 {
-  using T = ::cuda::std::
-
-    _If<thrust::detail::is_output_iterator<OutputIterator2>,
-        thrust::detail::it_value_t<InputIterator2>,
-        thrust::detail::it_value_t<OutputIterator2>>;
+  using T = ::cuda::std::_If<thrust::detail::is_output_iterator<OutputIterator2>,
+                             thrust::detail::it_value_t<InputIterator2>,
+                             thrust::detail::it_value_t<OutputIterator2>>;
 
   // use plus<T> as default BinaryFunction
   return thrust::reduce_by_key(

--- a/thrust/thrust/system/detail/generic/reverse.inl
+++ b/thrust/thrust/system/detail/generic/reverse.inl
@@ -25,14 +25,14 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/advance.h>
 #include <thrust/detail/copy.h>
-#include <thrust/distance.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/swap.h>
 #include <thrust/system/detail/generic/reverse.h>
 
-#include <cuda/std/iterator>
+#include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__iterator/distance.h>
+#include <cuda/std/__iterator/reverse_iterator.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/system/detail/generic/select_system.h
+++ b/thrust/thrust/system/detail/generic/select_system.h
@@ -32,7 +32,10 @@
 #include <thrust/iterator/detail/device_system_tag.h>
 #include <thrust/iterator/detail/minimum_system.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/void_t.h>
+#include <cuda/std/__utility/declval.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/detail/generic/sort.inl
+++ b/thrust/thrust/system/detail/generic/sort.inl
@@ -26,13 +26,16 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/detail/internal_functional.h>
-#include <thrust/distance.h>
 #include <thrust/find.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/zip_iterator.h>
 #include <thrust/system/detail/generic/sort.h>
 #include <thrust/tuple.h>
+
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__iterator/distance.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/system/detail/generic/swap_ranges.inl
+++ b/thrust/thrust/system/detail/generic/swap_ranges.inl
@@ -31,7 +31,7 @@
 #include <thrust/system/detail/generic/swap_ranges.h>
 #include <thrust/tuple.h>
 
-#include <cuda/std/utility>
+#include <cuda/std/__utility/swap.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/system/detail/generic/tabulate.inl
+++ b/thrust/thrust/system/detail/generic/tabulate.inl
@@ -25,11 +25,13 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/distance.h>
+
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/detail/generic/tabulate.h>
 #include <thrust/transform.h>
+
+#include <cuda/std/__iterator/distance.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/system/detail/generic/transform_scan.inl
+++ b/thrust/thrust/system/detail/generic/transform_scan.inl
@@ -30,7 +30,7 @@
 #include <thrust/scan.h>
 #include <thrust/system/detail/generic/transform_scan.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/remove_cvref.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/system/detail/generic/unique.inl
+++ b/thrust/thrust/system/detail/generic/unique.inl
@@ -30,12 +30,13 @@
 #include <thrust/detail/internal_functional.h>
 #include <thrust/detail/range/head_flags.h>
 #include <thrust/detail/temporary_array.h>
-#include <thrust/distance.h>
 #include <thrust/functional.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/detail/generic/unique.h>
 #include <thrust/transform.h>
 #include <thrust/unique.h>
+
+#include <cuda/std/__functional/operations.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/system/detail/sequential/binary_search.h
+++ b/thrust/thrust/system/detail/sequential/binary_search.h
@@ -30,10 +30,12 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/advance.h>
 #include <thrust/detail/function.h>
-#include <thrust/distance.h>
 #include <thrust/iterator/iterator_traits.h>
+#include <thrust/system/detail/sequential/execution_policy.h>
+
+#include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__iterator/distance.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::sequential

--- a/thrust/thrust/system/detail/sequential/iter_swap.h
+++ b/thrust/thrust/system/detail/sequential/iter_swap.h
@@ -28,7 +28,7 @@
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/system/detail/sequential/execution_policy.h>
 
-#include <cuda/std/utility>
+#include <cuda/std/__utility/swap.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::sequential

--- a/thrust/thrust/system/detail/sequential/stable_merge_sort.h
+++ b/thrust/thrust/system/detail/sequential/stable_merge_sort.h
@@ -33,7 +33,6 @@
 #include <thrust/system/detail/sequential/insertion_sort.h>
 
 #include <cuda/std/__algorithm/min.h>
-#include <cuda/std/iterator>
 
 #include <nv/target>
 

--- a/thrust/thrust/system/detail/sequential/stable_radix_sort.h
+++ b/thrust/thrust/system/detail/sequential/stable_radix_sort.h
@@ -35,9 +35,9 @@
 #include <thrust/scatter.h>
 #include <thrust/system/detail/sequential/execution_policy.h>
 
+#include <cuda/std/__utility/declval.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
-#include <cuda/std/utility>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::sequential

--- a/thrust/thrust/system/omp/detail/copy.h
+++ b/thrust/thrust/system/omp/detail/copy.h
@@ -18,7 +18,7 @@
 #include <thrust/system/detail/sequential/copy.h>
 #include <thrust/system/omp/detail/execution_policy.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/is_convertible.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::omp::detail

--- a/thrust/thrust/system/omp/detail/for_each.h
+++ b/thrust/thrust/system/omp/detail/for_each.h
@@ -20,11 +20,12 @@
 
 #include <thrust/detail/function.h>
 #include <thrust/detail/static_assert.h>
-#include <thrust/distance.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/omp/detail/execution_policy.h>
 #include <thrust/system/omp/detail/pragma_omp.h>
+
+#include <cuda/std/__iterator/distance.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::omp::detail

--- a/thrust/thrust/system/omp/detail/reduce.h
+++ b/thrust/thrust/system/omp/detail/reduce.h
@@ -18,11 +18,12 @@
 #endif // no system header
 
 #include <thrust/detail/temporary_array.h>
-#include <thrust/distance.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/omp/detail/default_decomposition.h>
 #include <thrust/system/omp/detail/execution_policy.h>
 #include <thrust/system/omp/detail/reduce_intervals.h>
+
+#include <cuda/std/__iterator/distance.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::omp::detail

--- a/thrust/thrust/system/omp/detail/reduce_by_key.h
+++ b/thrust/thrust/system/omp/detail/reduce_by_key.h
@@ -17,7 +17,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/distance.h>
 #include <thrust/system/detail/generic/reduce_by_key.h>
 #include <thrust/system/omp/detail/execution_policy.h>
 

--- a/thrust/thrust/system/omp/detail/scan.h
+++ b/thrust/thrust/system/omp/detail/scan.h
@@ -14,19 +14,21 @@
 #endif // no system header
 
 // OMP parallel scan implementation
-#include <thrust/advance.h>
 #include <thrust/detail/function.h>
 #include <thrust/detail/temporary_array.h>
-#include <thrust/distance.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/omp/detail/execution_policy.h>
 #include <thrust/system/omp/detail/pragma_omp.h>
 
+#include <cuda/__cmath/ceil_div.h>
 #include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__iterator/distance.h>
 #include <cuda/std/__numeric/exclusive_scan.h>
 #include <cuda/std/__numeric/inclusive_scan.h>
 #include <cuda/std/__numeric/reduce.h>
-#include <cuda/std/cmath>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_same.h>
 
 #include <omp.h>
 

--- a/thrust/thrust/system/omp/pointer.h
+++ b/thrust/thrust/system/omp/pointer.h
@@ -34,7 +34,7 @@
 #include <thrust/detail/reference.h>
 #include <thrust/system/omp/detail/execution_policy.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/add_lvalue_reference.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::omp

--- a/thrust/thrust/system/tbb/detail/copy.h
+++ b/thrust/thrust/system/tbb/detail/copy.h
@@ -18,7 +18,7 @@
 #include <thrust/system/detail/sequential/copy.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/is_convertible.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::tbb::detail

--- a/thrust/thrust/system/tbb/detail/copy_if.h
+++ b/thrust/thrust/system/tbb/detail/copy_if.h
@@ -12,10 +12,13 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/detail/function.h>
-#include <thrust/distance.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
+
+#include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__iterator/distance.h>
 
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_scan.h>

--- a/thrust/thrust/system/tbb/detail/for_each.h
+++ b/thrust/thrust/system/tbb/detail/for_each.h
@@ -12,11 +12,13 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/detail/seq.h>
 #include <thrust/detail/static_assert.h>
-#include <thrust/distance.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
+
+#include <cuda/std/__iterator/distance.h>
 
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_for.h>

--- a/thrust/thrust/system/tbb/detail/reduce.h
+++ b/thrust/thrust/system/tbb/detail/reduce.h
@@ -18,10 +18,11 @@
 #endif // no system header
 #include <thrust/detail/function.h>
 #include <thrust/detail/static_assert.h>
-#include <thrust/distance.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/reduce.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
+
+#include <cuda/std/__iterator/distance.h>
 
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_reduce.h>

--- a/thrust/thrust/system/tbb/detail/reduce_by_key.h
+++ b/thrust/thrust/system/tbb/detail/reduce_by_key.h
@@ -22,9 +22,9 @@
 
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__iterator/reverse_iterator.h>
 #include <cuda/std/__type_traits/void_t.h>
 #include <cuda/std/cassert>
-#include <cuda/std/iterator>
 
 #include <thread>
 

--- a/thrust/thrust/system/tbb/detail/reduce_intervals.h
+++ b/thrust/thrust/system/tbb/detail/reduce_intervals.h
@@ -19,8 +19,8 @@
 #include <thrust/system/tbb/detail/execution_policy.h>
 
 #include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/cassert>
-#include <cuda/std/type_traits>
 
 #include <tbb/parallel_for.h>
 

--- a/thrust/thrust/system/tbb/detail/scan.h
+++ b/thrust/thrust/system/tbb/detail/scan.h
@@ -16,14 +16,14 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/advance.h>
 #include <thrust/detail/function.h>
 #include <thrust/detail/type_traits.h>
-#include <thrust/distance.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
 
 #include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__iterator/distance.h>
 
 #include <tbb/blocked_range.h>
 #include <tbb/parallel_scan.h>

--- a/thrust/thrust/system/tbb/detail/sort.h
+++ b/thrust/thrust/system/tbb/detail/sort.h
@@ -15,11 +15,12 @@
 #include <thrust/detail/copy.h>
 #include <thrust/detail/seq.h>
 #include <thrust/detail/temporary_array.h>
-#include <thrust/distance.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/merge.h>
 #include <thrust/sort.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
+
+#include <cuda/std/__iterator/distance.h>
 
 #include <tbb/parallel_invoke.h>
 

--- a/thrust/thrust/system/tbb/pointer.h
+++ b/thrust/thrust/system/tbb/pointer.h
@@ -20,7 +20,7 @@
 #include <thrust/detail/reference.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
 
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/add_lvalue_reference.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::tbb

--- a/thrust/thrust/transform.h
+++ b/thrust/thrust/transform.h
@@ -34,7 +34,7 @@
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/detail/generic/select_system.h>
 
-#include <cuda/std/iterator>
+#include <cuda/std/__iterator/incrementable_traits.h>
 
 // Include all active backend system implementations (generic, sequential, host and device)
 #include <thrust/system/detail/generic/transform.h>

--- a/thrust/thrust/type_traits/integer_sequence.h
+++ b/thrust/thrust/type_traits/integer_sequence.h
@@ -32,9 +32,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__utility/integer_sequence.h>
 #include <cuda/std/cstdint>
-#include <cuda/std/type_traits>
-#include <cuda/std/utility>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/type_traits/is_contiguous_iterator.h
+++ b/thrust/thrust/type_traits/is_contiguous_iterator.h
@@ -33,7 +33,10 @@
 #endif // no system header
 #include <thrust/detail/type_traits/is_thrust_pointer.h>
 
-#include <cuda/std/iterator>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__type_traits/is_pointer.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/type_traits/is_trivially_relocatable.h
+++ b/thrust/thrust/type_traits/is_trivially_relocatable.h
@@ -40,7 +40,8 @@
 #include <cuda/std/__fwd/pair.h>
 #include <cuda/std/__fwd/tuple.h>
 #include <cuda/std/__type_traits/conjunction.h>
-#include <cuda/std/type_traits>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_trivially_copyable.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -110,7 +111,7 @@ constexpr bool is_trivially_relocatable_v = is_trivially_relocatable<T>::value;
  */
 template <typename From, typename To>
 using is_trivially_relocatable_to =
-  integral_constant<bool, ::cuda::std::is_same<From, To>::value && is_trivially_relocatable<To>::value>;
+  integral_constant<bool, ::cuda::std::is_same_v<From, To> && is_trivially_relocatable<To>::value>;
 
 /*! \brief <tt>constexpr bool</tt> that is \c true if \c From is
  *  <a href="https://wg21.link/P1144"><i>TriviallyRelocatable</i></a>,
@@ -209,7 +210,7 @@ namespace detail
 // https://wg21.link/P1144R0#wording-inheritance
 template <typename T>
 struct is_trivially_relocatable_impl
-    : integral_constant<bool, ::cuda::std::is_trivially_copyable<T>::value || proclaim_trivially_relocatable<T>::value>
+    : integral_constant<bool, ::cuda::std::is_trivially_copyable_v<T> || proclaim_trivially_relocatable<T>::value>
 {};
 
 template <typename T, ::cuda::std::size_t N>

--- a/thrust/thrust/type_traits/unwrap_contiguous_iterator.h
+++ b/thrust/thrust/type_traits/unwrap_contiguous_iterator.h
@@ -21,7 +21,7 @@
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/type_traits/is_contiguous_iterator.h>
 
-#include <cuda/std/utility>
+#include <cuda/std/__utility/declval.h>
 
 THRUST_NAMESPACE_BEGIN
 


### PR DESCRIPTION
We only want to include what we need not the whole world

There are multiple cases where we only needed cuda::std::declval but included all of cuda::std::utility which is in the order of 100k LoC
