### PR TITLE
Replace uses of `thrust::pair` with `cuda::std::pair`

### DIFF
--- a/cub/test/catch2_test_c2h_checked_cuda_allocator.cu
+++ b/cub/test/catch2_test_c2h_checked_cuda_allocator.cu
@@ -36,7 +36,7 @@ C2H_TEST("c2h::device_vector throws when requested allocations exceed free devic
 C2H_TEST("c2h::device_policy throws when requested allocations exceed free device memory",
          "[c2h][checked_cuda_allocator][device_policy]")
 {
-  thrust::pair<char*, std::ptrdiff_t> buffer{nullptr, 0};
+  cuda::std::pair<char*, std::ptrdiff_t> buffer{nullptr, 0};
   auto policy = thrust::detail::derived_cast(thrust::detail::strip_const(c2h::device_policy));
 
   const std::size_t alloc_bytes = get_alloc_bytes();

--- a/libcudacxx/examples/concurrent_hash_table.cu
+++ b/libcudacxx/examples/concurrent_hash_table.cu
@@ -112,7 +112,7 @@ public:
   // TODO: Change return type to an enum with three possible values, succeeded,
   // exists, and full.
   template <typename UKey, typename... Args>
-  __host__ __device__ thrust::pair<value_iterator, bool> try_emplace(UKey&& key, Args&&... args)
+  __host__ __device__ cuda::std::pair<value_iterator, bool> try_emplace(UKey&& key, Args&&... args)
   {
     auto index{hash_(key) % capacity_};
     // Linearly probe the storage space up to `capacity_` times; if we haven't
@@ -130,7 +130,7 @@ public:
           new (keys_ + index) key_type(std::forward<UKey>(key));
           new (values_ + index) mapped_type(std::forward<Args>(args)...);
           states_[index].store(state_filled, cuda::std::memory_order_release);
-          return thrust::make_pair(values_ + index, true);
+          return cuda::std::make_pair(values_ + index, true);
         }
       }
       // If we are here, the element we are probing is not empty and we didn't
@@ -142,13 +142,13 @@ public:
       if (key_equal_(keys_[index], key))
       {
         // It is, so the element already exists.
-        return thrust::make_pair(values_ + index, false);
+        return cuda::std::make_pair(values_ + index, false);
       }
       // Otherwise, the element isn't a match, so move on to the next element.
       index = (index + 1) % capacity_;
     }
     // If we are here, the container is full.
-    return thrust::make_pair(value_iterator{}, false);
+    return cuda::std::make_pair(value_iterator{}, false);
   }
 
   __host__ __device__ mapped_type& operator[](key_type const& key)

--- a/libcudacxx/include/cuda/std/__memory/construct_at.h
+++ b/libcudacxx/include/cuda/std/__memory/construct_at.h
@@ -158,7 +158,7 @@ _CCCL_API constexpr _ForwardIterator __destroy(_ForwardIterator, _ForwardIterato
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp>
-_CCCL_API constexpr void __destroy_at(_Tp* __loc)
+_CCCL_API constexpr void __destroy_at([[maybe_unused]] _Tp* __loc)
 {
   _CCCL_ASSERT(__loc != nullptr, "null pointer given to __destroy_at");
   if constexpr (is_trivially_destructible_v<_Tp>)
@@ -201,7 +201,7 @@ __reverse_destroy(_BidirectionalIterator __first, _BidirectionalIterator __last)
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class _Tp>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 void destroy_at(_Tp* __loc)
+_CCCL_API inline _CCCL_CONSTEXPR_CXX20 void destroy_at([[maybe_unused]] _Tp* __loc)
 {
   _CCCL_ASSERT(__loc != nullptr, "null pointer given to __destroy_at");
   if constexpr (is_trivially_destructible_v<_Tp>)

--- a/thrust/benchmarks/bench/set_operations/difference_by_key.cu
+++ b/thrust/benchmarks/bench/set_operations/difference_by_key.cu
@@ -14,7 +14,7 @@ struct op_t
             class InputIterator4,
             class OutputIterator1,
             class OutputIterator2>
-  __host__ thrust::pair<OutputIterator1, OutputIterator2> operator()(
+  __host__ cuda::std::pair<OutputIterator1, OutputIterator2> operator()(
     const PolicyT& policy,
     InputIterator1 keys_first1,
     InputIterator1 keys_last1,

--- a/thrust/benchmarks/bench/set_operations/intersection_by_key.cu
+++ b/thrust/benchmarks/bench/set_operations/intersection_by_key.cu
@@ -14,7 +14,7 @@ struct op_t
             class InputIterator4,
             class OutputIterator1,
             class OutputIterator2>
-  __host__ thrust::pair<OutputIterator1, OutputIterator2> operator()(
+  __host__ cuda::std::pair<OutputIterator1, OutputIterator2> operator()(
     const PolicyT& policy,
     InputIterator1 keys_first1,
     InputIterator1 keys_last1,

--- a/thrust/benchmarks/bench/set_operations/symmetric_difference_by_key.cu
+++ b/thrust/benchmarks/bench/set_operations/symmetric_difference_by_key.cu
@@ -14,7 +14,7 @@ struct op_t
             class InputIterator4,
             class OutputIterator1,
             class OutputIterator2>
-  __host__ thrust::pair<OutputIterator1, OutputIterator2> operator()(
+  __host__ cuda::std::pair<OutputIterator1, OutputIterator2> operator()(
     const PolicyT& policy,
     InputIterator1 keys_first1,
     InputIterator1 keys_last1,

--- a/thrust/benchmarks/bench/set_operations/union_by_key.cu
+++ b/thrust/benchmarks/bench/set_operations/union_by_key.cu
@@ -14,7 +14,7 @@ struct op_t
             class InputIterator4,
             class OutputIterator1,
             class OutputIterator2>
-  __host__ thrust::pair<OutputIterator1, OutputIterator2> operator()(
+  __host__ cuda::std::pair<OutputIterator1, OutputIterator2> operator()(
     const PolicyT& policy,
     InputIterator1 keys_first1,
     InputIterator1 keys_last1,

--- a/thrust/examples/bounding_box.cu
+++ b/thrust/examples/bounding_box.cu
@@ -1,8 +1,9 @@
 #include <thrust/device_vector.h>
 #include <thrust/extrema.h>
-#include <thrust/pair.h>
 #include <thrust/random.h>
 #include <thrust/transform_reduce.h>
+
+#include <cuda/std/utility>
 
 // This example shows how to compute a bounding box
 // for a set of points in two dimensions.

--- a/thrust/examples/cuda/custom_temporary_allocation.cu
+++ b/thrust/examples/cuda/custom_temporary_allocation.cu
@@ -1,9 +1,10 @@
 #include <thrust/generate.h>
 #include <thrust/host_vector.h>
-#include <thrust/pair.h>
 #include <thrust/sort.h>
 #include <thrust/system/cuda/execution_policy.h>
 #include <thrust/system/cuda/vector.h>
+
+#include <cuda/std/utility>
 
 #include <cassert>
 #include <cstdlib>

--- a/thrust/testing/catch2_test_binary_search.cu
+++ b/thrust/testing/catch2_test_binary_search.cu
@@ -197,11 +197,11 @@ TEMPLATE_LIST_TEST_CASE("ScalarEqualRangeSimple", "[binary_search]", vector_list
 }
 
 template <typename ForwardIterator, typename LessThanComparable>
-thrust::pair<ForwardIterator, ForwardIterator>
+cuda::std::pair<ForwardIterator, ForwardIterator>
 equal_range(my_system& system, ForwardIterator first, ForwardIterator /*last*/, const LessThanComparable& /*value*/)
 {
   system.validate_dispatch();
-  return thrust::make_pair(first, first);
+  return cuda::std::make_pair(first, first);
 }
 
 TEST_CASE("ScalarEqualRangeDispatchExplicit", "[binary_search]")
@@ -215,11 +215,11 @@ TEST_CASE("ScalarEqualRangeDispatchExplicit", "[binary_search]")
 }
 
 template <typename ForwardIterator, typename LessThanComparable>
-thrust::pair<ForwardIterator, ForwardIterator>
+cuda::std::pair<ForwardIterator, ForwardIterator>
 equal_range(my_tag, ForwardIterator first, ForwardIterator /*last*/, const LessThanComparable& /*value*/)
 {
   *first = 13;
-  return thrust::make_pair(first, first);
+  return cuda::std::make_pair(first, first);
 }
 
 TEST_CASE("ScalarEqualRangeDispatchImplicit", "[binary_search]")

--- a/thrust/testing/catch2_test_transform.cu
+++ b/thrust/testing/catch2_test_transform.cu
@@ -2,9 +2,10 @@
 #include <thrust/iterator/discard_iterator.h>
 #include <thrust/iterator/retag.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/pair.h>
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
+
+#include <cuda/std/utility>
 
 #include "catch2_test_helper.h"
 #include "unittest/random.h"
@@ -376,9 +377,9 @@ TEMPLATE_LIST_TEST_CASE("UnaryToDiscardIterator", "[transform]", variable_list)
 struct repeat2
 {
   template <typename T>
-  _CCCL_HOST_DEVICE thrust::pair<T, T> operator()(T x)
+  _CCCL_HOST_DEVICE cuda::std::pair<T, T> operator()(T x)
   {
-    return thrust::make_pair(x, x);
+    return cuda::std::make_pair(x, x);
   }
 };
 

--- a/thrust/testing/cuda/binary_search.cu
+++ b/thrust/testing/cuda/binary_search.cu
@@ -1,8 +1,9 @@
 #include <thrust/binary_search.h>
 #include <thrust/device_vector.h>
 #include <thrust/distance.h>
-#include <thrust/pair.h>
 #include <thrust/sequence.h>
+
+#include <cuda/std/utility>
 
 #include <unittest/unittest.h>
 
@@ -10,7 +11,7 @@ void TestEqualRangeOnStream()
 { // Regression test for GH issue #921 (nvbug 2173437)
   using vector_t   = typename thrust::device_vector<int>;
   using iterator_t = typename vector_t::iterator;
-  using result_t   = thrust::pair<iterator_t, iterator_t>;
+  using result_t   = cuda::std::pair<iterator_t, iterator_t>;
 
   vector_t input(10);
   thrust::sequence(thrust::device, input.begin(), input.end(), 0);

--- a/thrust/testing/cuda/memory.cu
+++ b/thrust/testing/cuda/memory.cu
@@ -50,7 +50,7 @@ void TestGetTemporaryBufferDeviceSeq()
   const std::ptrdiff_t n = 9001;
 
   using pointer         = thrust::pointer<int, thrust::detail::seq_t>;
-  using ptr_and_sz_type = thrust::pair<pointer, std::ptrdiff_t>;
+  using ptr_and_sz_type = cuda::std::pair<pointer, std::ptrdiff_t>;
   thrust::device_vector<ptr_and_sz_type> d_result(1);
 
   get_temporary_buffer_kernel<<<1, 1>>>(n, d_result.begin());

--- a/thrust/testing/cuda/merge_by_key.cu
+++ b/thrust/testing/cuda/merge_by_key.cu
@@ -55,7 +55,7 @@ void TestMergeByKeyDevice(ExecutionPolicy exec)
 
   using Iterator = typename thrust::device_vector<int>::iterator;
 
-  thrust::device_vector<thrust::pair<Iterator, Iterator>> result_ends(1);
+  thrust::device_vector<cuda::std::pair<Iterator, Iterator>> result_ends(1);
 
   merge_by_key_kernel<<<1, 1>>>(
     exec,
@@ -71,7 +71,7 @@ void TestMergeByKeyDevice(ExecutionPolicy exec)
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
-  thrust::pair<Iterator, Iterator> ends = result_ends[0];
+  cuda::std::pair<Iterator, Iterator> ends = result_ends[0];
 
   ASSERT_EQUAL_QUIET(result_key.end(), ends.first);
   ASSERT_EQUAL_QUIET(result_val.end(), ends.second);
@@ -120,7 +120,7 @@ void TestMergeByKeyCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  thrust::pair<Iterator, Iterator> ends = thrust::merge_by_key(
+  cuda::std::pair<Iterator, Iterator> ends = thrust::merge_by_key(
     thrust::cuda::par.on(s),
     a_key.begin(),
     a_key.end(),

--- a/thrust/testing/cuda/minmax_element.cu
+++ b/thrust/testing/cuda/minmax_element.cu
@@ -30,7 +30,7 @@ void TestMinMaxElementDevice(ExecutionPolicy exec)
   typename thrust::device_vector<int>::iterator d_max;
 
   using pair_type =
-    thrust::pair<typename thrust::device_vector<int>::iterator, typename thrust::device_vector<int>::iterator>;
+    cuda::std::pair<typename thrust::device_vector<int>::iterator, typename thrust::device_vector<int>::iterator>;
 
   thrust::device_vector<pair_type> d_result(1);
 

--- a/thrust/testing/cuda/mismatch.cu
+++ b/thrust/testing/cuda/mismatch.cu
@@ -20,7 +20,7 @@ void TestMismatchDevice(ExecutionPolicy exec)
   thrust::device_vector<int> b = {1, 2, 4, 3};
 
   using pair_type =
-    thrust::pair<typename thrust::device_vector<int>::iterator, typename thrust::device_vector<int>::iterator>;
+    cuda::std::pair<typename thrust::device_vector<int>::iterator, typename thrust::device_vector<int>::iterator>;
 
   thrust::device_vector<pair_type> d_result(1);
 

--- a/thrust/testing/cuda/pair_sort.cu
+++ b/thrust/testing/cuda/pair_sort.cu
@@ -1,6 +1,7 @@
 #include <thrust/execution_policy.h>
-#include <thrust/pair.h>
 #include <thrust/sort.h>
+
+#include <cuda/std/utility>
 
 #include <unittest/unittest.h>
 
@@ -14,9 +15,9 @@ __global__ void stable_sort_kernel(ExecutionPolicy exec, Iterator first, Iterato
 struct make_pair_functor
 {
   template <typename T1, typename T2>
-  _CCCL_HOST_DEVICE thrust::pair<T1, T2> operator()(const T1& x, const T2& y)
+  _CCCL_HOST_DEVICE cuda::std::pair<T1, T2> operator()(const T1& x, const T2& y)
   {
-    return thrust::make_pair(x, y);
+    return cuda::std::make_pair(x, y);
   } // end operator()()
 }; // end make_pair_functor
 
@@ -24,7 +25,7 @@ template <typename ExecutionPolicy>
 void TestPairStableSortDevice(ExecutionPolicy exec)
 {
   size_t n = 10000;
-  using P  = thrust::pair<int, int>;
+  using P  = cuda::std::pair<int, int>;
 
   thrust::host_vector<int> h_p1 = unittest::random_integers<int>(n);
   thrust::host_vector<int> h_p2 = unittest::random_integers<int>(n);

--- a/thrust/testing/cuda/pair_sort_by_key.cu
+++ b/thrust/testing/cuda/pair_sort_by_key.cu
@@ -1,8 +1,9 @@
 #include <thrust/execution_policy.h>
-#include <thrust/pair.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
 #include <thrust/transform.h>
+
+#include <cuda/std/utility>
 
 #include <unittest/unittest.h>
 
@@ -17,9 +18,9 @@ stable_sort_by_key_kernel(ExecutionPolicy exec, Iterator1 keys_first, Iterator1 
 struct make_pair_functor
 {
   template <typename T1, typename T2>
-  _CCCL_HOST_DEVICE thrust::pair<T1, T2> operator()(const T1& x, const T2& y)
+  _CCCL_HOST_DEVICE cuda::std::pair<T1, T2> operator()(const T1& x, const T2& y)
   {
-    return thrust::make_pair(x, y);
+    return cuda::std::make_pair(x, y);
   } // end operator()()
 }; // end make_pair_functor
 
@@ -27,7 +28,7 @@ template <typename ExecutionPolicy>
 void TestPairStableSortByKeyDevice(ExecutionPolicy exec)
 {
   size_t n = 10000;
-  using P  = thrust::pair<int, int>;
+  using P  = cuda::std::pair<int, int>;
 
   // host arrays
   thrust::host_vector<int> h_p1 = unittest::random_integers<int>(n);

--- a/thrust/testing/cuda/partition.cu
+++ b/thrust/testing/cuda/partition.cu
@@ -187,7 +187,7 @@ void TestPartitionCopyDevice(ExecutionPolicy exec)
   thrust::device_vector<int> true_results(2);
   thrust::device_vector<int> false_results(3);
 
-  using pair_type = thrust::pair<iterator, iterator>;
+  using pair_type = cuda::std::pair<iterator, iterator>;
   thrust::device_vector<pair_type> iterators(1);
 
   partition_copy_kernel<<<1, 1>>>(
@@ -273,7 +273,7 @@ void TestPartitionCopyStencilDevice(ExecutionPolicy exec)
   thrust::device_vector<int> false_results(3);
 
   using iterator  = typename thrust::device_vector<int>::iterator;
-  using pair_type = thrust::pair<iterator, iterator>;
+  using pair_type = cuda::std::pair<iterator, iterator>;
   thrust::device_vector<pair_type> iterators(1);
 
   partition_copy_kernel<<<1, 1>>>(
@@ -474,7 +474,7 @@ void TestStablePartitionCopyDevice(ExecutionPolicy exec)
   thrust::device_vector<int> true_results(2);
   thrust::device_vector<int> false_results(3);
 
-  using pair_type = thrust::pair<iterator, iterator>;
+  using pair_type = cuda::std::pair<iterator, iterator>;
   thrust::device_vector<pair_type> iterators(1);
 
   stable_partition_copy_kernel<<<1, 1>>>(
@@ -560,7 +560,7 @@ void TestStablePartitionCopyStencilDevice(ExecutionPolicy exec)
   thrust::device_vector<int> false_results(3);
 
   using iterator  = typename thrust::device_vector<int>::iterator;
-  using pair_type = thrust::pair<iterator, iterator>;
+  using pair_type = cuda::std::pair<iterator, iterator>;
   thrust::device_vector<pair_type> iterators(1);
 
   stable_partition_copy_kernel<<<1, 1>>>(

--- a/thrust/testing/cuda/reduce_by_key.cu
+++ b/thrust/testing/cuda/reduce_by_key.cu
@@ -164,7 +164,7 @@ void TestReduceByKeyDevice(ExecutionPolicy exec)
   thrust::device_vector<T> values;
 
   using iterator_pair =
-    typename thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator>;
+    typename cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator>;
 
   thrust::device_vector<iterator_pair> new_last_vec(1);
   iterator_pair new_last;
@@ -293,7 +293,7 @@ void TestReduceByKeyCudaStreams(ExecutionPolicy policy)
   Vector keys;
   Vector values;
 
-  thrust::pair<Vector::iterator, Vector::iterator> new_last;
+  cuda::std::pair<Vector::iterator, Vector::iterator> new_last;
 
   // basic test
   initialize_keys(keys);

--- a/thrust/testing/cuda/set_difference_by_key.cu
+++ b/thrust/testing/cuda/set_difference_by_key.cu
@@ -41,7 +41,7 @@ void TestSetDifferenceByKeyDevice(ExecutionPolicy exec)
   Vector ref_key{2, 5}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
-  using iter_pair = thrust::pair<Iterator, Iterator>;
+  using iter_pair = cuda::std::pair<Iterator, Iterator>;
 
   thrust::device_vector<iter_pair> end_vec(1);
 
@@ -94,7 +94,7 @@ void TestSetDifferenceByKeyCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
     thrust::cuda::par.on(s),
     a_key.begin(),
     a_key.end(),

--- a/thrust/testing/cuda/set_intersection_by_key.cu
+++ b/thrust/testing/cuda/set_intersection_by_key.cu
@@ -38,7 +38,7 @@ void TestSetIntersectionByKeyDevice(ExecutionPolicy exec)
   Vector ref_key{0, 4}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
-  using iter_pair = thrust::pair<Iterator, Iterator>;
+  using iter_pair = cuda::std::pair<Iterator, Iterator>;
   thrust::device_vector<iter_pair> end_vec(1);
 
   set_intersection_by_key_kernel<<<1, 1>>>(
@@ -54,7 +54,7 @@ void TestSetIntersectionByKeyDevice(ExecutionPolicy exec)
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
-  thrust::pair<Iterator, Iterator> end = end_vec.front();
+  cuda::std::pair<Iterator, Iterator> end = end_vec.front();
 
   ASSERT_EQUAL_QUIET(result_key.end(), end.first);
   ASSERT_EQUAL_QUIET(result_val.end(), end.second);
@@ -98,7 +98,7 @@ void TestSetIntersectionByKeyCudaStreams(ExecutionPolicy policy)
 
   auto streampolicy = policy.on(s);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(
     streampolicy,
     a_key.begin(),
     a_key.end(),

--- a/thrust/testing/cuda/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/cuda/set_symmetric_difference_by_key.cu
@@ -40,7 +40,7 @@ void TestSetSymmetricDifferenceByKeyDevice(ExecutionPolicy exec)
   Vector ref_key{2, 3, 3, 6, 7}, ref_val{0, 1, 1, 0, 1};
   Vector result_key(5), result_val(5);
 
-  using iter_pair = thrust::pair<Iterator, Iterator>;
+  using iter_pair = cuda::std::pair<Iterator, Iterator>;
   thrust::device_vector<iter_pair> end_vec(1);
 
   set_symmetric_difference_by_key_kernel<<<1, 1>>>(
@@ -92,7 +92,7 @@ void TestSetSymmetricDifferenceByKeyCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
     thrust::cuda::par.on(s),
     a_key.begin(),
     a_key.end(),

--- a/thrust/testing/cuda/set_union_by_key.cu
+++ b/thrust/testing/cuda/set_union_by_key.cu
@@ -40,7 +40,7 @@ void TestSetUnionByKeyDevice(ExecutionPolicy exec)
   Vector ref_key{0, 2, 3, 3, 4}, ref_val{0, 0, 1, 1, 0};
   Vector result_key(5), result_val(5);
 
-  thrust::device_vector<thrust::pair<Iterator, Iterator>> end_vec(1);
+  thrust::device_vector<cuda::std::pair<Iterator, Iterator>> end_vec(1);
 
   set_union_by_key_kernel<<<1, 1>>>(
     exec,
@@ -56,7 +56,7 @@ void TestSetUnionByKeyDevice(ExecutionPolicy exec)
   cudaError_t const err = cudaDeviceSynchronize();
   ASSERT_EQUAL(cudaSuccess, err);
 
-  thrust::pair<Iterator, Iterator> end = end_vec[0];
+  cuda::std::pair<Iterator, Iterator> end = end_vec[0];
 
   ASSERT_EQUAL_QUIET(result_key.end(), end.first);
   ASSERT_EQUAL_QUIET(result_val.end(), end.second);
@@ -91,7 +91,7 @@ void TestSetUnionByKeyCudaStreams()
   cudaStream_t s;
   cudaStreamCreate(&s);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_union_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_union_by_key(
     thrust::cuda::par.on(s),
     a_key.begin(),
     a_key.end(),

--- a/thrust/testing/cuda/unique_by_key.cu
+++ b/thrust/testing/cuda/unique_by_key.cu
@@ -56,7 +56,7 @@ void TestUniqueByKeyDevice(ExecutionPolicy exec)
   Vector keys;
   Vector values;
 
-  using iter_pair = thrust::pair<typename Vector::iterator, typename Vector::iterator>;
+  using iter_pair = cuda::std::pair<typename Vector::iterator, typename Vector::iterator>;
   thrust::device_vector<iter_pair> new_last_vec(1);
   iter_pair new_last;
 
@@ -134,7 +134,7 @@ void TestUniqueByKeyCudaStreams(ExecutionPolicy policy)
   Vector keys;
   Vector values;
 
-  using iter_pair = thrust::pair<Vector::iterator, Vector::iterator>;
+  using iter_pair = cuda::std::pair<Vector::iterator, Vector::iterator>;
   iter_pair new_last;
 
   // basic test
@@ -238,7 +238,7 @@ void TestUniqueCopyByKeyDevice(ExecutionPolicy exec)
   Vector keys;
   Vector values;
 
-  using iter_pair = thrust::pair<typename Vector::iterator, typename Vector::iterator>;
+  using iter_pair = cuda::std::pair<typename Vector::iterator, typename Vector::iterator>;
   thrust::device_vector<iter_pair> new_last_vec(1);
   iter_pair new_last;
 
@@ -328,7 +328,7 @@ void TestUniqueCopyByKeyCudaStreams(ExecutionPolicy policy)
   Vector keys;
   Vector values;
 
-  using iter_pair = thrust::pair<Vector::iterator, Vector::iterator>;
+  using iter_pair = cuda::std::pair<Vector::iterator, Vector::iterator>;
   iter_pair new_last;
 
   // basic test

--- a/thrust/testing/memory.cu
+++ b/thrust/testing/memory.cu
@@ -1,10 +1,11 @@
 #include <thrust/fill.h>
 #include <thrust/logical.h>
 #include <thrust/memory.h>
-#include <thrust/pair.h>
 #include <thrust/reverse.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+
+#include <cuda/std/utility>
 
 #include <iostream>
 
@@ -59,12 +60,12 @@ struct my_old_temporary_allocation_system : public thrust::device_execution_poli
 {};
 
 template <typename T>
-thrust::pair<thrust::pointer<T, my_old_temporary_allocation_system>, std::ptrdiff_t>
+cuda::std::pair<thrust::pointer<T, my_old_temporary_allocation_system>, std::ptrdiff_t>
 get_temporary_buffer(my_old_temporary_allocation_system, std::ptrdiff_t)
 {
   thrust::pointer<T, my_old_temporary_allocation_system> const result(reinterpret_cast<T*>(4217));
 
-  return thrust::make_pair(result, 314);
+  return cuda::std::make_pair(result, 314);
 }
 
 template <typename Pointer>
@@ -81,12 +82,12 @@ struct my_new_temporary_allocation_system : public thrust::device_execution_poli
 {};
 
 template <typename T>
-thrust::pair<thrust::pointer<T, my_new_temporary_allocation_system>, std::ptrdiff_t>
+cuda::std::pair<thrust::pointer<T, my_new_temporary_allocation_system>, std::ptrdiff_t>
 get_temporary_buffer(my_new_temporary_allocation_system, std::ptrdiff_t)
 {
   thrust::pointer<T, my_new_temporary_allocation_system> const result(reinterpret_cast<T*>(1742));
 
-  return thrust::make_pair(result, 413);
+  return cuda::std::make_pair(result, 413);
 }
 
 template <typename Pointer>
@@ -162,8 +163,8 @@ void TestGetTemporaryBuffer()
   const std::ptrdiff_t n = 9001;
 
   thrust::device_system_tag dev_tag;
-  using pointer                                    = thrust::pointer<int, thrust::device_system_tag>;
-  thrust::pair<pointer, std::ptrdiff_t> ptr_and_sz = thrust::get_temporary_buffer<int>(dev_tag, n);
+  using pointer                                       = thrust::pointer<int, thrust::device_system_tag>;
+  cuda::std::pair<pointer, std::ptrdiff_t> ptr_and_sz = thrust::get_temporary_buffer<int>(dev_tag, n);
 
   ASSERT_EQUAL(ptr_and_sz.second, n);
 
@@ -233,15 +234,15 @@ void TestFreeDispatchExplicit()
 DECLARE_UNITTEST(TestFreeDispatchExplicit);
 
 template <typename T>
-thrust::pair<thrust::pointer<T, my_memory_system>, std::ptrdiff_t>
+cuda::std::pair<thrust::pointer<T, my_memory_system>, std::ptrdiff_t>
 get_temporary_buffer(my_memory_system& system, std::ptrdiff_t n)
 {
   system.validate_dispatch();
 
   thrust::device_system_tag device_sys;
-  thrust::pair<thrust::pointer<T, thrust::device_system_tag>, std::ptrdiff_t> result =
+  cuda::std::pair<thrust::pointer<T, thrust::device_system_tag>, std::ptrdiff_t> result =
     thrust::get_temporary_buffer<T>(device_sys, n);
-  return thrust::make_pair(thrust::pointer<T, my_memory_system>(result.first.get()), result.second);
+  return cuda::std::make_pair(thrust::pointer<T, my_memory_system>(result.first.get()), result.second);
 }
 
 void TestGetTemporaryBufferDispatchExplicit()
@@ -249,8 +250,8 @@ void TestGetTemporaryBufferDispatchExplicit()
   const std::ptrdiff_t n = 9001;
 
   my_memory_system sys(0);
-  using pointer                                    = thrust::pointer<int, thrust::device_system_tag>;
-  thrust::pair<pointer, std::ptrdiff_t> ptr_and_sz = thrust::get_temporary_buffer<int>(sys, n);
+  using pointer                                       = thrust::pointer<int, thrust::device_system_tag>;
+  cuda::std::pair<pointer, std::ptrdiff_t> ptr_and_sz = thrust::get_temporary_buffer<int>(sys, n);
 
   ASSERT_EQUAL(ptr_and_sz.second, n);
   ASSERT_EQUAL(true, sys.is_valid());
@@ -299,7 +300,7 @@ void TestTemporaryBufferOldCustomization()
 {
   using system           = my_old_namespace::my_old_temporary_allocation_system;
   using pointer          = thrust::pointer<int, system>;
-  using pointer_and_size = thrust::pair<pointer, std::ptrdiff_t>;
+  using pointer_and_size = cuda::std::pair<pointer, std::ptrdiff_t>;
 
   system sys;
 
@@ -319,7 +320,7 @@ void TestTemporaryBufferNewCustomization()
 {
   using system           = my_new_namespace::my_new_temporary_allocation_system;
   using pointer          = thrust::pointer<int, system>;
-  using pointer_and_size = thrust::pair<pointer, std::ptrdiff_t>;
+  using pointer_and_size = cuda::std::pair<pointer, std::ptrdiff_t>;
 
   system sys;
 

--- a/thrust/testing/merge_by_key.cu
+++ b/thrust/testing/merge_by_key.cu
@@ -40,7 +40,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   my_system& system,
   InputIterator1,
   InputIterator1,
@@ -52,7 +52,7 @@ thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
   OutputIterator2 values_result)
 {
   system.validate_dispatch();
-  return thrust::make_pair(keys_result, values_result);
+  return cuda::std::make_pair(keys_result, values_result);
 }
 
 void TestMergeByKeyDispatchExplicit()
@@ -73,7 +73,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   my_tag,
   InputIterator1,
   InputIterator1,
@@ -85,7 +85,7 @@ thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
   OutputIterator2 values_result)
 {
   *keys_result = 13;
-  return thrust::make_pair(keys_result, values_result);
+  return cuda::std::make_pair(keys_result, values_result);
 }
 
 void TestMergeByKeyDispatchImplicit()
@@ -218,7 +218,7 @@ void TestMergeByKeyToDiscardIterator(size_t n)
   const thrust::device_vector<T> d_a_vals = h_a_vals;
   const thrust::device_vector<T> d_b_vals = h_b_vals;
 
-  using discard_pair = thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>>;
+  using discard_pair = cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>>;
 
   const discard_pair h_result = thrust::merge_by_key(
     h_a_keys.begin(),

--- a/thrust/testing/minmax_element.cu
+++ b/thrust/testing/minmax_element.cu
@@ -63,10 +63,11 @@ void TestMinMaxElement(const size_t n)
 DECLARE_VARIABLE_UNITTEST(TestMinMaxElement);
 
 template <typename ForwardIterator>
-thrust::pair<ForwardIterator, ForwardIterator> minmax_element(my_system& system, ForwardIterator first, ForwardIterator)
+cuda::std::pair<ForwardIterator, ForwardIterator>
+minmax_element(my_system& system, ForwardIterator first, ForwardIterator)
 {
   system.validate_dispatch();
-  return thrust::make_pair(first, first);
+  return cuda::std::make_pair(first, first);
 }
 
 void TestMinMaxElementDispatchExplicit()
@@ -81,10 +82,10 @@ void TestMinMaxElementDispatchExplicit()
 DECLARE_UNITTEST(TestMinMaxElementDispatchExplicit);
 
 template <typename ForwardIterator>
-thrust::pair<ForwardIterator, ForwardIterator> minmax_element(my_tag, ForwardIterator first, ForwardIterator)
+cuda::std::pair<ForwardIterator, ForwardIterator> minmax_element(my_tag, ForwardIterator first, ForwardIterator)
 {
   *first = 13;
-  return thrust::make_pair(first, first);
+  return cuda::std::make_pair(first, first);
 }
 
 void TestMinMaxElementDispatchImplicit()
@@ -104,7 +105,7 @@ void TestMinMaxElementWithBigIndexesHelper(int magnitude)
   Iter end = begin + (1ll << magnitude);
   ASSERT_EQUAL(::cuda::std::distance(begin, end), 1ll << magnitude);
 
-  thrust::pair<Iter, Iter> result = thrust::minmax_element(thrust::device, begin, end);
+  cuda::std::pair<Iter, Iter> result = thrust::minmax_element(thrust::device, begin, end);
   ASSERT_EQUAL(*result.first, 1);
   ASSERT_EQUAL(*result.second, (1ll << magnitude));
 

--- a/thrust/testing/mismatch.cu
+++ b/thrust/testing/mismatch.cu
@@ -24,11 +24,11 @@ void TestMismatchSimple()
 DECLARE_VECTOR_UNITTEST(TestMismatchSimple);
 
 template <typename InputIterator1, typename InputIterator2>
-thrust::pair<InputIterator1, InputIterator2>
+cuda::std::pair<InputIterator1, InputIterator2>
 mismatch(my_system& system, InputIterator1 first, InputIterator1, InputIterator2)
 {
   system.validate_dispatch();
-  return thrust::make_pair(first, first);
+  return cuda::std::make_pair(first, first);
 }
 
 void TestMismatchDispatchExplicit()
@@ -43,10 +43,10 @@ void TestMismatchDispatchExplicit()
 DECLARE_UNITTEST(TestMismatchDispatchExplicit);
 
 template <typename InputIterator1, typename InputIterator2>
-thrust::pair<InputIterator1, InputIterator2> mismatch(my_tag, InputIterator1 first, InputIterator1, InputIterator2)
+cuda::std::pair<InputIterator1, InputIterator2> mismatch(my_tag, InputIterator1 first, InputIterator1, InputIterator2)
 {
   *first = 13;
-  return thrust::make_pair(first, first);
+  return cuda::std::make_pair(first, first);
 }
 
 void TestMismatchDispatchImplicit()

--- a/thrust/testing/pair_reduce.cu
+++ b/thrust/testing/pair_reduce.cu
@@ -1,15 +1,16 @@
-#include <thrust/pair.h>
 #include <thrust/reduce.h>
 #include <thrust/transform.h>
+
+#include <cuda/std/utility>
 
 #include <unittest/unittest.h>
 
 struct make_pair_functor
 {
   template <typename T1, typename T2>
-  _CCCL_HOST_DEVICE thrust::pair<T1, T2> operator()(const T1& x, const T2& y)
+  _CCCL_HOST_DEVICE cuda::std::pair<T1, T2> operator()(const T1& x, const T2& y)
   {
-    return thrust::make_pair(x, y);
+    return cuda::std::make_pair(x, y);
   } // end operator()()
 }; // end make_pair_functor
 
@@ -21,7 +22,7 @@ struct add_pairs
     // Need cast to undo integer promotion, decltype(char{} + char{}) == int
     using P1T1 = typename Pair1::first_type;
     using P1T2 = typename Pair1::second_type;
-    return thrust::make_pair(static_cast<P1T1>(x.first + y.first), static_cast<P1T2>(x.second + y.second));
+    return cuda::std::make_pair(static_cast<P1T1>(x.first + y.first), static_cast<P1T2>(x.second + y.second));
   } // end operator()
 }; // end add_pairs
 
@@ -30,7 +31,7 @@ struct TestPairReduce
 {
   void operator()(const size_t n)
   {
-    using P = thrust::pair<T, T>;
+    using P = cuda::std::pair<T, T>;
 
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);
     thrust::host_vector<T> h_p2 = unittest::random_integers<T>(n);
@@ -43,7 +44,7 @@ struct TestPairReduce
     thrust::device_vector<T> d_p2    = h_p2;
     thrust::device_vector<P> d_pairs = h_pairs;
 
-    P init = thrust::make_pair(T{13}, T{13});
+    P init = cuda::std::make_pair(T{13}, T{13});
 
     // reduce on the host
     P h_result = thrust::reduce(h_pairs.begin(), h_pairs.end(), init, add_pairs());

--- a/thrust/testing/pair_scan.cu
+++ b/thrust/testing/pair_scan.cu
@@ -1,6 +1,7 @@
-#include <thrust/pair.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
+
+#include <cuda/std/utility>
 
 #include <unittest/unittest.h>
 
@@ -11,9 +12,9 @@
 struct make_pair_functor
 {
   template <typename T1, typename T2>
-  _CCCL_HOST_DEVICE thrust::pair<T1, T2> operator()(const T1& x, const T2& y)
+  _CCCL_HOST_DEVICE cuda::std::pair<T1, T2> operator()(const T1& x, const T2& y)
   {
-    return thrust::make_pair(x, y);
+    return cuda::std::make_pair(x, y);
   } // end operator()()
 }; // end make_pair_functor
 
@@ -22,7 +23,7 @@ struct add_pairs
   template <typename Pair1, typename Pair2>
   _CCCL_HOST_DEVICE Pair1 operator()(const Pair1& x, const Pair2& y)
   {
-    return thrust::make_pair(x.first + y.first, x.second + y.second);
+    return cuda::std::make_pair(x.first + y.first, x.second + y.second);
   } // end operator()
 }; // end add_pairs
 
@@ -31,7 +32,7 @@ struct TestPairScan
 {
   void operator()(const size_t n)
   {
-    using P = thrust::pair<T, T>;
+    using P = cuda::std::pair<T, T>;
 
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);
     thrust::host_vector<T> h_p2 = unittest::random_integers<T>(n);
@@ -46,7 +47,7 @@ struct TestPairScan
     thrust::device_vector<P> d_pairs = h_pairs;
     thrust::device_vector<P> d_output(n);
 
-    P init = thrust::make_pair(13, 13);
+    P init = cuda::std::make_pair(13, 13);
 
     // scan with plus
     thrust::inclusive_scan(h_pairs.begin(), h_pairs.end(), h_output.begin(), add_pairs());

--- a/thrust/testing/pair_scan_by_key.cu
+++ b/thrust/testing/pair_scan_by_key.cu
@@ -1,15 +1,16 @@
-#include <thrust/pair.h>
 #include <thrust/scan.h>
 #include <thrust/transform.h>
+
+#include <cuda/std/utility>
 
 #include <unittest/unittest.h>
 
 struct make_pair_functor
 {
   template <typename T1, typename T2>
-  _CCCL_HOST_DEVICE thrust::pair<T1, T2> operator()(const T1& x, const T2& y)
+  _CCCL_HOST_DEVICE cuda::std::pair<T1, T2> operator()(const T1& x, const T2& y)
   {
-    return thrust::make_pair(x, y);
+    return cuda::std::make_pair(x, y);
   } // end operator()()
 }; // end make_pair_functor
 
@@ -21,7 +22,7 @@ struct add_pairs
     // Need cast to undo integer promotion, decltype(char{} + char{}) == int
     using P1T1 = typename Pair1::first_type;
     using P1T2 = typename Pair1::second_type;
-    return thrust::make_pair(static_cast<P1T1>(x.first + y.first), static_cast<P1T2>(x.second + y.second));
+    return cuda::std::make_pair(static_cast<P1T1>(x.first + y.first), static_cast<P1T2>(x.second + y.second));
   } // end operator()
 }; // end add_pairs
 
@@ -30,7 +31,7 @@ struct TestPairScanByKey
 {
   void operator()(const size_t n)
   {
-    using P = thrust::pair<T, T>;
+    using P = cuda::std::pair<T, T>;
 
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);
     thrust::host_vector<T> h_p2 = unittest::random_integers<T>(n);
@@ -46,7 +47,7 @@ struct TestPairScanByKey
     thrust::host_vector<T> h_keys   = unittest::random_integers<bool>(n);
     thrust::device_vector<T> d_keys = h_keys;
 
-    P init = thrust::make_pair(T{13}, T{13});
+    P init = cuda::std::make_pair(T{13}, T{13});
 
     // scan on the host
     thrust::exclusive_scan_by_key(

--- a/thrust/testing/pair_sort.cu
+++ b/thrust/testing/pair_sort.cu
@@ -1,15 +1,16 @@
-#include <thrust/pair.h>
 #include <thrust/sequence.h>
 #include <thrust/sort.h>
+
+#include <cuda/std/utility>
 
 #include <unittest/unittest.h>
 
 struct make_pair_functor
 {
   template <typename T1, typename T2>
-  _CCCL_HOST_DEVICE thrust::pair<T1, T2> operator()(const T1& x, const T2& y)
+  _CCCL_HOST_DEVICE cuda::std::pair<T1, T2> operator()(const T1& x, const T2& y)
   {
-    return thrust::make_pair(x, y);
+    return cuda::std::make_pair(x, y);
   } // end operator()()
 }; // end make_pair_functor
 
@@ -18,7 +19,7 @@ struct TestPairStableSortByKey
 {
   void operator()(const size_t n)
   {
-    using P = thrust::pair<T, T>;
+    using P = cuda::std::pair<T, T>;
 
     // host arrays
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);

--- a/thrust/testing/pair_sort_by_key.cu
+++ b/thrust/testing/pair_sort_by_key.cu
@@ -1,14 +1,15 @@
-#include <thrust/pair.h>
 #include <thrust/sort.h>
+
+#include <cuda/std/utility>
 
 #include <unittest/unittest.h>
 
 struct make_pair_functor
 {
   template <typename T1, typename T2>
-  _CCCL_HOST_DEVICE thrust::pair<T1, T2> operator()(const T1& x, const T2& y)
+  _CCCL_HOST_DEVICE cuda::std::pair<T1, T2> operator()(const T1& x, const T2& y)
   {
-    return thrust::make_pair(x, y);
+    return cuda::std::make_pair(x, y);
   } // end operator()()
 }; // end make_pair_functor
 
@@ -17,7 +18,7 @@ struct TestPairStableSort
 {
   void operator()(const size_t n)
   {
-    using P = thrust::pair<T, T>;
+    using P = cuda::std::pair<T, T>;
 
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);
     thrust::host_vector<T> h_p2 = unittest::random_integers<T>(n);

--- a/thrust/testing/pair_transform.cu
+++ b/thrust/testing/pair_transform.cu
@@ -1,16 +1,17 @@
 #include <thrust/host_vector.h>
-#include <thrust/pair.h>
 #include <thrust/transform.h>
 #include <thrust/tuple.h>
+
+#include <cuda/std/utility>
 
 #include <unittest/unittest.h>
 
 struct make_pair_functor
 {
   template <typename T1, typename T2>
-  _CCCL_HOST_DEVICE thrust::pair<T1, T2> operator()(const T1& x, const T2& y)
+  _CCCL_HOST_DEVICE cuda::std::pair<T1, T2> operator()(const T1& x, const T2& y)
   {
-    return thrust::make_pair(x, y);
+    return cuda::std::make_pair(x, y);
   } // end operator()()
 }; // end make_pair_functor
 
@@ -22,7 +23,7 @@ struct add_pairs
     using T1 = typename ::cuda::std::common_type<typename Pair1::first_type, typename Pair2::first_type>::type;
     using T2 = typename ::cuda::std::common_type<typename Pair1::second_type, typename Pair2::second_type>::type;
 
-    return thrust::make_pair(static_cast<T1>(x.first + y.first), static_cast<T2>(x.second + y.second));
+    return cuda::std::make_pair(static_cast<T1>(x.first + y.first), static_cast<T2>(x.second + y.second));
   } // end operator()
 }; // end add_pairs
 
@@ -31,7 +32,7 @@ struct TestPairTransform
 {
   void operator()(const size_t n)
   {
-    using P = thrust::pair<T, T>;
+    using P = cuda::std::pair<T, T>;
 
     thrust::host_vector<T> h_p1 = unittest::random_integers<T>(n);
     thrust::host_vector<T> h_p2 = unittest::random_integers<T>(n);

--- a/thrust/testing/partition.cu
+++ b/thrust/testing/partition.cu
@@ -79,7 +79,7 @@ void TestPartitionCopySimple()
   Vector true_results(2);
   Vector false_results(3);
 
-  thrust::pair<typename Vector::iterator, typename Vector::iterator> ends =
+  cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends =
     thrust::partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), is_even<T>());
 
   Vector true_ref(2, 2);
@@ -105,7 +105,7 @@ void TestPartitionCopyStencilSimple()
   Vector true_results(2);
   Vector false_results(3);
 
-  thrust::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::partition_copy(
+  cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::partition_copy(
     data.begin(), data.end(), stencil.begin(), true_results.begin(), false_results.begin(), is_even<T>());
 
   Vector true_ref(2, 1);
@@ -164,7 +164,7 @@ void TestStablePartitionCopySimple()
   Vector true_results(2);
   Vector false_results(3);
 
-  thrust::pair<typename Vector::iterator, typename Vector::iterator> ends =
+  cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends =
     thrust::stable_partition_copy(data.begin(), data.end(), true_results.begin(), false_results.begin(), is_even<T>());
 
   Vector true_ref(2, 2);
@@ -187,7 +187,7 @@ void TestStablePartitionCopyStencilSimple()
   Vector true_results(2);
   Vector false_results(3);
 
-  thrust::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::stable_partition_copy(
+  cuda::std::pair<typename Vector::iterator, typename Vector::iterator> ends = thrust::stable_partition_copy(
     data.begin(), data.end(), stencil.begin(), true_results.begin(), false_results.begin(), ::cuda::std::identity{});
 
   Vector true_ref(2, 2);
@@ -280,11 +280,11 @@ struct TestPartitionCopy
     thrust::device_vector<T> d_true_results(n_true, 0);
     thrust::device_vector<T> d_false_results(n_false, 0);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::partition_copy(
         h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::partition_copy(
         d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
 
@@ -325,11 +325,11 @@ struct TestPartitionCopyStencil
     thrust::device_vector<T> d_true_results(n_true, 0);
     thrust::device_vector<T> d_false_results(n_false, 0);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::partition_copy(
         h_data.begin(), h_data.end(), h_stencil.begin(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::partition_copy(
         d_data.begin(), d_data.end(), d_stencil.begin(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
 
@@ -370,11 +370,11 @@ struct TestStablePartitionCopyStencil
     thrust::device_vector<T> d_true_results(n_true, 0);
     thrust::device_vector<T> d_false_results(n_false, 0);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::stable_partition_copy(
         h_data.begin(), h_data.end(), h_stencil.begin(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::stable_partition_copy(
         d_data.begin(), d_data.end(), d_stencil.begin(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
 
@@ -408,14 +408,14 @@ struct TestPartitionCopyToDiscardIterator
     std::ptrdiff_t n_false = n - n_true;
 
     // mask both ranges
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
       h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
       d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL_QUIET(reference1, h_result1);
     ASSERT_EQUAL_QUIET(reference1, d_result1);
@@ -424,19 +424,19 @@ struct TestPartitionCopyToDiscardIterator
     thrust::host_vector<T> h_trues(n_true);
     thrust::device_vector<T> d_trues(n_true);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::partition_copy(
         h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::partition_copy(
         d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
-      thrust::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
+      cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
-      thrust::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
+      cuda::std::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL(h_trues, d_trues);
     ASSERT_EQUAL_QUIET(h_reference2, h_result2);
@@ -446,19 +446,19 @@ struct TestPartitionCopyToDiscardIterator
     thrust::host_vector<T> h_falses(n_false);
     thrust::device_vector<T> d_falses(n_false);
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::partition_copy(
         h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::partition_copy(
         d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
 
     ASSERT_EQUAL(h_falses, d_falses);
     ASSERT_EQUAL_QUIET(h_reference3, h_result3);
@@ -482,7 +482,7 @@ struct TestPartitionCopyStencilToDiscardIterator
     std::ptrdiff_t n_false = n - n_true;
 
     // mask both ranges
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::partition_copy(
       h_data.begin(),
       h_data.end(),
       h_stencil.begin(),
@@ -490,7 +490,7 @@ struct TestPartitionCopyStencilToDiscardIterator
       thrust::make_discard_iterator(),
       is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::partition_copy(
       d_data.begin(),
       d_data.end(),
       d_stencil.begin(),
@@ -498,8 +498,8 @@ struct TestPartitionCopyStencilToDiscardIterator
       thrust::make_discard_iterator(),
       is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL_QUIET(reference1, h_result1);
     ASSERT_EQUAL_QUIET(reference1, d_result1);
@@ -508,19 +508,19 @@ struct TestPartitionCopyStencilToDiscardIterator
     thrust::host_vector<T> h_trues(n_true);
     thrust::device_vector<T> d_trues(n_true);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::partition_copy(
         h_data.begin(), h_data.end(), h_stencil.begin(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::partition_copy(
         d_data.begin(), d_data.end(), d_stencil.begin(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
-      thrust::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
+      cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
-      thrust::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
+      cuda::std::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL(h_trues, d_trues);
     ASSERT_EQUAL_QUIET(h_reference2, h_result2);
@@ -530,7 +530,7 @@ struct TestPartitionCopyStencilToDiscardIterator
     thrust::host_vector<T> h_falses(n_false);
     thrust::device_vector<T> d_falses(n_false);
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::partition_copy(
         h_data.begin(),
         h_data.end(),
@@ -539,7 +539,7 @@ struct TestPartitionCopyStencilToDiscardIterator
         h_falses.begin(),
         is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::partition_copy(
         d_data.begin(),
         d_data.end(),
@@ -548,11 +548,11 @@ struct TestPartitionCopyStencilToDiscardIterator
         d_falses.begin(),
         is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
 
     ASSERT_EQUAL(h_falses, d_falses);
     ASSERT_EQUAL_QUIET(h_reference3, h_result3);
@@ -632,11 +632,11 @@ struct TestStablePartitionCopy
     thrust::device_vector<T> d_true_results(n_true, 0);
     thrust::device_vector<T> d_false_results(n_false, 0);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_ends =
       thrust::stable_partition_copy(
         h_data.begin(), h_data.end(), h_true_results.begin(), h_false_results.begin(), is_even<T>());
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_ends =
       thrust::stable_partition_copy(
         d_data.begin(), d_data.end(), d_true_results.begin(), d_false_results.begin(), is_even<T>());
 
@@ -666,14 +666,14 @@ struct TestStablePartitionCopyToDiscardIterator
     std::ptrdiff_t n_false = n - n_true;
 
     // mask both ranges
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::stable_partition_copy(
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::stable_partition_copy(
       h_data.begin(), h_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
       d_data.begin(), d_data.end(), thrust::make_discard_iterator(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL_QUIET(reference1, h_result1);
     ASSERT_EQUAL_QUIET(reference1, d_result1);
@@ -682,19 +682,19 @@ struct TestStablePartitionCopyToDiscardIterator
     thrust::host_vector<T> h_trues(n_true);
     thrust::device_vector<T> d_trues(n_true);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::stable_partition_copy(
         h_data.begin(), h_data.end(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::stable_partition_copy(
         d_data.begin(), d_data.end(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
-      thrust::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
+      cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
-      thrust::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
+      cuda::std::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL(h_trues, d_trues);
     ASSERT_EQUAL_QUIET(h_reference2, h_result2);
@@ -704,19 +704,19 @@ struct TestStablePartitionCopyToDiscardIterator
     thrust::host_vector<T> h_falses(n_false);
     thrust::device_vector<T> d_falses(n_false);
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::stable_partition_copy(
         h_data.begin(), h_data.end(), thrust::make_discard_iterator(), h_falses.begin(), is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::stable_partition_copy(
         d_data.begin(), d_data.end(), thrust::make_discard_iterator(), d_falses.begin(), is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
 
     ASSERT_EQUAL(h_falses, d_falses);
     ASSERT_EQUAL_QUIET(h_reference3, h_result3);
@@ -741,7 +741,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
     std::ptrdiff_t n_false = n - n_true;
 
     // mask both ranges
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::stable_partition_copy(
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::stable_partition_copy(
       h_data.begin(),
       h_data.end(),
       h_stencil.begin(),
@@ -749,7 +749,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
       thrust::make_discard_iterator(),
       is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::stable_partition_copy(
       d_data.begin(),
       d_data.end(),
       d_stencil.begin(),
@@ -757,8 +757,8 @@ struct TestStablePartitionCopyStencilToDiscardIterator
       thrust::make_discard_iterator(),
       is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL_QUIET(reference1, h_result1);
     ASSERT_EQUAL_QUIET(reference1, d_result1);
@@ -767,19 +767,19 @@ struct TestStablePartitionCopyStencilToDiscardIterator
     thrust::host_vector<T> h_trues(n_true);
     thrust::device_vector<T> d_trues(n_true);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::stable_partition_copy(
         h_data.begin(), h_data.end(), h_stencil.begin(), h_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::stable_partition_copy(
         d_data.begin(), d_data.end(), d_stencil.begin(), d_trues.begin(), thrust::make_discard_iterator(), is_even<T>());
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
-      thrust::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, thrust::discard_iterator<>> h_reference2 =
+      cuda::std::make_pair(h_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
-      thrust::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, thrust::discard_iterator<>> d_reference2 =
+      cuda::std::make_pair(d_trues.begin() + n_true, thrust::make_discard_iterator(n_false));
 
     ASSERT_EQUAL(h_trues, d_trues);
     ASSERT_EQUAL_QUIET(h_reference2, h_result2);
@@ -789,7 +789,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
     thrust::host_vector<T> h_falses(n_false);
     thrust::device_vector<T> d_falses(n_false);
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_result3 =
       thrust::stable_partition_copy(
         h_data.begin(),
         h_data.end(),
@@ -798,7 +798,7 @@ struct TestStablePartitionCopyStencilToDiscardIterator
         h_falses.begin(),
         is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_result3 =
       thrust::stable_partition_copy(
         d_data.begin(),
         d_data.end(),
@@ -807,11 +807,11 @@ struct TestStablePartitionCopyStencilToDiscardIterator
         d_falses.begin(),
         is_even<T>());
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<T>::iterator> h_reference3 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), h_falses.begin() + n_false);
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
-      thrust::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<T>::iterator> d_reference3 =
+      cuda::std::make_pair(thrust::make_discard_iterator(n_true), d_falses.begin() + n_false);
 
     ASSERT_EQUAL(h_falses, d_falses);
     ASSERT_EQUAL_QUIET(h_reference3, h_result3);
@@ -996,11 +996,11 @@ void TestPartitionStencilDispatchImplicit()
 DECLARE_UNITTEST(TestPartitionStencilDispatchImplicit);
 
 template <typename InputIterator, typename OutputIterator1, typename OutputIterator2, typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   my_system& system, InputIterator, InputIterator, OutputIterator1 out_true, OutputIterator2 out_false, Predicate)
 {
   system.validate_dispatch();
-  return thrust::make_pair(out_true, out_false);
+  return cuda::std::make_pair(out_true, out_false);
 }
 
 void TestPartitionCopyDispatchExplicit()
@@ -1019,7 +1019,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   my_system& system,
   InputIterator1,
   InputIterator1,
@@ -1029,7 +1029,7 @@ thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
   Predicate)
 {
   system.validate_dispatch();
-  return thrust::make_pair(out_true, out_false);
+  return cuda::std::make_pair(out_true, out_false);
 }
 
 void TestPartitionCopyStencilDispatchExplicit()
@@ -1044,11 +1044,11 @@ void TestPartitionCopyStencilDispatchExplicit()
 DECLARE_UNITTEST(TestPartitionCopyStencilDispatchExplicit);
 
 template <typename InputIterator, typename OutputIterator1, typename OutputIterator2, typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   my_tag, InputIterator first, InputIterator, OutputIterator1 out_true, OutputIterator2 out_false, Predicate)
 {
   *first = 13;
-  return thrust::make_pair(out_true, out_false);
+  return cuda::std::make_pair(out_true, out_false);
 }
 
 void TestPartitionCopyDispatchImplicit()
@@ -1071,7 +1071,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   my_tag,
   InputIterator1 first,
   InputIterator1,
@@ -1081,7 +1081,7 @@ thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
   Predicate)
 {
   *first = 13;
-  return thrust::make_pair(out_true, out_false);
+  return cuda::std::make_pair(out_true, out_false);
 }
 
 void TestPartitionCopyStencilDispatchImplicit()
@@ -1172,11 +1172,11 @@ void TestStablePartitionStencilDispatchImplicit()
 DECLARE_UNITTEST(TestStablePartitionStencilDispatchImplicit);
 
 template <typename InputIterator, typename OutputIterator1, typename OutputIterator2, typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   my_system& system, InputIterator, InputIterator, OutputIterator1 out_true, OutputIterator2 out_false, Predicate)
 {
   system.validate_dispatch();
-  return thrust::make_pair(out_true, out_false);
+  return cuda::std::make_pair(out_true, out_false);
 }
 
 void TestStablePartitionCopyDispatchExplicit()
@@ -1195,7 +1195,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   my_system& system,
   InputIterator1,
   InputIterator1,
@@ -1205,7 +1205,7 @@ thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   Predicate)
 {
   system.validate_dispatch();
-  return thrust::make_pair(out_true, out_false);
+  return cuda::std::make_pair(out_true, out_false);
 }
 
 void TestStablePartitionCopyStencilDispatchExplicit()
@@ -1220,11 +1220,11 @@ void TestStablePartitionCopyStencilDispatchExplicit()
 DECLARE_UNITTEST(TestStablePartitionCopyStencilDispatchExplicit);
 
 template <typename InputIterator, typename OutputIterator1, typename OutputIterator2, typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   my_tag, InputIterator first, InputIterator, OutputIterator1 out_true, OutputIterator2 out_false, Predicate)
 {
   *first = 13;
-  return thrust::make_pair(out_true, out_false);
+  return cuda::std::make_pair(out_true, out_false);
 }
 
 void TestStablePartitionCopyDispatchImplicit()
@@ -1247,7 +1247,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   my_tag,
   InputIterator1 first,
   InputIterator1,
@@ -1257,7 +1257,7 @@ thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   Predicate)
 {
   *first = 13;
-  return thrust::make_pair(out_true, out_false);
+  return cuda::std::make_pair(out_true, out_false);
 }
 
 void TestStablePartitionCopyStencilDispatchImplicit()

--- a/thrust/testing/reduce_by_key.cu
+++ b/thrust/testing/reduce_by_key.cu
@@ -36,7 +36,7 @@ void TestReduceByKeySimple()
   Vector keys;
   Vector values;
 
-  typename thrust::pair<typename Vector::iterator, typename Vector::iterator> new_last;
+  typename cuda::std::pair<typename Vector::iterator, typename Vector::iterator> new_last;
 
   // basic test
   initialize_keys(keys);
@@ -127,8 +127,8 @@ struct TestReduceByKey
     using DeviceKeyIterator = typename thrust::device_vector<K>::iterator;
     using DeviceValIterator = typename thrust::device_vector<V>::iterator;
 
-    using HostIteratorPair   = typename thrust::pair<HostKeyIterator, HostValIterator>;
-    using DeviceIteratorPair = typename thrust::pair<DeviceKeyIterator, DeviceValIterator>;
+    using HostIteratorPair   = typename cuda::std::pair<HostKeyIterator, HostValIterator>;
+    using DeviceIteratorPair = typename cuda::std::pair<DeviceKeyIterator, DeviceValIterator>;
 
     HostIteratorPair h_last =
       thrust::reduce_by_key(h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys_output.begin(), h_vals_output.begin());
@@ -195,7 +195,7 @@ struct TestReduceByKeyToDiscardIterator
 VariableUnitTest<TestReduceByKeyToDiscardIterator, IntegralTypes> TestReduceByKeyToDiscardIteratorInstance;
 
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator1, typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   my_system& system,
   InputIterator1,
   InputIterator1,
@@ -204,7 +204,7 @@ thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   OutputIterator2 values_output)
 {
   system.validate_dispatch();
-  return thrust::make_pair(keys_output, values_output);
+  return cuda::std::make_pair(keys_output, values_output);
 }
 
 void TestReduceByKeyDispatchExplicit()
@@ -219,11 +219,11 @@ void TestReduceByKeyDispatchExplicit()
 DECLARE_UNITTEST(TestReduceByKeyDispatchExplicit);
 
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator1, typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   my_tag, InputIterator1, InputIterator1, InputIterator2, OutputIterator1 keys_output, OutputIterator2 values_output)
 {
   *keys_output = 13;
-  return thrust::make_pair(keys_output, values_output);
+  return cuda::std::make_pair(keys_output, values_output);
 }
 
 void TestReduceByKeyDispatchImplicit()

--- a/thrust/testing/set_difference_by_key.cu
+++ b/thrust/testing/set_difference_by_key.cu
@@ -11,7 +11,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   my_system& system,
   InputIterator1,
   InputIterator1,
@@ -23,7 +23,7 @@ thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   OutputIterator2 values_result)
 {
   system.validate_dispatch();
-  return thrust::make_pair(keys_result, values_result);
+  return cuda::std::make_pair(keys_result, values_result);
 }
 
 void TestSetDifferenceByKeyDispatchExplicit()
@@ -44,7 +44,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   my_tag,
   InputIterator1,
   InputIterator1,
@@ -56,7 +56,7 @@ thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   OutputIterator2 values_result)
 {
   *keys_result = 13;
-  return thrust::make_pair(keys_result, values_result);
+  return cuda::std::make_pair(keys_result, values_result);
 }
 
 void TestSetDifferenceByKeyDispatchImplicit()
@@ -93,7 +93,7 @@ void TestSetDifferenceByKeySimple()
 
   Vector result_key(2), result_val(2);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -144,9 +144,9 @@ void TestSetDifferenceByKey(const size_t n)
     thrust::device_vector<T> d_result_keys(n);
     thrust::device_vector<T> d_result_vals(n);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
     h_end = thrust::set_difference_by_key(
       h_a_keys.begin(),
@@ -199,9 +199,9 @@ void TestSetDifferenceByKeyEquivalentRanges(const size_t n)
   thrust::host_vector<T> h_result_key(n), h_result_val(n);
   thrust::device_vector<T> d_result_key(n), d_result_val(n);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_difference_by_key(
     h_a_key.begin(),
@@ -263,9 +263,9 @@ void TestSetDifferenceByKeyMultiset(const size_t n)
   thrust::host_vector<T> h_result_key(n), h_result_val(n);
   thrust::device_vector<T> d_result_key(n), d_result_val(n);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_difference_by_key(
     h_a_key.begin(),

--- a/thrust/testing/set_difference_by_key_descending.cu
+++ b/thrust/testing/set_difference_by_key_descending.cu
@@ -17,7 +17,7 @@ void TestSetDifferenceByKeyDescendingSimple()
 
   Vector result_key(2), result_val(2);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_difference_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -57,9 +57,9 @@ void TestSetDifferenceByKeyDescending(const size_t n)
   thrust::host_vector<T> h_result_key(n), h_result_val(n);
   thrust::device_vector<T> d_result_key(n), d_result_val(n);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_difference_by_key(
     h_a_key.begin(),

--- a/thrust/testing/set_intersection_by_key.cu
+++ b/thrust/testing/set_intersection_by_key.cu
@@ -10,7 +10,7 @@ template <typename InputIterator1,
           typename InputIterator3,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   my_system& system,
   InputIterator1,
   InputIterator1,
@@ -21,7 +21,7 @@ thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   OutputIterator2 values_result)
 {
   system.validate_dispatch();
-  return thrust::make_pair(keys_result, values_result);
+  return cuda::std::make_pair(keys_result, values_result);
 }
 
 void TestSetIntersectionByKeyDispatchExplicit()
@@ -41,7 +41,7 @@ template <typename InputIterator1,
           typename InputIterator3,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   my_tag,
   InputIterator1,
   InputIterator1,
@@ -52,7 +52,7 @@ thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   OutputIterator2 values_result)
 {
   *keys_result = 13;
-  return thrust::make_pair(keys_result, values_result);
+  return cuda::std::make_pair(keys_result, values_result);
 }
 
 void TestSetIntersectionByKeyDispatchImplicit()
@@ -83,7 +83,7 @@ void TestSetIntersectionByKeySimple()
   Vector ref_key{0, 4}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(
     a_key.begin(), a_key.end(), b_key.begin(), b_key.end(), a_val.begin(), result_key.begin(), result_val.begin());
 
   ASSERT_EQUAL_QUIET(result_key.end(), end.first);
@@ -125,9 +125,9 @@ void TestSetIntersectionByKey(const size_t n)
     thrust::device_vector<T> d_result_keys(n);
     thrust::device_vector<T> d_result_vals(n);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
     h_end = thrust::set_intersection_by_key(
       h_a_keys.begin(),
@@ -176,9 +176,9 @@ void TestSetIntersectionByKeyEquivalentRanges(const size_t n)
   thrust::host_vector<T> h_result_key(n), h_result_val(n);
   thrust::device_vector<T> d_result_key(n), d_result_val(n);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_intersection_by_key(
     h_a_key.begin(),
@@ -236,9 +236,9 @@ void TestSetIntersectionByKeyMultiset(const size_t n)
   thrust::host_vector<T> h_result_key(n), h_result_val(n);
   thrust::device_vector<T> d_result_key(n), d_result_val(n);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_intersection_by_key(
     h_a_key.begin(),

--- a/thrust/testing/set_intersection_by_key_descending.cu
+++ b/thrust/testing/set_intersection_by_key_descending.cu
@@ -16,7 +16,7 @@ void TestSetIntersectionByKeyDescendingSimple()
   Vector ref_key{4, 0}, ref_val{0, 0};
   Vector result_key(2), result_val(2);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_intersection_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -53,9 +53,9 @@ void TestSetIntersectionByKeyDescending(const size_t n)
   thrust::host_vector<T> h_result_key(n), h_result_val(n);
   thrust::device_vector<T> d_result_key(n), d_result_val(n);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_intersection_by_key(
     h_a_key.begin(),

--- a/thrust/testing/set_symmetric_difference_by_key.cu
+++ b/thrust/testing/set_symmetric_difference_by_key.cu
@@ -11,7 +11,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   my_system& system,
   InputIterator1,
   InputIterator1,
@@ -23,7 +23,7 @@ thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   OutputIterator2 values_result)
 {
   system.validate_dispatch();
-  return thrust::make_pair(keys_result, values_result);
+  return cuda::std::make_pair(keys_result, values_result);
 }
 
 void TestSetSymmetricDifferenceByKeyDispatchExplicit()
@@ -44,7 +44,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   my_tag,
   InputIterator1,
   InputIterator1,
@@ -56,7 +56,7 @@ thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   OutputIterator2 values_result)
 {
   *keys_result = 13;
-  return thrust::make_pair(keys_result, values_result);
+  return cuda::std::make_pair(keys_result, values_result);
 }
 
 void TestSetSymmetricDifferenceByKeyDispatchImplicit()
@@ -88,7 +88,7 @@ void TestSetSymmetricDifferenceByKeySimple()
   Vector ref_key{2, 3, 3, 6, 7}, ref_val{0, 1, 1, 0, 1};
   Vector result_key(5), result_val(5);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -141,9 +141,9 @@ void TestSetSymmetricDifferenceByKey(const size_t n)
     thrust::device_vector<T> d_result_keys(max_size);
     thrust::device_vector<T> d_result_vals(max_size);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
     h_end = thrust::set_symmetric_difference_by_key(
       h_a_keys.begin(),
@@ -198,9 +198,9 @@ void TestSetSymmetricDifferenceByKeyEquivalentRanges(const size_t n)
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_symmetric_difference_by_key(
     h_a_key.begin(),
@@ -263,9 +263,9 @@ void TestSetSymmetricDifferenceByKeyMultiset(const size_t n)
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_symmetric_difference_by_key(
     h_a_key.begin(),

--- a/thrust/testing/set_symmetric_difference_by_key_descending.cu
+++ b/thrust/testing/set_symmetric_difference_by_key_descending.cu
@@ -16,7 +16,7 @@ void TestSetSymmetricDifferenceByKeyDescendingSimple()
   Vector ref_key{7, 6, 3, 3, 2}, ref_val{1, 0, 1, 1, 0};
   Vector result_key(5), result_val(5);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_symmetric_difference_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -57,9 +57,9 @@ void TestSetSymmetricDifferenceByKeyDescending(const size_t n)
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_symmetric_difference_by_key(
     h_a_key.begin(),

--- a/thrust/testing/set_union_by_key.cu
+++ b/thrust/testing/set_union_by_key.cu
@@ -11,7 +11,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   my_system& system,
   InputIterator1,
   InputIterator1,
@@ -23,7 +23,7 @@ thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   OutputIterator2 values_result)
 {
   system.validate_dispatch();
-  return thrust::make_pair(keys_result, values_result);
+  return cuda::std::make_pair(keys_result, values_result);
 }
 
 void TestSetUnionByKeyDispatchExplicit()
@@ -44,7 +44,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   my_tag,
   InputIterator1,
   InputIterator1,
@@ -56,7 +56,7 @@ thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   OutputIterator2 values_result)
 {
   *keys_result = 13;
-  return thrust::make_pair(keys_result, values_result);
+  return cuda::std::make_pair(keys_result, values_result);
 }
 
 void TestSetUnionByKeyDispatchImplicit()
@@ -88,7 +88,7 @@ void TestSetUnionByKeySimple()
   Vector ref_key{0, 2, 3, 3, 4}, ref_val{0, 0, 1, 1, 0};
   Vector result_key(5), result_val(5);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_union_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_union_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -141,9 +141,9 @@ void TestSetUnionByKey(const size_t n)
     thrust::device_vector<T> d_result_keys(max_size);
     thrust::device_vector<T> d_result_vals(max_size);
 
-    thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+    cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-    thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+    cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
     h_end = thrust::set_union_by_key(
       h_a_keys.begin(),
@@ -198,9 +198,9 @@ void TestSetUnionByKeyEquivalentRanges(const size_t n)
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_union_by_key(
     h_a_key.begin(),
@@ -263,9 +263,9 @@ void TestSetUnionByKeyMultiset(const size_t n)
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_union_by_key(
     h_a_key.begin(),

--- a/thrust/testing/set_union_by_key_descending.cu
+++ b/thrust/testing/set_union_by_key_descending.cu
@@ -16,7 +16,7 @@ void TestSetUnionByKeyDescendingSimple()
   Vector ref_key{4, 3, 3, 2, 0}, ref_val{0, 1, 1, 0, 0};
   Vector result_key(5), result_val(5);
 
-  thrust::pair<Iterator, Iterator> end = thrust::set_union_by_key(
+  cuda::std::pair<Iterator, Iterator> end = thrust::set_union_by_key(
     a_key.begin(),
     a_key.end(),
     b_key.begin(),
@@ -57,9 +57,9 @@ void TestSetUnionByKeyDescending(const size_t n)
   thrust::host_vector<T> h_result_key(max_size), h_result_val(max_size);
   thrust::device_vector<T> d_result_key(max_size), d_result_val(max_size);
 
-  thrust::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
+  cuda::std::pair<typename thrust::host_vector<T>::iterator, typename thrust::host_vector<T>::iterator> h_end;
 
-  thrust::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
+  cuda::std::pair<typename thrust::device_vector<T>::iterator, typename thrust::device_vector<T>::iterator> d_end;
 
   h_end = thrust::set_union_by_key(
     h_a_key.begin(),

--- a/thrust/testing/type_traits.cu
+++ b/thrust/testing/type_traits.cu
@@ -5,11 +5,11 @@
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/transform_iterator.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/pair.h>
 #include <thrust/tuple.h>
 #include <thrust/type_traits/is_contiguous_iterator.h>
 
 #include <cuda/__cccl_config>
+#include <cuda/std/utility>
 
 #if _CCCL_COMPILER(GCC, >=, 7)
 // This header pulls in an unsuppressable warning on GCC 6
@@ -189,25 +189,25 @@ void TestTriviallyRelocatable()
 #if _CCCL_COMPILER(GCC, >=, 7)
   static_assert(thrust::is_trivially_relocatable<thrust::complex<float>>::value, "");
   static_assert(thrust::is_trivially_relocatable<::cuda::std::complex<float>>::value, "");
-  static_assert(thrust::is_trivially_relocatable<thrust::pair<int, thrust::complex<float>>>::value, "");
+  static_assert(thrust::is_trivially_relocatable<cuda::std::pair<int, thrust::complex<float>>>::value, "");
   static_assert(thrust::is_trivially_relocatable<::cuda::std::pair<int, ::cuda::std::complex<float>>>::value, "");
   static_assert(thrust::is_trivially_relocatable<thrust::tuple<int, thrust::complex<float>, char>>::value, "");
   static_assert(thrust::is_trivially_relocatable<::cuda::std::tuple<int, ::cuda::std::complex<float>, char>>::value,
                 "");
 #endif // _CCCL_COMPILER(GCC, >=, 7)
   static_assert(thrust::is_trivially_relocatable<
-                  ::cuda::std::tuple<thrust::pair<int, thrust::tuple<int, ::cuda::std::tuple<>>>,
+                  ::cuda::std::tuple<cuda::std::pair<int, thrust::tuple<int, ::cuda::std::tuple<>>>,
                                      thrust::tuple<::cuda::std::pair<int, thrust::tuple<>>, int>>>::value,
                 "");
 
-  static_assert(!thrust::is_trivially_relocatable<thrust::pair<int, std::string>>::value, "");
+  static_assert(!thrust::is_trivially_relocatable<cuda::std::pair<int, std::string>>::value, "");
   static_assert(!thrust::is_trivially_relocatable<::cuda::std::pair<int, std::string>>::value, "");
   static_assert(!thrust::is_trivially_relocatable<thrust::tuple<int, float, std::string>>::value, "");
   static_assert(!thrust::is_trivially_relocatable<::cuda::std::tuple<int, float, std::string>>::value, "");
 
   // test propagation of relocatability through pair and tuple
   static_assert(thrust::is_trivially_relocatable<NonTriviallyCopyable>::value, "");
-  static_assert(thrust::is_trivially_relocatable<thrust::pair<NonTriviallyCopyable, int>>::value, "");
+  static_assert(thrust::is_trivially_relocatable<cuda::std::pair<NonTriviallyCopyable, int>>::value, "");
   static_assert(thrust::is_trivially_relocatable<::cuda::std::pair<NonTriviallyCopyable, int>>::value, "");
   static_assert(thrust::is_trivially_relocatable<thrust::tuple<NonTriviallyCopyable>>::value, "");
   static_assert(thrust::is_trivially_relocatable<::cuda::std::tuple<NonTriviallyCopyable>>::value, "");

--- a/thrust/testing/unique_by_key.cu
+++ b/thrust/testing/unique_by_key.cu
@@ -23,11 +23,11 @@ struct index_to_value_t
 };
 
 template <typename ForwardIterator1, typename ForwardIterator2>
-thrust::pair<ForwardIterator1, ForwardIterator2>
+cuda::std::pair<ForwardIterator1, ForwardIterator2>
 unique_by_key(my_system& system, ForwardIterator1 keys_first, ForwardIterator1, ForwardIterator2 values_first)
 {
   system.validate_dispatch();
-  return thrust::make_pair(keys_first, values_first);
+  return cuda::std::make_pair(keys_first, values_first);
 }
 
 void TestUniqueByKeyDispatchExplicit()
@@ -42,11 +42,11 @@ void TestUniqueByKeyDispatchExplicit()
 DECLARE_UNITTEST(TestUniqueByKeyDispatchExplicit);
 
 template <typename ForwardIterator1, typename ForwardIterator2>
-thrust::pair<ForwardIterator1, ForwardIterator2>
+cuda::std::pair<ForwardIterator1, ForwardIterator2>
 unique_by_key(my_tag, ForwardIterator1 keys_first, ForwardIterator1, ForwardIterator2 values_first)
 {
   *keys_first = 13;
-  return thrust::make_pair(keys_first, values_first);
+  return cuda::std::make_pair(keys_first, values_first);
 }
 
 void TestUniqueByKeyDispatchImplicit()
@@ -61,7 +61,7 @@ void TestUniqueByKeyDispatchImplicit()
 DECLARE_UNITTEST(TestUniqueByKeyDispatchImplicit);
 
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator1, typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   my_system& system,
   InputIterator1,
   InputIterator1,
@@ -70,7 +70,7 @@ thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   OutputIterator2 values_output)
 {
   system.validate_dispatch();
-  return thrust::make_pair(keys_output, values_output);
+  return cuda::std::make_pair(keys_output, values_output);
 }
 
 void TestUniqueByKeyCopyDispatchExplicit()
@@ -85,11 +85,11 @@ void TestUniqueByKeyCopyDispatchExplicit()
 DECLARE_UNITTEST(TestUniqueByKeyCopyDispatchExplicit);
 
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator1, typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   my_tag, InputIterator1, InputIterator1, InputIterator2, OutputIterator1 keys_output, OutputIterator2 values_output)
 {
   *keys_output = 13;
-  return thrust::make_pair(keys_output, values_output);
+  return cuda::std::make_pair(keys_output, values_output);
 }
 
 void TestUniqueByKeyCopyDispatchImplicit()
@@ -138,7 +138,7 @@ void TestUniqueByKeySimple()
   Vector keys;
   Vector values;
 
-  typename thrust::pair<typename Vector::iterator, typename Vector::iterator> new_last;
+  typename cuda::std::pair<typename Vector::iterator, typename Vector::iterator> new_last;
 
   // basic test
   initialize_keys(keys);
@@ -184,7 +184,7 @@ void TestUniqueCopyByKeySimple()
   Vector keys;
   Vector values;
 
-  typename thrust::pair<typename Vector::iterator, typename Vector::iterator> new_last;
+  typename cuda::std::pair<typename Vector::iterator, typename Vector::iterator> new_last;
 
   // basic test
   initialize_keys(keys);
@@ -243,8 +243,8 @@ struct TestUniqueByKey
     using DeviceKeyIterator = typename thrust::device_vector<K>::iterator;
     using DeviceValIterator = typename thrust::device_vector<V>::iterator;
 
-    using HostIteratorPair   = typename thrust::pair<HostKeyIterator, HostValIterator>;
-    using DeviceIteratorPair = typename thrust::pair<DeviceKeyIterator, DeviceValIterator>;
+    using HostIteratorPair   = typename cuda::std::pair<HostKeyIterator, HostValIterator>;
+    using DeviceIteratorPair = typename cuda::std::pair<DeviceKeyIterator, DeviceValIterator>;
 
     HostIteratorPair h_last   = thrust::unique_by_key(h_keys.begin(), h_keys.end(), h_vals.begin());
     DeviceIteratorPair d_last = thrust::unique_by_key(d_keys.begin(), d_keys.end(), d_vals.begin());
@@ -287,8 +287,8 @@ struct TestUniqueCopyByKey
     using DeviceKeyIterator = typename thrust::device_vector<K>::iterator;
     using DeviceValIterator = typename thrust::device_vector<V>::iterator;
 
-    using HostIteratorPair   = typename thrust::pair<HostKeyIterator, HostValIterator>;
-    using DeviceIteratorPair = typename thrust::pair<DeviceKeyIterator, DeviceValIterator>;
+    using HostIteratorPair   = typename cuda::std::pair<HostKeyIterator, HostValIterator>;
+    using DeviceIteratorPair = typename cuda::std::pair<DeviceKeyIterator, DeviceValIterator>;
 
     HostIteratorPair h_last = thrust::unique_by_key_copy(
       h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys_output.begin(), h_vals_output.begin());
@@ -335,51 +335,51 @@ struct TestUniqueCopyByKeyToDiscardIterator
     size_t num_unique_keys = h_unique_keys.size();
 
     // mask both outputs
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::unique_by_key_copy(
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> h_result1 = thrust::unique_by_key_copy(
       h_keys.begin(), h_keys.end(), h_vals.begin(), thrust::make_discard_iterator(), thrust::make_discard_iterator());
 
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::unique_by_key_copy(
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> d_result1 = thrust::unique_by_key_copy(
       d_keys.begin(), d_keys.end(), d_vals.begin(), thrust::make_discard_iterator(), thrust::make_discard_iterator());
 
-    thrust::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 =
-      thrust::make_pair(thrust::make_discard_iterator(num_unique_keys), thrust::make_discard_iterator(num_unique_keys));
+    cuda::std::pair<thrust::discard_iterator<>, thrust::discard_iterator<>> reference1 = cuda::std::make_pair(
+      thrust::make_discard_iterator(num_unique_keys), thrust::make_discard_iterator(num_unique_keys));
 
     ASSERT_EQUAL_QUIET(reference1, h_result1);
     ASSERT_EQUAL_QUIET(reference1, d_result1);
 
     // mask values output
-    thrust::pair<typename thrust::host_vector<K>::iterator, thrust::discard_iterator<>> h_result2 =
+    cuda::std::pair<typename thrust::host_vector<K>::iterator, thrust::discard_iterator<>> h_result2 =
       thrust::unique_by_key_copy(
         h_keys.begin(), h_keys.end(), h_vals.begin(), h_keys_output.begin(), thrust::make_discard_iterator());
 
-    thrust::pair<typename thrust::device_vector<K>::iterator, thrust::discard_iterator<>> d_result2 =
+    cuda::std::pair<typename thrust::device_vector<K>::iterator, thrust::discard_iterator<>> d_result2 =
       thrust::unique_by_key_copy(
         d_keys.begin(), d_keys.end(), d_vals.begin(), d_keys_output.begin(), thrust::make_discard_iterator());
 
-    thrust::pair<typename thrust::host_vector<K>::iterator, thrust::discard_iterator<>> h_reference2 =
-      thrust::make_pair(h_keys_output.begin() + num_unique_keys, thrust::make_discard_iterator(num_unique_keys));
+    cuda::std::pair<typename thrust::host_vector<K>::iterator, thrust::discard_iterator<>> h_reference2 =
+      cuda::std::make_pair(h_keys_output.begin() + num_unique_keys, thrust::make_discard_iterator(num_unique_keys));
 
-    thrust::pair<typename thrust::device_vector<K>::iterator, thrust::discard_iterator<>> d_reference2 =
-      thrust::make_pair(d_keys_output.begin() + num_unique_keys, thrust::make_discard_iterator(num_unique_keys));
+    cuda::std::pair<typename thrust::device_vector<K>::iterator, thrust::discard_iterator<>> d_reference2 =
+      cuda::std::make_pair(d_keys_output.begin() + num_unique_keys, thrust::make_discard_iterator(num_unique_keys));
 
     ASSERT_EQUAL(h_keys_output, d_keys_output);
     ASSERT_EQUAL_QUIET(h_reference2, h_result2);
     ASSERT_EQUAL_QUIET(d_reference2, d_result2);
 
     // mask keys output
-    thrust::pair<thrust::discard_iterator<>, typename thrust::host_vector<V>::iterator> h_result3 =
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<V>::iterator> h_result3 =
       thrust::unique_by_key_copy(
         h_keys.begin(), h_keys.end(), h_vals.begin(), thrust::make_discard_iterator(), h_vals_output.begin());
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::device_vector<V>::iterator> d_result3 =
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<V>::iterator> d_result3 =
       thrust::unique_by_key_copy(
         d_keys.begin(), d_keys.end(), d_vals.begin(), thrust::make_discard_iterator(), d_vals_output.begin());
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::host_vector<V>::iterator> h_reference3 =
-      thrust::make_pair(thrust::make_discard_iterator(num_unique_keys), h_vals_output.begin() + num_unique_keys);
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::host_vector<V>::iterator> h_reference3 =
+      cuda::std::make_pair(thrust::make_discard_iterator(num_unique_keys), h_vals_output.begin() + num_unique_keys);
 
-    thrust::pair<thrust::discard_iterator<>, typename thrust::device_vector<V>::iterator> d_reference3 =
-      thrust::make_pair(thrust::make_discard_iterator(num_unique_keys), d_vals_output.begin() + num_unique_keys);
+    cuda::std::pair<thrust::discard_iterator<>, typename thrust::device_vector<V>::iterator> d_reference3 =
+      cuda::std::make_pair(thrust::make_discard_iterator(num_unique_keys), d_vals_output.begin() + num_unique_keys);
 
     ASSERT_EQUAL(h_vals_output, d_vals_output);
     ASSERT_EQUAL_QUIET(h_reference3, h_result3);
@@ -477,7 +477,7 @@ struct Entry
 
 void TestKeysWithoutEqualityOperator()
 {
-  using Key = thrust::pair<std::int32_t, Entry>;
+  using Key = cuda::std::pair<std::int32_t, Entry>;
 
   const auto k1 = Key{1, {}};
   const auto k2 = Key{2, {}};

--- a/thrust/thrust/binary_search.h
+++ b/thrust/thrust/binary_search.h
@@ -30,7 +30,8 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/detail/execution_policy.h>
-#include <thrust/pair.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -774,7 +775,7 @@ bool binary_search(ForwardIterator first, ForwardIterator last, const T& value, 
  *  \see \p binary_search
  */
 template <typename DerivedPolicy, typename ForwardIterator, typename LessThanComparable>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> equal_range(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator first,
   ForwardIterator last,
@@ -839,7 +840,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
  *  \see \p binary_search
  */
 template <class ForwardIterator, class LessThanComparable>
-thrust::pair<ForwardIterator, ForwardIterator>
+::cuda::std::pair<ForwardIterator, ForwardIterator>
 equal_range(ForwardIterator first, ForwardIterator last, const LessThanComparable& value);
 
 /*! \p equal_range is a version of binary search: it attempts to find
@@ -917,7 +918,7 @@ equal_range(ForwardIterator first, ForwardIterator last, const LessThanComparabl
  *  \see \p binary_search
  */
 template <typename DerivedPolicy, typename ForwardIterator, typename T, typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> equal_range(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator first,
   ForwardIterator last,
@@ -994,7 +995,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
  *  \see \p binary_search
  */
 template <class ForwardIterator, class T, class StrictWeakOrdering>
-thrust::pair<ForwardIterator, ForwardIterator>
+::cuda::std::pair<ForwardIterator, ForwardIterator>
 equal_range(ForwardIterator first, ForwardIterator last, const T& value, StrictWeakOrdering comp);
 
 /*! \addtogroup vectorized_binary_search Vectorized Searches

--- a/thrust/thrust/detail/allocator/temporary_allocator.h
+++ b/thrust/thrust/detail/allocator/temporary_allocator.h
@@ -32,9 +32,9 @@
 #include <thrust/detail/execution_policy.h>
 #include <thrust/detail/temporary_buffer.h>
 #include <thrust/memory.h>
-#include <thrust/pair.h>
 #include <thrust/system/detail/bad_alloc.h>
 
+#include <cuda/std/__utility/pair.h>
 #include <cuda/std/cassert>
 
 #include <nv/target>
@@ -108,7 +108,7 @@ public:
   } // end system()
 
 private:
-  using pointer_and_size = thrust::pair<pointer, size_type>;
+  using pointer_and_size = ::cuda::std::pair<pointer, size_type>;
 }; // end temporary_allocator
 } // namespace detail
 THRUST_NAMESPACE_END

--- a/thrust/thrust/detail/binary_search.inl
+++ b/thrust/thrust/detail/binary_search.inl
@@ -128,7 +128,7 @@ _CCCL_HOST_DEVICE bool binary_search(
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, typename ForwardIterator, typename T, typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> equal_range(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator first,
   ForwardIterator last,
@@ -142,7 +142,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, typename ForwardIterator, typename LessThanComparable>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> equal_range(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator first,
   ForwardIterator last,
@@ -365,7 +365,7 @@ bool binary_search(ForwardIterator first, ForwardIterator last, const T& value, 
 }
 
 template <typename ForwardIterator, typename LessThanComparable>
-thrust::pair<ForwardIterator, ForwardIterator>
+::cuda::std::pair<ForwardIterator, ForwardIterator>
 equal_range(ForwardIterator first, ForwardIterator last, const LessThanComparable& value)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::equal_range");
@@ -379,7 +379,7 @@ equal_range(ForwardIterator first, ForwardIterator last, const LessThanComparabl
 }
 
 template <typename ForwardIterator, typename T, typename StrictWeakOrdering>
-thrust::pair<ForwardIterator, ForwardIterator>
+::cuda::std::pair<ForwardIterator, ForwardIterator>
 equal_range(ForwardIterator first, ForwardIterator last, const T& value, StrictWeakOrdering comp)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::equal_range");

--- a/thrust/thrust/detail/execute_with_allocator.h
+++ b/thrust/thrust/detail/execute_with_allocator.h
@@ -30,16 +30,16 @@
 #include <thrust/detail/execute_with_allocator_fwd.h>
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/detail/type_traits/pointer_traits.h>
-#include <thrust/pair.h>
 
 #include <cuda/__cmath/ceil_div.h>
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
 namespace detail
 {
 template <typename T, typename Allocator, template <typename> class BaseSystem>
-_CCCL_HOST thrust::pair<T*, std::ptrdiff_t>
+_CCCL_HOST ::cuda::std::pair<T*, std::ptrdiff_t>
 get_temporary_buffer(thrust::detail::execute_with_allocator<Allocator, BaseSystem>& system, std::ptrdiff_t n)
 {
   using naked_allocator = ::cuda::std::remove_reference_t<Allocator>;
@@ -55,7 +55,7 @@ get_temporary_buffer(thrust::detail::execute_with_allocator<Allocator, BaseSyste
   void_pointer ptr = alloc_traits::allocate(system.get_allocator(), num_elements);
 
   // Return the pointer and the number of elements of type T allocated.
-  return thrust::make_pair(thrust::reinterpret_pointer_cast<T*>(ptr), n);
+  return ::cuda::std::make_pair(thrust::reinterpret_pointer_cast<T*>(ptr), n);
 }
 
 template <typename Pointer, typename Allocator, template <typename> class BaseSystem>

--- a/thrust/thrust/detail/extrema.inl
+++ b/thrust/thrust/detail/extrema.inl
@@ -93,7 +93,7 @@ _CCCL_HOST_DEVICE ForwardIterator max_element(
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, typename ForwardIterator>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_element(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last)
 {
   _CCCL_NVTX_RANGE_SCOPE("minmax_element");
@@ -103,7 +103,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, typename ForwardIterator, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_element(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator first,
   ForwardIterator last,
@@ -167,7 +167,7 @@ ForwardIterator max_element(ForwardIterator first, ForwardIterator last, BinaryP
 } // end max_element()
 
 template <typename ForwardIterator>
-thrust::pair<ForwardIterator, ForwardIterator> minmax_element(ForwardIterator first, ForwardIterator last)
+::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_element(ForwardIterator first, ForwardIterator last)
 {
   _CCCL_NVTX_RANGE_SCOPE("minmax_element");
   using thrust::system::detail::generic::select_system;
@@ -180,7 +180,7 @@ thrust::pair<ForwardIterator, ForwardIterator> minmax_element(ForwardIterator fi
 } // end minmax_element()
 
 template <typename ForwardIterator, typename BinaryPredicate>
-thrust::pair<ForwardIterator, ForwardIterator>
+::cuda::std::pair<ForwardIterator, ForwardIterator>
 minmax_element(ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   _CCCL_NVTX_RANGE_SCOPE("minmax_element");

--- a/thrust/thrust/detail/merge.inl
+++ b/thrust/thrust/detail/merge.inl
@@ -90,7 +90,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -124,7 +124,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Compare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -199,7 +199,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -246,7 +246,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,

--- a/thrust/thrust/detail/mismatch.inl
+++ b/thrust/thrust/detail/mismatch.inl
@@ -47,7 +47,7 @@ THRUST_NAMESPACE_BEGIN
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2>
+_CCCL_HOST_DEVICE ::cuda::std::pair<InputIterator1, InputIterator2>
 mismatch(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
          InputIterator1 first1,
          InputIterator1 last1,
@@ -60,7 +60,7 @@ mismatch(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
+_CCCL_HOST_DEVICE ::cuda::std::pair<InputIterator1, InputIterator2> mismatch(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 first1,
   InputIterator1 last1,
@@ -73,7 +73,8 @@ _CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
 } // end mismatch()
 
 template <typename InputIterator1, typename InputIterator2>
-thrust::pair<InputIterator1, InputIterator2> mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2)
+::cuda::std::pair<InputIterator1, InputIterator2>
+mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::mismatch");
   using thrust::system::detail::generic::select_system;
@@ -88,7 +89,7 @@ thrust::pair<InputIterator1, InputIterator2> mismatch(InputIterator1 first1, Inp
 } // end mismatch()
 
 template <typename InputIterator1, typename InputIterator2, typename BinaryPredicate>
-thrust::pair<InputIterator1, InputIterator2>
+::cuda::std::pair<InputIterator1, InputIterator2>
 mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, BinaryPredicate pred)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::mismatch");

--- a/thrust/thrust/detail/partition.inl
+++ b/thrust/thrust/detail/partition.inl
@@ -78,7 +78,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator first,
   InputIterator last,
@@ -99,7 +99,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 first,
   InputIterator1 last,
@@ -147,7 +147,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator first,
   InputIterator last,
@@ -168,7 +168,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 first,
   InputIterator1 last,
@@ -266,7 +266,7 @@ ForwardIterator stable_partition(ForwardIterator first, ForwardIterator last, In
 } // end stable_partition()
 
 template <typename InputIterator, typename OutputIterator1, typename OutputIterator2, typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   InputIterator first, InputIterator last, OutputIterator1 out_true, OutputIterator2 out_false, Predicate pred)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::partition_copy");
@@ -288,7 +288,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   InputIterator1 first,
   InputIterator1 last,
   InputIterator2 stencil,
@@ -314,7 +314,7 @@ thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
 } // end partition_copy()
 
 template <typename InputIterator, typename OutputIterator1, typename OutputIterator2, typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   InputIterator first, InputIterator last, OutputIterator1 out_true, OutputIterator2 out_false, Predicate pred)
 {
   _CCCL_NVTX_RANGE_SCOPE("thrust::stable_partition_copy");
@@ -336,7 +336,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   InputIterator1 first,
   InputIterator1 last,
   InputIterator2 stencil,

--- a/thrust/thrust/detail/reduce.inl
+++ b/thrust/thrust/detail/reduce.inl
@@ -133,7 +133,7 @@ template <typename DerivedPolicy,
           typename InputIterator2,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -159,7 +159,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -188,7 +188,7 @@ template <typename DerivedPolicy,
           typename OutputIterator2,
           typename BinaryPredicate,
           typename BinaryFunction>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -293,7 +293,7 @@ void reduce_into(InputIterator first, InputIterator last, OutputIterator output,
 }
 
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator1, typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
   InputIterator2 values_first,
@@ -322,7 +322,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
   InputIterator2 values_first,
@@ -359,7 +359,7 @@ template <typename InputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate,
           typename BinaryFunction>
-thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
   InputIterator2 values_first,

--- a/thrust/thrust/detail/set_operations.inl
+++ b/thrust/thrust/detail/set_operations.inl
@@ -89,7 +89,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -123,7 +123,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -194,7 +194,7 @@ template <typename DerivedPolicy,
           typename InputIterator3,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -225,7 +225,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -295,7 +295,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -329,7 +329,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -401,7 +401,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -435,7 +435,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -510,7 +510,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -557,7 +557,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -643,7 +643,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -685,7 +685,7 @@ template <typename InputIterator1,
           typename InputIterator3,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -770,7 +770,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -817,7 +817,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -904,7 +904,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -951,7 +951,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,

--- a/thrust/thrust/detail/temporary_buffer.h
+++ b/thrust/thrust/detail/temporary_buffer.h
@@ -30,7 +30,8 @@
 #include <thrust/detail/execution_policy.h>
 #include <thrust/detail/pointer.h>
 #include <thrust/detail/raw_pointer_cast.h>
-#include <thrust/pair.h>
+
+#include <cuda/std/__utility/pair.h>
 
 // Include all active backend system implementations (generic, sequential, host and device)
 #include <thrust/system/detail/generic/temporary_buffer.h>
@@ -50,8 +51,8 @@ THRUST_NAMESPACE_BEGIN
 namespace detail
 {
 template <typename T, typename DerivedPolicy, typename Pair>
-_CCCL_HOST_DEVICE
-thrust::pair<thrust::pointer<T, DerivedPolicy>, typename thrust::pointer<T, DerivedPolicy>::difference_type>
+_CCCL_HOST_DEVICE ::cuda::std::pair<thrust::pointer<T, DerivedPolicy>,
+                                    typename thrust::pointer<T, DerivedPolicy>::difference_type>
 down_cast_pair(Pair p)
 {
   // XXX should use a hypothetical thrust::static_pointer_cast here
@@ -59,15 +60,15 @@ down_cast_pair(Pair p)
     thrust::pointer<T, DerivedPolicy>(static_cast<T*>(thrust::raw_pointer_cast(p.first)));
 
   using result_type =
-    thrust::pair<thrust::pointer<T, DerivedPolicy>, typename thrust::pointer<T, DerivedPolicy>::difference_type>;
+    ::cuda::std::pair<thrust::pointer<T, DerivedPolicy>, typename thrust::pointer<T, DerivedPolicy>::difference_type>;
   return result_type(ptr, p.second);
 } // end down_cast_pair()
 } // namespace detail
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename T, typename DerivedPolicy>
-_CCCL_HOST_DEVICE
-thrust::pair<thrust::pointer<T, DerivedPolicy>, typename thrust::pointer<T, DerivedPolicy>::difference_type>
+_CCCL_HOST_DEVICE ::cuda::std::pair<thrust::pointer<T, DerivedPolicy>,
+                                    typename thrust::pointer<T, DerivedPolicy>::difference_type>
 get_temporary_buffer(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
                      typename thrust::pointer<T, DerivedPolicy>::difference_type n)
 {

--- a/thrust/thrust/detail/unique.inl
+++ b/thrust/thrust/detail/unique.inl
@@ -106,7 +106,7 @@ _CCCL_HOST_DEVICE OutputIterator unique_copy(
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
@@ -120,7 +120,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
@@ -139,7 +139,7 @@ template <typename DerivedPolicy,
           typename InputIterator2,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -165,7 +165,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -243,7 +243,7 @@ OutputIterator unique_copy(InputIterator first, InputIterator last, OutputIterat
 } // end unique_copy()
 
 template <typename ForwardIterator1, typename ForwardIterator2>
-thrust::pair<ForwardIterator1, ForwardIterator2>
+::cuda::std::pair<ForwardIterator1, ForwardIterator2>
 unique_by_key(ForwardIterator1 keys_first, ForwardIterator1 keys_last, ForwardIterator2 values_first)
 {
   _CCCL_NVTX_RANGE_SCOPE("unique_by_key");
@@ -259,7 +259,7 @@ unique_by_key(ForwardIterator1 keys_first, ForwardIterator1 keys_last, ForwardIt
 } // end unique_by_key()
 
 template <typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
-thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   ForwardIterator1 keys_first, ForwardIterator1 keys_last, ForwardIterator2 values_first, BinaryPredicate binary_pred)
 {
   _CCCL_NVTX_RANGE_SCOPE("unique_by_key");
@@ -275,7 +275,7 @@ thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
 } // end unique_by_key()
 
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator1, typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
   InputIterator2 values_first,
@@ -304,7 +304,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
   InputIterator2 values_first,

--- a/thrust/thrust/extrema.h
+++ b/thrust/thrust/extrema.h
@@ -475,7 +475,7 @@ ForwardIterator max_element(ForwardIterator first, ForwardIterator last, BinaryP
  *  #include <thrust/execution_policy.h>
  *  ...
  *  int data[6] = {1, 0, 2, 2, 1, 3};
- *  :::cuda::std::pair<int *, int *> result = thrust::minmax_element(thrust::host, data, data + 6);
+ *  cuda::std::pair<int *, int *> result = thrust::minmax_element(thrust::host, data, data + 6);
  *
  *  // result.first is data + 1
  *  // result.second is data + 5
@@ -509,7 +509,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_ele
  *  #include <thrust/extrema.h>
  *  ...
  *  int data[6] = {1, 0, 2, 2, 1, 3};
- *  :::cuda::std::pair<int *, int *> result = thrust::minmax_element(data, data + 6);
+ *  cuda::std::pair<int *, int *> result = thrust::minmax_element(data, data + 6);
  *
  *  // result.first is data + 1
  *  // result.second is data + 5
@@ -571,7 +571,7 @@ template <typename ForwardIterator>
  *  ...
  *  key_value data[4] = { {4,5}, {0,7}, {2,3}, {6,1} };
  *
- *  :::cuda::std::pair<key_value*,key_value*> extrema = thrust::minmax_element(thrust::host, data, data + 4,
+ *  cuda::std::pair<key_value*,key_value*> extrema = thrust::minmax_element(thrust::host, data, data + 4,
  * compare_key_value());
  *
  *  // extrema.first   == data + 1
@@ -632,7 +632,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_ele
  *  ...
  *  key_value data[4] = { {4,5}, {0,7}, {2,3}, {6,1} };
  *
- *  :::cuda::std::pair<key_value*,key_value*> extrema = thrust::minmax_element(data, data + 4, compare_key_value());
+ *  cuda::std::pair<key_value*,key_value*> extrema = thrust::minmax_element(data, data + 4, compare_key_value());
  *
  *  // extrema.first   == data + 1
  *  // *extrema.first  == {0,7}

--- a/thrust/thrust/extrema.h
+++ b/thrust/thrust/extrema.h
@@ -30,10 +30,10 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/detail/execution_policy.h>
-#include <thrust/pair.h>
 
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -475,7 +475,7 @@ ForwardIterator max_element(ForwardIterator first, ForwardIterator last, BinaryP
  *  #include <thrust/execution_policy.h>
  *  ...
  *  int data[6] = {1, 0, 2, 2, 1, 3};
- *  thrust::pair<int *, int *> result = thrust::minmax_element(thrust::host, data, data + 6);
+ *  :::cuda::std::pair<int *, int *> result = thrust::minmax_element(thrust::host, data, data + 6);
  *
  *  // result.first is data + 1
  *  // result.second is data + 5
@@ -488,7 +488,7 @@ ForwardIterator max_element(ForwardIterator first, ForwardIterator last, BinaryP
  *  \see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1840.pdf
  */
 template <typename DerivedPolicy, typename ForwardIterator>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_element(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last);
 
 /*! \p minmax_element finds the smallest and largest elements in the range <tt>[first, last)</tt>.
@@ -509,7 +509,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
  *  #include <thrust/extrema.h>
  *  ...
  *  int data[6] = {1, 0, 2, 2, 1, 3};
- *  thrust::pair<int *, int *> result = thrust::minmax_element(data, data + 6);
+ *  :::cuda::std::pair<int *, int *> result = thrust::minmax_element(data, data + 6);
  *
  *  // result.first is data + 1
  *  // result.second is data + 5
@@ -522,7 +522,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
  *  \see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1840.pdf
  */
 template <typename ForwardIterator>
-thrust::pair<ForwardIterator, ForwardIterator> minmax_element(ForwardIterator first, ForwardIterator last);
+::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_element(ForwardIterator first, ForwardIterator last);
 
 /*! \p minmax_element finds the smallest and largest elements in the range <tt>[first, last)</tt>.
  *  It returns a pair of iterators <tt>(imin, imax)</tt> where \c imin is the same iterator
@@ -549,7 +549,7 @@ thrust::pair<ForwardIterator, ForwardIterator> minmax_element(ForwardIterator fi
  *
  *  \code
  *  #include <thrust/extrema.h>
- *  #include <thrust/pair.h>
+ *  #include <cuda/std/__utility/pair.h>
  *  #include <thrust/execution_policy.h>
  *  ...
  *
@@ -571,7 +571,7 @@ thrust::pair<ForwardIterator, ForwardIterator> minmax_element(ForwardIterator fi
  *  ...
  *  key_value data[4] = { {4,5}, {0,7}, {2,3}, {6,1} };
  *
- *  thrust::pair<key_value*,key_value*> extrema = thrust::minmax_element(thrust::host, data, data + 4,
+ *  :::cuda::std::pair<key_value*,key_value*> extrema = thrust::minmax_element(thrust::host, data, data + 4,
  * compare_key_value());
  *
  *  // extrema.first   == data + 1
@@ -585,7 +585,7 @@ thrust::pair<ForwardIterator, ForwardIterator> minmax_element(ForwardIterator fi
  *  \see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1840.pdf
  */
 template <typename DerivedPolicy, typename ForwardIterator, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_element(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator first,
   ForwardIterator last,
@@ -612,7 +612,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
  *
  *  \code
  *  #include <thrust/extrema.h>
- *  #include <thrust/pair.h>
+ *  #include <cuda/std/__utility/pair.h>
  *
  *  struct key_value
  *  {
@@ -632,7 +632,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
  *  ...
  *  key_value data[4] = { {4,5}, {0,7}, {2,3}, {6,1} };
  *
- *  thrust::pair<key_value*,key_value*> extrema = thrust::minmax_element(data, data + 4, compare_key_value());
+ *  :::cuda::std::pair<key_value*,key_value*> extrema = thrust::minmax_element(data, data + 4, compare_key_value());
  *
  *  // extrema.first   == data + 1
  *  // *extrema.first  == {0,7}
@@ -645,7 +645,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
  *  \see http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2005/n1840.pdf
  */
 template <typename ForwardIterator, typename BinaryPredicate>
-thrust::pair<ForwardIterator, ForwardIterator>
+::cuda::std::pair<ForwardIterator, ForwardIterator>
 minmax_element(ForwardIterator first, ForwardIterator last, BinaryPredicate comp);
 
 /*! \} // end extrema

--- a/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
+++ b/thrust/thrust/iterator/detail/tuple_of_iterator_references.h
@@ -28,11 +28,11 @@
 
 #include <thrust/detail/raw_reference_cast.h>
 #include <thrust/detail/reference_forward_declaration.h>
-#include <thrust/pair.h>
 #include <thrust/tuple.h>
 
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__utility/move.h>
+#include <cuda/std/__utility/pair.h>
 #include <cuda/std/tuple>
 
 THRUST_NAMESPACE_BEGIN
@@ -92,7 +92,7 @@ public:
   // XXX might be worthwhile to guard this with an enable_if is_assignable
   _CCCL_EXEC_CHECK_DISABLE
   template <typename U1, typename U2>
-  _CCCL_HOST_DEVICE tuple_of_iterator_references& operator=(const pair<U1, U2>& other)
+  _CCCL_HOST_DEVICE tuple_of_iterator_references& operator=(const ::cuda::std::pair<U1, U2>& other)
   {
     super_t::operator=(other);
     return *this;

--- a/thrust/thrust/memory.h
+++ b/thrust/thrust/memory.h
@@ -148,7 +148,7 @@ malloc(const thrust::detail::execution_policy_base<DerivedPolicy>& system, std::
  *  // allocate storage for 100 ints with thrust::get_temporary_buffer
  *  const int N = 100;
  *
- *  using ptr_and_size_t = :::cuda::std::pair<
+ *  using ptr_and_size_t = cuda::std::pair<
  *    thrust::pointer<int,thrust::device_system_tag>,
  *    std::ptrdiff_t
  *  >;
@@ -230,7 +230,7 @@ _CCCL_HOST_DEVICE void free(const thrust::detail::execution_policy_base<DerivedP
  *  // allocate storage for 100 ints with thrust::get_temporary_buffer
  *  const int N = 100;
  *
- *  using ptr_and_size_t = :::cuda::std::pair<
+ *  using ptr_and_size_t = cuda::std::pair<
  *    thrust::pointer<int,thrust::device_system_tag>,
  *    std::ptrdiff_t
  *  >;

--- a/thrust/thrust/memory.h
+++ b/thrust/thrust/memory.h
@@ -148,7 +148,7 @@ malloc(const thrust::detail::execution_policy_base<DerivedPolicy>& system, std::
  *  // allocate storage for 100 ints with thrust::get_temporary_buffer
  *  const int N = 100;
  *
- *  using ptr_and_size_t = thrust::pair<
+ *  using ptr_and_size_t = :::cuda::std::pair<
  *    thrust::pointer<int,thrust::device_system_tag>,
  *    std::ptrdiff_t
  *  >;
@@ -170,8 +170,8 @@ malloc(const thrust::detail::execution_policy_base<DerivedPolicy>& system, std::
  *  \see return_temporary_buffer
  */
 template <typename T, typename DerivedPolicy>
-_CCCL_HOST_DEVICE
-thrust::pair<thrust::pointer<T, DerivedPolicy>, typename thrust::pointer<T, DerivedPolicy>::difference_type>
+_CCCL_HOST_DEVICE ::cuda::std::pair<thrust::pointer<T, DerivedPolicy>,
+                                    typename thrust::pointer<T, DerivedPolicy>::difference_type>
 get_temporary_buffer(const thrust::detail::execution_policy_base<DerivedPolicy>& system,
                      typename thrust::pointer<T, DerivedPolicy>::difference_type n);
 
@@ -230,7 +230,7 @@ _CCCL_HOST_DEVICE void free(const thrust::detail::execution_policy_base<DerivedP
  *  // allocate storage for 100 ints with thrust::get_temporary_buffer
  *  const int N = 100;
  *
- *  using ptr_and_size_t = thrust::pair<
+ *  using ptr_and_size_t = :::cuda::std::pair<
  *    thrust::pointer<int,thrust::device_system_tag>,
  *    std::ptrdiff_t
  *  >;

--- a/thrust/thrust/merge.h
+++ b/thrust/thrust/merge.h
@@ -30,7 +30,8 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/detail/execution_policy.h>
-#include <thrust/pair.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -384,7 +385,7 @@ merge(InputIterator1 first1,
  *  int keys_result[13];
  *  int vals_result[13];
  *
- *  thrust::pair<int*,int*> end =
+ *  :::cuda::std::pair<int*,int*> end =
  *    thrust::merge_by_key(thrust::host,
  *                         A_keys, A_keys + 6,
  *                         B_keys, B_keys + 7,
@@ -406,7 +407,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -486,7 +487,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
  *  int keys_result[13];
  *  int vals_result[13];
  *
- *  thrust::pair<int*,int*> end = thrust::merge_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals, B_vals,
+ *  :::cuda::std::pair<int*,int*> end = thrust::merge_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals, B_vals,
  * keys_result, vals_result);
  *
  *  // keys_result = {1, 1, 1, 2, 3, 3, 5, 5, 7, 8, 9, 11, 13}
@@ -503,7 +504,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -585,7 +586,7 @@ thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
  *  int keys_result[13];
  *  int vals_result[13];
  *
- *  thrust::pair<int*,int*> end =
+ *  :::cuda::std::pair<int*,int*> end =
  *    thrust::merge_by_key(thrust::host,
  *                         A_keys, A_keys + 6,
  *                         B_keys, B_keys + 7,
@@ -609,7 +610,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Compare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -688,7 +689,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
  *  int keys_result[13];
  *  int vals_result[13];
  *
- *  thrust::pair<int*,int*> end = thrust::merge_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals, B_vals,
+ *  :::cuda::std::pair<int*,int*> end = thrust::merge_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals, B_vals,
  * keys_result, vals_result, ::cuda::std::greater<int>());
  *
  *  // keys_result = {13, 11, 9, 8, 7, 5, 5, 3, 3, 2, 1, 1, 1}
@@ -706,7 +707,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,

--- a/thrust/thrust/merge.h
+++ b/thrust/thrust/merge.h
@@ -385,7 +385,7 @@ merge(InputIterator1 first1,
  *  int keys_result[13];
  *  int vals_result[13];
  *
- *  :::cuda::std::pair<int*,int*> end =
+ *  cuda::std::pair<int*,int*> end =
  *    thrust::merge_by_key(thrust::host,
  *                         A_keys, A_keys + 6,
  *                         B_keys, B_keys + 7,
@@ -487,7 +487,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_k
  *  int keys_result[13];
  *  int vals_result[13];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::merge_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals, B_vals,
+ *  cuda::std::pair<int*,int*> end = thrust::merge_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals, B_vals,
  * keys_result, vals_result);
  *
  *  // keys_result = {1, 1, 1, 2, 3, 3, 5, 5, 7, 8, 9, 11, 13}
@@ -586,7 +586,7 @@ template <typename InputIterator1,
  *  int keys_result[13];
  *  int vals_result[13];
  *
- *  :::cuda::std::pair<int*,int*> end =
+ *  cuda::std::pair<int*,int*> end =
  *    thrust::merge_by_key(thrust::host,
  *                         A_keys, A_keys + 6,
  *                         B_keys, B_keys + 7,
@@ -689,7 +689,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_k
  *  int keys_result[13];
  *  int vals_result[13];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::merge_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals, B_vals,
+ *  cuda::std::pair<int*,int*> end = thrust::merge_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals, B_vals,
  * keys_result, vals_result, ::cuda::std::greater<int>());
  *
  *  // keys_result = {13, 11, 9, 8, 7, 5, 5, 3, 3, 2, 1, 1, 1}

--- a/thrust/thrust/mismatch.h
+++ b/thrust/thrust/mismatch.h
@@ -30,7 +30,8 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/detail/execution_policy.h>
-#include <thrust/pair.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -80,7 +81,7 @@ THRUST_NAMESPACE_BEGIN
  *  vec1[3] = 7;  vec2[3] = 7;
  *
  *  using Iterator = thrust::device_vector<int>::iterator;
- *  thrust::pair<Iterator,Iterator> result;
+ *  :::cuda::std::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(thrust::device, vec1.begin(), vec1.end(), vec2.begin());
  *
@@ -92,7 +93,7 @@ THRUST_NAMESPACE_BEGIN
  *  \see find_if
  */
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2>
+_CCCL_HOST_DEVICE ::cuda::std::pair<InputIterator1, InputIterator2>
 mismatch(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
          InputIterator1 first1,
          InputIterator1 last1,
@@ -131,7 +132,7 @@ mismatch(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
  *  vec1[3] = 7;  vec2[3] = 7;
  *
  *  using Iterator = thrust::device_vector<int>::iterator;
- *  thrust::pair<Iterator,Iterator> result;
+ *  :::cuda::std::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(vec1.begin(), vec1.end(), vec2.begin());
  *
@@ -143,7 +144,7 @@ mismatch(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
  *  \see find_if
  */
 template <typename InputIterator1, typename InputIterator2>
-thrust::pair<InputIterator1, InputIterator2>
+::cuda::std::pair<InputIterator1, InputIterator2>
 mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2);
 
 /*! \p mismatch finds the first position where the two ranges <tt>[first1, last1)</tt>
@@ -185,7 +186,7 @@ mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2);
  *  vec1[3] = 7;  vec2[3] = 7;
  *
  *  using Iterator = thrust::device_vector<int>::iterator;
- *  thrust::pair<Iterator,Iterator> result;
+ *  :::cuda::std::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(thrust::device, vec1.begin(), vec1.end(), vec2.begin(), ::cuda::std::equal_to<int>());
  *
@@ -197,7 +198,7 @@ mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2);
  *  \see find_if
  */
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
+_CCCL_HOST_DEVICE ::cuda::std::pair<InputIterator1, InputIterator2> mismatch(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 first1,
   InputIterator1 last1,
@@ -238,7 +239,7 @@ _CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
  *  vec1[3] = 7;  vec2[3] = 7;
  *
  *  using Iterator = thrust::device_vector<int>::iterator;
- *  thrust::pair<Iterator,Iterator> result;
+ *  :::cuda::std::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(vec1.begin(), vec1.end(), vec2.begin(), ::cuda::std::equal_to<int>());
  *
@@ -250,7 +251,7 @@ _CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
  *  \see find_if
  */
 template <typename InputIterator1, typename InputIterator2, typename BinaryPredicate>
-thrust::pair<InputIterator1, InputIterator2>
+::cuda::std::pair<InputIterator1, InputIterator2>
 mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, BinaryPredicate pred);
 
 /*! \} // end searching

--- a/thrust/thrust/mismatch.h
+++ b/thrust/thrust/mismatch.h
@@ -81,7 +81,7 @@ THRUST_NAMESPACE_BEGIN
  *  vec1[3] = 7;  vec2[3] = 7;
  *
  *  using Iterator = thrust::device_vector<int>::iterator;
- *  :::cuda::std::pair<Iterator,Iterator> result;
+ *  cuda::std::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(thrust::device, vec1.begin(), vec1.end(), vec2.begin());
  *
@@ -132,7 +132,7 @@ mismatch(const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
  *  vec1[3] = 7;  vec2[3] = 7;
  *
  *  using Iterator = thrust::device_vector<int>::iterator;
- *  :::cuda::std::pair<Iterator,Iterator> result;
+ *  cuda::std::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(vec1.begin(), vec1.end(), vec2.begin());
  *
@@ -186,7 +186,7 @@ mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2);
  *  vec1[3] = 7;  vec2[3] = 7;
  *
  *  using Iterator = thrust::device_vector<int>::iterator;
- *  :::cuda::std::pair<Iterator,Iterator> result;
+ *  cuda::std::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(thrust::device, vec1.begin(), vec1.end(), vec2.begin(), ::cuda::std::equal_to<int>());
  *
@@ -239,7 +239,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<InputIterator1, InputIterator2> mismatch(
  *  vec1[3] = 7;  vec2[3] = 7;
  *
  *  using Iterator = thrust::device_vector<int>::iterator;
- *  :::cuda::std::pair<Iterator,Iterator> result;
+ *  cuda::std::pair<Iterator,Iterator> result;
  *
  *  result = thrust::mismatch(vec1.begin(), vec1.end(), vec2.begin(), ::cuda::std::equal_to<int>());
  *

--- a/thrust/thrust/partition.h
+++ b/thrust/thrust/partition.h
@@ -30,7 +30,8 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/detail/execution_policy.h>
-#include <thrust/pair.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -361,7 +362,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator first,
   InputIterator last,
@@ -433,7 +434,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
  *  \see \p partition
  */
 template <typename InputIterator, typename OutputIterator1, typename OutputIterator2, typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   InputIterator first, InputIterator last, OutputIterator1 out_true, OutputIterator2 out_false, Predicate pred);
 
 /*! \p partition_copy differs from \p partition only in that the reordered
@@ -508,7 +509,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 first,
   InputIterator1 last,
@@ -582,7 +583,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   InputIterator1 first,
   InputIterator1 last,
   InputIterator2 stencil,
@@ -920,7 +921,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator first,
   InputIterator last,
@@ -994,7 +995,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partitio
  *  \see \p stable_partition
  */
 template <typename InputIterator, typename OutputIterator1, typename OutputIterator2, typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   InputIterator first, InputIterator last, OutputIterator1 out_true, OutputIterator2 out_false, Predicate pred);
 
 /*! \p stable_partition_copy differs from \p stable_partition only in that the reordered
@@ -1071,7 +1072,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 first,
   InputIterator1 last,
@@ -1147,7 +1148,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   InputIterator1 first,
   InputIterator1 last,
   InputIterator2 stencil,

--- a/thrust/thrust/random/detail/normal_distribution_base.h
+++ b/thrust/thrust/random/detail/normal_distribution_base.h
@@ -37,7 +37,6 @@
 #include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/__cmath/roots.h>
 #include <cuda/std/__cmath/trigonometric_functions.h>
-#include <cuda/std/__utility/pair.h>
 #include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/random/detail/normal_distribution_base.h
+++ b/thrust/thrust/random/detail/normal_distribution_base.h
@@ -32,12 +32,12 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
 #include <thrust/random/uniform_real_distribution.h>
 
 #include <cuda/std/__cmath/logarithms.h>
 #include <cuda/std/__cmath/roots.h>
 #include <cuda/std/__cmath/trigonometric_functions.h>
+#include <cuda/std/__utility/pair.h>
 #include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/random/normal_distribution.h
+++ b/thrust/thrust/random/normal_distribution.h
@@ -29,9 +29,10 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
 #include <thrust/random/detail/normal_distribution_base.h>
 #include <thrust/random/detail/random_core_access.h>
+
+#include <cuda/std/__utility/pair.h>
 
 #include <iostream>
 
@@ -100,7 +101,7 @@ public:
   /*! \typedef param_type
    *  \brief The type of the object encapsulating this \p normal_distribution's parameters.
    */
-  using param_type = thrust::pair<RealType, RealType>;
+  using param_type = ::cuda::std::pair<RealType, RealType>;
 
   // constructors and reset functions
 

--- a/thrust/thrust/random/uniform_int_distribution.h
+++ b/thrust/thrust/random/uniform_int_distribution.h
@@ -29,9 +29,9 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
 #include <thrust/random/detail/random_core_access.h>
 
+#include <cuda/std/__utility/pair.h>
 #include <cuda/std/limits>
 
 #include <iostream>
@@ -105,7 +105,7 @@ public:
   /*! \typedef param_type
    *  \brief The type of the object encapsulating this \p uniform_int_distribution's parameters.
    */
-  using param_type = thrust::pair<IntType, IntType>;
+  using param_type = ::cuda::std::pair<IntType, IntType>;
 
   // constructors and reset functions
 

--- a/thrust/thrust/random/uniform_real_distribution.h
+++ b/thrust/thrust/random/uniform_real_distribution.h
@@ -29,8 +29,9 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
 #include <thrust/random/detail/random_core_access.h>
+
+#include <cuda/std/__utility/pair.h>
 
 #include <iostream>
 
@@ -102,7 +103,7 @@ public:
   /*! \typedef param_type
    *  \brief The type of the object encapsulating this \p uniform_real_distribution's parameters.
    */
-  using param_type = thrust::pair<RealType, RealType>;
+  using param_type = ::cuda::std::pair<RealType, RealType>;
 
   // constructors and reset functions
 

--- a/thrust/thrust/reduce.h
+++ b/thrust/thrust/reduce.h
@@ -31,7 +31,8 @@
 #endif // no system header
 #include <thrust/detail/execution_policy.h>
 #include <thrust/iterator/iterator_traits.h>
-#include <thrust/pair.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -721,7 +722,7 @@ void reduce_into(InputIterator first, InputIterator last, OutputIterator output,
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::reduce_by_key(thrust::host, A, A + N, B, C, D);
  *
  *  // The first four keys in C are now {1, 3, 2, 1} and new_end.first - C is 4.
@@ -738,7 +739,7 @@ template <typename DerivedPolicy,
           typename InputIterator2,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -785,7 +786,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::reduce_by_key(A, A + N, B, C, D);
  *
  *  // The first four keys in C are now {1, 3, 2, 1} and new_end.first - C is 4.
@@ -798,7 +799,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
  *  \see unique_by_key_copy
  */
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator1, typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
   InputIterator2 values_first,
@@ -852,7 +853,7 @@ thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::reduce_by_key(thrust::host, A, A + N, B, C, D, binary_pred);
  *
@@ -871,7 +872,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -921,7 +922,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::reduce_by_key(A, A + N, B, C, D, binary_pred);
  *
@@ -939,7 +940,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
   InputIterator2 values_first,
@@ -999,7 +1000,7 @@ thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  ::cuda::std::plus<int> binary_op;
  *  new_end = thrust::reduce_by_key(thrust::host, A, A + N, B, C, D, binary_pred, binary_op);
@@ -1020,7 +1021,7 @@ template <typename DerivedPolicy,
           typename OutputIterator2,
           typename BinaryPredicate,
           typename BinaryFunction>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -1076,7 +1077,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  ::cuda::std::plus<int> binary_op;
  *  new_end = thrust::reduce_by_key(A, A + N, B, C, D, binary_pred, binary_op);
@@ -1096,7 +1097,7 @@ template <typename InputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate,
           typename BinaryFunction>
-thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
   InputIterator2 values_first,

--- a/thrust/thrust/reduce.h
+++ b/thrust/thrust/reduce.h
@@ -722,7 +722,7 @@ void reduce_into(InputIterator first, InputIterator last, OutputIterator output,
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::reduce_by_key(thrust::host, A, A + N, B, C, D);
  *
  *  // The first four keys in C are now {1, 3, 2, 1} and new_end.first - C is 4.
@@ -786,7 +786,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::reduce_by_key(A, A + N, B, C, D);
  *
  *  // The first four keys in C are now {1, 3, 2, 1} and new_end.first - C is 4.
@@ -853,7 +853,7 @@ template <typename InputIterator1, typename InputIterator2, typename OutputItera
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::reduce_by_key(thrust::host, A, A + N, B, C, D, binary_pred);
  *
@@ -922,7 +922,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::reduce_by_key(A, A + N, B, C, D, binary_pred);
  *
@@ -1000,7 +1000,7 @@ template <typename InputIterator1,
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  ::cuda::std::plus<int> binary_op;
  *  new_end = thrust::reduce_by_key(thrust::host, A, A + N, B, C, D, binary_pred, binary_op);
@@ -1077,7 +1077,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  ::cuda::std::plus<int> binary_op;
  *  new_end = thrust::reduce_by_key(A, A + N, B, C, D, binary_pred, binary_op);

--- a/thrust/thrust/set_operations.h
+++ b/thrust/thrust/set_operations.h
@@ -1373,7 +1373,7 @@ OutputIterator set_union(
  *  int keys_result[3];
  *  int vals_result[3];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys +
+ *  cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys +
  * 5, A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 4, 6}
  *  // vals_result is now {0, 0, 0}
@@ -1475,7 +1475,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_differ
  *  int keys_result[3];
  *  int vals_result[3];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5, A_vals,
+ *  cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5, A_vals,
  * B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 4, 6}
  *  // vals_result is now {0, 0, 0}
@@ -1585,7 +1585,7 @@ template <typename InputIterator1,
  *  int keys_result[3];
  *  int vals_result[3];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys +
+ *  cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys +
  * 5, A_vals, B_vals, keys_result, vals_result, ::cuda::std::greater<int>());
  *  // keys_result is now {0, 4, 6}
  *  // vals_result is now {0, 0, 0}
@@ -1693,7 +1693,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_differ
  *  int keys_result[3];
  *  int vals_result[3];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5, A_vals,
+ *  cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5, A_vals,
  * B_vals, keys_result, vals_result, ::cuda::std::greater<int>());
  *  // keys_result is now {0, 4, 6}
  *  // vals_result is now {0, 0, 0}
@@ -1801,7 +1801,7 @@ template <typename InputIterator1,
  *  int keys_result[7];
  *  int vals_result[7];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys
+ *  cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys
  * + 7, A_vals, keys_result, vals_result);
  *
  *  // keys_result is now {1, 3, 5}
@@ -1902,7 +1902,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_inters
  *  int keys_result[7];
  *  int vals_result[7];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals,
+ *  cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals,
  * keys_result, vals_result);
  *
  *  // keys_result is now {1, 3, 5}
@@ -2011,7 +2011,7 @@ template <typename InputIterator1,
  *  int keys_result[7];
  *  int vals_result[7];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys
+ *  cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys
  * + 7, A_vals, keys_result, vals_result, ::cuda::std::greater<int>());
  *
  *  // keys_result is now {5, 3, 1}
@@ -2118,7 +2118,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_inters
  *  int keys_result[7];
  *  int vals_result[7];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals,
+ *  cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals,
  * keys_result, vals_result, ::cuda::std::greater<int>());
  *
  *  // keys_result is now {5, 3, 1}
@@ -2228,7 +2228,7 @@ template <typename InputIterator1,
  *  int keys_result[6];
  *  int vals_result[6];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
+ *  cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
  * B_keys, B_keys + 5, A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 4, 5, 6, 7, 8}
  *  // vals_result is now {0, 0, 1, 0, 0, 1}
@@ -2333,7 +2333,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmet
  *  int keys_result[6];
  *  int vals_result[6];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
+ *  cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
  * A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 4, 5, 6, 7, 8}
  *  // vals_result is now {0, 0, 1, 0, 0, 1}
@@ -2446,7 +2446,7 @@ template <typename InputIterator1,
  *  int keys_result[6];
  *  int vals_result[6];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
+ *  cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
  * B_keys, B_keys + 5, A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {8, 7, 6, 5, 4, 0}
  *  // vals_result is now {1, 0, 0, 1, 0, 0}
@@ -2557,7 +2557,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmet
  *  int keys_result[6];
  *  int vals_result[6];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
+ *  cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
  * A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {8, 7, 6, 5, 4, 0}
  *  // vals_result is now {1, 0, 0, 1, 0, 0}
@@ -2666,7 +2666,7 @@ template <typename InputIterator1,
  *  int keys_result[11];
  *  int vals_result[11];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
+ *  cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
  * B_keys, B_keys + 5, A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12}
  *  // vals_result is now {0, 1, 0, 1, 0, 1, 0, 1, 0, 1,  0,  0}
@@ -2769,7 +2769,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_
  *  int keys_result[11];
  *  int vals_result[11];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
+ *  cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
  * A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12}
  *  // vals_result is now {0, 1, 0, 1, 0, 1, 0, 1, 0, 1,  0,  0}
@@ -2880,7 +2880,7 @@ template <typename InputIterator1,
  *  int keys_result[11];
  *  int vals_result[11];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
+ *  cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
  * B_keys, B_keys + 5, A_vals, B_vals, keys_result, vals_result, ::cuda::std::greater<int>());
  *  // keys_result is now {12, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
  *  // vals_result is now { 0,  1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}
@@ -2989,7 +2989,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_
  *  int keys_result[11];
  *  int vals_result[11];
  *
- *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
+ *  cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
  * A_vals, B_vals, keys_result, vals_result, ::cuda::std::greater<int>());
  *  // keys_result is now {12, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
  *  // vals_result is now { 0,  1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}

--- a/thrust/thrust/set_operations.h
+++ b/thrust/thrust/set_operations.h
@@ -30,7 +30,8 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/detail/execution_policy.h>
-#include <thrust/pair.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -1372,8 +1373,8 @@ OutputIterator set_union(
  *  int keys_result[3];
  *  int vals_result[3];
  *
- *  thrust::pair<int*,int*> end = thrust::set_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys + 5,
- * A_vals, B_vals, keys_result, vals_result);
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys +
+ * 5, A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 4, 6}
  *  // vals_result is now {0, 0, 0}
  *  \endcode
@@ -1391,7 +1392,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -1474,8 +1475,8 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_
  *  int keys_result[3];
  *  int vals_result[3];
  *
- *  thrust::pair<int*,int*> end = thrust::set_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5, A_vals, B_vals,
- * keys_result, vals_result);
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5, A_vals,
+ * B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 4, 6}
  *  // vals_result is now {0, 0, 0}
  *  \endcode
@@ -1492,7 +1493,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -1584,8 +1585,8 @@ thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
  *  int keys_result[3];
  *  int vals_result[3];
  *
- *  thrust::pair<int*,int*> end = thrust::set_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys + 5,
- * A_vals, B_vals, keys_result, vals_result, ::cuda::std::greater<int>());
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys +
+ * 5, A_vals, B_vals, keys_result, vals_result, ::cuda::std::greater<int>());
  *  // keys_result is now {0, 4, 6}
  *  // vals_result is now {0, 0, 0}
  *  \endcode
@@ -1604,7 +1605,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -1692,8 +1693,8 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_
  *  int keys_result[3];
  *  int vals_result[3];
  *
- *  thrust::pair<int*,int*> end = thrust::set_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5, A_vals, B_vals,
- * keys_result, vals_result, ::cuda::std::greater<int>());
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5, A_vals,
+ * B_vals, keys_result, vals_result, ::cuda::std::greater<int>());
  *  // keys_result is now {0, 4, 6}
  *  // vals_result is now {0, 0, 0}
  *  \endcode
@@ -1711,7 +1712,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -1800,8 +1801,8 @@ thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
  *  int keys_result[7];
  *  int vals_result[7];
  *
- *  thrust::pair<int*,int*> end = thrust::set_intersection_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys + 7,
- * A_vals, keys_result, vals_result);
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys
+ * + 7, A_vals, keys_result, vals_result);
  *
  *  // keys_result is now {1, 3, 5}
  *  // vals_result is now {0, 0, 0}
@@ -1819,7 +1820,7 @@ template <typename DerivedPolicy,
           typename InputIterator3,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -1901,7 +1902,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersectio
  *  int keys_result[7];
  *  int vals_result[7];
  *
- *  thrust::pair<int*,int*> end = thrust::set_intersection_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals,
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals,
  * keys_result, vals_result);
  *
  *  // keys_result is now {1, 3, 5}
@@ -1919,7 +1920,7 @@ template <typename InputIterator1,
           typename InputIterator3,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -2010,8 +2011,8 @@ thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
  *  int keys_result[7];
  *  int vals_result[7];
  *
- *  thrust::pair<int*,int*> end = thrust::set_intersection_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys + 7,
- * A_vals, keys_result, vals_result, ::cuda::std::greater<int>());
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(thrust::host, A_keys, A_keys + 6, B_keys, B_keys
+ * + 7, A_vals, keys_result, vals_result, ::cuda::std::greater<int>());
  *
  *  // keys_result is now {5, 3, 1}
  *  // vals_result is now {0, 0, 0}
@@ -2030,7 +2031,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -2117,7 +2118,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersectio
  *  int keys_result[7];
  *  int vals_result[7];
  *
- *  thrust::pair<int*,int*> end = thrust::set_intersection_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals,
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_intersection_by_key(A_keys, A_keys + 6, B_keys, B_keys + 7, A_vals,
  * keys_result, vals_result, ::cuda::std::greater<int>());
  *
  *  // keys_result is now {5, 3, 1}
@@ -2136,7 +2137,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -2227,8 +2228,8 @@ thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
  *  int keys_result[6];
  *  int vals_result[6];
  *
- *  thrust::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys,
- * B_keys + 5, A_vals, B_vals, keys_result, vals_result);
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
+ * B_keys, B_keys + 5, A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 4, 5, 6, 7, 8}
  *  // vals_result is now {0, 0, 1, 0, 0, 1}
  *  \endcode
@@ -2246,7 +2247,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -2332,7 +2333,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_d
  *  int keys_result[6];
  *  int vals_result[6];
  *
- *  thrust::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
  * A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 4, 5, 6, 7, 8}
  *  // vals_result is now {0, 0, 1, 0, 0, 1}
@@ -2350,7 +2351,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -2445,8 +2446,8 @@ thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
  *  int keys_result[6];
  *  int vals_result[6];
  *
- *  thrust::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys,
- * B_keys + 5, A_vals, B_vals, keys_result, vals_result);
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
+ * B_keys, B_keys + 5, A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {8, 7, 6, 5, 4, 0}
  *  // vals_result is now {1, 0, 0, 1, 0, 0}
  *  \endcode
@@ -2465,7 +2466,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -2556,7 +2557,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_d
  *  int keys_result[6];
  *  int vals_result[6];
  *
- *  thrust::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
  * A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {8, 7, 6, 5, 4, 0}
  *  // vals_result is now {1, 0, 0, 1, 0, 0}
@@ -2575,7 +2576,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -2665,8 +2666,8 @@ thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
  *  int keys_result[11];
  *  int vals_result[11];
  *
- *  thrust::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys,
- * B_keys + 5, A_vals, B_vals, keys_result, vals_result);
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
+ * B_keys, B_keys + 5, A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12}
  *  // vals_result is now {0, 1, 0, 1, 0, 1, 0, 1, 0, 1,  0,  0}
  *  \endcode
@@ -2684,7 +2685,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -2768,7 +2769,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_ke
  *  int keys_result[11];
  *  int vals_result[11];
  *
- *  thrust::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
  * A_vals, B_vals, keys_result, vals_result);
  *  // keys_result is now {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12}
  *  // vals_result is now {0, 1, 0, 1, 0, 1, 0, 1, 0, 1,  0,  0}
@@ -2786,7 +2787,7 @@ template <typename InputIterator1,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,
@@ -2879,8 +2880,8 @@ thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
  *  int keys_result[11];
  *  int vals_result[11];
  *
- *  thrust::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6, B_keys,
- * B_keys + 5, A_vals, B_vals, keys_result, vals_result, ::cuda::std::greater<int>());
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(thrust::host, A_keys, A_keys + 6,
+ * B_keys, B_keys + 5, A_vals, B_vals, keys_result, vals_result, ::cuda::std::greater<int>());
  *  // keys_result is now {12, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
  *  // vals_result is now { 0,  1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}
  *  \endcode
@@ -2899,7 +2900,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -2988,7 +2989,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_ke
  *  int keys_result[11];
  *  int vals_result[11];
  *
- *  thrust::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
+ *  :::cuda::std::pair<int*,int*> end = thrust::set_symmetric_difference_by_key(A_keys, A_keys + 6, B_keys, B_keys + 5,
  * A_vals, B_vals, keys_result, vals_result, ::cuda::std::greater<int>());
  *  // keys_result is now {12, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0}
  *  // vals_result is now { 0,  1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0}
@@ -3007,7 +3008,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakCompare>
-thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
   InputIterator2 keys_first2,

--- a/thrust/thrust/system/cuda/detail/extrema.h
+++ b/thrust/thrust/system/cuda/detail/extrema.h
@@ -46,12 +46,12 @@
 #  include <thrust/extrema.h>
 #  include <thrust/iterator/counting_iterator.h>
 #  include <thrust/iterator/transform_iterator.h>
-#  include <thrust/pair.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/reduce.h>
 
 #  include <cuda/std/__functional/operations.h>
 #  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__utility/pair.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
@@ -428,10 +428,10 @@ ItemsIt _CCCL_HOST_DEVICE max_element(execution_policy<Derived>& policy, ItemsIt
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class Derived, class ItemsIt, class BinaryPred>
-pair<ItemsIt, ItemsIt> _CCCL_HOST_DEVICE
+::cuda::std::pair<ItemsIt, ItemsIt> _CCCL_HOST_DEVICE
 minmax_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred)
 {
-  auto ret = thrust::make_pair(last, last);
+  auto ret = ::cuda::std::make_pair(last, last);
   if (first == last)
   {
     return ret;
@@ -455,14 +455,15 @@ minmax_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, B
      zip_iterator begin    = make_zip_iterator(iter_tuple);
      two_pairs_type result = __extrema::extrema(
        policy, transform_t(begin, duplicate_t()), num_items, arg_minmax_t(binary_pred), (two_pairs_type*) (nullptr));
-     ret = thrust::make_pair(first + get<1>(get<0>(result)), first + get<1>(get<1>(result)));),
+     ret = ::cuda::std::make_pair(first + get<1>(get<0>(result)), first + get<1>(get<1>(result)));),
     // CDP Sequential impl:
     (ret = thrust::minmax_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);));
   return ret;
 }
 
 template <class Derived, class ItemsIt>
-pair<ItemsIt, ItemsIt> _CCCL_HOST_DEVICE minmax_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
+::cuda::std::pair<ItemsIt, ItemsIt> _CCCL_HOST_DEVICE
+minmax_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
 {
   using value_type = thrust::detail::it_value_t<ItemsIt>;
   return cuda_cub::minmax_element(policy, first, last, ::cuda::std::less<value_type>());

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -18,12 +18,12 @@
 
 #  include <thrust/detail/temporary_array.h>
 #  include <thrust/iterator/iterator_traits.h>
-#  include <thrust/pair.h>
 #  include <thrust/system/cuda/detail/dispatch.h>
 #  include <thrust/system/cuda/detail/util.h>
 
 #  include <cuda/std/__functional/operations.h>
 #  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__utility/pair.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
@@ -115,7 +115,7 @@ template <class Derived,
           class KeysOutputIt,
           class ItemsOutputIt,
           class CompareOp = ::cuda::std::less<>>
-pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE merge_by_key(
+::cuda::std::pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE merge_by_key(
   execution_policy<Derived>& policy,
   KeysIt1 keys1_begin,
   KeysIt1 keys1_end,

--- a/thrust/thrust/system/cuda/detail/mismatch.h
+++ b/thrust/thrust/system/cuda/detail/mismatch.h
@@ -39,22 +39,22 @@
 #if _CCCL_HAS_CUDA_COMPILER()
 #  include <thrust/system/cuda/config.h>
 
-#  include <thrust/pair.h>
 #  include <thrust/system/cuda/detail/execution_policy.h>
 
 #  include <cuda/__iterator/zip_function.h>
 #  include <cuda/__iterator/zip_iterator.h>
 #  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
 template <class Derived, class InputIt1, class InputIt2, class BinaryPred>
-pair<InputIt1, InputIt2> _CCCL_HOST_DEVICE
+::cuda::std::pair<InputIt1, InputIt2> _CCCL_HOST_DEVICE
 mismatch(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, InputIt2 first2, BinaryPred binary_pred);
 
 template <class Derived, class InputIt1, class InputIt2>
-pair<InputIt1, InputIt2> _CCCL_HOST_DEVICE
+::cuda::std::pair<InputIt1, InputIt2> _CCCL_HOST_DEVICE
 mismatch(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, InputIt2 first2);
 } // namespace cuda_cub
 THRUST_NAMESPACE_END
@@ -65,7 +65,7 @@ THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
 template <class Derived, class InputIt1, class InputIt2, class BinaryPred>
-pair<InputIt1, InputIt2> _CCCL_HOST_DEVICE
+::cuda::std::pair<InputIt1, InputIt2> _CCCL_HOST_DEVICE
 mismatch(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, InputIt2 first2, BinaryPred binary_pred)
 {
   const auto n            = ::cuda::std::distance(first1, last1);
@@ -73,11 +73,11 @@ mismatch(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, Inp
   const auto last         = ::cuda::make_zip_iterator(last1, first2 + n);
   const auto mismatch_pos = cuda_cub::find_if_not(policy, first, last, ::cuda::zip_function(binary_pred));
   const auto dist         = ::cuda::std::distance(first, mismatch_pos);
-  return thrust::make_pair(first1 + dist, first2 + dist);
+  return ::cuda::std::make_pair(first1 + dist, first2 + dist);
 }
 
 template <class Derived, class InputIt1, class InputIt2>
-pair<InputIt1, InputIt2> _CCCL_HOST_DEVICE
+::cuda::std::pair<InputIt1, InputIt2> _CCCL_HOST_DEVICE
 mismatch(execution_policy<Derived>& policy, InputIt1 first1, InputIt1 last1, InputIt2 first2)
 {
   using InputType1 = thrust::detail::it_value_t<InputIt1>;

--- a/thrust/thrust/system/cuda/detail/partition.h
+++ b/thrust/thrust/system/cuda/detail/partition.h
@@ -45,7 +45,6 @@
 #  include <cub/util_math.cuh>
 
 #  include <thrust/detail/temporary_array.h>
-#  include <thrust/pair.h>
 #  include <thrust/partition.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/execution_policy.h>
@@ -55,6 +54,7 @@
 #  include <thrust/system/cuda/detail/util.h>
 
 #  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__utility/pair.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
@@ -208,7 +208,7 @@ template <typename Derived,
           typename SelectedOutIt,
           typename RejectedOutIt,
           typename Predicate>
-THRUST_RUNTIME_FUNCTION pair<SelectedOutIt, RejectedOutIt> stable_partition_copy(
+THRUST_RUNTIME_FUNCTION ::cuda::std::pair<SelectedOutIt, RejectedOutIt> stable_partition_copy(
   execution_policy<Derived>& policy,
   InputIt first,
   InputIt last,
@@ -219,14 +219,14 @@ THRUST_RUNTIME_FUNCTION pair<SelectedOutIt, RejectedOutIt> stable_partition_copy
 {
   if (::cuda::std::distance(first, last) <= 0)
   {
-    return thrust::make_pair(selected_result, rejected_result);
+    return ::cuda::std::make_pair(selected_result, rejected_result);
   }
 
   using output_it_wrapper_t = cub::detail::select::partition_distinct_output_t<SelectedOutIt, RejectedOutIt>;
   std::size_t num_items     = static_cast<std::size_t>(::cuda::std::distance(first, last));
   std::size_t num_selected =
     partition(policy, first, last, stencil, output_it_wrapper_t{selected_result, rejected_result}, predicate);
-  return thrust::make_pair(selected_result + num_selected, rejected_result + num_items - num_selected);
+  return ::cuda::std::make_pair(selected_result + num_selected, rejected_result + num_items - num_selected);
 }
 
 template <typename Derived, typename InputIt, typename StencilIt, typename Predicate>
@@ -259,7 +259,7 @@ THRUST_RUNTIME_FUNCTION InputIt inplace_partition(
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class Derived, class InputIt, class StencilIt, class SelectedOutIt, class RejectedOutIt, class Predicate>
-pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE partition_copy(
+::cuda::std::pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE partition_copy(
   execution_policy<Derived>& policy,
   InputIt first,
   InputIt last,
@@ -268,7 +268,7 @@ pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE partition_copy(
   RejectedOutIt rejected_result,
   Predicate predicate)
 {
-  auto ret = thrust::make_pair(selected_result, rejected_result);
+  auto ret = ::cuda::std::make_pair(selected_result, rejected_result);
   THRUST_CDP_DISPATCH(
     (ret = detail::stable_partition_copy(policy, first, last, stencil, selected_result, rejected_result, predicate);),
     (ret = thrust::partition_copy(
@@ -278,7 +278,7 @@ pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE partition_copy(
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class Derived, class InputIt, class SelectedOutIt, class RejectedOutIt, class Predicate>
-pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE partition_copy(
+::cuda::std::pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE partition_copy(
   execution_policy<Derived>& policy,
   InputIt first,
   InputIt last,
@@ -286,7 +286,7 @@ pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE partition_copy(
   RejectedOutIt rejected_result,
   Predicate predicate)
 {
-  auto ret = thrust::make_pair(selected_result, rejected_result);
+  auto ret = ::cuda::std::make_pair(selected_result, rejected_result);
   THRUST_CDP_DISPATCH(
     (ret = detail::stable_partition_copy(
        policy, first, last, static_cast<cub::NullType*>(nullptr), selected_result, rejected_result, predicate);),
@@ -297,7 +297,7 @@ pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE partition_copy(
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class Derived, class InputIt, class StencilIt, class SelectedOutIt, class RejectedOutIt, class Predicate>
-pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE stable_partition_copy(
+::cuda::std::pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE stable_partition_copy(
   execution_policy<Derived>& policy,
   InputIt first,
   InputIt last,
@@ -306,7 +306,7 @@ pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE stable_partition_copy(
   RejectedOutIt rejected_result,
   Predicate predicate)
 {
-  auto ret = thrust::make_pair(selected_result, rejected_result);
+  auto ret = ::cuda::std::make_pair(selected_result, rejected_result);
   THRUST_CDP_DISPATCH(
     (ret = detail::stable_partition_copy(policy, first, last, stencil, selected_result, rejected_result, predicate);),
     (ret = thrust::stable_partition_copy(
@@ -316,7 +316,7 @@ pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE stable_partition_copy(
 
 _CCCL_EXEC_CHECK_DISABLE
 template <class Derived, class InputIt, class SelectedOutIt, class RejectedOutIt, class Predicate>
-pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE stable_partition_copy(
+::cuda::std::pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE stable_partition_copy(
   execution_policy<Derived>& policy,
   InputIt first,
   InputIt last,
@@ -324,7 +324,7 @@ pair<SelectedOutIt, RejectedOutIt> _CCCL_HOST_DEVICE stable_partition_copy(
   RejectedOutIt rejected_result,
   Predicate predicate)
 {
-  auto ret = thrust::make_pair(selected_result, rejected_result);
+  auto ret = ::cuda::std::make_pair(selected_result, rejected_result);
   THRUST_CDP_DISPATCH(
     (ret = detail::stable_partition_copy(
        policy, first, last, static_cast<cub::NullType*>(nullptr), selected_result, rejected_result, predicate);),

--- a/thrust/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/thrust/system/cuda/detail/reduce_by_key.h
@@ -51,7 +51,6 @@
 #  include <thrust/detail/type_traits.h>
 #  include <thrust/detail/type_traits/iterator/is_output_iterator.h>
 #  include <thrust/functional.h>
-#  include <thrust/pair.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/core/agent_launcher.h>
 #  include <thrust/system/cuda/detail/execution_policy.h>
@@ -65,6 +64,7 @@
 #  include <cuda/std/__type_traits/conditional.h>
 #  include <cuda/std/__type_traits/is_arithmetic.h>
 #  include <cuda/std/__type_traits/is_same.h>
+#  include <cuda/std/__utility/pair.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
@@ -75,7 +75,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -800,7 +800,7 @@ template <typename Size,
           typename ValuesOutputIt,
           typename EqualityOp,
           typename ReductionOp>
-THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ValuesOutputIt> reduce_by_key_dispatch(
+THRUST_RUNTIME_FUNCTION ::cuda::std::pair<KeysOutputIt, ValuesOutputIt> reduce_by_key_dispatch(
   execution_policy<Derived>& policy,
   KeysInputIt keys_first,
   Size num_items,
@@ -815,7 +815,7 @@ THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ValuesOutputIt> reduce_by_key_dispatc
 
   if (num_items == 0)
   {
-    return thrust::make_pair(keys_output, values_output);
+    return ::cuda::std::make_pair(keys_output, values_output);
   }
 
   cudaError_t status;
@@ -868,7 +868,7 @@ THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ValuesOutputIt> reduce_by_key_dispatc
 
   const auto num_runs_out = cuda_cub::get_value(policy, d_num_runs_out);
 
-  return thrust::make_pair(keys_output + num_runs_out, values_output + num_runs_out);
+  return ::cuda::std::make_pair(keys_output + num_runs_out, values_output + num_runs_out);
 }
 
 template <typename Derived,
@@ -878,7 +878,7 @@ template <typename Derived,
           typename ValuesOutputIt,
           typename EqualityOp,
           typename ReductionOp>
-THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ValuesOutputIt> reduce_by_key(
+THRUST_RUNTIME_FUNCTION ::cuda::std::pair<KeysOutputIt, ValuesOutputIt> reduce_by_key(
   execution_policy<Derived>& policy,
   KeysInputIt keys_first,
   KeysInputIt keys_last,
@@ -892,7 +892,7 @@ THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ValuesOutputIt> reduce_by_key(
 
   size_type num_items = ::cuda::std::distance(keys_first, keys_last);
 
-  pair<KeysOutputIt, ValuesOutputIt> result = thrust::make_pair(keys_output, values_output);
+  ::cuda::std::pair<KeysOutputIt, ValuesOutputIt> result = ::cuda::std::make_pair(keys_output, values_output);
 
   if (num_items == 0)
   {
@@ -921,7 +921,7 @@ template <class Derived,
           class ValOutputIt,
           class BinaryPred,
           class BinaryOp>
-pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
+::cuda::std::pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
   execution_policy<Derived>& policy,
   KeyInputIt keys_first,
   KeyInputIt keys_last,
@@ -931,7 +931,7 @@ pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
   BinaryPred binary_pred,
   BinaryOp binary_op)
 {
-  auto ret = thrust::make_pair(keys_output, values_output);
+  auto ret = ::cuda::std::make_pair(keys_output, values_output);
   THRUST_CDP_DISPATCH(
     (ret = __reduce_by_key::reduce_by_key(
        policy, keys_first, keys_last, values_first, keys_output, values_output, binary_pred, binary_op);),
@@ -948,7 +948,7 @@ pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
 }
 
 template <class Derived, class KeyInputIt, class ValInputIt, class KeyOutputIt, class ValOutputIt, class BinaryPred>
-pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
+::cuda::std::pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
   execution_policy<Derived>& policy,
   KeyInputIt keys_first,
   KeyInputIt keys_last,
@@ -972,7 +972,7 @@ pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
 }
 
 template <class Derived, class KeyInputIt, class ValInputIt, class KeyOutputIt, class ValOutputIt>
-pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
+::cuda::std::pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE reduce_by_key(
   execution_policy<Derived>& policy,
   KeyInputIt keys_first,
   KeyInputIt keys_last,

--- a/thrust/thrust/system/cuda/detail/set_operations.h
+++ b/thrust/thrust/system/cuda/detail/set_operations.h
@@ -44,7 +44,6 @@
 #  include <thrust/detail/alignment.h>
 #  include <thrust/detail/temporary_array.h>
 #  include <thrust/extrema.h>
-#  include <thrust/pair.h>
 #  include <thrust/set_operations.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/core/agent_launcher.h>
@@ -57,6 +56,7 @@
 #  include <cuda/std/__bit/popcount.h>
 #  include <cuda/std/__functional/operations.h>
 #  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__utility/pair.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
@@ -153,7 +153,7 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE Size merge_path(It1 a, Size aCount, It2 b, Si
 }
 
 template <class It1, class It2, class Size, class Size2, class CompareOp>
-_CCCL_DEVICE_API _CCCL_FORCEINLINE pair<Size, Size>
+_CCCL_DEVICE_API _CCCL_FORCEINLINE ::cuda::std::pair<Size, Size>
 balanced_path(It1 keys1, It2 keys2, Size num_keys1, Size num_keys2, Size diag, Size2 levels, CompareOp compare_op)
 {
   using T = thrust::detail::it_value_t<It1>;
@@ -195,7 +195,7 @@ balanced_path(It1 keys1, It2 keys2, Size num_keys1, Size num_keys2, Size diag, S
 
     index1 = start1 + advance1;
   }
-  return thrust::make_pair(index1, (diag - index1) + star);
+  return ::cuda::std::make_pair(index1, (diag - index1) + star);
 } // func balanced_path
 
 template <int _BLOCK_THREADS,
@@ -362,7 +362,7 @@ struct SetOpAgent
     ValuesOutputIt values_out;
     CompareOp compare_op;
     SetOp set_op;
-    pair<Size, Size>* partitions;
+    ::cuda::std::pair<Size, Size>* partitions;
     std::size_t* output_count;
 
     //---------------------------------------------------------------------
@@ -469,8 +469,8 @@ struct SetOpAgent
     {
       using core::detail::uninitialized_array;
 
-      pair<Size, Size> partition_beg = partitions[tile_idx + 0];
-      pair<Size, Size> partition_end = partitions[tile_idx + 1];
+      ::cuda::std::pair<Size, Size> partition_beg = partitions[tile_idx + 0];
+      ::cuda::std::pair<Size, Size> partition_end = partitions[tile_idx + 1];
 
       Size keys1_beg = partition_beg.first;
       Size keys1_end = partition_end.first;
@@ -493,7 +493,7 @@ struct SetOpAgent
 
       int diag_loc = min<int>(ITEMS_PER_THREAD * threadIdx.x, num_keys1 + num_keys2);
 
-      pair<int, int> partition_loc = balanced_path(
+      ::cuda::std::pair<int, int> partition_loc = balanced_path(
         &storage.load_storage.keys_shared[0],
         &storage.load_storage.keys_shared[num_keys1],
         num_keys1,
@@ -514,7 +514,7 @@ struct SetOpAgent
 
       __syncthreads();
 
-      pair<int, int> partition1_loc = thrust::make_pair(
+      ::cuda::std::pair<int, int> partition1_loc = ::cuda::std::make_pair(
         storage.load_storage.offset[threadIdx.x] >> 16, storage.load_storage.offset[threadIdx.x] & 0xFFFF);
 
       int keys1_end_loc = partition1_loc.first;
@@ -639,7 +639,7 @@ struct SetOpAgent
       ValuesOutputIt values_out_,
       CompareOp compare_op_,
       SetOp set_op_,
-      pair<Size, Size>* partitions_,
+      ::cuda::std::pair<Size, Size>* partitions_,
       std::size_t* output_count_)
         : storage(storage_)
         , tile_state(tile_state_)
@@ -685,7 +685,7 @@ struct SetOpAgent
     ValuesOutputIt values_output,
     CompareOp compare_op,
     SetOp set_op,
-    pair<Size, Size>* partitions,
+    ::cuda::std::pair<Size, Size>* partitions,
     std::size_t* output_count,
     ScanTileState tile_state,
     char* shmem)
@@ -728,7 +728,7 @@ struct PartitionAgent
     Size keys1_count,
     Size keys2_count,
     Size num_partitions,
-    pair<Size, Size>* partitions,
+    ::cuda::std::pair<Size, Size>* partitions,
     CompareOp compare_op,
     int items_per_tile,
     char* /*shmem*/)
@@ -736,8 +736,9 @@ struct PartitionAgent
     Size partition_idx = blockDim.x * blockIdx.x + threadIdx.x;
     if (partition_idx < num_partitions)
     {
-      Size partition_at         = min<Size>(partition_idx * items_per_tile, keys1_count + keys2_count);
-      pair<Size, Size> diag     = balanced_path(keys1, keys2, keys1_count, keys2_count, partition_at, 4ll, compare_op);
+      Size partition_at = min<Size>(partition_idx * items_per_tile, keys1_count + keys2_count);
+      ::cuda::std::pair<Size, Size> diag =
+        balanced_path(keys1, keys2, keys1_count, keys2_count, partition_at, 4ll, compare_op);
       partitions[partition_idx] = diag;
     }
   }
@@ -1081,8 +1082,8 @@ cudaError_t THRUST_RUNTIME_FUNCTION doit_step(
   status = tile_state.Init(static_cast<int>(num_tiles), allocations[0], allocation_sizes[0]);
   _CUDA_CUB_RET_IF_FAIL(status);
 
-  pair<Size, Size>* partitions = (pair<Size, Size>*) allocations[1];
-  char* vshmem_ptr             = vshmem_storage > 0 ? (char*) allocations[2] : nullptr;
+  ::cuda::std::pair<Size, Size>* partitions = (::cuda::std::pair<Size, Size>*) allocations[1];
+  char* vshmem_ptr                          = vshmem_storage > 0 ? (char*) allocations[2] : nullptr;
 
   init_agent ia(init_plan, num_tiles, stream, "set_op::init_agent");
   ia.launch(tile_state, num_tiles);
@@ -1122,7 +1123,7 @@ template <typename HAS_VALUES,
           typename ValuesOutputIt,
           typename CompareOp,
           typename SetOp>
-THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ValuesOutputIt> set_operations(
+THRUST_RUNTIME_FUNCTION ::cuda::std::pair<KeysOutputIt, ValuesOutputIt> set_operations(
   execution_policy<Derived>& policy,
   KeysIt1 keys1_first,
   KeysIt1 keys1_last,
@@ -1142,7 +1143,7 @@ THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ValuesOutputIt> set_operations(
 
   if (num_keys1 + num_keys2 == 0)
   {
-    return thrust::make_pair(keys_output, values_output);
+    return ::cuda::std::make_pair(keys_output, values_output);
   }
 
   size_t temp_storage_bytes = 0;
@@ -1213,7 +1214,7 @@ THRUST_RUNTIME_FUNCTION pair<KeysOutputIt, ValuesOutputIt> set_operations(
 
   std::size_t output_count = cuda_cub::get_value(policy, d_output_count);
 
-  return thrust::make_pair(keys_output + output_count, values_output + output_count);
+  return ::cuda::std::make_pair(keys_output + output_count, values_output + output_count);
 }
 } // namespace __set_operations
 
@@ -1424,7 +1425,7 @@ template <class Derived,
           class KeysOutputIt,
           class ItemsOutputIt,
           class CompareOp>
-pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_difference_by_key(
+::cuda::std::pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_difference_by_key(
   execution_policy<Derived>& policy,
   KeysIt1 keys1_first,
   KeysIt1 keys1_last,
@@ -1436,7 +1437,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_difference_by_key(
   ItemsOutputIt items_result,
   CompareOp compare_op)
 {
-  auto ret = thrust::make_pair(keys_result, items_result);
+  auto ret = ::cuda::std::make_pair(keys_result, items_result);
   THRUST_CDP_DISPATCH(
     (ret = __set_operations::set_operations<thrust::detail::true_type>(
        policy,
@@ -1465,7 +1466,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_difference_by_key(
 }
 
 template <class Derived, class KeysIt1, class KeysIt2, class ItemsIt1, class ItemsIt2, class KeysOutputIt, class ItemsOutputIt>
-pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_difference_by_key(
+::cuda::std::pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_difference_by_key(
   execution_policy<Derived>& policy,
   KeysIt1 keys1_first,
   KeysIt1 keys1_last,
@@ -1501,7 +1502,7 @@ template <class Derived,
           class KeysOutputIt,
           class ItemsOutputIt,
           class CompareOp>
-pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_intersection_by_key(
+::cuda::std::pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_intersection_by_key(
   execution_policy<Derived>& policy,
   KeysIt1 keys1_first,
   KeysIt1 keys1_last,
@@ -1512,7 +1513,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_intersection_by_key(
   ItemsOutputIt items_result,
   CompareOp compare_op)
 {
-  auto ret = thrust::make_pair(keys_result, items_result);
+  auto ret = ::cuda::std::make_pair(keys_result, items_result);
   THRUST_CDP_DISPATCH(
     (ret = __set_operations::set_operations<thrust::detail::true_type>(
        policy,
@@ -1540,7 +1541,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_intersection_by_key(
 }
 
 template <class Derived, class KeysIt1, class KeysIt2, class ItemsIt1, class ItemsIt2, class KeysOutputIt, class ItemsOutputIt>
-pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_intersection_by_key(
+::cuda::std::pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_intersection_by_key(
   execution_policy<Derived>& policy,
   KeysIt1 keys1_first,
   KeysIt1 keys1_last,
@@ -1574,7 +1575,7 @@ template <class Derived,
           class KeysOutputIt,
           class ItemsOutputIt,
           class CompareOp>
-pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_symmetric_difference_by_key(
+::cuda::std::pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_symmetric_difference_by_key(
   execution_policy<Derived>& policy,
   KeysIt1 keys1_first,
   KeysIt1 keys1_last,
@@ -1586,7 +1587,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_symmetric_difference_by_
   ItemsOutputIt items_result,
   CompareOp compare_op)
 {
-  auto ret = thrust::make_pair(keys_result, items_result);
+  auto ret = ::cuda::std::make_pair(keys_result, items_result);
   THRUST_CDP_DISPATCH(
     (ret = __set_operations::set_operations<thrust::detail::true_type>(
        policy,
@@ -1615,7 +1616,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_symmetric_difference_by_
 }
 
 template <class Derived, class KeysIt1, class KeysIt2, class ItemsIt1, class ItemsIt2, class KeysOutputIt, class ItemsOutputIt>
-pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_symmetric_difference_by_key(
+::cuda::std::pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_symmetric_difference_by_key(
   execution_policy<Derived>& policy,
   KeysIt1 keys1_first,
   KeysIt1 keys1_last,
@@ -1651,7 +1652,7 @@ template <class Derived,
           class KeysOutputIt,
           class ItemsOutputIt,
           class CompareOp>
-pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_union_by_key(
+::cuda::std::pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_union_by_key(
   execution_policy<Derived>& policy,
   KeysIt1 keys1_first,
   KeysIt1 keys1_last,
@@ -1663,7 +1664,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_union_by_key(
   ItemsOutputIt items_result,
   CompareOp compare_op)
 {
-  auto ret = thrust::make_pair(keys_result, items_result);
+  auto ret = ::cuda::std::make_pair(keys_result, items_result);
   THRUST_CDP_DISPATCH(
     (ret = __set_operations::set_operations<thrust::detail::true_type>(
        policy,
@@ -1692,7 +1693,7 @@ pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_union_by_key(
 }
 
 template <class Derived, class KeysIt1, class KeysIt2, class ItemsIt1, class ItemsIt2, class KeysOutputIt, class ItemsOutputIt>
-pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_union_by_key(
+::cuda::std::pair<KeysOutputIt, ItemsOutputIt> _CCCL_HOST_DEVICE set_union_by_key(
   execution_policy<Derived>& policy,
   KeysIt1 keys1_first,
   KeysIt1 keys1_last,

--- a/thrust/thrust/system/cuda/detail/temporary_buffer.h
+++ b/thrust/thrust/system/cuda/detail/temporary_buffer.h
@@ -58,7 +58,7 @@ _CCCL_HOST ::cuda::std::pair<T*, ::cuda::std::ptrdiff_t> get_temporary_buffer(pa
     }
   }
 
-  return make_pair(reinterpret_pointer_cast<T*>(ptr), n);
+  return ::cuda::std::make_pair(reinterpret_pointer_cast<T*>(ptr), n);
 }
 
 template <typename Pointer>
@@ -104,7 +104,7 @@ get_temporary_buffer(execute_on_stream_nosync& system, ::cuda::std::ptrdiff_t n)
     }
   }
 
-  return make_pair(reinterpret_pointer_cast<T*>(ptr), n);
+  return ::cuda::std::make_pair(reinterpret_pointer_cast<T*>(ptr), n);
 }
 
 template <typename Pointer>

--- a/thrust/thrust/system/cuda/detail/temporary_buffer.h
+++ b/thrust/thrust/system/cuda/detail/temporary_buffer.h
@@ -30,6 +30,8 @@
 #include <thrust/system/cuda/detail/execution_policy.h>
 #include <thrust/system/detail/bad_alloc.h>
 
+#include <cuda/std/__utility/pair.h>
+
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
@@ -37,7 +39,7 @@ namespace cuda_cub
 // overloads should be selected.
 
 template <typename T>
-_CCCL_HOST pair<T*, ::cuda::std::ptrdiff_t> get_temporary_buffer(par_nosync_t&, ::cuda::std::ptrdiff_t n)
+_CCCL_HOST ::cuda::std::pair<T*, ::cuda::std::ptrdiff_t> get_temporary_buffer(par_nosync_t&, ::cuda::std::ptrdiff_t n)
 {
   void* ptr;
   cudaError_t status = cudaMallocAsync(&ptr, sizeof(T) * n, nullptr);
@@ -82,7 +84,7 @@ _CCCL_HOST void return_temporary_buffer(par_nosync_t&, Pointer ptr, ::cuda::std:
 }
 
 template <typename T>
-_CCCL_HOST pair<T*, ::cuda::std::ptrdiff_t>
+_CCCL_HOST ::cuda::std::pair<T*, ::cuda::std::ptrdiff_t>
 get_temporary_buffer(execute_on_stream_nosync& system, ::cuda::std::ptrdiff_t n)
 {
   void* ptr;

--- a/thrust/thrust/system/cuda/detail/unique_by_key.h
+++ b/thrust/thrust/system/cuda/detail/unique_by_key.h
@@ -46,7 +46,6 @@
 #  include <thrust/detail/alignment.h>
 #  include <thrust/detail/temporary_array.h>
 #  include <thrust/functional.h>
-#  include <thrust/pair.h>
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/core/agent_launcher.h>
 #  include <thrust/system/cuda/detail/execution_policy.h>
@@ -55,12 +54,13 @@
 
 #  include <cuda/std/__functional/operations.h>
 #  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__utility/pair.h>
 #  include <cuda/std/cstdint>
 
 THRUST_NAMESPACE_BEGIN
 
 template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
@@ -70,7 +70,7 @@ template <typename DerivedPolicy,
           typename InputIterator2,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -101,7 +101,7 @@ struct DispatchUniqueByKey
     ValOutputIt values_out,
     OffsetT num_items,
     BinaryPred binary_pred,
-    pair<KeyOutputIt, ValOutputIt>& result_end)
+    ::cuda::std::pair<KeyOutputIt, ValOutputIt>& result_end)
   {
     cudaError_t status         = cudaSuccess;
     cudaStream_t stream        = cuda_cub::stream(policy);
@@ -134,7 +134,7 @@ struct DispatchUniqueByKey
     // Return for empty problems
     if (num_items == 0)
     {
-      result_end = thrust::make_pair(keys_out, values_out);
+      result_end = ::cuda::std::make_pair(keys_out, values_out);
       return status;
     }
 
@@ -160,7 +160,7 @@ struct DispatchUniqueByKey
     _CUDA_CUB_RET_IF_FAIL(status);
     OffsetT num_selected = get_value(policy, d_num_selected_out);
 
-    result_end = thrust::make_pair(keys_out + num_selected, values_out + num_selected);
+    result_end = ::cuda::std::make_pair(keys_out + num_selected, values_out + num_selected);
     return status;
   }
 };
@@ -171,7 +171,7 @@ template <typename Derived,
           typename KeyOutputIt,
           typename ValOutputIt,
           typename BinaryPred>
-THRUST_RUNTIME_FUNCTION pair<KeyOutputIt, ValOutputIt> unique_by_key(
+THRUST_RUNTIME_FUNCTION ::cuda::std::pair<KeyOutputIt, ValOutputIt> unique_by_key(
   execution_policy<Derived>& policy,
   KeyInputIt keys_first,
   KeyInputIt keys_last,
@@ -183,7 +183,7 @@ THRUST_RUNTIME_FUNCTION pair<KeyOutputIt, ValOutputIt> unique_by_key(
   using size_type = thrust::detail::it_difference_t<KeyInputIt>;
 
   size_type num_items = static_cast<size_type>(::cuda::std::distance(keys_first, keys_last));
-  pair<KeyOutputIt, ValOutputIt> result_end{};
+  ::cuda::std::pair<KeyOutputIt, ValOutputIt> result_end{};
   cudaError_t status        = cudaSuccess;
   size_t temp_storage_bytes = 0;
 
@@ -244,7 +244,7 @@ THRUST_RUNTIME_FUNCTION pair<KeyOutputIt, ValOutputIt> unique_by_key(
 //-------------------------
 _CCCL_EXEC_CHECK_DISABLE
 template <class Derived, class KeyInputIt, class ValInputIt, class KeyOutputIt, class ValOutputIt, class BinaryPred>
-pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE unique_by_key_copy(
+::cuda::std::pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE unique_by_key_copy(
   execution_policy<Derived>& policy,
   KeyInputIt keys_first,
   KeyInputIt keys_last,
@@ -253,7 +253,7 @@ pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE unique_by_key_copy(
   ValOutputIt values_result,
   BinaryPred binary_pred)
 {
-  auto ret = thrust::make_pair(keys_result, values_result);
+  auto ret = ::cuda::std::make_pair(keys_result, values_result);
   THRUST_CDP_DISPATCH(
     (ret = detail::unique_by_key(policy, keys_first, keys_last, values_first, keys_result, values_result, binary_pred);),
     (ret = thrust::unique_by_key_copy(
@@ -262,7 +262,7 @@ pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE unique_by_key_copy(
 }
 
 template <class Derived, class KeyInputIt, class ValInputIt, class KeyOutputIt, class ValOutputIt>
-pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE unique_by_key_copy(
+::cuda::std::pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE unique_by_key_copy(
   execution_policy<Derived>& policy,
   KeyInputIt keys_first,
   KeyInputIt keys_last,
@@ -276,14 +276,14 @@ pair<KeyOutputIt, ValOutputIt> _CCCL_HOST_DEVICE unique_by_key_copy(
 }
 
 template <class Derived, class KeyInputIt, class ValInputIt, class BinaryPred>
-pair<KeyInputIt, ValInputIt> _CCCL_HOST_DEVICE unique_by_key(
+::cuda::std::pair<KeyInputIt, ValInputIt> _CCCL_HOST_DEVICE unique_by_key(
   execution_policy<Derived>& policy,
   KeyInputIt keys_first,
   KeyInputIt keys_last,
   ValInputIt values_first,
   BinaryPred binary_pred)
 {
-  auto ret = thrust::make_pair(keys_first, values_first);
+  auto ret = ::cuda::std::make_pair(keys_first, values_first);
   THRUST_CDP_DISPATCH(
     (ret = cuda_cub::unique_by_key_copy(
        policy, keys_first, keys_last, values_first, keys_first, values_first, binary_pred);),
@@ -292,7 +292,7 @@ pair<KeyInputIt, ValInputIt> _CCCL_HOST_DEVICE unique_by_key(
 }
 
 template <class Derived, class KeyInputIt, class ValInputIt>
-pair<KeyInputIt, ValInputIt> _CCCL_HOST_DEVICE
+::cuda::std::pair<KeyInputIt, ValInputIt> _CCCL_HOST_DEVICE
 unique_by_key(execution_policy<Derived>& policy, KeyInputIt keys_first, KeyInputIt keys_last, ValInputIt values_first)
 {
   using key_type = thrust::detail::it_value_t<KeyInputIt>;

--- a/thrust/thrust/system/detail/generic/binary_search.h
+++ b/thrust/thrust/system/detail/generic/binary_search.h
@@ -140,14 +140,14 @@ _CCCL_HOST_DEVICE OutputIterator binary_search(
   StrictWeakOrdering comp);
 
 template <typename DerivedPolicy, typename ForwardIterator, typename LessThanComparable>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> equal_range(
   thrust::execution_policy<DerivedPolicy>& exec,
   ForwardIterator first,
   ForwardIterator last,
   const LessThanComparable& value);
 
 template <typename DerivedPolicy, typename ForwardIterator, typename LessThanComparable, typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> equal_range(
   thrust::execution_policy<DerivedPolicy>& exec,
   ForwardIterator first,
   ForwardIterator last,

--- a/thrust/thrust/system/detail/generic/binary_search.inl
+++ b/thrust/thrust/system/detail/generic/binary_search.inl
@@ -345,7 +345,7 @@ _CCCL_HOST_DEVICE OutputIterator binary_search(
 }
 
 template <typename DerivedPolicy, typename ForwardIterator, typename LessThanComparable>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> equal_range(
   thrust::execution_policy<DerivedPolicy>& exec,
   ForwardIterator first,
   ForwardIterator last,
@@ -355,7 +355,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
 }
 
 template <typename DerivedPolicy, typename ForwardIterator, typename T, typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> equal_range(
   thrust::execution_policy<DerivedPolicy>& exec,
   ForwardIterator first,
   ForwardIterator last,
@@ -364,7 +364,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> equal_range(
 {
   ForwardIterator lb = thrust::lower_bound(exec, first, last, value, comp);
   ForwardIterator ub = thrust::upper_bound(exec, first, last, value, comp);
-  return thrust::make_pair(lb, ub);
+  return ::cuda::std::make_pair(lb, ub);
 }
 } // namespace system::detail::generic
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/generic/extrema.h
+++ b/thrust/thrust/system/detail/generic/extrema.h
@@ -29,8 +29,9 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/tag.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
@@ -52,11 +53,11 @@ _CCCL_HOST_DEVICE ForwardIterator min_element(
   thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, BinaryPredicate comp);
 
 template <typename DerivedPolicy, typename ForwardIterator>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator>
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator>
 minmax_element(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last);
 
 template <typename DerivedPolicy, typename ForwardIterator, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_element(
   thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, BinaryPredicate comp);
 } // namespace system::detail::generic
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/generic/extrema.inl
+++ b/thrust/thrust/system/detail/generic/extrema.inl
@@ -31,9 +31,10 @@
 #include <thrust/iterator/counting_iterator.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/zip_iterator.h>
-#include <thrust/pair.h>
 #include <thrust/reduce.h>
 #include <thrust/transform_reduce.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
@@ -208,7 +209,7 @@ _CCCL_HOST_DEVICE ForwardIterator max_element(
 } // end max_element()
 
 template <typename DerivedPolicy, typename ForwardIterator>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator>
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator>
 minmax_element(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last)
 {
   using value_type = thrust::detail::it_value_t<ForwardIterator>;
@@ -217,12 +218,12 @@ minmax_element(thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator fi
 } // end minmax_element()
 
 template <typename DerivedPolicy, typename ForwardIterator, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_element(
   thrust::execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   if (first == last)
   {
-    return thrust::make_pair(last, last);
+    return ::cuda::std::make_pair(last, last);
   }
 
   using InputType = thrust::detail::it_value_t<ForwardIterator>;
@@ -238,8 +239,8 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
         thrust::tuple<InputType, IndexType>(thrust::detail::get_iterator_value(derived_cast(exec), first), 0)),
       detail::minmax_element_reduction<InputType, IndexType, BinaryPredicate>(comp));
 
-  return thrust::make_pair(first + thrust::get<1>(thrust::get<0>(result)),
-                           first + thrust::get<1>(thrust::get<1>(result)));
+  return ::cuda::std::make_pair(
+    first + thrust::get<1>(thrust::get<0>(result)), first + thrust::get<1>(thrust::get<1>(result)));
 } // end minmax_element()
 } // namespace system::detail::generic
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/generic/memory.h
+++ b/thrust/thrust/system/detail/generic/memory.h
@@ -33,8 +33,9 @@
 #include <thrust/detail/execution_policy.h>
 #include <thrust/detail/pointer.h>
 #include <thrust/detail/type_traits.h>
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/tag.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/system/detail/generic/memory.h
+++ b/thrust/thrust/system/detail/generic/memory.h
@@ -35,8 +35,6 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/system/detail/generic/tag.h>
 
-#include <cuda/std/__utility/pair.h>
-
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
 {

--- a/thrust/thrust/system/detail/generic/merge.h
+++ b/thrust/thrust/system/detail/generic/merge.h
@@ -62,7 +62,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Compare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -81,7 +81,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,

--- a/thrust/thrust/system/detail/generic/merge.inl
+++ b/thrust/thrust/system/detail/generic/merge.inl
@@ -74,7 +74,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Compare>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -108,7 +108,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
     thrust::merge(exec, zipped_first1, zipped_last1, zipped_first2, zipped_last2, zipped_result, comp_first)
       .get_iterator_tuple();
 
-  return thrust::make_pair(thrust::get<0>(result), thrust::get<1>(result));
+  return ::cuda::std::make_pair(thrust::get<0>(result), thrust::get<1>(result));
 } // end merge_by_key()
 
 template <typename DerivedPolicy,
@@ -118,7 +118,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,

--- a/thrust/thrust/system/detail/generic/mismatch.h
+++ b/thrust/thrust/system/detail/generic/mismatch.h
@@ -31,11 +31,11 @@ THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
 {
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
+_CCCL_HOST_DEVICE ::cuda::std::pair<InputIterator1, InputIterator2> mismatch(
   thrust::execution_policy<DerivedPolicy>& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2);
 
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
+_CCCL_HOST_DEVICE ::cuda::std::pair<InputIterator1, InputIterator2> mismatch(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 first1,
   InputIterator1 last1,

--- a/thrust/thrust/system/detail/generic/mismatch.inl
+++ b/thrust/thrust/system/detail/generic/mismatch.inl
@@ -34,7 +34,7 @@ THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
 {
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
+_CCCL_HOST_DEVICE ::cuda::std::pair<InputIterator1, InputIterator2> mismatch(
   thrust::execution_policy<DerivedPolicy>& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2)
 {
   using namespace thrust::placeholders;
@@ -43,7 +43,7 @@ _CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
 } // end mismatch()
 
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
+_CCCL_HOST_DEVICE ::cuda::std::pair<InputIterator1, InputIterator2> mismatch(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 first1,
   InputIterator1 last1,
@@ -60,7 +60,8 @@ _CCCL_HOST_DEVICE thrust::pair<InputIterator1, InputIterator2> mismatch(
   ZipIterator result =
     thrust::find_if_not(exec, zipped_first, zipped_last, thrust::detail::tuple_binary_predicate<BinaryPredicate>{pred});
 
-  return thrust::make_pair(thrust::get<0>(result.get_iterator_tuple()), thrust::get<1>(result.get_iterator_tuple()));
+  return ::cuda::std::make_pair(
+    thrust::get<0>(result.get_iterator_tuple()), thrust::get<1>(result.get_iterator_tuple()));
 } // end mismatch()
 } // namespace system::detail::generic
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/generic/partition.h
+++ b/thrust/thrust/system/detail/generic/partition.h
@@ -51,7 +51,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator first,
   InputIterator last,
@@ -65,7 +65,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 first,
   InputIterator1 last,
@@ -91,7 +91,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator first,
   InputIterator last,
@@ -105,7 +105,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 first,
   InputIterator1 last,

--- a/thrust/thrust/system/detail/generic/partition.inl
+++ b/thrust/thrust/system/detail/generic/partition.inl
@@ -31,7 +31,6 @@
 #include <thrust/detail/temporary_array.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/transform_iterator.h>
-#include <thrust/pair.h>
 #include <thrust/partition.h>
 #include <thrust/remove.h>
 #include <thrust/sort.h>
@@ -39,6 +38,7 @@
 
 #include <cuda/std/__functional/not_fn.h>
 #include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
@@ -92,7 +92,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator first,
   InputIterator last,
@@ -108,7 +108,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partitio
   // remove_copy_if the false partition to out_false
   OutputIterator2 end_of_false_partition = thrust::remove_copy_if(exec, first, last, out_false, pred);
 
-  return thrust::make_pair(end_of_true_partition, end_of_false_partition);
+  return ::cuda::std::make_pair(end_of_true_partition, end_of_false_partition);
 } // end stable_partition_copy()
 
 template <typename DerivedPolicy,
@@ -117,7 +117,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 first,
   InputIterator1 last,
@@ -134,7 +134,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partitio
   // remove_copy_if the false partition to out_false
   OutputIterator2 end_of_false_partition = thrust::remove_copy_if(exec, first, last, stencil, out_false, pred);
 
-  return thrust::make_pair(end_of_true_partition, end_of_false_partition);
+  return ::cuda::std::make_pair(end_of_true_partition, end_of_false_partition);
 } // end stable_partition_copy()
 
 template <typename DerivedPolicy, typename ForwardIterator, typename Predicate>
@@ -160,7 +160,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator first,
   InputIterator last,
@@ -177,7 +177,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> partition_copy(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 first,
   InputIterator1 last,

--- a/thrust/thrust/system/detail/generic/reduce_by_key.h
+++ b/thrust/thrust/system/detail/generic/reduce_by_key.h
@@ -36,7 +36,7 @@ template <typename DerivedPolicy,
           typename InputIterator2,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -50,7 +50,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -66,7 +66,7 @@ template <typename DerivedPolicy,
           typename OutputIterator2,
           typename BinaryPredicate,
           typename BinaryFunction>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,

--- a/thrust/thrust/system/detail/generic/reduce_by_key.inl
+++ b/thrust/thrust/system/detail/generic/reduce_by_key.inl
@@ -72,7 +72,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator2,
           typename BinaryPredicate,
           typename BinaryFunction>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -91,7 +91,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
 
   if (keys_first == keys_last)
   {
-    return thrust::make_pair(keys_output, values_output);
+    return ::cuda::std::make_pair(keys_output, values_output);
   }
 
   // input size
@@ -133,7 +133,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   thrust::scatter_if(
     exec, scanned_values.begin(), scanned_values.end(), scanned_tail_flags.begin(), tail_flags.begin(), values_output);
 
-  return thrust::make_pair(keys_output + N, values_output + N);
+  return ::cuda::std::make_pair(keys_output + N, values_output + N);
 } // end reduce_by_key()
 
 template <typename ExecutionPolicy,
@@ -141,7 +141,7 @@ template <typename ExecutionPolicy,
           typename InputIterator2,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -162,7 +162,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,

--- a/thrust/thrust/system/detail/generic/scalar/binary_search.h
+++ b/thrust/thrust/system/detail/generic/scalar/binary_search.h
@@ -25,7 +25,7 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -48,7 +48,7 @@ _CCCL_HOST_DEVICE RandomAccessIterator
 upper_bound(RandomAccessIterator first, RandomAccessIterator last, const T& val, BinaryPredicate comp);
 
 template <typename RandomAccessIterator, typename T, typename BinaryPredicate>
-_CCCL_HOST_DEVICE pair<RandomAccessIterator, RandomAccessIterator>
+_CCCL_HOST_DEVICE ::cuda::std::pair<RandomAccessIterator, RandomAccessIterator>
 equal_range(RandomAccessIterator first, RandomAccessIterator last, const T& val, BinaryPredicate comp);
 
 template <typename RandomAccessIterator, typename T, typename Compare>

--- a/thrust/thrust/system/detail/generic/scalar/binary_search.inl
+++ b/thrust/thrust/system/detail/generic/scalar/binary_search.inl
@@ -27,7 +27,8 @@
 #endif // no system header
 #include <thrust/detail/function.h>
 #include <thrust/iterator/iterator_traits.h>
-#include <thrust/pair.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -100,11 +101,11 @@ upper_bound(RandomAccessIterator first, RandomAccessIterator last, const T& val,
 }
 
 template <typename RandomAccessIterator, typename T, typename BinaryPredicate>
-_CCCL_HOST_DEVICE pair<RandomAccessIterator, RandomAccessIterator>
+_CCCL_HOST_DEVICE ::cuda::std::pair<RandomAccessIterator, RandomAccessIterator>
 equal_range(RandomAccessIterator first, RandomAccessIterator last, const T& val, BinaryPredicate comp)
 {
   RandomAccessIterator lb = thrust::system::detail::generic::scalar::lower_bound(first, last, val, comp);
-  return thrust::make_pair(lb, thrust::system::detail::generic::scalar::upper_bound(lb, last, val, comp));
+  return ::cuda::std::make_pair(lb, thrust::system::detail::generic::scalar::upper_bound(lb, last, val, comp));
 }
 
 template <typename RandomAccessIterator, typename T, typename Compare>

--- a/thrust/thrust/system/detail/generic/set_operations.h
+++ b/thrust/thrust/system/detail/generic/set_operations.h
@@ -25,8 +25,9 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/tag.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
@@ -62,7 +63,7 @@ template <typename ExecutionPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -81,7 +82,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -123,7 +124,7 @@ template <typename ExecutionPolicy,
           typename InputIterator3,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   thrust::execution_policy<ExecutionPolicy>& system,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -140,7 +141,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   thrust::execution_policy<ExecutionPolicy>& system,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -182,7 +183,7 @@ template <typename ExecutionPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   thrust::execution_policy<ExecutionPolicy>& system,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -201,7 +202,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   thrust::execution_policy<ExecutionPolicy>& system,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -244,7 +245,7 @@ template <typename ExecutionPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   thrust::execution_policy<ExecutionPolicy>& system,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -263,7 +264,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   thrust::execution_policy<ExecutionPolicy>& system,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,

--- a/thrust/thrust/system/detail/generic/set_operations.inl
+++ b/thrust/thrust/system/detail/generic/set_operations.inl
@@ -56,7 +56,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -89,7 +89,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_difference_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -123,7 +123,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_difference_
     thrust::set_difference(exec, zipped_first1, zipped_last1, zipped_first2, zipped_last2, zipped_result, comp_first)
       .get_iterator_tuple();
 
-  return thrust::make_pair(thrust::get<0>(result), thrust::get<1>(result));
+  return ::cuda::std::make_pair(thrust::get<0>(result), thrust::get<1>(result));
 } // end set_difference_by_key()
 
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2, typename OutputIterator>
@@ -145,7 +145,7 @@ template <typename DerivedPolicy,
           typename InputIterator3,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -175,7 +175,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_intersection_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -215,7 +215,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_intersectio
     thrust::set_intersection(exec, zipped_first1, zipped_last1, zipped_first2, zipped_last2, zipped_result, comp_first)
       .get_iterator_tuple();
 
-  return thrust::make_pair(thrust::get<0>(result), thrust::get<1>(result));
+  return ::cuda::std::make_pair(thrust::get<0>(result), thrust::get<1>(result));
 } // end set_intersection_by_key()
 
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2, typename OutputIterator>
@@ -238,7 +238,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -271,7 +271,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_symmetric_difference_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -306,7 +306,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_symmetric_d
       exec, zipped_first1, zipped_last1, zipped_first2, zipped_last2, zipped_result, comp_first)
       .get_iterator_tuple();
 
-  return thrust::make_pair(thrust::get<0>(result), thrust::get<1>(result));
+  return ::cuda::std::make_pair(thrust::get<0>(result), thrust::get<1>(result));
 } // end set_symmetric_difference_by_key()
 
 template <typename DerivedPolicy, typename InputIterator1, typename InputIterator2, typename OutputIterator>
@@ -329,7 +329,7 @@ template <typename DerivedPolicy,
           typename InputIterator4,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -362,7 +362,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> set_union_by_key(
   thrust::execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -396,7 +396,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> set_union_by_ke
     thrust::set_union(exec, zipped_first1, zipped_last1, zipped_first2, zipped_last2, zipped_result, comp_first)
       .get_iterator_tuple();
 
-  return thrust::make_pair(thrust::get<0>(result), thrust::get<1>(result));
+  return ::cuda::std::make_pair(thrust::get<0>(result), thrust::get<1>(result));
 } // end set_union_by_key()
 
 template <typename DerivedPolicy,

--- a/thrust/thrust/system/detail/generic/temporary_buffer.h
+++ b/thrust/thrust/system/detail/generic/temporary_buffer.h
@@ -26,15 +26,16 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/detail/pointer.h>
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/tag.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
 {
 template <typename T, typename DerivedPolicy>
-_CCCL_HOST_DEVICE
-thrust::pair<thrust::pointer<T, DerivedPolicy>, typename thrust::pointer<T, DerivedPolicy>::difference_type>
+_CCCL_HOST_DEVICE ::cuda::std::pair<thrust::pointer<T, DerivedPolicy>,
+                                    typename thrust::pointer<T, DerivedPolicy>::difference_type>
 get_temporary_buffer(thrust::execution_policy<DerivedPolicy>& exec,
                      typename thrust::pointer<T, DerivedPolicy>::difference_type n);
 

--- a/thrust/thrust/system/detail/generic/temporary_buffer.inl
+++ b/thrust/thrust/system/detail/generic/temporary_buffer.inl
@@ -27,15 +27,16 @@
 #endif // no system header
 #include <thrust/detail/malloc_and_free.h>
 #include <thrust/detail/pointer.h>
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/temporary_buffer.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
 {
 template <typename T, typename DerivedPolicy>
-_CCCL_HOST_DEVICE
-thrust::pair<thrust::pointer<T, DerivedPolicy>, typename thrust::pointer<T, DerivedPolicy>::difference_type>
+_CCCL_HOST_DEVICE ::cuda::std::pair<thrust::pointer<T, DerivedPolicy>,
+                                    typename thrust::pointer<T, DerivedPolicy>::difference_type>
 get_temporary_buffer(thrust::execution_policy<DerivedPolicy>& exec,
                      typename thrust::pointer<T, DerivedPolicy>::difference_type n)
 {
@@ -47,7 +48,7 @@ get_temporary_buffer(thrust::execution_policy<DerivedPolicy>& exec,
     n = 0;
   } // end if
 
-  return thrust::make_pair(ptr, n);
+  return ::cuda::std::make_pair(ptr, n);
 } // end get_temporary_buffer()
 
 _CCCL_EXEC_CHECK_DISABLE

--- a/thrust/thrust/system/detail/generic/unique_by_key.h
+++ b/thrust/thrust/system/detail/generic/unique_by_key.h
@@ -25,21 +25,22 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/tag.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
 {
 template <typename ExecutionPolicy, typename ForwardIterator1, typename ForwardIterator2>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   thrust::execution_policy<ExecutionPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
   ForwardIterator2 values_first);
 
 template <typename ExecutionPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   thrust::execution_policy<ExecutionPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
@@ -51,7 +52,7 @@ template <typename ExecutionPolicy,
           typename InputIterator2,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -65,7 +66,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,

--- a/thrust/thrust/system/detail/generic/unique_by_key.inl
+++ b/thrust/thrust/system/detail/generic/unique_by_key.inl
@@ -39,7 +39,7 @@ THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic
 {
 template <typename ExecutionPolicy, typename ForwardIterator1, typename ForwardIterator2>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   thrust::execution_policy<ExecutionPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
@@ -50,7 +50,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key
 } // end unique_by_key()
 
 template <typename ExecutionPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   thrust::execution_policy<ExecutionPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
@@ -73,7 +73,7 @@ template <typename ExecutionPolicy,
           typename InputIterator2,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -92,7 +92,7 @@ template <typename ExecutionPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   thrust::execution_policy<ExecutionPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -118,7 +118,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_c
 
   difference_type output_size = result - thrust::make_zip_iterator(keys_output, values_output);
 
-  return thrust::make_pair(keys_output + output_size, values_output + output_size);
+  return ::cuda::std::make_pair(keys_output + output_size, values_output + output_size);
 } // end unique_by_key_copy()
 } // namespace system::detail::generic
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/sequential/extrema.h
+++ b/thrust/thrust/system/detail/sequential/extrema.h
@@ -30,8 +30,9 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/detail/function.h>
-#include <thrust/pair.h>
 #include <thrust/system/detail/sequential/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::sequential
@@ -80,7 +81,7 @@ _CCCL_HOST_DEVICE ForwardIterator max_element(
 
 _CCCL_EXEC_CHECK_DISABLE
 template <typename DerivedPolicy, typename ForwardIterator, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator, ForwardIterator> minmax_element(
   sequential::execution_policy<DerivedPolicy>&, ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   // wrap comp
@@ -102,7 +103,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator, ForwardIterator> minmax_element(
     }
   }
 
-  return thrust::make_pair(imin, imax);
+  return ::cuda::std::make_pair(imin, imax);
 }
 } // namespace system::detail::sequential
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/sequential/merge.h
+++ b/thrust/thrust/system/detail/sequential/merge.h
@@ -83,7 +83,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   sequential::execution_policy<DerivedPolicy>&,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -141,7 +141,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
     ++values_result;
   }
 
-  return thrust::make_pair(keys_result, values_result);
+  return ::cuda::std::make_pair(keys_result, values_result);
 }
 } // namespace system::detail::sequential
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/sequential/partition.h
+++ b/thrust/thrust/system/detail/sequential/partition.h
@@ -31,8 +31,9 @@
 #endif // no system header
 #include <thrust/detail/function.h>
 #include <thrust/detail/temporary_array.h>
-#include <thrust/pair.h>
 #include <thrust/system/detail/sequential/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -230,7 +231,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   sequential::execution_policy<DerivedPolicy>&,
   InputIterator first,
   InputIterator last,
@@ -255,7 +256,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partitio
     } // end else
   }
 
-  return thrust::make_pair(out_true, out_false);
+  return ::cuda::std::make_pair(out_true, out_false);
 }
 
 _CCCL_EXEC_CHECK_DISABLE
@@ -265,7 +266,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   sequential::execution_policy<DerivedPolicy>&,
   InputIterator1 first,
   InputIterator1 last,
@@ -291,7 +292,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> stable_partitio
     } // end else
   }
 
-  return thrust::make_pair(out_true, out_false);
+  return ::cuda::std::make_pair(out_true, out_false);
 }
 } // namespace system::detail::sequential
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/sequential/reduce_by_key.h
+++ b/thrust/thrust/system/detail/sequential/reduce_by_key.h
@@ -26,8 +26,9 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/iterator/iterator_traits.h>
-#include <thrust/pair.h>
 #include <thrust/system/detail/sequential/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::sequential
@@ -40,7 +41,7 @@ template <typename DerivedPolicy,
           typename OutputIterator2,
           typename BinaryPredicate,
           typename BinaryFunction>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   sequential::execution_policy<DerivedPolicy>&,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -90,7 +91,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
     ++values_output;
   }
 
-  return thrust::make_pair(keys_output, values_output);
+  return ::cuda::std::make_pair(keys_output, values_output);
 }
 } // namespace system::detail::sequential
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/detail/sequential/unique.h
+++ b/thrust/thrust/system/detail/sequential/unique.h
@@ -32,8 +32,6 @@
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/detail/sequential/execution_policy.h>
 
-#include <cuda/std/__utility/pair.h>
-
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::sequential
 {

--- a/thrust/thrust/system/detail/sequential/unique.h
+++ b/thrust/thrust/system/detail/sequential/unique.h
@@ -30,8 +30,9 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/iterator/iterator_traits.h>
-#include <thrust/pair.h>
 #include <thrust/system/detail/sequential/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::sequential

--- a/thrust/thrust/system/detail/sequential/unique_by_key.h
+++ b/thrust/thrust/system/detail/sequential/unique_by_key.h
@@ -30,8 +30,9 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/iterator/iterator_traits.h>
-#include <thrust/pair.h>
 #include <thrust/system/detail/sequential/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::sequential
@@ -43,7 +44,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   sequential::execution_policy<DerivedPolicy>&,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -85,11 +86,11 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_c
     ++values_output;
   }
 
-  return thrust::make_pair(keys_output, values_output);
+  return ::cuda::std::make_pair(keys_output, values_output);
 } // end unique_by_key_copy()
 
 template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   sequential::execution_policy<DerivedPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,

--- a/thrust/thrust/system/omp/detail/extrema.h
+++ b/thrust/thrust/system/omp/detail/extrema.h
@@ -36,7 +36,7 @@ min_element(execution_policy<DerivedPolicy>& exec, ForwardIterator first, Forwar
 } // end min_element()
 
 template <typename DerivedPolicy, typename ForwardIterator, typename BinaryPredicate>
-thrust::pair<ForwardIterator, ForwardIterator>
+::cuda::std::pair<ForwardIterator, ForwardIterator>
 minmax_element(execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   // omp prefers generic::minmax_element to cpp::minmax_element

--- a/thrust/thrust/system/omp/detail/partition.h
+++ b/thrust/thrust/system/omp/detail/partition.h
@@ -17,9 +17,10 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/partition.h>
 #include <thrust/system/omp/detail/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::omp::detail
@@ -49,7 +50,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   execution_policy<DerivedPolicy>& exec,
   InputIterator first,
   InputIterator last,
@@ -67,7 +68,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   execution_policy<DerivedPolicy>& exec,
   InputIterator1 first,
   InputIterator1 last,

--- a/thrust/thrust/system/omp/detail/reduce_by_key.h
+++ b/thrust/thrust/system/omp/detail/reduce_by_key.h
@@ -30,7 +30,7 @@ template <typename DerivedPolicy,
           typename OutputIterator2,
           typename BinaryPredicate,
           typename BinaryFunction>
-thrust::pair<OutputIterator1, OutputIterator2> reduce_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_key(
   execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,

--- a/thrust/thrust/system/omp/detail/unique.h
+++ b/thrust/thrust/system/omp/detail/unique.h
@@ -13,9 +13,10 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/unique.h>
 #include <thrust/system/omp/detail/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::omp::detail

--- a/thrust/thrust/system/omp/detail/unique_by_key.h
+++ b/thrust/thrust/system/omp/detail/unique_by_key.h
@@ -13,15 +13,16 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/unique_by_key.h>
 #include <thrust/system/omp/detail/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::omp::detail
 {
 template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
-thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   execution_policy<DerivedPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
@@ -38,7 +39,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,

--- a/thrust/thrust/system/tbb/detail/extrema.h
+++ b/thrust/thrust/system/tbb/detail/extrema.h
@@ -35,7 +35,7 @@ min_element(execution_policy<DerivedPolicy>& exec, ForwardIterator first, Forwar
 } // end min_element()
 
 template <typename DerivedPolicy, typename ForwardIterator, typename BinaryPredicate>
-thrust::pair<ForwardIterator, ForwardIterator>
+::cuda::std::pair<ForwardIterator, ForwardIterator>
 minmax_element(execution_policy<DerivedPolicy>& exec, ForwardIterator first, ForwardIterator last, BinaryPredicate comp)
 {
   // tbb prefers generic::minmax_element to cpp::minmax_element

--- a/thrust/thrust/system/tbb/detail/merge.h
+++ b/thrust/thrust/system/tbb/detail/merge.h
@@ -263,7 +263,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename StrictWeakOrdering>
-thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
+::cuda::std::pair<OutputIterator1, OutputIterator2> merge_by_key(
   execution_policy<DerivedPolicy>&,
   InputIterator1 keys_first1,
   InputIterator1 keys_last1,
@@ -296,7 +296,7 @@ thrust::pair<OutputIterator1, OutputIterator2> merge_by_key(
   ::cuda::std::advance(values_result,
                        ::cuda::std::distance(keys_first1, keys_last1) + ::cuda::std::distance(keys_first2, keys_last2));
 
-  return thrust::make_pair(keys_result, values_result);
+  return ::cuda::std::make_pair(keys_result, values_result);
 }
 } // end namespace system::tbb::detail
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/tbb/detail/partition.h
+++ b/thrust/thrust/system/tbb/detail/partition.h
@@ -12,9 +12,10 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/partition.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::tbb::detail
@@ -44,7 +45,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   execution_policy<DerivedPolicy>& exec,
   InputIterator first,
   InputIterator last,
@@ -62,7 +63,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename Predicate>
-thrust::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> stable_partition_copy(
   execution_policy<DerivedPolicy>& exec,
   InputIterator1 first,
   InputIterator1 last,

--- a/thrust/thrust/system/tbb/detail/reduce_by_key.h
+++ b/thrust/thrust/system/tbb/detail/reduce_by_key.h
@@ -15,7 +15,6 @@
 #include <thrust/detail/range/tail_flags.h>
 #include <thrust/detail/seq.h>
 #include <thrust/detail/temporary_array.h>
-#include <thrust/pair.h>
 #include <thrust/scan.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
 #include <thrust/system/tbb/detail/reduce_intervals.h>
@@ -24,6 +23,7 @@
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__iterator/reverse_iterator.h>
 #include <cuda/std/__type_traits/void_t.h>
+#include <cuda/std/__utility/pair.h>
 #include <cuda/std/cassert>
 
 #include <thread>
@@ -49,9 +49,9 @@ struct partial_sum_type
 };
 
 template <typename InputIterator1, typename InputIterator2, typename BinaryPredicate, typename BinaryFunction>
-thrust::pair<InputIterator1,
-             thrust::pair<thrust::detail::it_value_t<InputIterator1>,
-                          typename partial_sum_type<InputIterator2, BinaryFunction>::type>>
+::cuda::std::pair<InputIterator1,
+                  ::cuda::std::pair<thrust::detail::it_value_t<InputIterator1>,
+                                    typename partial_sum_type<InputIterator2, BinaryFunction>::type>>
 reduce_last_segment_backward(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -76,7 +76,7 @@ reduce_last_segment_backward(
     result_value = binary_op(result_value, *values_first_r);
   }
 
-  return thrust::make_pair(keys_first_r.base(), thrust::make_pair(result_key, result_value));
+  return ::cuda::std::make_pair(keys_first_r.base(), ::cuda::std::make_pair(result_key, result_value));
 }
 
 template <typename InputIterator1,
@@ -100,8 +100,8 @@ reduce_by_key_with_carry(
 {
   // first, consume the last sequence to produce the carry
   // XXX is there an elegant way to pose this such that we don't need to default construct carry?
-  thrust::pair<thrust::detail::it_value_t<InputIterator1>,
-               typename partial_sum_type<InputIterator2, BinaryFunction>::type>
+  ::cuda::std::pair<thrust::detail::it_value_t<InputIterator1>,
+                    typename partial_sum_type<InputIterator2, BinaryFunction>::type>
     carry;
 
   thrust::tie(keys_last, carry) =
@@ -195,7 +195,7 @@ struct serial_reduce_by_key_body
     using value_type = typename partial_sum_type<Iterator2, BinaryFunction>::type;
 
     // XXX is there a way to pose this so that we don't require default construction of carry?
-    thrust::pair<key_type, value_type> carry;
+    ::cuda::std::pair<key_type, value_type> carry;
 
     thrust::tie(my_keys_result, my_values_result, carry.first, carry.second) = reduce_by_key_with_carry(
       my_keys_first, my_keys_last, my_values_first, my_keys_result, my_values_result, binary_pred, binary_op);
@@ -273,7 +273,7 @@ template <typename DerivedPolicy,
           typename Iterator4,
           typename BinaryPredicate,
           typename BinaryFunction>
-thrust::pair<Iterator3, Iterator4> reduce_by_key(
+::cuda::std::pair<Iterator3, Iterator4> reduce_by_key(
   thrust::tbb::execution_policy<DerivedPolicy>& exec,
   Iterator1 keys_first,
   Iterator1 keys_last,
@@ -287,7 +287,7 @@ thrust::pair<Iterator3, Iterator4> reduce_by_key(
   difference_type n     = keys_last - keys_first;
   if (n == 0)
   {
-    return thrust::make_pair(keys_result, values_result);
+    return ::cuda::std::make_pair(keys_result, values_result);
   }
 
   // XXX this value is a tuning opportunity
@@ -372,7 +372,7 @@ thrust::pair<Iterator3, Iterator4> reduce_by_key(
     }
   }
 
-  return thrust::make_pair(keys_result + size_of_result, values_result + size_of_result);
+  return ::cuda::std::make_pair(keys_result + size_of_result, values_result + size_of_result);
 }
 } // namespace system::tbb::detail
 THRUST_NAMESPACE_END

--- a/thrust/thrust/system/tbb/detail/unique.h
+++ b/thrust/thrust/system/tbb/detail/unique.h
@@ -15,8 +15,6 @@
 #include <thrust/system/detail/generic/unique.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
 
-#include <cuda/std/__utility/pair.h>
-
 THRUST_NAMESPACE_BEGIN
 namespace system::tbb::detail
 {

--- a/thrust/thrust/system/tbb/detail/unique.h
+++ b/thrust/thrust/system/tbb/detail/unique.h
@@ -12,9 +12,10 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/unique.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::tbb::detail

--- a/thrust/thrust/system/tbb/detail/unique_by_key.h
+++ b/thrust/thrust/system/tbb/detail/unique_by_key.h
@@ -12,15 +12,16 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
-#include <thrust/pair.h>
 #include <thrust/system/detail/generic/unique_by_key.h>
 #include <thrust/system/tbb/detail/execution_policy.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::tbb::detail
 {
 template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
-thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   execution_policy<DerivedPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
@@ -37,7 +38,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   execution_policy<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,

--- a/thrust/thrust/unique.h
+++ b/thrust/thrust/unique.h
@@ -467,7 +467,7 @@ OutputIterator unique_copy(InputIterator first, InputIterator last, OutputIterat
  *  int A[N] = {1, 3, 3, 3, 2, 2, 1}; // keys
  *  int B[N] = {9, 8, 7, 6, 5, 4, 3}; // values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::unique_by_key(thrust::host, A, A + N, B);
  *
  *  // The first four keys in A are now {1, 3, 2, 1} and new_end.first - A is 4.
@@ -524,7 +524,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_b
  *  int A[N] = {1, 3, 3, 3, 2, 2, 1}; // keys
  *  int B[N] = {9, 8, 7, 6, 5, 4, 3}; // values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::unique_by_key(A, A + N, B);
  *
  *  // The first four keys in A are now {1, 3, 2, 1} and new_end.first - A is 4.
@@ -581,7 +581,7 @@ unique_by_key(ForwardIterator1 keys_first, ForwardIterator1 keys_last, ForwardIt
  *  int A[N] = {1, 3, 3, 3, 2, 2, 1}; // keys
  *  int B[N] = {9, 8, 7, 6, 5, 4, 3}; // values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::unique_by_key(thrust::host, A, A + N, B, binary_pred);
  *
@@ -637,7 +637,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_b
  *  int A[N] = {1, 3, 3, 3, 2, 2, 1}; // keys
  *  int B[N] = {9, 8, 7, 6, 5, 4, 3}; // values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::unique_by_key(A, A + N, B, binary_pred);
  *
@@ -699,7 +699,7 @@ template <typename ForwardIterator1, typename ForwardIterator2, typename BinaryP
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::unique_by_key_copy(thrust::host, A, A + N, B, C, D);
  *
  *  // The first four keys in C are now {1, 3, 2, 1} and new_end.first - C is 4.
@@ -763,7 +763,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::unique_by_key_copy(A, A + N, B, C, D);
  *
  *  // The first four keys in C are now {1, 3, 2, 1} and new_end.first - C is 4.
@@ -830,7 +830,7 @@ template <typename InputIterator1, typename InputIterator2, typename OutputItera
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::unique_by_key_copy(thrust::host, A, A + N, B, C, D, binary_pred);
  *
@@ -899,7 +899,7 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  :::cuda::std::pair<int*,int*> new_end;
+ *  cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::unique_by_key_copy(A, A + N, B, C, D, binary_pred);
  *

--- a/thrust/thrust/unique.h
+++ b/thrust/thrust/unique.h
@@ -31,7 +31,8 @@
 #endif // no system header
 #include <thrust/detail/execution_policy.h>
 #include <thrust/iterator/iterator_traits.h>
-#include <thrust/pair.h>
+
+#include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -466,7 +467,7 @@ OutputIterator unique_copy(InputIterator first, InputIterator last, OutputIterat
  *  int A[N] = {1, 3, 3, 3, 2, 2, 1}; // keys
  *  int B[N] = {9, 8, 7, 6, 5, 4, 3}; // values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::unique_by_key(thrust::host, A, A + N, B);
  *
  *  // The first four keys in A are now {1, 3, 2, 1} and new_end.first - A is 4.
@@ -478,7 +479,7 @@ OutputIterator unique_copy(InputIterator first, InputIterator last, OutputIterat
  *  \see reduce_by_key
  */
 template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
@@ -523,7 +524,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key
  *  int A[N] = {1, 3, 3, 3, 2, 2, 1}; // keys
  *  int B[N] = {9, 8, 7, 6, 5, 4, 3}; // values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::unique_by_key(A, A + N, B);
  *
  *  // The first four keys in A are now {1, 3, 2, 1} and new_end.first - A is 4.
@@ -535,7 +536,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key
  *  \see reduce_by_key
  */
 template <typename ForwardIterator1, typename ForwardIterator2>
-thrust::pair<ForwardIterator1, ForwardIterator2>
+::cuda::std::pair<ForwardIterator1, ForwardIterator2>
 unique_by_key(ForwardIterator1 keys_first, ForwardIterator1 keys_last, ForwardIterator2 values_first);
 
 /*! \p unique_by_key is a generalization of \p unique to key-value pairs.
@@ -580,7 +581,7 @@ unique_by_key(ForwardIterator1 keys_first, ForwardIterator1 keys_last, ForwardIt
  *  int A[N] = {1, 3, 3, 3, 2, 2, 1}; // keys
  *  int B[N] = {9, 8, 7, 6, 5, 4, 3}; // values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::unique_by_key(thrust::host, A, A + N, B, binary_pred);
  *
@@ -593,7 +594,7 @@ unique_by_key(ForwardIterator1 keys_first, ForwardIterator1 keys_last, ForwardIt
  *  \see reduce_by_key
  */
 template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+_CCCL_HOST_DEVICE ::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   ForwardIterator1 keys_first,
   ForwardIterator1 keys_last,
@@ -636,7 +637,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key
  *  int A[N] = {1, 3, 3, 3, 2, 2, 1}; // keys
  *  int B[N] = {9, 8, 7, 6, 5, 4, 3}; // values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::unique_by_key(A, A + N, B, binary_pred);
  *
@@ -649,7 +650,7 @@ _CCCL_HOST_DEVICE thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key
  *  \see reduce_by_key
  */
 template <typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
-thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
+::cuda::std::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
   ForwardIterator1 keys_first, ForwardIterator1 keys_last, ForwardIterator2 values_first, BinaryPredicate binary_pred);
 
 /*! \p unique_by_key_copy is a generalization of \p unique_copy to key-value pairs.
@@ -698,7 +699,7 @@ thrust::pair<ForwardIterator1, ForwardIterator2> unique_by_key(
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::unique_by_key_copy(thrust::host, A, A + N, B, C, D);
  *
  *  // The first four keys in C are now {1, 3, 2, 1} and new_end.first - C is 4.
@@ -714,7 +715,7 @@ template <typename DerivedPolicy,
           typename InputIterator2,
           typename OutputIterator1,
           typename OutputIterator2>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -762,7 +763,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_c
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  new_end = thrust::unique_by_key_copy(A, A + N, B, C, D);
  *
  *  // The first four keys in C are now {1, 3, 2, 1} and new_end.first - C is 4.
@@ -774,7 +775,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_c
  *  \see reduce_by_key
  */
 template <typename InputIterator1, typename InputIterator2, typename OutputIterator1, typename OutputIterator2>
-thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
   InputIterator2 values_first,
@@ -829,7 +830,7 @@ thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::unique_by_key_copy(thrust::host, A, A + N, B, C, D, binary_pred);
  *
@@ -847,7 +848,7 @@ template <typename DerivedPolicy,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-_CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+_CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
   InputIterator1 keys_first,
   InputIterator1 keys_last,
@@ -898,7 +899,7 @@ _CCCL_HOST_DEVICE thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_c
  *  int C[N];                         // output keys
  *  int D[N];                         // output values
  *
- *  thrust::pair<int*,int*> new_end;
+ *  :::cuda::std::pair<int*,int*> new_end;
  *  ::cuda::std::equal_to<int> binary_pred;
  *  new_end = thrust::unique_by_key_copy(A, A + N, B, C, D, binary_pred);
  *
@@ -915,7 +916,7 @@ template <typename InputIterator1,
           typename OutputIterator1,
           typename OutputIterator2,
           typename BinaryPredicate>
-thrust::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
+::cuda::std::pair<OutputIterator1, OutputIterator2> unique_by_key_copy(
   InputIterator1 keys_first,
   InputIterator1 keys_last,
   InputIterator2 values_first,


### PR DESCRIPTION
Its an alias anyhow, so just use the right thing
