### PR TITLE
Drop old namespace macros

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -994,14 +994,14 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::Min");
 
-    static_assert(!_CUDA_STD_EXEC::__queryable_with<EnvT, _CUDA_EXEC::determinism::__get_determinism_t>,
+    static_assert(!::cuda::std::execution::__queryable_with<EnvT, ::cuda::execution::determinism::__get_determinism_t>,
                   "Determinism should be used inside requires to have an effect.");
-    using requirements_t =
-      _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_requirements_t, _CUDA_STD_EXEC::env<>>;
+    using requirements_t = ::cuda::std::execution::
+      __query_result_or_t<EnvT, ::cuda::execution::__get_requirements_t, ::cuda::std::execution::env<>>;
     using requested_determinism_t =
-      _CUDA_STD_EXEC::__query_result_or_t<requirements_t, //
-                                          _CUDA_EXEC::determinism::__get_determinism_t,
-                                          _CUDA_EXEC::determinism::run_to_run_t>;
+      ::cuda::std::execution::__query_result_or_t<requirements_t, //
+                                                  ::cuda::execution::determinism::__get_determinism_t,
+                                                  ::cuda::execution::determinism::run_to_run_t>;
 
     // Static assert to reject gpu_to_gpu determinism since it's not properly implemented
     static_assert(!::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::gpu_to_gpu_t>,
@@ -1011,13 +1011,15 @@ public:
     using determinism_t = ::cuda::execution::determinism::run_to_run_t;
 
     // Query relevant properties from the environment
-    auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
-    auto mr     = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
+    auto stream = ::cuda::std::execution::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
+    auto mr =
+      ::cuda::std::execution::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
 
     void* d_temp_storage      = nullptr;
     size_t temp_storage_bytes = 0;
 
-    using tuning_t = _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_tuning_t, _CUDA_STD_EXEC::env<>>;
+    using tuning_t =
+      ::cuda::std::execution::__query_result_or_t<EnvT, ::cuda::execution::__get_tuning_t, ::cuda::std::execution::env<>>;
 
     using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
 
@@ -1281,14 +1283,14 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMin");
 
-    static_assert(!_CUDA_STD_EXEC::__queryable_with<EnvT, _CUDA_EXEC::determinism::__get_determinism_t>,
+    static_assert(!::cuda::std::execution::__queryable_with<EnvT, ::cuda::execution::determinism::__get_determinism_t>,
                   "Determinism should be used inside requires to have an effect.");
-    using requirements_t =
-      _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_requirements_t, _CUDA_STD_EXEC::env<>>;
+    using requirements_t = ::cuda::std::execution::
+      __query_result_or_t<EnvT, ::cuda::execution::__get_requirements_t, ::cuda::std::execution::env<>>;
     using requested_determinism_t =
-      _CUDA_STD_EXEC::__query_result_or_t<requirements_t, //
-                                          _CUDA_EXEC::determinism::__get_determinism_t,
-                                          _CUDA_EXEC::determinism::run_to_run_t>;
+      ::cuda::std::execution::__query_result_or_t<requirements_t, //
+                                                  ::cuda::execution::determinism::__get_determinism_t,
+                                                  ::cuda::execution::determinism::run_to_run_t>;
 
     // Static assert to reject gpu_to_gpu determinism since it's not properly implemented
     static_assert(!::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::gpu_to_gpu_t>,
@@ -1298,13 +1300,15 @@ public:
     using determinism_t = ::cuda::execution::determinism::run_to_run_t;
 
     // Query relevant properties from the environment
-    auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
-    auto mr     = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
+    auto stream = ::cuda::std::execution::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
+    auto mr =
+      ::cuda::std::execution::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
 
     void* d_temp_storage      = nullptr;
     size_t temp_storage_bytes = 0;
 
-    using tuning_t = _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_tuning_t, _CUDA_STD_EXEC::env<>>;
+    using tuning_t =
+      ::cuda::std::execution::__query_result_or_t<EnvT, ::cuda::execution::__get_tuning_t, ::cuda::std::execution::env<>>;
 
     // Reduction operation
     using ReduceOpT           = cub::ArgMin;
@@ -1662,14 +1666,14 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::Max");
 
-    static_assert(!_CUDA_STD_EXEC::__queryable_with<EnvT, _CUDA_EXEC::determinism::__get_determinism_t>,
+    static_assert(!::cuda::std::execution::__queryable_with<EnvT, ::cuda::execution::determinism::__get_determinism_t>,
                   "Determinism should be used inside requires to have an effect.");
-    using requirements_t =
-      _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_requirements_t, _CUDA_STD_EXEC::env<>>;
+    using requirements_t = ::cuda::std::execution::
+      __query_result_or_t<EnvT, ::cuda::execution::__get_requirements_t, ::cuda::std::execution::env<>>;
     using requested_determinism_t =
-      _CUDA_STD_EXEC::__query_result_or_t<requirements_t, //
-                                          _CUDA_EXEC::determinism::__get_determinism_t,
-                                          _CUDA_EXEC::determinism::run_to_run_t>;
+      ::cuda::std::execution::__query_result_or_t<requirements_t, //
+                                                  ::cuda::execution::determinism::__get_determinism_t,
+                                                  ::cuda::execution::determinism::run_to_run_t>;
 
     // Static assert to reject gpu_to_gpu determinism since it's not properly implemented
     static_assert(!::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::gpu_to_gpu_t>,
@@ -1679,13 +1683,15 @@ public:
     using determinism_t = ::cuda::execution::determinism::run_to_run_t;
 
     // Query relevant properties from the environment
-    auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
-    auto mr     = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
+    auto stream = ::cuda::std::execution::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
+    auto mr =
+      ::cuda::std::execution::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
 
     void* d_temp_storage      = nullptr;
     size_t temp_storage_bytes = 0;
 
-    using tuning_t = _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_tuning_t, _CUDA_STD_EXEC::env<>>;
+    using tuning_t =
+      ::cuda::std::execution::__query_result_or_t<EnvT, ::cuda::execution::__get_tuning_t, ::cuda::std::execution::env<>>;
 
     using OutputT = cub::detail::non_void_value_t<OutputIteratorT, cub::detail::it_value_t<InputIteratorT>>;
 
@@ -2073,14 +2079,14 @@ public:
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMax");
 
-    static_assert(!_CUDA_STD_EXEC::__queryable_with<EnvT, _CUDA_EXEC::determinism::__get_determinism_t>,
+    static_assert(!::cuda::std::execution::__queryable_with<EnvT, ::cuda::execution::determinism::__get_determinism_t>,
                   "Determinism should be used inside requires to have an effect.");
-    using requirements_t =
-      _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_requirements_t, _CUDA_STD_EXEC::env<>>;
+    using requirements_t = ::cuda::std::execution::
+      __query_result_or_t<EnvT, ::cuda::execution::__get_requirements_t, ::cuda::std::execution::env<>>;
     using requested_determinism_t =
-      _CUDA_STD_EXEC::__query_result_or_t<requirements_t, //
-                                          _CUDA_EXEC::determinism::__get_determinism_t,
-                                          _CUDA_EXEC::determinism::run_to_run_t>;
+      ::cuda::std::execution::__query_result_or_t<requirements_t, //
+                                                  ::cuda::execution::determinism::__get_determinism_t,
+                                                  ::cuda::execution::determinism::run_to_run_t>;
 
     // Static assert to reject gpu_to_gpu determinism since it's not properly implemented
     static_assert(!::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::gpu_to_gpu_t>,
@@ -2090,13 +2096,15 @@ public:
     using determinism_t = ::cuda::execution::determinism::run_to_run_t;
 
     // Query relevant properties from the environment
-    auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
-    auto mr     = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
+    auto stream = ::cuda::std::execution::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
+    auto mr =
+      ::cuda::std::execution::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
 
     void* d_temp_storage      = nullptr;
     size_t temp_storage_bytes = 0;
 
-    using tuning_t = _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_tuning_t, _CUDA_STD_EXEC::env<>>;
+    using tuning_t =
+      ::cuda::std::execution::__query_result_or_t<EnvT, ::cuda::execution::__get_tuning_t, ::cuda::std::execution::env<>>;
 
     // Reduction operation
     using ReduceOpT           = cub::ArgMax;

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -158,16 +158,16 @@ struct DeviceScan
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t scan_impl_env(
     InputIteratorT d_in, OutputIteratorT d_out, ScanOpT scan_op, InitValueT init, NumItemsT num_items, EnvT env)
   {
-    static_assert(!_CUDA_STD_EXEC::__queryable_with<EnvT, _CUDA_EXEC::determinism::__get_determinism_t>,
+    static_assert(!::cuda::std::execution::__queryable_with<EnvT, ::cuda::execution::determinism::__get_determinism_t>,
                   "Determinism should be used inside requires to have an effect.");
 
-    using requirements_t =
-      _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_requirements_t, _CUDA_STD_EXEC::env<>>;
+    using requirements_t = ::cuda::std::execution::
+      __query_result_or_t<EnvT, ::cuda::execution::__get_requirements_t, ::cuda::std::execution::env<>>;
 
     using requested_determinism_t =
-      _CUDA_STD_EXEC::__query_result_or_t<requirements_t, //
-                                          _CUDA_EXEC::determinism::__get_determinism_t,
-                                          _CUDA_EXEC::determinism::run_to_run_t>;
+      ::cuda::std::execution::__query_result_or_t<requirements_t, //
+                                                  ::cuda::execution::determinism::__get_determinism_t,
+                                                  ::cuda::execution::determinism::run_to_run_t>;
 
     // Static assert to reject gpu_to_gpu determinism since it's not implemented
     static_assert(!::cuda::std::is_same_v<requested_determinism_t, ::cuda::execution::determinism::gpu_to_gpu_t>,
@@ -179,13 +179,15 @@ struct DeviceScan
     using determinism_t = ::cuda::execution::determinism::run_to_run_t;
 
     // Query relevant properties from the environment
-    auto stream = _CUDA_STD_EXEC::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
-    auto mr     = _CUDA_STD_EXEC::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
+    auto stream = ::cuda::std::execution::__query_or(env, ::cuda::get_stream, ::cuda::stream_ref{cudaStream_t{}});
+    auto mr =
+      ::cuda::std::execution::__query_or(env, ::cuda::mr::__get_memory_resource, detail::device_memory_resource{});
 
     void* d_temp_storage      = nullptr;
     size_t temp_storage_bytes = 0;
 
-    using tuning_t = _CUDA_STD_EXEC::__query_result_or_t<EnvT, _CUDA_EXEC::__get_tuning_t, _CUDA_STD_EXEC::env<>>;
+    using tuning_t =
+      ::cuda::std::execution::__query_result_or_t<EnvT, ::cuda::execution::__get_tuning_t, ::cuda::std::execution::env<>>;
 
     // Query the required temporary storage size
     cudaError_t error = scan_impl_determinism<tuning_t>(
@@ -378,7 +380,7 @@ struct DeviceScan
   //!   **[inferred]** An integral type representing the number of input elements
   //!
   //! @tparam EnvT
-  //!   **[inferred]** Execution environment type. Default is `_CUDA_STD_EXEC::env<>`.
+  //!   **[inferred]** Execution environment type. Default is `::cuda::std::execution::env<>`.
   //!
   //! @param[in] d_in
   //!   Random-access iterator to the input sequence of data items
@@ -391,9 +393,12 @@ struct DeviceScan
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Default is `_CUDA_STD_EXEC::env{}`.
+  //!   **[optional]** Execution environment. Default is `::cuda::std::execution::env{}`.
   //!   @endrst
-  template <typename InputIteratorT, typename OutputIteratorT, typename NumItemsT, typename EnvT = _CUDA_STD_EXEC::env<>>
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename NumItemsT,
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   ExclusiveSum(InputIteratorT d_in, OutputIteratorT d_out, NumItemsT num_items, EnvT env = {})
   {
@@ -659,7 +664,7 @@ struct DeviceScan
   //!   **[inferred]** An integral type representing the number of input elements
   //!
   //! @tparam EnvT
-  //!   **[inferred]** Execution environment type. Default is `_CUDA_STD_EXEC::env<>`.
+  //!   **[inferred]** Execution environment type. Default is `::cuda::std::execution::env<>`.
   //!
   //! @param[in] d_in
   //!   Random-access iterator to the input sequence of data items
@@ -678,14 +683,14 @@ struct DeviceScan
   //!
   //! @param[in] env
   //!   @rst
-  //!   **[optional]** Execution environment. Default is `_CUDA_STD_EXEC::env{}`.
+  //!   **[optional]** Execution environment. Default is `::cuda::std::execution::env{}`.
   //!   @endrst
   template <typename InputIteratorT,
             typename OutputIteratorT,
             typename ScanOpT,
             typename InitValueT,
             typename NumItemsT,
-            typename EnvT = _CUDA_STD_EXEC::env<>>
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t ExclusiveScan(
     InputIteratorT d_in,
     OutputIteratorT d_out,

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
@@ -31,9 +31,9 @@ struct SegmentedSortPolicyWrapper : PolicyT
 
 template <typename StaticPolicyT>
 struct SegmentedSortPolicyWrapper<StaticPolicyT,
-                                  _CUDA_VSTD::void_t<typename StaticPolicyT::LargeSegmentPolicy,
-                                                     typename StaticPolicyT::SmallSegmentPolicy,
-                                                     typename StaticPolicyT::MediumSegmentPolicy>> : StaticPolicyT
+                                  ::cuda::std::void_t<typename StaticPolicyT::LargeSegmentPolicy,
+                                                      typename StaticPolicyT::SmallSegmentPolicy,
+                                                      typename StaticPolicyT::MediumSegmentPolicy>> : StaticPolicyT
 {
   _CCCL_HOST_DEVICE SegmentedSortPolicyWrapper(StaticPolicyT base)
       : StaticPolicyT(base)

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -34,7 +34,7 @@ struct ThreeWayPartitionPolicyWrapper : PolicyT
 };
 
 template <typename StaticPolicyT>
-struct ThreeWayPartitionPolicyWrapper<StaticPolicyT, _CUDA_VSTD::void_t<typename StaticPolicyT::ThreeWayPartitionPolicy>>
+struct ThreeWayPartitionPolicyWrapper<StaticPolicyT, ::cuda::std::void_t<typename StaticPolicyT::ThreeWayPartitionPolicy>>
     : StaticPolicyT
 {
   _CCCL_HOST_DEVICE ThreeWayPartitionPolicyWrapper(StaticPolicyT base)

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -68,7 +68,7 @@ struct green_context
 #  if _CCCL_CTK_AT_LEAST(13, 0)
   [[nodiscard]] _CCCL_HOST_API green_context_id id() const
   {
-    return green_context_id{_CUDA_DRIVER::__greenCtxGetId(__green_ctx)};
+    return green_context_id{::cuda::__driver::__greenCtxGetId(__green_ctx)};
   }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 

--- a/cudax/include/cuda/experimental/__kernel/attributes.cuh
+++ b/cudax/include/cuda/experimental/__kernel/attributes.cuh
@@ -48,7 +48,7 @@ struct __kernel_attr_impl
   [[nodiscard]] type operator()(kernel_ref<_Signature> __kernel, device_ref __dev) const
   {
     return static_cast<type>(
-      _CUDA_DRIVER::__kernelGetAttribute(_Attr, __kernel.get(), _CUDA_DRIVER::__deviceGet(__dev.get())));
+      ::cuda::__driver::__kernelGetAttribute(_Attr, __kernel.get(), ::cuda::__driver::__deviceGet(__dev.get())));
   }
 };
 

--- a/cudax/include/cuda/experimental/__kernel/kernel_ref.cuh
+++ b/cudax/include/cuda/experimental/__kernel/kernel_ref.cuh
@@ -95,7 +95,7 @@ public:
   //! @throws cuda_error if the kernel name cannot be obtained
   [[nodiscard]] ::cuda::std::string_view name() const
   {
-    return _CUDA_DRIVER::__kernelGetName(__kernel_);
+    return ::cuda::__driver::__kernelGetName(__kernel_);
   }
 #endif // _CCCL_CTK_AT_LEAST(12, 3)
 

--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -220,7 +220,7 @@ private:
     cudaError_t status = cudaSuccess;
 
     int max_dynamic_shared_size{};
-    status = _CUDA_DRIVER::__functionGetAttributeNoThrow(
+    status = ::cuda::__driver::__functionGetAttributeNoThrow(
       max_dynamic_shared_size, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, kernel);
     if (status != cudaSuccess)
     {
@@ -233,7 +233,7 @@ private:
     {
       // TODO since 12.6 there is a per launch option available, we should switch once compatibility is not an issue
       // TODO should we validate the max amount with device props or just pass it through and rely on driver error?
-      status = _CUDA_DRIVER::__functionSetAttributeNoThrow(
+      status = ::cuda::__driver::__functionSetAttributeNoThrow(
         kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, size_needed);
       if (status != cudaSuccess)
       {

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -60,7 +60,7 @@ __global__ static void __kernel_launcher_no_config(_Kernel __kernel_fn, _Args...
 template <class... _Args>
 [[nodiscard]] _CCCL_HOST_API CUfunction __get_cufunction_of(kernel_ref<void(_Args...)> __kernel)
 {
-  return _CUDA_DRIVER::__kernelGetFunction(__kernel.get());
+  return ::cuda::__driver::__kernelGetFunction(__kernel.get());
 }
 
 template <class... _Args>
@@ -90,12 +90,12 @@ __do_launch(_GraphInserter&& __inserter, ::CUlaunchConfig& __config, ::CUfunctio
 
   auto __dependencies = __inserter.get_dependencies();
 
-  const auto __node = _CUDA_DRIVER::__graphAddKernelNode(
+  const auto __node = ::cuda::__driver::__graphAddKernelNode(
     __inserter.get_graph().get(), __dependencies.data(), __dependencies.size(), __node_params);
 
   for (unsigned int __i = 0; __i < __config.numAttrs; ++__i)
   {
-    _CUDA_DRIVER::__graphKernelNodeSetAttribute(__node, __config.attrs[__i].id, __config.attrs[__i].value);
+    ::cuda::__driver::__graphKernelNodeSetAttribute(__node, __config.attrs[__i].id, __config.attrs[__i].value);
   }
 
   // TODO skip the update if called on rvalue?
@@ -111,7 +111,7 @@ _CCCL_HOST_API void inline __do_launch(
 #if defined(_CUDAX_LAUNCH_CONFIG_TEST)
   test_launch_kernel_replacement(__config, __kernel, __args_ptrs);
 #else // ^^^ _CUDAX_LAUNCH_CONFIG_TEST ^^^ / vvv !_CUDAX_LAUNCH_CONFIG_TEST vvv
-  _CUDA_DRIVER::__launchKernel(__config, __kernel, __args_ptrs);
+  ::cuda::__driver::__launchKernel(__config, __kernel, __args_ptrs);
 #endif // ^^^ !_CUDAX_LAUNCH_CONFIG_TEST ^^^
 }
 

--- a/cudax/include/cuda/experimental/__library/library.cuh
+++ b/cudax/include/cuda/experimental/__library/library.cuh
@@ -79,7 +79,7 @@ struct library : public library_ref
   {
     if (__library_ != value_type{})
     {
-      [[maybe_unused]] const auto __status = _CUDA_DRIVER::__libraryUnloadNoThrow(__library_);
+      [[maybe_unused]] const auto __status = ::cuda::__driver::__libraryUnloadNoThrow(__library_);
     }
   }
 

--- a/cudax/include/cuda/experimental/__library/library_ref.cuh
+++ b/cudax/include/cuda/experimental/__library/library_ref.cuh
@@ -73,7 +73,7 @@ public:
   [[nodiscard]] bool has_kernel(const char* __name) const
   {
     ::CUkernel __kernel{};
-    switch (const auto __res = _CUDA_DRIVER::__libraryGetKernelNoThrow(__kernel, __library_, __name))
+    switch (const auto __res = ::cuda::__driver::__libraryGetKernelNoThrow(__kernel, __library_, __name))
     {
       case ::cudaSuccess:
         return true;
@@ -97,7 +97,7 @@ public:
   [[nodiscard]] kernel_ref<_Signature> kernel(const char* __name) const
   {
     ::CUkernel __kernel{};
-    if (const auto __res = _CUDA_DRIVER::__libraryGetKernelNoThrow(__kernel, __library_, __name);
+    if (const auto __res = ::cuda::__driver::__libraryGetKernelNoThrow(__kernel, __library_, __name);
         __res != ::cudaSuccess)
     {
       ::cuda::__throw_cuda_error(__res, "Failed to get the kernel from the library");
@@ -119,7 +119,7 @@ public:
 
     ::CUdeviceptr __dptr{};
     ::cuda::std::size_t __size{};
-    switch (const auto __res = _CUDA_DRIVER::__libraryGetGlobalNoThrow(__dptr, __size, __library_, __name))
+    switch (const auto __res = ::cuda::__driver::__libraryGetGlobalNoThrow(__dptr, __size, __library_, __name))
     {
       case ::cudaSuccess:
         return true;
@@ -144,7 +144,7 @@ public:
 
     ::CUdeviceptr __dptr{};
     ::cuda::std::size_t __size{};
-    if (const auto __res = _CUDA_DRIVER::__libraryGetGlobalNoThrow(__dptr, __size, __library_, __name);
+    if (const auto __res = ::cuda::__driver::__libraryGetGlobalNoThrow(__dptr, __size, __library_, __name);
         __res != ::cudaSuccess)
     {
       ::cuda::__throw_cuda_error(__res, "Failed to get the global symbol from the library");
@@ -165,7 +165,7 @@ public:
   {
     ::CUdeviceptr __dptr{};
     ::cuda::std::size_t __size{};
-    switch (const auto __res = _CUDA_DRIVER::__libraryGetManagedNoThrow(__dptr, __size, __library_, __name))
+    switch (const auto __res = ::cuda::__driver::__libraryGetManagedNoThrow(__dptr, __size, __library_, __name))
     {
       case ::cudaSuccess:
         return true;
@@ -189,7 +189,7 @@ public:
   {
     ::CUdeviceptr __dptr{};
     ::cuda::std::size_t __size{};
-    if (const auto __res = _CUDA_DRIVER::__libraryGetManagedNoThrow(__dptr, __size, __library_, __name);
+    if (const auto __res = ::cuda::__driver::__libraryGetManagedNoThrow(__dptr, __size, __library_, __name);
         __res != ::cudaSuccess)
     {
       ::cuda::__throw_cuda_error(__res, "Failed to get the managed symbol from the library");

--- a/cudax/test/kernel/kernel_ref.cu
+++ b/cudax/test/kernel/kernel_ref.cu
@@ -176,10 +176,10 @@ template <const auto& Attr, ::CUfunction_attribute ExpectedAttr, class ExpectedR
 
 C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
 {
-  CUlibrary lib = _CUDA_DRIVER::__libraryLoadData(kernel_ptx_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  CUlibrary lib = ::cuda::__driver::__libraryLoadData(kernel_ptx_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
 
-  CUkernel kernel_ptx1_handle = _CUDA_DRIVER::__libraryGetKernel(lib, "kernel_ptx1");
-  CUkernel kernel_ptx2_handle = _CUDA_DRIVER::__libraryGetKernel(lib, "kernel_ptx2");
+  CUkernel kernel_ptx1_handle = ::cuda::__driver::__libraryGetKernel(lib, "kernel_ptx1");
+  CUkernel kernel_ptx2_handle = ::cuda::__driver::__libraryGetKernel(lib, "kernel_ptx2");
 
   cuda::device_ref device{0};
   cuda::__ensure_current_context context_guard{device};
@@ -314,5 +314,5 @@ C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
   }
 #endif // _CCCL_CTK_AT_LEAST(12, 1)
 
-  CUDAX_REQUIRE(_CUDA_DRIVER::__libraryUnloadNoThrow(lib) == cudaSuccess);
+  CUDAX_REQUIRE(::cuda::__driver::__libraryUnloadNoThrow(lib) == cudaSuccess);
 }

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -76,7 +76,7 @@ void test_launch_kernel_replacement(CUlaunchConfig& config, CUfunction kernel, v
 
   if (!has_cluster || !skip_device_exec(arch_filter<std::less<int>, 90>))
   {
-    return _CUDA_DRIVER::__launchKernel(config, kernel, args);
+    return ::cuda::__driver::__launchKernel(config, kernel, args);
   }
 }
 

--- a/cudax/test/library/library.cu
+++ b/cudax/test/library/library.cu
@@ -105,8 +105,8 @@ C2H_CCCLRT_TEST("Library", "[library]")
   constexpr char const_symbol_name[]   = "const_data";
   constexpr char managed_symbol_name[] = "managed_data";
 
-  CUlibrary lib1_native = _CUDA_DRIVER::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
-  CUlibrary lib2_native = _CUDA_DRIVER::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  CUlibrary lib1_native = ::cuda::__driver::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  CUlibrary lib2_native = ::cuda::__driver::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
 
   const cuda::device_ref device{0};
 
@@ -203,7 +203,7 @@ C2H_CCCLRT_TEST("Library", "[library]")
     auto kernel        = lib.kernel<void(int*, int)>(kernel_name);
 
     CUkernel kernel_handle;
-    CUDAX_REQUIRE(_CUDA_DRIVER::__libraryGetKernelNoThrow(kernel_handle, lib1_native, kernel_name) == cudaSuccess);
+    CUDAX_REQUIRE(::cuda::__driver::__libraryGetKernelNoThrow(kernel_handle, lib1_native, kernel_name) == cudaSuccess);
     CUDAX_REQUIRE(kernel.get() == kernel_handle);
 
     (void) lib.release(); // prevent library unload in destructor
@@ -238,9 +238,9 @@ C2H_CCCLRT_TEST("Library", "[library]")
 
       CUdeviceptr global_symbol_ptr;
       cuda::std::size_t global_symbol_size;
-      CUDAX_REQUIRE(
-        _CUDA_DRIVER::__libraryGetGlobalNoThrow(global_symbol_ptr, global_symbol_size, lib1_native, global_symbol_name)
-        == cudaSuccess);
+      CUDAX_REQUIRE(::cuda::__driver::__libraryGetGlobalNoThrow(
+                      global_symbol_ptr, global_symbol_size, lib1_native, global_symbol_name)
+                    == cudaSuccess);
 
       CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(global_sym.ptr) == global_symbol_ptr);
       CUDAX_REQUIRE(global_sym.size == global_symbol_size);
@@ -256,7 +256,7 @@ C2H_CCCLRT_TEST("Library", "[library]")
       CUdeviceptr const_symbol_ptr;
       cuda::std::size_t const_symbol_size;
       CUDAX_REQUIRE(
-        _CUDA_DRIVER::__libraryGetGlobalNoThrow(const_symbol_ptr, const_symbol_size, lib1_native, const_symbol_name)
+        ::cuda::__driver::__libraryGetGlobalNoThrow(const_symbol_ptr, const_symbol_size, lib1_native, const_symbol_name)
         == cudaSuccess);
 
       CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(const_sym.ptr) == const_symbol_ptr);
@@ -289,9 +289,9 @@ C2H_CCCLRT_TEST("Library", "[library]")
 
     CUdeviceptr managed_symbol_ptr;
     cuda::std::size_t managed_symbol_size;
-    CUDAX_REQUIRE(
-      _CUDA_DRIVER::__libraryGetManagedNoThrow(managed_symbol_ptr, managed_symbol_size, lib1_native, managed_symbol_name)
-      == cudaSuccess);
+    CUDAX_REQUIRE(::cuda::__driver::__libraryGetManagedNoThrow(
+                    managed_symbol_ptr, managed_symbol_size, lib1_native, managed_symbol_name)
+                  == cudaSuccess);
 
     CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(managed_sym.ptr) == managed_symbol_ptr);
     CUDAX_REQUIRE(managed_sym.size == managed_symbol_size);

--- a/cudax/test/library/library_ref.cu
+++ b/cudax/test/library/library_ref.cu
@@ -105,8 +105,8 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
   constexpr char const_symbol_name[]   = "const_data";
   constexpr char managed_symbol_name[] = "managed_data";
 
-  CUlibrary lib1 = _CUDA_DRIVER::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
-  CUlibrary lib2 = _CUDA_DRIVER::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  CUlibrary lib1 = ::cuda::__driver::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  CUlibrary lib2 = ::cuda::__driver::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
 
   const cuda::device_ref device{0};
 
@@ -161,7 +161,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     auto kernel = lib_ref.kernel<void(int*, int)>(kernel_name);
 
     CUkernel kernel_handle;
-    CUDAX_REQUIRE(_CUDA_DRIVER::__libraryGetKernelNoThrow(kernel_handle, lib1, kernel_name) == cudaSuccess);
+    CUDAX_REQUIRE(::cuda::__driver::__libraryGetKernelNoThrow(kernel_handle, lib1, kernel_name) == cudaSuccess);
     CUDAX_REQUIRE(kernel.get() == kernel_handle);
   }
 
@@ -194,7 +194,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
       CUdeviceptr global_symbol_ptr;
       cuda::std::size_t global_symbol_size;
       CUDAX_REQUIRE(
-        _CUDA_DRIVER::__libraryGetGlobalNoThrow(global_symbol_ptr, global_symbol_size, lib1, global_symbol_name)
+        ::cuda::__driver::__libraryGetGlobalNoThrow(global_symbol_ptr, global_symbol_size, lib1, global_symbol_name)
         == cudaSuccess);
 
       CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(global_sym.ptr) == global_symbol_ptr);
@@ -211,7 +211,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
       CUdeviceptr const_symbol_ptr;
       cuda::std::size_t const_symbol_size;
       CUDAX_REQUIRE(
-        _CUDA_DRIVER::__libraryGetGlobalNoThrow(const_symbol_ptr, const_symbol_size, lib1, const_symbol_name)
+        ::cuda::__driver::__libraryGetGlobalNoThrow(const_symbol_ptr, const_symbol_size, lib1, const_symbol_name)
         == cudaSuccess);
 
       CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(const_sym.ptr) == const_symbol_ptr);
@@ -241,7 +241,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     CUdeviceptr managed_symbol_ptr;
     cuda::std::size_t managed_symbol_size;
     CUDAX_REQUIRE(
-      _CUDA_DRIVER::__libraryGetManagedNoThrow(managed_symbol_ptr, managed_symbol_size, lib1, managed_symbol_name)
+      ::cuda::__driver::__libraryGetManagedNoThrow(managed_symbol_ptr, managed_symbol_size, lib1, managed_symbol_name)
       == cudaSuccess);
 
     CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(managed_sym.ptr) == managed_symbol_ptr);
@@ -266,6 +266,6 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     CUDAX_REQUIRE(lib_ref1 != lib_ref2);
   }
 
-  CUDAX_REQUIRE(_CUDA_DRIVER::__libraryUnloadNoThrow(lib1) == cudaSuccess);
-  CUDAX_REQUIRE(_CUDA_DRIVER::__libraryUnloadNoThrow(lib2) == cudaSuccess);
+  CUDAX_REQUIRE(::cuda::__driver::__libraryUnloadNoThrow(lib1) == cudaSuccess);
+  CUDAX_REQUIRE(::cuda::__driver::__libraryUnloadNoThrow(lib2) == cudaSuccess);
 }

--- a/libcudacxx/include/cuda/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/__algorithm/copy.h
@@ -89,7 +89,7 @@ _CCCL_HOST_API void __copy_bytes_impl(
   __attributes.dstLocHint.type    = static_cast<::CUmemLocationType>(__config.dst_location_hint.type);
 
   ::cuda::__ensure_current_context guard(__stream);
-  _CUDA_DRIVER::__memcpyAsyncWithAttributes(
+  ::cuda::__driver::__memcpyAsyncWithAttributes(
     __dst.data(), __src.data(), __src.size_bytes(), __stream.get(), __attributes);
 #  else
   ::cuda::__driver::__memcpyAsync(__dst.data(), __src.data(), __src.size_bytes(), __stream.get());

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -283,7 +283,7 @@ _CCCL_HOST_API inline void __memcpyAsyncWithAttributes(
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuMemcpyBatchAsync, cuMemcpyBatchAsync, 13, 0);
   size_t __zero           = 0;
-  _CUDA_DRIVER::__call_driver_fn(
+  ::cuda::__driver::__call_driver_fn(
     __driver_fn,
     "Failed to perform a memcpy with attributes",
     reinterpret_cast<::CUdeviceptr*>(&__dst),
@@ -646,7 +646,7 @@ _CCCL_HOST_API inline void __eventSynchronize(::CUevent __evnt)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuKernelGetFunction);
   ::CUfunction __result;
-  _CUDA_DRIVER::__call_driver_fn(__driver_fn, "Failed to get kernel function", &__result, __kernel);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get kernel function", &__result, __kernel);
   return __result;
 }
 
@@ -655,7 +655,7 @@ __kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdev
 {
   int __value;
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuKernelGetAttribute);
-  _CUDA_DRIVER::__call_driver_fn(__driver_fn, "Failed to get kernel attribute", &__value, __attr, __kernel, __dev);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get kernel attribute", &__value, __attr, __kernel, __dev);
   return __value;
 }
 
@@ -664,7 +664,7 @@ __kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdev
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuKernelGetName, cuKernelGetName, 12, 3);
   const char* __name;
-  _CUDA_DRIVER::__call_driver_fn(__driver_fn, "Failed to get kernel name", &__name, __kernel);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get kernel name", &__name, __kernel);
   return __name;
 }
 #  endif // _CCCL_CTK_AT_LEAST(12, 3)
@@ -680,7 +680,7 @@ __kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdev
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLibraryLoadData);
   ::CUlibrary __result;
-  _CUDA_DRIVER::__call_driver_fn(
+  ::cuda::__driver::__call_driver_fn(
     __driver_fn,
     "Failed to load a library from data",
     &__result,
@@ -698,7 +698,7 @@ __kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdev
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLibraryGetKernel);
   ::CUkernel __result;
-  _CUDA_DRIVER::__call_driver_fn(__driver_fn, "Failed to get kernel from library", &__result, __library, __name);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get kernel from library", &__result, __library, __name);
   return __result;
 }
 
@@ -713,7 +713,7 @@ __kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdev
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuKernelGetLibrary, cuKernelGetLibrary, 12, 5);
   ::CUlibrary __lib;
-  _CUDA_DRIVER::__call_driver_fn(__driver_fn, "Failed to get the library from kernel", &__lib, __kernel);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the library from kernel", &__lib, __kernel);
   return __lib;
 }
 #  endif // _CCCL_CTK_AT_LEAST(12, 5)
@@ -765,7 +765,7 @@ _CCCL_HOST_API inline void
 __launchKernel(::CUlaunchConfig& __config, ::CUfunction __kernel, void* __args[], void* __extra[] = nullptr)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLaunchKernelEx);
-  _CUDA_DRIVER::__call_driver_fn(__driver_fn, "Failed to launch kernel", &__config, __kernel, __args, __extra);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to launch kernel", &__config, __kernel, __args, __extra);
 }
 
 // Graph management
@@ -775,7 +775,7 @@ __launchKernel(::CUlaunchConfig& __config, ::CUfunction __kernel, void* __args[]
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuGraphAddKernelNode);
   ::CUgraphNode __result;
-  _CUDA_DRIVER::__call_driver_fn(
+  ::cuda::__driver::__call_driver_fn(
     __driver_fn, "Failed to add a node to a graph", &__result, __graph, __deps, __ndeps, &__node_params);
   return __result;
 }
@@ -784,7 +784,7 @@ _CCCL_HOST_API inline void
 __graphKernelNodeSetAttribute(::CUgraphNode __node, ::CUkernelNodeAttrID __id, const ::CUkernelNodeAttrValue& __value)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuGraphKernelNodeSetAttribute);
-  _CUDA_DRIVER::__call_driver_fn(__driver_fn, "Failed to set kernel node parameters", __node, __id, &__value);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to set kernel node parameters", __node, __id, &__value);
 }
 
 // Peer Context Memory Access
@@ -793,7 +793,7 @@ __graphKernelNodeSetAttribute(::CUgraphNode __node, ::CUkernelNodeAttrID __id, c
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceCanAccessPeer);
   int __result;
-  _CUDA_DRIVER::__call_driver_fn(
+  ::cuda::__driver::__call_driver_fn(
     __driver_fn, "Failed to query if device can access peer's memory", &__result, __dev, __peer_dev);
   return static_cast<bool>(__result);
 }
@@ -831,7 +831,7 @@ __graphKernelNodeSetAttribute(::CUgraphNode __node, ::CUkernelNodeAttrID __id, c
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxGetId, cuGreenCtxGetId, 13, 0);
   unsigned long long __id;
-  _CUDA_DRIVER::__call_driver_fn(__driver_fn, "Failed to get the ID of a green context", __green_ctx, &__id);
+  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the ID of a green context", __green_ctx, &__id);
   return __id;
 }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)

--- a/libcudacxx/include/cuda/std/__internal/namespaces.h
+++ b/libcudacxx/include/cuda/std/__internal/namespaces.h
@@ -127,19 +127,6 @@
 #  define _CCCL_END_NAMESPACE_STD   } _LIBCUDACXX_PROLOGUE_INCLUDE_CHECK()
 #endif
 
-// Shorthands for different qualifiers
-#  define _CUDA_VSTD_NOVERSION ::cuda::std
-#  define _CUDA_VSTD           ::cuda::std::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_DEVICE         ::cuda::device::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_VRANGES        ::cuda::std::ranges::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_VIEWS          ::cuda::std::ranges::views::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_VMR            ::cuda::mr::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_VPTX           ::cuda::ptx::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_VSTD_FS        ::cuda::std::__fs::filesystem::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_STD_EXEC       ::cuda::std::execution::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_EXEC           ::cuda::execution::_LIBCUDACXX_ABI_NAMESPACE
-#  define _CUDA_DRIVER         ::cuda::__driver::_LIBCUDACXX_ABI_NAMESPACE
-
 // clang-format on
 
 #endif // _CUDA_STD___INTERNAL_NAMESPACES_H


### PR DESCRIPTION
We already replaced them previously but they crept back
