### PR TITLE
Cleanup dependencies between internal targets.

### DIFF
--- a/.gersemi/ext/builtins.py
+++ b/.gersemi/ext/builtins.py
@@ -15,8 +15,15 @@ from gersemi.builtin_commands import builtin_commands
 # - function
 # - macro
 
+# Patch up https://github.com/BlankSpruce/gersemi/pull/80 if needed:
+mod_find_package = builtin_commands["find_package"]
+if "REQUIRED" in mod_find_package["multi_value_keywords"]:
+    mod_find_package["multi_value_keywords"].remove("REQUIRED")
+    mod_find_package["options"] += ["REQUIRED"]
+
 command_definitions = {
     "if ": builtin_commands["if"],
     "elseif ": builtin_commands["elseif"],
     "foreach ": builtin_commands["foreach"],
+    "find_package": mod_find_package,
 }

--- a/lib/cmake/cub/cub-config.cmake
+++ b/lib/cmake/cub/cub-config.cmake
@@ -95,7 +95,8 @@ if (NOT TARGET CUB::libcudacxx)
         ${CUB_VERSION}
         EXACT
         CONFIG
-        REQUIRED ${_CUB_QUIET_FLAG}
+        REQUIRED
+        ${_CUB_QUIET_FLAG}
         NO_DEFAULT_PATH # Only check the explicit HINTS below:
         HINTS "${CMAKE_CURRENT_LIST_DIR}/../libcudacxx/"
       )

--- a/lib/cmake/cudax/cudax-config.cmake
+++ b/lib/cmake/cudax/cudax-config.cmake
@@ -44,7 +44,8 @@ if (NOT TARGET cudax::libcudacxx)
       libcudacxx
       ${cudax_VERSION}
       CONFIG
-      REQUIRED ${cudax_quiet_flag}
+      REQUIRED
+      ${cudax_quiet_flag}
     )
   endif()
   add_library(cudax::libcudacxx ALIAS libcudacxx::libcudacxx)

--- a/lib/cmake/thrust/thrust-config.cmake
+++ b/lib/cmake/thrust/thrust-config.cmake
@@ -949,7 +949,8 @@ if (NOT TARGET Thrust::libcudacxx)
         ${Thrust_VERSION}
         EXACT
         CONFIG
-        REQUIRED ${_THRUST_QUIET_FLAG}
+        REQUIRED
+        ${_THRUST_QUIET_FLAG}
         NO_DEFAULT_PATH # Only check the explicit HINTS below:
         HINTS "${_THRUST_CMAKE_DIR}/../libcudacxx/"
       )


### PR DESCRIPTION
1. Add the missing Thrust dependency to CUB.
2. Remove fallback paths that allowed non-sibling CCCL packages to be used when searching for dependencies.
3. Change version checks to exact (rather than minimum).