### PR TITLE
Rework native hierarchy levels and queries

### DIFF
--- a/libcudacxx/include/cuda/__fwd/hierarchy.h
+++ b/libcudacxx/include/cuda/__fwd/hierarchy.h
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___FWD_HIERARCHY_H
+#define _CUDA___FWD_HIERARCHY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__type_traits/is_base_of.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+// hierarchy level
+
+template <class _Level>
+struct hierarchy_level_base;
+
+template <class _Level>
+struct __native_hierarchy_level_base;
+
+struct grid_level;
+struct cluster_level;
+struct block_level;
+struct warp_level;
+struct thread_level;
+
+template <class _Tp>
+inline constexpr bool __is_hierarchy_level_v = ::cuda::std::is_base_of_v<hierarchy_level_base<_Tp>, _Tp>;
+
+template <class _Tp>
+inline constexpr bool __is_native_hierarchy_level_v =
+  ::cuda::std::is_base_of_v<__native_hierarchy_level_base<_Tp>, _Tp>;
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___FWD_HIERARCHY_H

--- a/libcudacxx/include/cuda/__hierarchy/block_level.h
+++ b/libcudacxx/include/cuda/__hierarchy/block_level.h
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___HIERARCHY_BLOCK_LEVEL_H
+#define _CUDA___HIERARCHY_BLOCK_LEVEL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/hierarchy.h>
+#include <cuda/__hierarchy/hierarchy_query_result.h>
+#include <cuda/__hierarchy/native_hierarchy_level_base.h>
+#include <cuda/std/__mdspan/extents.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+struct block_level : __native_hierarchy_level_base<block_level>
+{
+  using __next_level = cluster_level;
+
+  using __base_type = __native_hierarchy_level_base<block_level>;
+  using __base_type::extents;
+  using __base_type::index;
+
+  // interactions with cluster level
+
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, unsigned> extents(const cluster_level&) noexcept
+  {
+    ::dim3 __dims{1u, 1u, 1u};
+    NV_IF_TARGET(NV_PROVIDES_SM_90, (__dims = ::__clusterDim();))
+    return ::cuda::std::dims<3, unsigned>{__dims.z, __dims.y, __dims.x};
+  }
+  [[nodiscard]] _CCCL_DEVICE_API static hierarchy_query_result<unsigned, 3> index(const cluster_level&) noexcept
+  {
+    ::dim3 __idx{0u, 0u, 0u};
+    NV_IF_TARGET(NV_PROVIDES_SM_90, (__idx = ::__clusterRelativeBlockIdx();))
+    return {__idx.z, __idx.y, __idx.x};
+  }
+
+  // interactions with grid level
+
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, unsigned> extents(const grid_level&) noexcept
+  {
+    return ::cuda::std::dims<3, unsigned>{gridDim.z, gridDim.y, gridDim.x};
+  }
+  [[nodiscard]] _CCCL_DEVICE_API static hierarchy_query_result<unsigned, 3> index(const grid_level&) noexcept
+  {
+    return {blockIdx.z, blockIdx.y, blockIdx.x};
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+_CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
+
+_CCCL_GLOBAL_CONSTANT ::cuda::block_level block;
+
+_CCCL_END_NAMESPACE_CUDA_DEVICE
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___HIERARCHY_BLOCK_LEVEL_H

--- a/libcudacxx/include/cuda/__hierarchy/cluster_level.h
+++ b/libcudacxx/include/cuda/__hierarchy/cluster_level.h
@@ -1,0 +1,67 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___HIERARCHY_CLUSTER_LEVEL_H
+#define _CUDA___HIERARCHY_CLUSTER_LEVEL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/hierarchy.h>
+#include <cuda/__hierarchy/hierarchy_query_result.h>
+#include <cuda/__hierarchy/native_hierarchy_level_base.h>
+#include <cuda/std/__mdspan/extents.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+struct cluster_level : __native_hierarchy_level_base<cluster_level>
+{
+  using __next_level = grid_level;
+
+  using __base_type = __native_hierarchy_level_base<cluster_level>;
+  using __base_type::extents;
+  using __base_type::index;
+
+  // interactions with grid level
+
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, unsigned> extents(const grid_level&) noexcept
+  {
+    ::dim3 __dims{1u, 1u, 1u};
+    NV_IF_TARGET(NV_PROVIDES_SM_90, (__dims = ::__clusterGridDimInClusters();))
+    return ::cuda::std::dims<3, unsigned>{__dims.z, __dims.y, __dims.x};
+  }
+  [[nodiscard]] _CCCL_DEVICE_API static hierarchy_query_result<unsigned, 3> index(const grid_level&) noexcept
+  {
+    ::dim3 __idx{0u, 0u, 0u};
+    NV_IF_TARGET(NV_PROVIDES_SM_90, (__idx = ::__clusterIdx();))
+    return {__idx.z, __idx.y, __idx.x};
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+_CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
+
+_CCCL_GLOBAL_CONSTANT cluster_level cluster;
+
+_CCCL_END_NAMESPACE_CUDA_DEVICE
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___HIERARCHY_CLUSTER_LEVEL_H

--- a/libcudacxx/include/cuda/__hierarchy/grid_level.h
+++ b/libcudacxx/include/cuda/__hierarchy/grid_level.h
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___HIERARCHY_GRID_LEVEL_H
+#define _CUDA___HIERARCHY_GRID_LEVEL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/hierarchy.h>
+#include <cuda/__hierarchy/native_hierarchy_level_base.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+struct grid_level : __native_hierarchy_level_base<grid_level>
+{};
+
+_CCCL_END_NAMESPACE_CUDA
+
+_CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
+
+_CCCL_GLOBAL_CONSTANT grid_level grid;
+
+_CCCL_END_NAMESPACE_CUDA_DEVICE
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___HIERARCHY_GRID_LEVEL_H

--- a/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
@@ -1,0 +1,151 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___HIERARCHY_HIERARCHY_LEVEL_BASE_H
+#define _CUDA___HIERARCHY_HIERARCHY_LEVEL_BASE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/hierarchy.h>
+#include <cuda/__hierarchy/hierarchy_query_result.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__cstddef/types.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+template <class _Level>
+struct hierarchy_level_base
+{
+  using level_type = _Level;
+
+  // todo: use this once cuda::hierarchy is being implemented
+  //
+  // _CCCL_TEMPLATE(class _InLevel, class _Hierarchy)
+  // _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel> _CCCL_AND __is_hierarchy_v<_Hierarchy>)
+  // [[nodiscard]] _CCCL_DEVICE_API static constexpr auto dims(const _InLevel& __level, const _Hierarchy& __hier)
+  // noexcept
+  // {
+  //   return __dims_impl(__level, __hier);
+  // }
+
+  // _CCCL_TEMPLATE(class _InLevel, class _Hierarchy)
+  // _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel> _CCCL_AND __is_hierarchy_v<_Hierarchy>)
+  // [[nodiscard]] _CCCL_DEVICE_API static constexpr auto static_dims(const _InLevel& __level, const _Hierarchy& __hier)
+  // noexcept
+  // {
+  //   return __static_dims_impl(__level, __hier);
+  // }
+
+  // _CCCL_TEMPLATE(class _InLevel, class _Hierarchy)
+  // _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel> _CCCL_AND __is_hierarchy_v<_Hierarchy>)
+  // [[nodiscard]] _CCCL_DEVICE_API static constexpr auto extents(const _InLevel& __level, const _Hierarchy& __hier)
+  // noexcept {}
+
+  // _CCCL_TEMPLATE(class _InLevel, class _Hierarchy)
+  // _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel> _CCCL_AND __is_hierarchy_v<_Hierarchy>)
+  // [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t
+  // count(const _InLevel& __level, const _Hierarchy& __hier) noexcept
+  // {
+  //   return __count_impl(__level, __hier);
+  // }
+
+  // _CCCL_TEMPLATE(class _InLevel, class _Hierarchy)
+  // _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel> _CCCL_AND __is_hierarchy_v<_Hierarchy>)
+  // [[nodiscard]] _CCCL_DEVICE_API static constexpr auto index(const _InLevel& __level, const _Hierarchy& __hier)
+  // noexcept
+  // {}
+
+  // _CCCL_TEMPLATE(class _InLevel, class _Hierarchy)
+  // _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel> _CCCL_AND __is_hierarchy_v<_Hierarchy>)
+  // [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t
+  // rank(const _InLevel& __level, const _Hierarchy& __hier) noexcept
+  // {
+  //   return __rank_impl(__level, __hier);
+  // }
+
+private:
+  template <class>
+  friend struct __native_hierarchy_level_base;
+
+  template <class... _Args>
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr auto __dims_impl(const _Args&... __args) noexcept
+  {
+    auto __exts = _Level::extents(__args...);
+    using _Exts = decltype(__exts);
+
+    hierarchy_query_result<typename _Exts::index_type, _Exts::rank()> __ret{};
+    for (::cuda::std::size_t __i = 0; __i < _Exts::rank(); ++__i)
+    {
+      __ret[__i] = __exts.extent(__i);
+    }
+    return __ret;
+  }
+
+  template <class... _Args>
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr auto __static_dims_impl(const _Args&... __args) noexcept
+  {
+    using _Exts = decltype(_Level::extents(__args...));
+
+    hierarchy_query_result<::cuda::std::size_t, _Exts::rank()> __ret{};
+    for (::cuda::std::size_t __i = 0; __i < _Exts::rank(); ++__i)
+    {
+      __ret[__i] = _Exts::static_extent(__i);
+    }
+    return __ret;
+  }
+
+  template <class... _Args>
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t __count_impl(const _Args&... __args) noexcept
+  {
+    const auto __exts = _Level::extents(__args...);
+
+    ::cuda::std::size_t __ret = 1;
+    for (::cuda::std::size_t __i = 0; __i < __exts.rank(); ++__i)
+    {
+      __ret *= __exts.extent(__i);
+    }
+    return __ret;
+  }
+
+  template <class... _Args>
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::size_t __rank_impl(const _Args&... __args) noexcept
+  {
+    const auto __exts = _Level::extents(__args...);
+    const auto __idcs = _Level::index(__args...);
+
+    ::cuda::std::size_t __ret = 0;
+    for (::cuda::std::size_t __i = 0; __i < __exts.rank(); ++__i)
+    {
+      ::cuda::std::size_t __inc = __idcs[__i];
+      for (::cuda::std::size_t __j = __i + 1; __j < __exts.rank(); ++__j)
+      {
+        __inc *= __exts.extent(__j);
+      }
+      __ret += __inc;
+    }
+    return __ret;
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___HIERARCHY_HIERARCHY_LEVEL_BASE_H

--- a/libcudacxx/include/cuda/__hierarchy/hierarchy_query_result.h
+++ b/libcudacxx/include/cuda/__hierarchy/hierarchy_query_result.h
@@ -1,0 +1,284 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___HIERARCHY_HIERARCHY_QUERY_RESULT_H
+#define _CUDA___HIERARCHY_HIERARCHY_QUERY_RESULT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// #include <cuda/__type_traits/vector_type.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_nothrow_convertible.h>
+#include <cuda/std/__type_traits/is_same.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+template <class _Tp, ::cuda::std::size_t _Np>
+struct hierarchy_query_result
+{
+  using value_type                            = _Tp;
+  static constexpr ::cuda::std::size_t __rank = _Np;
+
+  _Tp __rest_[_Np - 3];
+  _Tp z;
+  _Tp y;
+  _Tp x;
+
+  _CCCL_HIDE_FROM_ABI constexpr hierarchy_query_result() noexcept = default;
+
+  _CCCL_TEMPLATE(class... _Args)
+  _CCCL_REQUIRES((sizeof...(_Args) == _Np) _CCCL_AND(::cuda::std::is_convertible_v<_Args, _Tp>&&...))
+  _CCCL_API constexpr hierarchy_query_result(_Args&&... __args) noexcept(
+    (::cuda::std::is_nothrow_convertible_v<_Args, _Tp> && ...))
+      : __rest_{}
+      , z{}
+      , y{}
+      , x{}
+  {
+    _Tp __tmp[]{__args...};
+    for (::cuda::std::size_t __i = 0; __i < _Np; ++__i)
+    {
+      operator[](__i) = __tmp[__i];
+    }
+  }
+
+  _CCCL_HIDE_FROM_ABI constexpr hierarchy_query_result(const hierarchy_query_result&) noexcept = default;
+  _CCCL_HIDE_FROM_ABI constexpr hierarchy_query_result(hierarchy_query_result&&) noexcept      = default;
+
+  [[nodiscard]] _CCCL_API constexpr _Tp& operator[](::cuda::std::size_t __i) noexcept
+  {
+    if (__i < _Np - 3)
+    {
+      return __rest_[__i];
+    }
+    if (__i == _Np - 3)
+    {
+      return z;
+    }
+    if (__i == _Np - 2)
+    {
+      return y;
+    }
+    if (__i == _Np - 1)
+    {
+      return x;
+    }
+    _CCCL_UNREACHABLE();
+  }
+  [[nodiscard]] _CCCL_API constexpr const _Tp& operator[](::cuda::std::size_t __i) const noexcept
+  {
+    if (__i < _Np - 3)
+    {
+      return __rest_[__i];
+    }
+    if (__i == _Np - 3)
+    {
+      return z;
+    }
+    if (__i == _Np - 2)
+    {
+      return y;
+    }
+    if (__i == _Np - 1)
+    {
+      return x;
+    }
+    _CCCL_UNREACHABLE();
+  }
+
+  // _CCCL_TEMPLATE(class _Tp2 = _Tp, ::cuda::std::size_t _Np2 = _Np)
+  // _CCCL_REQUIRES(__has_vector_type_v<_Tp, _Np2>)
+  // _CCCL_API constexpr operator __vector_type_t<_Tp2, _Np2>() const noexcept
+  // {
+  //   // only 4 element vector types will be instantiated
+  //   __vector_type_t<_Tp2, _Np2> __ret{};
+  //   __ret.x = x;
+  //   __ret.y = y;
+  //   __ret.z = z;
+  //   __ret.w = operator[](_Np2 - 4);
+  //   return __ret;
+  // }
+};
+
+template <class _Tp>
+struct hierarchy_query_result<_Tp, 0>
+{
+  using value_type                            = _Tp;
+  static constexpr ::cuda::std::size_t __rank = 0;
+
+  [[nodiscard]] _CCCL_API constexpr _Tp& operator[](::cuda::std::size_t) noexcept
+  {
+    _CCCL_UNREACHABLE();
+  }
+  [[nodiscard]] _CCCL_API constexpr const _Tp& operator[](::cuda::std::size_t) const noexcept
+  {
+    _CCCL_UNREACHABLE();
+  }
+};
+
+template <class _Tp>
+struct hierarchy_query_result<_Tp, 1>
+{
+  using value_type                            = _Tp;
+  static constexpr ::cuda::std::size_t __rank = 1;
+
+  _Tp x;
+
+  [[nodiscard]] _CCCL_API constexpr _Tp& operator[](::cuda::std::size_t __i) noexcept
+  {
+    if (__i == 0)
+    {
+      return x;
+    }
+    _CCCL_UNREACHABLE();
+  }
+  [[nodiscard]] _CCCL_API constexpr const _Tp& operator[](::cuda::std::size_t __i) const noexcept
+  {
+    if (__i == 0)
+    {
+      return x;
+    }
+    _CCCL_UNREACHABLE();
+  }
+
+  // _CCCL_TEMPLATE(class _Tp2 = _Tp)
+  // _CCCL_REQUIRES(__has_vector_type_v<_Tp, 1>)
+  // _CCCL_API constexpr operator __vector_type_t<_Tp2, 1>() const noexcept
+  // {
+  //   __vector_type_t<_Tp2, 1> __ret{};
+  //   __ret.x = x;
+  //   return __ret;
+  // }
+};
+
+template <class _Tp>
+struct hierarchy_query_result<_Tp, 2>
+{
+  using value_type                            = _Tp;
+  static constexpr ::cuda::std::size_t __rank = 2;
+
+  _Tp y;
+  _Tp x;
+
+  [[nodiscard]] _CCCL_API constexpr _Tp& operator[](::cuda::std::size_t __i) noexcept
+  {
+    if (__i == 0)
+    {
+      return y;
+    }
+    if (__i == 1)
+    {
+      return x;
+    }
+    _CCCL_UNREACHABLE();
+  }
+  [[nodiscard]] _CCCL_API constexpr const _Tp& operator[](::cuda::std::size_t __i) const noexcept
+  {
+    if (__i == 0)
+    {
+      return y;
+    }
+    if (__i == 1)
+    {
+      return x;
+    }
+    _CCCL_UNREACHABLE();
+  }
+
+  // _CCCL_TEMPLATE(class _Tp2 = _Tp, )
+  // _CCCL_REQUIRES(__has_vector_type_v<_Tp, 2>)
+  // _CCCL_API constexpr operator __vector_type_t<_Tp2, 2>() const noexcept
+  // {
+  //   __vector_type_t<_Tp2, 2> __ret{};
+  //   __ret.x = x;
+  //   __ret.y = y;
+  //   return __ret;
+  // }
+};
+
+template <class _Tp>
+struct hierarchy_query_result<_Tp, 3>
+{
+  using value_type                            = _Tp;
+  static constexpr ::cuda::std::size_t __rank = 3;
+
+  _Tp z;
+  _Tp y;
+  _Tp x;
+
+  [[nodiscard]] _CCCL_API constexpr _Tp& operator[](::cuda::std::size_t __i) noexcept
+  {
+    if (__i == 0)
+    {
+      return z;
+    }
+    if (__i == 1)
+    {
+      return y;
+    }
+    if (__i == 2)
+    {
+      return x;
+    }
+    _CCCL_UNREACHABLE();
+  }
+  [[nodiscard]] _CCCL_API constexpr const _Tp& operator[](::cuda::std::size_t __i) const noexcept
+  {
+    if (__i == 0)
+    {
+      return z;
+    }
+    if (__i == 1)
+    {
+      return y;
+    }
+    if (__i == 2)
+    {
+      return x;
+    }
+    _CCCL_UNREACHABLE();
+  }
+
+  // _CCCL_TEMPLATE(class _Tp2 = _Tp)
+  // _CCCL_REQUIRES(__has_vector_type_v<_Tp, 3>)
+  // _CCCL_API constexpr operator __vector_type_t<_Tp2, 3>() const noexcept
+  // {
+  //   __vector_type_t<_Tp2, 3> __ret{};
+  //   __ret.x = x;
+  //   __ret.y = y;
+  //   __ret.z = z;
+  //   return __ret;
+  // }
+
+  // _CCCL_TEMPLATE(class _Tp2 = _Tp)
+  // _CCCL_REQUIRES(::cuda::std::is_same_v<_Tp2, unsigned>)
+  // _CCCL_API constexpr operator ::dim3() const noexcept
+  // {
+  //   return ::dim3{operator uint3()};
+  // }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___HIERARCHY_HIERARCHY_QUERY_RESULT_H

--- a/libcudacxx/include/cuda/__hierarchy/native_hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/native_hierarchy_level_base.h
@@ -1,0 +1,213 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___HIERARCHY_NATIVE_HIERARCHY_LEVEL_BASE_H
+#define _CUDA___HIERARCHY_NATIVE_HIERARCHY_LEVEL_BASE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/hierarchy.h>
+#include <cuda/__hierarchy/hierarchy_level_base.h>
+#include <cuda/__hierarchy/hierarchy_query_result.h>
+#include <cuda/__hierarchy/traits.h>
+#include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__functional/operations.h>
+#include <cuda/std/__mdspan/extents.h>
+#include <cuda/std/__type_traits/common_type.h>
+#include <cuda/std/__utility/integer_sequence.h>
+#include <cuda/std/array>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+template <class _Op>
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL ::cuda::std::size_t
+__merge_static_extents(::cuda::std::size_t __lhs, ::cuda::std::size_t __rhs) noexcept
+{
+  if (__lhs == ::cuda::std::dynamic_extent || __rhs == ::cuda::std::dynamic_extent)
+  {
+    return ::cuda::std::dynamic_extent;
+  }
+  else
+  {
+    return _Op{}(__lhs, __rhs);
+  }
+}
+
+template <class _ResultIndex, class _Op, class _LhsExts, class _RhsExts, ::cuda::std::size_t... _Is>
+[[nodiscard]] _CCCL_API constexpr auto __extents_op_impl(::cuda::std::index_sequence<_Is...>) noexcept
+{
+  if constexpr (_LhsExts::rank() == _RhsExts::rank())
+  {
+    return ::cuda::std::extents<
+      _ResultIndex,
+      ::cuda::__merge_static_extents<_Op>(_LhsExts::static_extent(_Is), _RhsExts::static_extent(_Is))...>{};
+  }
+  else
+  {
+    // todo: make this work when ranks don't match
+    static_assert(::cuda::std::__always_false_v<_Op>);
+  }
+}
+
+template <class _Op, class _LhsExts, class _RhsExts>
+[[nodiscard]] _CCCL_API constexpr auto __extents_op(const _LhsExts& __lhs, const _RhsExts& __rhs) noexcept
+{
+  using _ResultIndex = ::cuda::std::common_type_t<typename _LhsExts::index_type, typename _RhsExts::index_type>;
+  constexpr ::cuda::std::size_t __result_rank = ::cuda::std::max(_LhsExts::rank(), _RhsExts::rank());
+  using _Result = decltype(::cuda::__extents_op_impl<_ResultIndex, _Op, _LhsExts, _RhsExts>(
+    ::cuda::std::make_index_sequence<__result_rank>{}));
+
+  // todo: make this work when ranks don't match
+  static_assert(_LhsExts::rank() == _RhsExts::rank());
+  ::cuda::std::array<_ResultIndex, __result_rank> __ret{};
+  _Op __op{};
+  for (::cuda::std::size_t __i = 0; __i < __result_rank; ++__i)
+  {
+    if (_Result::static_extent(__i) == ::cuda::std::dynamic_extent)
+    {
+      __ret[__i] = __op(__lhs.extent(__i), __rhs.extent(__i));
+    }
+    else
+    {
+      __ret[__i] = _Result::static_extent(__i);
+    }
+  }
+  return _Result{__ret};
+}
+
+template <class _LhsIndex, ::cuda::std::size_t... _LhsExts, class _RhsIndex, ::cuda::std::size_t... _RhsExts>
+[[nodiscard]] _CCCL_API constexpr auto __extents_add(const ::cuda::std::extents<_LhsIndex, _LhsExts...>& __lhs,
+                                                     const ::cuda::std::extents<_RhsIndex, _RhsExts...>& __rhs) noexcept
+{
+  return ::cuda::__extents_op<::cuda::std::plus<>>(__lhs, __rhs);
+}
+
+template <class _LhsIndex, ::cuda::std::size_t... _LhsExts, class _RhsIndex, ::cuda::std::size_t... _RhsExts>
+[[nodiscard]] _CCCL_API constexpr auto __extents_mul(const ::cuda::std::extents<_LhsIndex, _LhsExts...>& __lhs,
+                                                     const ::cuda::std::extents<_RhsIndex, _RhsExts...>& __rhs) noexcept
+{
+  return ::cuda::__extents_op<::cuda::std::multiplies<>>(__lhs, __rhs);
+}
+
+template <class _Level>
+struct __native_hierarchy_level_base : hierarchy_level_base<_Level>
+{
+  // todo: use this once cuda::hierarchy is implemented
+  //
+  // using __base_type = hierarchy_level_base<_Level>;
+  // using __base_type::count;
+  // using __base_type::dims;
+  // using __base_type::extents;
+  // using __base_type::index;
+  // using __base_type::rank;
+  // using __base_type::static_dims;
+
+  _CCCL_TEMPLATE(class _InLevel)
+  _CCCL_REQUIRES(__is_native_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API static auto dims(const _InLevel& __level) noexcept
+  {
+    return __dims_impl(__level);
+  }
+
+  _CCCL_TEMPLATE(class _InLevel)
+  _CCCL_REQUIRES(__is_native_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr auto static_dims(const _InLevel& __level) noexcept
+  {
+    return __static_dims_impl(__level);
+  }
+
+  _CCCL_TEMPLATE(class _InLevel)
+  _CCCL_REQUIRES(__is_native_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API static auto extents(const _InLevel& __level) noexcept
+  {
+    static_assert(__is_natively_reachable_hierarchy_level_v<_Level, _InLevel>,
+                  "_InLevel must be reachable from _Level");
+
+    using _NextLevel = typename _Level::__next_level;
+    auto __next_exts = _NextLevel::extents(__level);
+    auto __curr_exts = _Level::extents(_NextLevel{});
+    return ::cuda::__extents_mul(__curr_exts, __next_exts);
+  }
+
+  _CCCL_TEMPLATE(class _InLevel)
+  _CCCL_REQUIRES(__is_native_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::size_t count(const _InLevel& __level) noexcept
+  {
+    return __count_impl(__level);
+  }
+
+  _CCCL_TEMPLATE(class _InLevel)
+  _CCCL_REQUIRES(__is_native_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API static auto index(const _InLevel& __level) noexcept
+  {
+    static_assert(__is_natively_reachable_hierarchy_level_v<_Level, _InLevel>,
+                  "_InLevel must be reachable from _Level");
+
+    using _NextLevel       = typename _Level::__next_level;
+    const auto __curr_exts = _Level::extents(_NextLevel{});
+    const auto __next_idx  = _NextLevel::index(__level);
+    const auto __curr_idx  = _Level::index(_NextLevel{});
+
+    using _CurrExts = decltype(__curr_exts);
+    using _NextIdx  = decltype(__next_idx);
+    using _CurrIdx  = decltype(__curr_idx);
+
+    constexpr auto __curr_rank = _CurrExts::rank();
+    constexpr auto __next_rank = _CurrIdx::__rank;
+
+    using _Val = ::cuda::std::
+      common_type_t<typename _CurrExts::index_type, typename _NextIdx::value_type, typename _CurrIdx::value_type>;
+    constexpr ::cuda::std::size_t __rank = cuda::std::max(__curr_rank, __next_rank);
+
+    hierarchy_query_result<_Val, __rank> __ret{};
+    for (::cuda::std::size_t __i = 0; __i < __rank; ++__i)
+    {
+      if constexpr (__curr_rank == __next_rank)
+      {
+        __ret[__i] = __curr_idx[__i] + __curr_exts.extent(__i) * __next_idx[__i];
+      }
+      else
+      {
+        // todo: make this work when ranks don't match
+        static_assert(__curr_rank == __next_rank);
+      }
+    }
+    return __ret;
+  }
+
+  _CCCL_TEMPLATE(class _InLevel)
+  _CCCL_REQUIRES(__is_native_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::size_t rank(const _InLevel& __level) noexcept
+  {
+    return __rank_impl(__level);
+  }
+};
+
+template <>
+struct __native_hierarchy_level_base<grid_level> : hierarchy_level_base<grid_level>
+{};
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___HIERARCHY_NATIVE_HIERARCHY_LEVEL_BASE_H

--- a/libcudacxx/include/cuda/__hierarchy/thread_level.h
+++ b/libcudacxx/include/cuda/__hierarchy/thread_level.h
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___HIERARCHY_THREAD_LEVEL_H
+#define _CUDA___HIERARCHY_THREAD_LEVEL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/hierarchy.h>
+#include <cuda/__hierarchy/hierarchy_query_result.h>
+#include <cuda/__hierarchy/native_hierarchy_level_base.h>
+#include <cuda/std/__mdspan/extents.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+struct thread_level : __native_hierarchy_level_base<thread_level>
+{
+  using __next_level = block_level;
+
+  using __base_type = __native_hierarchy_level_base<thread_level>;
+  using __base_type::extents;
+  using __base_type::index;
+
+  // interactions with block level
+
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, unsigned> extents(const block_level&) noexcept
+  {
+    return ::cuda::std::dims<3, unsigned>{blockDim.z, blockDim.y, blockDim.x};
+  }
+  [[nodiscard]] _CCCL_DEVICE_API static hierarchy_query_result<unsigned, 3> index(const block_level&) noexcept
+  {
+    return {threadIdx.z, threadIdx.y, threadIdx.x};
+  }
+
+  // interactions with warp level
+
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr ::cuda::std::extents<unsigned, 32> extents(const warp_level&) noexcept
+  {
+    return {};
+  }
+  [[nodiscard]] _CCCL_DEVICE_API static hierarchy_query_result<unsigned, 1> index(const warp_level&) noexcept
+  {
+    return {::cuda::ptx::get_sreg_laneid()};
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+_CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
+
+_CCCL_GLOBAL_CONSTANT thread_level thread;
+
+_CCCL_END_NAMESPACE_CUDA_DEVICE
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___HIERARCHY_THREAD_LEVEL_H

--- a/libcudacxx/include/cuda/__hierarchy/traits.h
+++ b/libcudacxx/include/cuda/__hierarchy/traits.h
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___HIERARCHY_TRAITS_H
+#define _CUDA___HIERARCHY_TRAITS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__type_traits/void_t.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+// __is_natively_reachable_hierarchy_level_v
+
+template <class _FromLevel, class _CurrLevel, class _ToLevel, class = void>
+inline constexpr bool __is_natively_reachable_hierarchy_level_helper_v = false;
+template <class _FromLevel, class _CurrLevel, class _ToLevel>
+inline constexpr bool __is_natively_reachable_hierarchy_level_helper_v<
+  _FromLevel,
+  _CurrLevel,
+  _ToLevel,
+  ::cuda::std::void_t<typename _CurrLevel::__next_level>> =
+  __is_natively_reachable_hierarchy_level_helper_v<_FromLevel, typename _CurrLevel::__next_level, _ToLevel>;
+template <class _Level, class _ToLevel>
+inline constexpr bool __is_natively_reachable_hierarchy_level_helper_v<_Level, _Level, _ToLevel> = false;
+template <class _FromLevel, class _Level>
+inline constexpr bool __is_natively_reachable_hierarchy_level_helper_v<_FromLevel, _Level, _Level> = true;
+
+template <class _FromLevel, class _ToLevel, class = void>
+inline constexpr bool __is_natively_reachable_hierarchy_level_v = false;
+template <class _FromLevel, class _ToLevel>
+inline constexpr bool
+  __is_natively_reachable_hierarchy_level_v<_FromLevel, _ToLevel, ::cuda::std::void_t<typename _FromLevel::__next_level>> =
+    __is_native_hierarchy_level_v<_ToLevel>
+    && __is_natively_reachable_hierarchy_level_helper_v<_FromLevel, typename _FromLevel::__next_level, _ToLevel>;
+
+_CCCL_END_NAMESPACE_CUDA
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___HIERARCHY_TRAITS_H

--- a/libcudacxx/include/cuda/__hierarchy/warp_level.h
+++ b/libcudacxx/include/cuda/__hierarchy/warp_level.h
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___HIERARCHY_WARP_LEVEL_H
+#define _CUDA___HIERARCHY_WARP_LEVEL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__fwd/hierarchy.h>
+#include <cuda/__hierarchy/hierarchy_query_result.h>
+#include <cuda/__hierarchy/native_hierarchy_level_base.h>
+#include <cuda/__ptx/instructions/get_sreg.h>
+#include <cuda/std/__mdspan/extents.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+struct warp_level : __native_hierarchy_level_base<warp_level>
+{
+  using __next_level = block_level;
+
+  using __base_type = __native_hierarchy_level_base<warp_level>;
+  using __base_type::extents;
+  using __base_type::index;
+
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<1, unsigned> extents(const block_level&) noexcept
+  {
+    return ::cuda::std::dims<1, unsigned>{::cuda::ptx::get_sreg_nwarpid()};
+  }
+  [[nodiscard]] _CCCL_DEVICE_API static hierarchy_query_result<unsigned, 1> index(const warp_level&) noexcept
+  {
+    return {::cuda::ptx::get_sreg_warpid()};
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+_CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
+
+_CCCL_GLOBAL_CONSTANT warp_level warp;
+
+_CCCL_END_NAMESPACE_CUDA_DEVICE
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA___HIERARCHY_WARP_LEVEL_H

--- a/libcudacxx/include/cuda/__hierarchy_
+++ b/libcudacxx/include/cuda/__hierarchy_
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_HIERARCHY
+#define _CUDA_HIERARCHY
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__hierarchy/block_level.h>
+#include <cuda/__hierarchy/cluster_level.h>
+#include <cuda/__hierarchy/grid_level.h>
+#include <cuda/__hierarchy/hierarchy_level_base.h>
+#include <cuda/__hierarchy/hierarchy_query_result.h>
+#include <cuda/__hierarchy/native_hierarchy_level_base.h>
+#include <cuda/__hierarchy/thread_level.h>
+#include <cuda/__hierarchy/traits.h>
+#include <cuda/__hierarchy/warp_level.h>
+#include <cuda/version>
+
+#endif // _CUDA_HIERARCHY

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/hierarchy_query_result.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/hierarchy_query_result.pass.cpp
@@ -1,0 +1,151 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__hierarchy_>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+template <class T, T... Vs>
+__host__ __device__ constexpr cuda::hierarchy_query_result<T, sizeof...(Vs)>
+make_instance(cuda::std::integer_sequence<T, Vs...>)
+{
+  return cuda::hierarchy_query_result<T, sizeof...(Vs)>{Vs...};
+}
+
+template <class T, cuda::std::size_t N, class Vec>
+__host__ __device__ constexpr void compare_vector(cuda::hierarchy_query_result<T, N> v, Vec vec)
+{
+  assert(vec.x == v.x);
+  if constexpr (N >= 2)
+  {
+    assert(vec.y == v.y);
+  }
+  if constexpr (N >= 3)
+  {
+    assert(vec.z == v.z);
+  }
+  if constexpr (N >= 4)
+  {
+    assert(vec.w == v.w);
+  }
+}
+
+template <class T, cuda::std::size_t N>
+__host__ __device__ constexpr void test()
+{
+  using Type = cuda::hierarchy_query_result<T, N>;
+
+  // 1. Test value_type
+  static_assert(cuda::std::is_same_v<typename Type::value_type, T>);
+
+  // 2. Test constructors
+  static_assert(cuda::std::is_trivially_default_constructible_v<Type>);
+  static_assert(cuda::std::is_trivially_copyable_v<Type>);
+
+  // 3. Test public members
+  {
+    auto v = make_instance(cuda::std::make_integer_sequence<T, N>{});
+    if constexpr (N >= 1)
+    {
+      assert(v.x == static_cast<T>(N) - 1);
+    }
+    if constexpr (N >= 2)
+    {
+      assert(v.y == static_cast<T>(N) - 2);
+    }
+    if constexpr (N >= 3)
+    {
+      assert(v.z == static_cast<T>(N) - 3);
+    }
+  }
+
+  // 4. Test operator[] const
+  static_assert(cuda::std::is_same_v<const T&, decltype(cuda::std::declval<const Type>()[cuda::std::size_t{}])>);
+  static_assert(noexcept(cuda::std::declval<const Type>()[cuda::std::size_t{}]));
+  if constexpr (N > 0)
+  {
+    const auto v = make_instance(cuda::std::make_integer_sequence<T, N>{});
+    for (cuda::std::size_t i = 0; i < N; ++i)
+    {
+      assert(v[i] == static_cast<T>(i));
+    }
+  }
+
+  // 5. Test operator[]
+  static_assert(cuda::std::is_same_v<T&, decltype(cuda::std::declval<Type>()[cuda::std::size_t{}])>);
+  static_assert(noexcept(cuda::std::declval<Type>()[cuda::std::size_t{}]));
+  if constexpr (N > 0)
+  {
+    auto v = make_instance(cuda::std::make_integer_sequence<T, N>{});
+    for (cuda::std::size_t i = 0; i < N; ++i)
+    {
+      assert(v[i] == static_cast<T>(i));
+    }
+  }
+
+  // // 6. Test operator vector-type
+  // static_assert((N < 1 || N > 4) || cuda::std::is_nothrow_convertible_v<Type, cuda::__vector_type_t<T, N>>);
+  // if constexpr (N > 0 && N <= 4)
+  // {
+  //   using Vec    = cuda::__vector_type_t<T, N>;
+  //   const auto v = make_instance(cuda::std::make_integer_sequence<T, N>{});
+  //   Vec vec      = v;
+  //   compare_vector(v, vec);
+  // }
+
+  // // 7. Test operator dim3 for unsigned type of size 3
+  // static_assert((!cuda::std::is_same_v<T, unsigned> || N != 3) || cuda::std::is_nothrow_convertible_v<Type, dim3>);
+  // if constexpr (cuda::std::is_same_v<T, unsigned> && N == 3)
+  // {
+  //   const auto v = make_instance(cuda::std::make_integer_sequence<T, N>{});
+  //   dim3 vec     = v;
+  //   compare_vector(v, vec);
+  // }
+}
+
+template <class T>
+__host__ __device__ constexpr void test()
+{
+  test<T, 0>();
+  test<T, 1>();
+  test<T, 2>();
+  test<T, 3>();
+  test<T, 4>();
+  test<T, 6>();
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<signed char>();
+  test<signed short>();
+  test<signed int>();
+  test<signed long>();
+  test<signed long long>();
+#if _CCCL_HAS_INT128()
+  test<__int128_t>();
+#endif // _CCCL_HAS_INT128();
+
+  test<unsigned char>();
+  test<unsigned short>();
+  test<unsigned int>();
+  test<unsigned long>();
+  test<unsigned long long>();
+#if _CCCL_HAS_INT128()
+  test<__uint128_t>();
+#endif // _CCCL_HAS_INT128();
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_queries.pass.cpp
@@ -1,0 +1,201 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__hierarchy_>
+#include <cuda/std/cassert>
+#include <cuda/std/cstddef>
+#include <cuda/std/mdspan>
+#include <cuda/std/type_traits>
+
+template <class T>
+__device__ void test_result(cuda::hierarchy_query_result<T, 1> res, unsigned exp)
+{
+  assert(res.x == exp);
+}
+
+__device__ void test_result(cuda::hierarchy_query_result<unsigned, 3> res, uint3 exp)
+{
+  assert(res.x == exp.x);
+  assert(res.y == exp.y);
+  assert(res.z == exp.z);
+}
+
+__device__ void test_result(cuda::hierarchy_query_result<cuda::std::size_t, 1> res, cuda::std::size_t exp)
+{
+  assert(res.x == exp);
+}
+
+__device__ void test_result(cuda::hierarchy_query_result<cuda::std::size_t, 3> res, ulonglong3 exp)
+{
+  assert(res.x == exp.x);
+  assert(res.y == exp.y);
+  assert(res.z == exp.z);
+}
+
+template <class Index, cuda::std::size_t... Exts>
+__device__ void test_result(cuda::std::extents<Index, Exts...> res, cuda::std::extents<Index, Exts...> exp)
+{
+  for (cuda::std::size_t i = 0; i < sizeof...(Exts); ++i)
+  {
+    assert(res.extent(i) == exp.extent(i));
+  }
+}
+
+__device__ void test_thread()
+{
+  constexpr ulonglong3 dynamic_extent3 = {
+    cuda::std::dynamic_extent, cuda::std::dynamic_extent, cuda::std::dynamic_extent};
+
+  // 1. Test cuda::device::thread.dims(x)
+  test_result(cuda::device::thread.dims(cuda::device::warp), warpSize);
+  test_result(cuda::device::thread.dims(cuda::device::block), blockDim);
+  {
+    uint3 exp = blockDim;
+    NV_IF_TARGET(NV_PROVIDES_SM_90, ({
+                   exp.x *= __clusterGridDimInClusters().x;
+                   exp.y *= __clusterGridDimInClusters().y;
+                   exp.z *= __clusterGridDimInClusters().z;
+                 }))
+    test_result(cuda::device::thread.dims(cuda::device::cluster), exp);
+  }
+  {
+    const uint3 exp{blockDim.x * gridDim.x, blockDim.y * gridDim.y, blockDim.z * gridDim.z};
+    test_result(cuda::device::thread.dims(cuda::device::grid), exp);
+  }
+
+  // 2. Test cuda::device::thread.static_dims(x)
+  test_result(cuda::device::thread.static_dims(cuda::device::warp), cuda::std::size_t{32});
+  test_result(cuda::device::thread.static_dims(cuda::device::block), dynamic_extent3);
+  test_result(cuda::device::thread.static_dims(cuda::device::cluster), dynamic_extent3);
+  test_result(cuda::device::thread.static_dims(cuda::device::grid), dynamic_extent3);
+
+  // 3. Test cuda::device::thread.extents(x)
+  test_result(cuda::device::thread.extents(cuda::device::warp), cuda::std::extents<unsigned, 32>{});
+  test_result(cuda::device::thread.extents(cuda::device::block),
+              cuda::std::dims<3, unsigned>{blockDim.z, blockDim.y, blockDim.x});
+  {
+    uint3 exp = blockDim;
+    NV_IF_TARGET(NV_PROVIDES_SM_90, ({
+                   exp.x *= __clusterGridDimInClusters().x;
+                   exp.y *= __clusterGridDimInClusters().y;
+                   exp.z *= __clusterGridDimInClusters().z;
+                 }))
+    test_result(cuda::device::thread.extents(cuda::device::cluster), cuda::std::dims<3, unsigned>{exp.z, exp.y, exp.x});
+  }
+  {
+    const uint3 exp{blockDim.x * gridDim.x, blockDim.y * gridDim.y, blockDim.z * gridDim.z};
+    test_result(cuda::device::thread.extents(cuda::device::grid), cuda::std::dims<3, unsigned>{exp.z, exp.y, exp.x});
+  }
+
+  // 4. Test cuda::device::thread.count(x)
+  assert(cuda::device::thread.count(cuda::device::warp) == 32);
+  assert(cuda::device::thread.count(cuda::device::block) == cuda::std::size_t{blockDim.z} * blockDim.y * blockDim.x);
+  {
+    uint3 exp = blockDim;
+    NV_IF_TARGET(NV_PROVIDES_SM_90, ({
+                   exp.x *= __clusterDim().x;
+                   exp.y *= __clusterDim().y;
+                   exp.z *= __clusterDim().z;
+                 }))
+    assert(cuda::device::thread.count(cuda::device::cluster) == cuda::std::size_t{exp.z} * exp.y * exp.x);
+  }
+  {
+    const uint3 exp{blockDim.x * gridDim.x, blockDim.y * gridDim.y, blockDim.z * gridDim.z};
+    assert(cuda::device::thread.count(cuda::device::grid) == cuda::std::size_t{exp.z} * exp.y * exp.x);
+  }
+
+  // 5. test cuda::device::thread.index(x)
+  test_result(cuda::device::thread.index(cuda::device::warp), cuda::ptx::get_sreg_laneid());
+  test_result(cuda::device::thread.index(cuda::device::block), threadIdx);
+  {
+    uint3 exp = threadIdx;
+    NV_IF_TARGET(NV_PROVIDES_SM_90, ({
+                   exp.x += blockDim.x * __clusterRelativeBlockIdx().x;
+                   exp.y += blockDim.y * __clusterRelativeBlockIdx().y;
+                   exp.z += blockDim.z * __clusterRelativeBlockIdx().z;
+                 }))
+    test_result(cuda::device::thread.index(cuda::device::cluster), exp);
+  }
+  {
+    const uint3 exp{
+      threadIdx.x + blockDim.x * blockIdx.x,
+      threadIdx.y + blockDim.y * blockIdx.y,
+      threadIdx.z + blockDim.z * blockIdx.z,
+    };
+    test_result(cuda::device::thread.index(cuda::device::grid), exp);
+  }
+
+  // 6. Test cuda::device::thread.rank(x)
+  assert(cuda::device::thread.rank(cuda::device::warp) == cuda::ptx::get_sreg_laneid());
+  assert(cuda::device::thread.rank(cuda::device::block)
+         == ((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x) + threadIdx.x);
+  {
+    cuda::std::size_t exp = 0;
+    NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,
+                      ({
+                        exp = ((((__clusterRelativeBlockIdx().z * blockDim.z + threadIdx.z) * gridDim.y * blockDim.y)
+                                + __clusterRelativeBlockIdx().y * blockDim.y + threadIdx.y)
+                               * gridDim.x * blockDim.x)
+                            + __clusterRelativeBlockIdx().x * blockDim.x + threadIdx.x;
+                      }),
+                      ({ exp = ((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x) + threadIdx.x; }))
+    assert(cuda::device::thread.rank(cuda::device::cluster) == exp);
+  }
+  {
+    const cuda::std::size_t exp =
+      ((((blockIdx.z * blockDim.z + threadIdx.z) * gridDim.y * blockDim.y) + blockIdx.y * blockDim.y + threadIdx.y)
+       * gridDim.x * blockDim.x)
+      + blockIdx.x * blockDim.x + threadIdx.x;
+    assert(cuda::device::thread.rank(cuda::device::grid) == exp);
+  }
+}
+
+#if !_CCCL_COMPILER(NVRTC)
+__global__ void test_kernel()
+{
+  test_thread();
+}
+
+void test()
+{
+  test_kernel<<<1, 128>>>();
+  test_kernel<<<128, 1>>>();
+  test_kernel<<<{2, 3}, {4, 2}>>>();
+  test_kernel<<<{2, 3, 4}, {4, 2, 8}>>>();
+
+  // thread block clusters require compute capability at least 9.0
+  int cc_major{};
+  assert(cudaDeviceGetAttribute(&cc_major, cudaDevAttrComputeCapabilityMajor, 0) == cudaSuccess);
+  if (cc_major < 9)
+  {
+    return;
+  }
+
+  cudaLaunchAttribute attribute[1]{};
+  attribute[0].id               = cudaLaunchAttributeClusterDimension;
+  attribute[0].val.clusterDim.x = 2;
+  attribute[0].val.clusterDim.y = 8;
+  attribute[0].val.clusterDim.z = 4;
+
+  cudaLaunchConfig_t config{};
+  config.gridDim  = {4, 16, 8};
+  config.blockDim = {2, 8, 4};
+  config.attrs    = attribute;
+  config.numAttrs = 1;
+
+  assert(cudaLaunchKernelEx(&config, test_kernel) == cudaSuccess);
+  assert(cudaDeviceSynchronize() == cudaSuccess);
+}
+#endif // !_CCCL_COMPILER(NVRTC)
+
+int main(int, char**)
+{
+  NV_IF_ELSE_TARGET(NV_IS_HOST, (test();), (test_thread();))
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_query_signatures.compile.pass.cpp
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__hierarchy_>
+#include <cuda/std/mdspan>
+#include <cuda/std/type_traits>
+
+template <class Level, class T>
+using HierQueryRet = cuda::hierarchy_query_result<T, cuda::std::is_same_v<Level, cuda::warp_level> ? 1 : 3>;
+
+template <class Level>
+__device__ void test_signatures(const Level& level)
+{
+  // 1. Test cuda::thread_level::dims(x) signature
+  static_assert(cuda::std::is_same_v<HierQueryRet<Level, unsigned>, decltype(cuda::thread_level::dims(level))>);
+  static_assert(noexcept(cuda::thread_level::dims(level)));
+
+  // 2. Test cuda::thread_level::static_dims(x) signature
+  static_assert(
+    cuda::std::is_same_v<HierQueryRet<Level, cuda::std::size_t>, decltype(cuda::thread_level::static_dims(level))>);
+  static_assert(noexcept(cuda::thread_level::static_dims(level)));
+
+  // 3. Test cuda::thread_level::extents(x) signature
+  using ExtentsRet = cuda::std::conditional_t<cuda::std::is_same_v<Level, cuda::warp_level>,
+                                              cuda::std::extents<unsigned, 32>,
+                                              cuda::std::dims<3, unsigned>>;
+  static_assert(cuda::std::is_same_v<ExtentsRet, decltype(cuda::thread_level::extents(level))>);
+  static_assert(noexcept(cuda::thread_level::extents(level)));
+
+  // 4. Test cuda::thread_level::count(x) signature
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::count(level))>);
+  static_assert(noexcept(cuda::thread_level::count(level)));
+
+  // 5. Test cuda::thread_level::index(x) signature
+  static_assert(cuda::std::is_same_v<HierQueryRet<Level, unsigned>, decltype(cuda::thread_level::index(level))>);
+  static_assert(noexcept(cuda::thread_level::index(level)));
+
+  // 4. Test cuda::thread_level::rank(x) signature
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::rank(level))>);
+  static_assert(noexcept(cuda::thread_level::rank(level)));
+}
+
+__device__ void test()
+{
+  test_signatures(cuda::device::warp);
+  test_signatures(cuda::device::block);
+  test_signatures(cuda::device::cluster);
+  test_signatures(cuda::device::grid);
+}
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/traits/is_natively_reachable_hierarchy_level_v.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/traits/is_natively_reachable_hierarchy_level_v.compile.pass.cpp
@@ -1,0 +1,56 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/__hierarchy_>
+
+struct MyLevel : cuda::hierarchy_level_base<MyLevel>
+{};
+
+template <class FromLevel, class ToLevel>
+inline constexpr bool trait_v = cuda::__is_natively_reachable_hierarchy_level_v<FromLevel, ToLevel>;
+
+static_assert(!trait_v<cuda::thread_level, cuda::thread_level>);
+static_assert(!trait_v<cuda::thread_level, cuda::warp_level>);
+static_assert(trait_v<cuda::thread_level, cuda::block_level>);
+static_assert(trait_v<cuda::thread_level, cuda::cluster_level>);
+static_assert(trait_v<cuda::thread_level, cuda::grid_level>);
+static_assert(!trait_v<cuda::thread_level, MyLevel>);
+
+static_assert(!trait_v<cuda::warp_level, cuda::thread_level>);
+static_assert(!trait_v<cuda::warp_level, cuda::warp_level>);
+static_assert(trait_v<cuda::warp_level, cuda::block_level>);
+static_assert(trait_v<cuda::warp_level, cuda::cluster_level>);
+static_assert(trait_v<cuda::warp_level, cuda::grid_level>);
+static_assert(!trait_v<cuda::warp_level, MyLevel>);
+
+static_assert(!trait_v<cuda::block_level, cuda::thread_level>);
+static_assert(!trait_v<cuda::block_level, cuda::warp_level>);
+static_assert(!trait_v<cuda::block_level, cuda::block_level>);
+static_assert(trait_v<cuda::block_level, cuda::cluster_level>);
+static_assert(trait_v<cuda::block_level, cuda::grid_level>);
+static_assert(!trait_v<cuda::block_level, MyLevel>);
+
+static_assert(!trait_v<cuda::cluster_level, cuda::thread_level>);
+static_assert(!trait_v<cuda::cluster_level, cuda::warp_level>);
+static_assert(!trait_v<cuda::cluster_level, cuda::block_level>);
+static_assert(!trait_v<cuda::cluster_level, cuda::cluster_level>);
+static_assert(trait_v<cuda::cluster_level, cuda::grid_level>);
+static_assert(!trait_v<cuda::cluster_level, MyLevel>);
+
+static_assert(!trait_v<cuda::grid_level, cuda::thread_level>);
+static_assert(!trait_v<cuda::grid_level, cuda::warp_level>);
+static_assert(!trait_v<cuda::grid_level, cuda::block_level>);
+static_assert(!trait_v<cuda::grid_level, cuda::cluster_level>);
+static_assert(!trait_v<cuda::grid_level, cuda::grid_level>);
+static_assert(!trait_v<cuda::grid_level, MyLevel>);
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
This PR implements the first part of hierarchy levels support in libcu++. It implements the native hierarchy levels:
- `cuda::device::grid`
- `cuda::device::cluster`
- `cuda::device::block`
- `cuda::device::warp`
- `cuda::device::thread`

and operations `dims`, `static_dims`, `extents`, `count`, `index` and `rank` on them.