### PR TITLE
Add `__version_(at_least|below)` utilities to CUDA Driver wrappers

### DIFF
--- a/cudax/include/cuda/experimental/__launch/configuration.cuh
+++ b/cudax/include/cuda/experimental/__launch/configuration.cuh
@@ -322,7 +322,7 @@ template <class _Tp>
   ::cudaError_t __status = ::cudaSuccess;
 
   // Since CUDA 12.4, querying CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES requires the function to be loaded.
-  if (::cuda::__driver::__getVersion() >= 12040)
+  if (::cuda::__driver::__version_at_least(12, 4))
   {
     __status = ::cuda::__driver::__functionLoadNoThrow(__kernel);
     if (__status != ::cudaSuccess)

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -75,7 +75,7 @@ struct stream_ref : ::cuda::stream_ref
     CUcontext __stream_ctx;
     ::cuda::experimental::logical_device::kinds __ctx_kind = ::cuda::experimental::logical_device::kinds::device;
 #if _CCCL_CTK_AT_LEAST(12, 5)
-    if (__driver::__getVersion() >= 12050)
+    if (::cuda::__driver::__version_at_least(12, 5))
     {
       auto __ctx = ::cuda::__driver::__streamGetCtx_v2(__stream);
       if (__ctx.__ctx_kind_ == ::cuda::__driver::__ctx_from_stream::__kind::__green)


### PR DESCRIPTION
We already have these utilities for header's version checks, this PR brings them to `cuda::__driver::` namespace, so we can use them to check the version of the CUDA driver in runtime and prevent misspelled versions.