### PR TITLE
Investigate building with libc++ and clang-cuda

### DIFF
--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -21,6 +21,8 @@ workflows:
   #       args: '--preset libcudacxx --lit-tests "cuda/utility/basic_any.pass.cpp"' }
   #
   override:
+    - {jobs: ['build'], cpu: 'arm64', project: 'libcudacxx', std: 'all', cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', cmake_options: '-DCCCL_USE_LIBCXX=ON', sm: '75;80;90;100'}
+    - {jobs: ['build'], project: 'libcudacxx', std: 'all', cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', cmake_options: '-DCCCL_USE_LIBCXX=ON', sm: '75;80;90;100'}
 
   pull_request:
     # Old CTK: Oldest/newest supported host compilers:

--- a/cmake/CCCLBuildCompilerTargets.cmake
+++ b/cmake/CCCLBuildCompilerTargets.cmake
@@ -116,11 +116,6 @@ function(cccl_build_compiler_targets)
     list(APPEND cxx_compile_definitions "CCCL_DISABLE_RTTI")
   endif()
 
-  #  if (CCCL_USE_LIBCXX)
-  #    list(APPEND cxx_compile_options "-stdlib=libc++")
-  #    list(APPEND cxx_compile_definitions "_ALLOW_UNSUPPORTED_LIBCPP=1")
-  #  endif()
-
   if ("MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
     list(APPEND cuda_compile_options "--use-local-env")
     list(APPEND cxx_compile_options "/bigobj")
@@ -248,6 +243,28 @@ function(cccl_build_compiler_targets)
     "${cxx_compile_options}"
     "${cxx_compile_definitions}"
   )
+
+  # Specifically add libc++ testing if requested
+  if (CCCL_USE_LIBCXX) # Not working currently because catch2 is not building with libc++
+    target_compile_definitions(
+      cccl.compiler_interface
+      INTERFACE _ALLOW_UNSUPPORTED_LIBCPP=1
+    )
+    target_compile_options(
+      cccl.compiler_interface
+      INTERFACE
+        $<$<COMPILE_LANG_AND_ID:CUDA,Clang>:-Xclang
+        -stdlib=libc++
+        -Xclang
+        -stdlib++-isystem
+        /usr/include/c++/v1>
+        $<$<COMPILE_LANG_AND_ID:CXX,Clang>:
+        -stdlib=libc++
+        -stdlib++-isystem
+        /usr/include/c++/v1>
+    )
+    target_link_options(cccl.compiler_interface INTERFACE -stdlib=libc++)
+  endif()
 
   # Clang-cuda only:
   target_compile_options(

--- a/cmake/CCCLGetDependencies.cmake
+++ b/cmake/CCCLGetDependencies.cmake
@@ -24,6 +24,19 @@ endmacro()
 macro(cccl_get_catch2)
   include("${_cccl_cpm_file}")
   CPMAddPackage("gh:catchorg/Catch2@3.12.0")
+  if (CCCL_USE_LIBCXX)
+    target_compile_definitions(Catch2 PRIVATE _ALLOW_UNSUPPORTED_LIBCPP=1)
+    target_compile_options(
+      Catch2
+      PRIVATE
+        -Xclang
+        -stdlib=libc++
+        -Xclang
+        -stdlib++-isystem
+        /usr/include/c++/v1
+    )
+    target_link_options(Catch2 PRIVATE -stdlib=libc++)
+  endif()
 endmacro()
 
 macro(cccl_get_cccl)

--- a/libcudacxx/cmake/LibcudacxxBuildCompilerTargets.cmake
+++ b/libcudacxx/cmake/LibcudacxxBuildCompilerTargets.cmake
@@ -13,11 +13,6 @@ function(libcudacxx_build_compiler_targets)
   set(cxx_compile_options)
   set(cxx_compile_definitions)
 
-  #  if (CCCL_USE_LIBCXX)
-  #    list(APPEND cxx_compile_options "-stdlib=libc++")
-  #    list(APPEND cxx_compile_definitions "_ALLOW_UNSUPPORTED_LIBCPP=1")
-  #  endif()
-
   # Set test specific flags
   list(APPEND cxx_compile_definitions "CCCL_ENABLE_ASSERTIONS")
   list(APPEND cxx_compile_definitions "CCCL_IGNORE_DEPRECATED_CPP_DIALECT")

--- a/libcudacxx/cmake/LibcudacxxPublicHeaderTestingHost.cmake
+++ b/libcudacxx/cmake/LibcudacxxPublicHeaderTestingHost.cmake
@@ -27,11 +27,6 @@ file(
 set(public_host_header_cxx_compile_options)
 set(public_host_header_cxx_compile_definitions)
 
-# Specifically add libc++ testing if requested to the libcudacxx host suite
-if (CCCL_USE_LIBCXX)
-  list(APPEND public_host_header_cxx_compile_options "-stdlib=libc++")
-endif()
-
 function(
   libcudacxx_add_public_header_test_host_target
   target_name
@@ -56,6 +51,12 @@ function(
     ${target_name}
     PRIVATE ${public_host_header_cxx_compile_options}
   )
+  if (CCCL_USE_LIBCXX) # In some headers clang complains about unused -stdlib=libc++
+    target_compile_options(
+      ${target_name}
+      PRIVATE -Wno-unused-command-line-argument
+    )
+  endif()
   target_link_libraries(${target_name} PUBLIC libcudacxx.compiler_interface)
   if (with_ctk)
     target_link_libraries(${target_name} PUBLIC CUDA::cudart)

--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -126,11 +126,12 @@ else()
 endif()
 
 # enable libc++ support
-if (CCCL_USE_LIBCXX)
-  string(
-    APPEND LIBCUDACXX_TEST_COMPILER_FLAGS
-    " -Xclang -stdlib=libc++ -Xclang -stdlib++-isystem /usr/include/c++/v1"
-  )
+if ("MSVC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+  set(LIBCUDACXX_HOST_STL "msvc")
+elseif (CCCL_USE_LIBCXX)
+  set(LIBCUDACXX_HOST_STL "libc++")
+else()
+  set(LIBCUDACXX_HOST_STL "libstdc++")
 endif()
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -125,6 +125,14 @@ else()
   set(LIBCUDACXX_ENABLE_TILE False)
 endif()
 
+# enable libc++ support
+if (CCCL_USE_LIBCXX)
+  string(
+    APPEND LIBCUDACXX_TEST_COMPILER_FLAGS
+    " -Xclang -stdlib=libc++ -Xclang -stdlib++-isystem /usr/include/c++/v1"
+  )
+endif()
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
   string(APPEND LIBCUDACXX_TEST_LINKER_FLAGS " -latomic")
 endif()

--- a/libcudacxx/test/libcudacxx/lit.site.cfg.in
+++ b/libcudacxx/test/libcudacxx/lit.site.cfg.in
@@ -7,6 +7,7 @@ config.libcudacxx_obj_root      = "@LIBCUDACXX_BINARY_DIR@"
 config.cxx_library_root         = "@LIBCUDACXX_LIBRARY_DIR@"
 config.std                      = "@LIBCUDACXX_TEST_STANDARD_VER@"
 config.enable_tile              = "@LIBCUDACXX_ENABLE_TILE@"
+config.cxx_stdlib_under_test    = "@LIBCUDACXX_HOST_STL@"
 config.enable_exceptions        = True
 config.enable_experimental      = False
 config.enable_filesystem        = False

--- a/libcudacxx/test/utils/libcudacxx/test/config.py
+++ b/libcudacxx/test/utils/libcudacxx/test/config.py
@@ -876,6 +876,11 @@ class Configuration(object):
         if nvcc_host_compiler and self.cxx.type == "nvcc":
             self.cxx.compile_flags += ["-ccbin={0}".format(nvcc_host_compiler)]
 
+        if nvcc_host_compiler and self.cxx_stdlib_under_test == "libc++":
+            self.cxx.compile_flags += [
+                "-Xclang -stdlib=libc++ -Xclang -stdlib++-isystem /usr/include/c++/v1"
+            ]
+
         # Try and get the std version from the command line. Fall back to
         # default given in lit.site.cfg is not present. If default is not
         # present then force c++11.


### PR DESCRIPTION
fixes https://github.com/NVIDIA/cccl/issues/7502

We are currently not supporting libc++ but this is something we might want to test better in the future.

This explores building our libcu++ tests with clang-cuda