### PR TITLE
Fix misspelling of contiguous range in documentation

### DIFF
--- a/docs/libcudacxx/standard_api/ranges_library.rst
+++ b/docs/libcudacxx/standard_api/ranges_library.rst
@@ -27,10 +27,10 @@ Extensions
 
   .. code:: cpp
 
-    template<cuda::std::contiguos_range Range>
+    template<cuda::std::contiguous_range Range>
     void do_something_with_ranges_in_cpp20(Range&& range) {...}
 
-    template<class Range, cuda::std::enable_if_t<cuda::std::contiguos_range<Range>, int> = 0>
+    template<class Range, cuda::std::enable_if_t<cuda::std::contiguous_range<Range>, int> = 0>
     void do_something_with_ranges_in_cpp17(Range&& range) {...}
 
 Restrictions


### PR DESCRIPTION
This PR fixes a typo in the libcudacxx ranges library documentation where 'contiguous range' was misspelled.