### PR TITLE
Implement internal vector type traits

### DIFF
--- a/libcudacxx/include/cuda/__type_traits/vector_type.h
+++ b/libcudacxx/include/cuda/__type_traits/vector_type.h
@@ -193,7 +193,7 @@ template <class _Tp, ::cuda::std::size_t _Size>
     else if constexpr (_Size == 4)
     {
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-      return ::long4_16a{};
+      return ::long4_32a{};
 #  else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
       return ::long4{};
 #  endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
@@ -220,7 +220,7 @@ template <class _Tp, ::cuda::std::size_t _Size>
     else if constexpr (_Size == 4)
     {
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-      return ::ulong4_16a{};
+      return ::ulong4_32a{};
 #  else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
       return ::ulong4{};
 #  endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
@@ -247,7 +247,7 @@ template <class _Tp, ::cuda::std::size_t _Size>
     else if constexpr (_Size == 4)
     {
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-      return ::longlong4_16a{};
+      return ::longlong4_32a{};
 #  else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
       return ::longlong4{};
 #  endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
@@ -274,7 +274,7 @@ template <class _Tp, ::cuda::std::size_t _Size>
     else if constexpr (_Size == 4)
     {
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-      return ::ulonglong4_16a{};
+      return ::ulonglong4_32a{};
 #  else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
       return ::ulonglong4{};
 #  endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
@@ -324,7 +324,7 @@ template <class _Tp, ::cuda::std::size_t _Size>
     else if constexpr (_Size == 4)
     {
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-      return ::double4_16a{};
+      return ::double4_32a{};
 #  else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
       return ::double4{};
 #  endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
@@ -340,10 +340,10 @@ template <class _Tp, ::cuda::std::size_t _Size>
   }
 }
 
-template <class _Tp, size_t _Size>
+template <class _Tp, ::cuda::std::size_t _Size>
 using __vector_type_t = decltype(::cuda::__cccl_vector_type_t_impl<_Tp, _Size>());
 
-template <class _Tp, size_t _Size>
+template <class _Tp, ::cuda::std::size_t _Size>
 inline constexpr bool __has_vector_type_v = !::cuda::std::is_same_v<__vector_type_t<_Tp, _Size>, void>;
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/test/libcudacxx/libcxx/type_traits/vector_type.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/type_traits/vector_type.compile.pass.cpp
@@ -58,7 +58,7 @@ __host__ __device__ void test()
   test<signed long, 2, long2>();
   test<signed long, 3, long3>();
 #if _CCCL_CTK_AT_LEAST(13, 0)
-  test<signed long, 4, long4_16a>();
+  test<signed long, 4, long4_32a>();
 #else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
   test<signed long, 4, long4>();
 #endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
@@ -67,7 +67,7 @@ __host__ __device__ void test()
   test<unsigned long, 2, ulong2>();
   test<unsigned long, 3, ulong3>();
 #if _CCCL_CTK_AT_LEAST(13, 0)
-  test<unsigned long, 4, ulong4_16a>();
+  test<unsigned long, 4, ulong4_32a>();
 #else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
   test<unsigned long, 4, ulong4>();
 #endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
@@ -76,7 +76,7 @@ __host__ __device__ void test()
   test<signed long long, 2, longlong2>();
   test<signed long long, 3, longlong3>();
 #if _CCCL_CTK_AT_LEAST(13, 0)
-  test<signed long long, 4, longlong4_16a>();
+  test<signed long long, 4, longlong4_32a>();
 #else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
   test<signed long long, 4, longlong4>();
 #endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
@@ -85,7 +85,7 @@ __host__ __device__ void test()
   test<unsigned long long, 2, ulonglong2>();
   test<unsigned long long, 3, ulonglong3>();
 #if _CCCL_CTK_AT_LEAST(13, 0)
-  test<unsigned long long, 4, ulonglong4_16a>();
+  test<unsigned long long, 4, ulonglong4_32a>();
 #else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
   test<unsigned long long, 4, ulonglong4>();
 #endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
@@ -99,7 +99,7 @@ __host__ __device__ void test()
   test<double, 2, double2>();
   test<double, 3, double3>();
 #if _CCCL_CTK_AT_LEAST(13, 0)
-  test<double, 4, double4_16a>();
+  test<double, 4, double4_32a>();
 #else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
   test<double, 4, double4>();
 #endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^


### PR DESCRIPTION
The PR introduces interanl `cuda::__vector_type_t` and `cuda::__has_vector_type_v` traits for crating CUDA vector types from type and size.

I will need this type for hierarchy query result type.