### PR TITLE
Try and improve our `is_nothrow_constructible` fallback

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/is_nothrow_constructible.h
+++ b/libcudacxx/include/cuda/std/__type_traits/is_nothrow_constructible.h
@@ -41,39 +41,27 @@ inline constexpr bool is_nothrow_constructible_v = _CCCL_BUILTIN_IS_NOTHROW_CONS
 
 #else
 
-template <bool, bool, class _Tp, class... _Args>
-struct __cccl_is_nothrow_constructible;
+template <bool, class _Tp, class... _Args>
+inline constexpr bool __cccl_is_nothrow_constructible = false;
 
 template <class _Tp, class... _Args>
-struct __cccl_is_nothrow_constructible</*is constructible*/ true, /*is reference*/ false, _Tp, _Args...>
-    : public integral_constant<bool, noexcept(_Tp(::cuda::std::declval<_Args>()...))>
-{};
-
-template <class _Tp>
-_CCCL_API inline void __implicit_conversion_to(_Tp) noexcept
-{}
+inline constexpr bool __cccl_is_nothrow_constructible<true, _Tp, _Args...> =
+  noexcept(_Tp(::cuda::std::declval<_Args>()...));
 
 template <class _Tp, class _Arg>
-struct __cccl_is_nothrow_constructible</*is constructible*/ true, /*is reference*/ true, _Tp, _Arg>
-    : public integral_constant<bool, noexcept(__implicit_conversion_to<_Tp>(::cuda::std::declval<_Arg>()))>
-{};
-
-template <class _Tp, bool _IsReference, class... _Args>
-struct __cccl_is_nothrow_constructible</*is constructible*/ false, _IsReference, _Tp, _Args...> : public false_type
-{};
-
-template <class _Tp, class... _Args>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_constructible
-    : __cccl_is_nothrow_constructible<is_constructible_v<_Tp, _Args...>, is_reference_v<_Tp>, _Tp, _Args...>
-{};
+inline constexpr bool __cccl_is_nothrow_constructible<true, _Tp, _Arg> =
+  noexcept(static_cast<_Tp>(::cuda::std::declval<_Arg>()));
 
 template <class _Tp, size_t _Ns>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT
-is_nothrow_constructible<_Tp[_Ns]> : __cccl_is_nothrow_constructible<is_constructible_v<_Tp>, is_reference_v<_Tp>, _Tp>
-{};
+inline constexpr bool __cccl_is_nothrow_constructible<true, _Tp[_Ns]> = __cccl_is_nothrow_constructible<true, _Tp>;
 
 template <class _Tp, class... _Args>
-inline constexpr bool is_nothrow_constructible_v = is_nothrow_constructible<_Tp, _Args...>::value;
+inline constexpr bool is_nothrow_constructible_v =
+  __cccl_is_nothrow_constructible<is_constructible_v<_Tp, _Args...>, _Tp, _Args...>;
+
+template <class _Tp, class... _Args>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT is_nothrow_constructible : bool_constant<is_nothrow_constructible_v<_Tp, _Args...>>
+{};
 
 #endif // defined(_CCCL_BUILTIN_IS_NOTHROW_CONSTRUCTIBLE) && !defined(_LIBCUDACXX_USE_IS_NOTHROW_CONSTRUCTIBLE_FALLBACK)
 

--- a/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_constructible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/meta/meta.unary/meta.unary.prop/is_nothrow_constructible.pass.cpp
@@ -87,6 +87,36 @@ struct Tuple
   __host__ __device__ Tuple(Empty&&) noexcept {}
 };
 
+struct ConvertibleToInt
+{
+  __host__ __device__ constexpr operator int() const
+  {
+    return 42;
+  }
+};
+
+struct NothrowConvertibleToInt
+{
+  __host__ __device__ constexpr operator int() const noexcept
+  {
+    return 42;
+  }
+};
+
+__host__ __device__ void test_is_nothrow_constructible_only_conversion()
+{
+  {
+    static_assert(cuda::std::is_constructible_v<int, ConvertibleToInt>);
+    static_assert(!cuda::std::is_nothrow_constructible<int, ConvertibleToInt>::value);
+    static_assert(!cuda::std::is_nothrow_constructible_v<int, ConvertibleToInt>);
+  }
+  {
+    static_assert(cuda::std::is_constructible_v<int, NothrowConvertibleToInt>);
+    static_assert(cuda::std::is_nothrow_constructible<int, NothrowConvertibleToInt>::value);
+    static_assert(cuda::std::is_nothrow_constructible_v<int, NothrowConvertibleToInt>);
+  }
+}
+
 int main(int, char**)
 {
   test_is_nothrow_constructible<int>();
@@ -102,6 +132,9 @@ int main(int, char**)
 
   static_assert(!cuda::std::is_constructible<Tuple&, Empty>::value, "");
   test_is_not_nothrow_constructible<Tuple&, Empty>(); // See bug #19616.
+
+  // conversion only types
+  test_is_nothrow_constructible_only_conversion();
 
   return 0;
 }


### PR DESCRIPTION
We were treating references differently, but afaik that was not necessary, we should only make sure that we support types that are convertible but canot construct, so the static cast is fine
