### PR TITLE
implement `indeterminate_domain` from P3826R2

### DIFF
--- a/cudax/include/cuda/experimental/__execution/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/bulk.cuh
@@ -198,18 +198,30 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __bulk_t
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure_base_t
   {
     template <class _Sndr>
-    [[nodiscard]] _CCCL_API friend constexpr auto operator|(_Sndr&& __sndr, __closure_base_t __self)
+    [[nodiscard]] _CCCL_API constexpr auto operator()(_Sndr&& __sndr) &&
     {
       static_assert(__is_sender<_Sndr>);
 
       if constexpr (!dependent_sender<_Sndr>)
       {
         using __sndr_t = typename _BulkTag::template __sndr_t<_Sndr, _Policy, _Shape, _Fn>;
-        __assert_valid_completion_signatures(get_completion_signatures<__sndr_t>());
+        __assert_valid_completion_signatures(execution::get_completion_signatures<__sndr_t>());
       }
 
       return typename _BulkTag::template __sndr_t<_Sndr, _Policy, _Shape, _Fn>{
-        {{}, static_cast<__closure_base_t&&>(__self), static_cast<_Sndr&&>(__sndr)}};
+        {{}, static_cast<__closure_base_t&&>(*this), static_cast<_Sndr&&>(__sndr)}};
+    }
+
+    template <class _Sndr>
+    [[nodiscard]] _CCCL_API constexpr auto operator()(_Sndr&& __sndr) const&
+    {
+      return __closure_base_t(*this)(static_cast<_Sndr&&>(__sndr));
+    }
+
+    template <class _Sndr>
+    [[nodiscard]] _CCCL_API friend constexpr auto operator|(_Sndr&& __sndr, __closure_base_t __self)
+    {
+      return static_cast<__closure_base_t&&>(__self)(static_cast<_Sndr&&>(__sndr));
     }
 
     /*_CCCL_NO_UNIQUE_ADDRESS*/ _Policy __policy_;

--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -128,13 +128,13 @@ using __partition_completion_signatures_t _CCCL_NODEBUG_ALIAS = //
     (declval<::cuda::std::__undefined<__partitioned_completions<>>&>() * ... * static_cast<_Sigs*>(nullptr))));
 
 template <class _Completions>
-using __partitioned_completions_of _CCCL_NODEBUG_ALIAS = typename _Completions::__partitioned::type;
+using __partitioned_completions_of_t _CCCL_NODEBUG_ALIAS = typename _Completions::__partitioned::type;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // completion signatures type traits
 template <class _Sigs, template <class...> class _Tuple, template <class...> class _Variant>
 using __value_types _CCCL_NODEBUG_ALIAS =
-  typename __partitioned_completions_of<_Sigs>::template __value_types<_Tuple, _Variant>;
+  typename __partitioned_completions_of_t<_Sigs>::template __value_types<_Tuple, _Variant>;
 
 template <class _Sndr, class _Env, template <class...> class _Tuple, template <class...> class _Variant>
 using value_types_of_t _CCCL_NODEBUG_ALIAS =
@@ -146,7 +146,7 @@ template <class _Sigs,
           template <class...> class _Variant,
           template <class...> class _Transform = ::cuda::std::__type_self_t>
 using __error_types _CCCL_NODEBUG_ALIAS =
-  typename __partitioned_completions_of<_Sigs>::template __error_types<_Variant, _Transform>;
+  typename __partitioned_completions_of_t<_Sigs>::template __error_types<_Variant, _Transform>;
 
 template <class _Sndr, class _Env, template <class...> class _Variant>
 using error_types_of_t _CCCL_NODEBUG_ALIAS =
@@ -154,10 +154,10 @@ using error_types_of_t _CCCL_NODEBUG_ALIAS =
 
 template <class _Sigs, template <class...> class _Variant, class _Type = set_stopped_t()>
 using __stopped_types _CCCL_NODEBUG_ALIAS =
-  typename __partitioned_completions_of<_Sigs>::template __stopped_types<_Variant, _Type>;
+  typename __partitioned_completions_of_t<_Sigs>::template __stopped_types<_Variant, _Type>;
 
 template <class _Sigs>
-inline constexpr bool __sends_stopped = __partitioned_completions_of<_Sigs>::__count_stopped::value != 0;
+inline constexpr bool __sends_stopped = __partitioned_completions_of_t<_Sigs>::__count_stopped::value != 0;
 
 template <class _Sndr, class... _Env>
 inline constexpr bool sends_stopped = __sends_stopped<completion_signatures_of_t<_Sndr, _Env...>>;

--- a/cudax/include/cuda/experimental/__execution/concepts.cuh
+++ b/cudax/include/cuda/experimental/__execution/concepts.cuh
@@ -36,13 +36,6 @@
 
 namespace cuda::experimental::execution
 {
-// Utilities:
-template <class _Ty>
-_CCCL_API constexpr auto __is_constexpr_helper(_Ty) -> bool
-{
-  return true;
-}
-
 // Receiver concepts:
 template <class _Rcvr>
 _CCCL_CONCEPT receiver = //

--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -22,9 +22,12 @@
 #endif // no system header
 
 #include <cuda/__type_traits/is_specialization_of.h>
+#include <cuda/std/__concepts/same_as.h>
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__functional/compose.h>
 #include <cuda/std/__tuple_dir/ignore.h>
+#include <cuda/std/__type_traits/common_type.h>
+#include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/decay.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_empty.h>
@@ -96,7 +99,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
     return _Tag{}.apply_sender(static_cast<_Sndr&&>(__sndr), static_cast<_Args&&>(__args)...);
   }
 
-  //! @brief Transforms a sender with an optional environment.
+  //! @brief Transforms a sender with an environment.
   //!
   //! @tparam _OpTag Either start_t or set_value_t.
   //! @tparam _Sndr The type of the sender.
@@ -118,10 +121,65 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT default_domain
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr>
   [[nodiscard]] _CCCL_API static constexpr auto
-  transform_sender(::cuda::std::__ignore_t, _Sndr&& __sndr, ::cuda::std::__ignore_t = {}) //
+  transform_sender(::cuda::std::__ignore_t, _Sndr&& __sndr, ::cuda::std::__ignore_t) //
     noexcept(__nothrow_movable<_Sndr>) -> _Sndr
   {
     return static_cast<_Sndr&&>(__sndr);
+  }
+};
+
+//! @brief Concept that checks whether a domain's sender transform behaves like that of
+//! @c default_domain when passed the same arguments. The concept is modeled when either
+//! of the following is
+template <class _Domain, class _OpTag, class _Sndr, class _Env>
+_CCCL_CONCEPT __default_domain_like =
+  __same_as<decay_t<__transform_sender_result_t<default_domain, _OpTag, _Sndr, _Env>>,
+            decay_t<::cuda::std::__type_call<
+              ::cuda::std::__type_try_catch<
+                ::cuda::std::__type_quote<__transform_sender_result_t>,
+                ::cuda::std::__type_always<__transform_sender_result_t<default_domain, _OpTag, _Sndr, _Env>>>,
+              _Domain,
+              _OpTag,
+              _Sndr,
+              _Env>>>;
+
+/**
+ * @brief Tag type representing an indeterminate (unspecified) execution domain.
+ *
+ * This domain tag is used when a sender can complete with a given disposition
+ * from multiple execution domains.
+ *
+ * @tparam _Domains...: the (possibly empty) set of domains that a sender's
+ * completion may originate from.
+ */
+template <class... _Domains>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT indeterminate_domain
+{
+  _CCCL_HIDE_FROM_ABI indeterminate_domain() = default;
+
+  _CCCL_API constexpr indeterminate_domain(::cuda::std::__ignore_t) noexcept {}
+
+  //! @brief Transforms a sender with an optional environment.
+  //!
+  //! @tparam _OpTag Either start_t or set_value_t.
+  //! @tparam _Sndr The type of the sender.
+  //! @tparam _Env The type of the environment.
+  //! @param __sndr The sender to be transformed.
+  //! @param __env The environment used for the transformation.
+  //! @return `default_domain{}.transform_sender(_OpTag{}, std::forward<_Sndr>(__sndr), __env)`
+  //! @pre Every type in @c _Domains... must behave like @c default_domain when passed the
+  //! same arguments. If this check fails, the @c static_assert triggers with: "ERROR:
+  //! indeterminate domains: cannot pick an algorithm customization"
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _OpTag, class _Sndr, class _Env)
+  _CCCL_REQUIRES(__has_transform_sender<tag_of_t<_Sndr>, _OpTag, _Sndr, _Env>)
+  [[nodiscard]] _CCCL_API static constexpr auto transform_sender(_OpTag, _Sndr&& __sndr, const _Env& __env) //
+    noexcept(__nothrow_transform_sender<tag_of_t<_Sndr>, _OpTag, _Sndr, _Env>)
+      -> __transform_sender_result_t<tag_of_t<_Sndr>, _OpTag, _Sndr, _Env>
+  {
+    static_assert((__default_domain_like<_Domains, _OpTag, _Sndr, _Env> && ...),
+                  "ERROR: indeterminate domains: cannot pick an algorithm customization");
+    return tag_of_t<_Sndr>{}.transform_sender(_OpTag{}, static_cast<_Sndr&&>(__sndr), __env);
   }
 };
 
@@ -196,6 +254,12 @@ struct get_domain_t
     return __domain_t{};
   }
 
+  //! @brief Fall back to the default domain if no other domain is found.
+  [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::std::__ignore_t) const noexcept -> default_domain
+  {
+    return {};
+  }
+
   _CCCL_API static constexpr auto query(forwarding_query_t) noexcept
   {
     return true;
@@ -220,16 +284,27 @@ struct get_completion_domain_t
   {
     _CCCL_TEMPLATE(class _Attrs)
     _CCCL_REQUIRES(__queryable_with<_Attrs, get_completion_domain_t>)
-    _CCCL_API constexpr auto operator()(const _Attrs& __attrs, cuda::std::__ignore_t = {}) const noexcept
-      -> decay_t<__query_result_t<_Attrs, get_completion_domain_t>>;
+    _CCCL_API constexpr auto operator()(const _Attrs&, cuda::std::__ignore_t = {}) const noexcept
+    {
+      return decay_t<__query_result_t<_Attrs, get_completion_domain_t>>{};
+    }
 
     _CCCL_TEMPLATE(class _Attrs, class _Env)
     _CCCL_REQUIRES(__queryable_with<_Attrs, get_completion_domain_t, const _Env&>)
-    _CCCL_API constexpr auto operator()(const _Attrs& __attrs, const _Env& __env) const noexcept
-      -> decay_t<__query_result_t<_Attrs, get_completion_domain_t, const _Env&>>;
+    _CCCL_API constexpr auto operator()(const _Attrs&, const _Env&) const noexcept
+    {
+      return decay_t<__query_result_t<_Attrs, get_completion_domain_t, const _Env&>>{};
+    }
   };
 
 private:
+  template <class _Sch, class Domain, class... _Env>
+  _CCCL_API static constexpr void __check_scheduler_domain() noexcept
+  {
+    static_assert(__same_as<Domain, __scheduler_domain_t<_Sch, const _Env&...>>,
+                  "the sender's completion scheduler's domain does not match the domain returned by the scheduler");
+  }
+
   template <class _Attrs, class... _Env, class _Domain>
   [[nodiscard]] _CCCL_TRIVIAL_API static _CCCL_CONSTEVAL auto __check_domain(_Domain) noexcept -> _Domain
   {
@@ -240,8 +315,7 @@ private:
       using __sch_t = decay_t<__call_result_t<get_completion_scheduler_t<_Tag>, const _Attrs&, const _Env&...>>;
       if constexpr (!__same_as<__sch_t, _Attrs>) // prevent infinite recursion
       {
-        static_assert(__same_as<_Domain, __scheduler_domain_t<__sch_t, const _Env&...>>,
-                      "the sender claims to complete on a domain that is not the domain of its completion scheduler");
+        get_completion_domain_t::__check_scheduler_domain<__sch_t, _Domain, _Env...>();
       }
     }
     return {};
@@ -324,7 +398,89 @@ template <>
 _CCCL_GLOBAL_CONSTANT get_completion_domain_t<set_error_t> get_completion_domain<set_error_t>{};
 template <>
 _CCCL_GLOBAL_CONSTANT get_completion_domain_t<set_stopped_t> get_completion_domain<set_stopped_t>{};
+
+struct __not_a_domain
+{
+  _CCCL_HIDE_FROM_ABI __not_a_domain() = default;
+  template <class _Domain>
+  _CCCL_API constexpr __not_a_domain(_Domain&&) noexcept
+  {}
+};
+
+template <class... _Domains>
+using __indeterminate_domain_t =
+  ::cuda::std::_If<sizeof...(_Domains) == 1, decltype((_Domains(), ...)), indeterminate_domain<_Domains...>>;
+
+template <class _DomainSet>
+using __domain_from_set_t =
+  ::cuda::std::__type_apply<::cuda::std::_If<::cuda::std::__type_set_contains_v<_DomainSet, __not_a_domain>,
+                                             ::cuda::std::__type_always<__not_a_domain>,
+                                             ::cuda::std::__type_quote<__indeterminate_domain_t>>,
+                            _DomainSet>;
+
+template <class... _Domains>
+using __make_domain_t = __domain_from_set_t<::cuda::std::__make_type_set<_Domains...>>;
+
+// Common domain for a set of domains
+template <class... _Domains>
+struct __common_domain
+{
+  using type =
+    ::cuda::std::__type_call<::cuda::std::__type_try_catch<::cuda::std::__type_quote<::cuda::std::common_type_t>,
+                                                           ::cuda::std::__type_quote<__make_domain_t>>,
+                             _Domains...>;
+};
+
+template <class... _Domains>
+using __common_domain_t = typename __common_domain<_Domains...>::type;
+
+namespace __detail
+{
+template <class _Tag, class _Sndr, class... _Env>
+extern __call_result_or_t<get_completion_domain_t<_Tag>, indeterminate_domain<>, env_of_t<_Sndr>, _Env...>
+  __compl_domain_v;
+
+template <class _Tag, class _Sndr>
+extern __call_result_or_t<get_completion_domain_t<_Tag>,
+                          // If we ask for the completion domain early (without an env)
+                          // and it cannot be determined, then:
+                          // - if the sender knows it can never complete with _Tag, return
+                          //   indeterminate_domain<>
+                          // - otherwise, return __not_a_domain (indicating that the
+                          //   completion domain may only be knowable later, when an env
+                          //   is available)
+                          ::cuda::std::_If<__never_completes_with<_Sndr, _Tag>, indeterminate_domain<>, __not_a_domain>,
+                          env_of_t<_Sndr>>
+  __compl_domain_v<_Tag, _Sndr>;
+} // namespace __detail
+
+template <class _Tag, class _Sndr, class... _Env>
+using __compl_domain_t = decltype(__detail::__compl_domain_v<_Tag, _Sndr, _Env...>);
 } // namespace cuda::experimental::execution
+
+// Specializations of cuda::std::common_type for execution::indeterminate_domain
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class... _Ds, class _Domain>
+struct common_type<::cuda::experimental::execution::indeterminate_domain<_Ds...>, _Domain>
+{
+  using type = ::cuda::experimental::execution::__make_domain_t<_Ds..., _Domain>;
+};
+
+template <class _Domain, class... _Ds>
+struct common_type<_Domain, ::cuda::experimental::execution::indeterminate_domain<_Ds...>>
+{
+  using type = ::cuda::experimental::execution::__make_domain_t<_Ds..., _Domain>;
+};
+
+template <class... _As, class... _Bs>
+struct common_type<::cuda::experimental::execution::indeterminate_domain<_As...>,
+                   ::cuda::experimental::execution::indeterminate_domain<_Bs...>>
+{
+  using type = ::cuda::experimental::execution::__make_domain_t<_As..., _Bs...>;
+};
+
+_CCCL_END_NAMESPACE_CUDA_STD
 
 #include <cuda/experimental/__execution/epilogue.cuh>
 

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -65,12 +65,12 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __fwd_env_;
 template <class _Env>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __env_ref_
 {
-  _CCCL_TEMPLATE(class _Query, class... _As)
-  _CCCL_REQUIRES(__queryable_with<_Env, _Query, _As...>)
-  [[nodiscard]] _CCCL_API constexpr auto query(_Query, _As&&... __args) const
-    noexcept(__nothrow_queryable_with<_Env, _Query, _As...>) -> __query_result_t<_Env, _Query, _As...>
+  _CCCL_TEMPLATE(class _Query, class... _Args)
+  _CCCL_REQUIRES(__queryable_with<_Env, _Query, _Args...>)
+  [[nodiscard]] _CCCL_API constexpr auto query(_Query, _Args&&... __args) const
+    noexcept(__nothrow_queryable_with<_Env, _Query, _Args...>) -> __query_result_t<_Env, _Query, _Args...>
   {
-    return __env_.query(_Query{}, static_cast<_As&&>(__args)...);
+    return __env_.query(_Query{}, static_cast<_Args&&>(__args)...);
   }
 
   _Env const& __env_;
@@ -209,31 +209,6 @@ struct __mk_sch_env_t
 };
 
 _CCCL_GLOBAL_CONSTANT __mk_sch_env_t __mk_sch_env{};
-
-//////////////////////////////////////////////////////////////////////////////////////////
-// __sch_attrs
-
-//! @brief __sch_attrs_t is a utility that builds an attributes queryable from a
-//! scheduler. It defines the `get_completion_scheduler` query and provides a default for
-//! the `get_completion_domain` query.
-template <class _Sch>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT __sch_attrs_t
-{
-  [[nodiscard]] _CCCL_API constexpr auto query(get_completion_scheduler_t<set_value_t>) const noexcept -> _Sch
-  {
-    return __sch_;
-  }
-
-  [[nodiscard]] _CCCL_API constexpr auto query(get_completion_domain_t<set_value_t>) const noexcept
-  {
-    return __call_result_or_t<get_completion_domain_t<set_value_t>, default_domain, _Sch>{};
-  }
-
-  _Sch __sch_;
-};
-
-template <class _Sch>
-_CCCL_HOST_DEVICE __sch_attrs_t(_Sch) -> __sch_attrs_t<_Sch>;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // __inln_attrs

--- a/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/get_completion_signatures.cuh
@@ -338,13 +338,6 @@ template <class _Sndr>
   return ::cuda::std::is_base_of_v<dependent_sender_error, _Completions>;
 }
 #endif // ^^^ no constexpr exceptions ^^^
-
-template <class _SetTag, class _Sndr, class... _Env>
-_CCCL_CONCEPT __has_completions_for = _CCCL_REQUIRES_EXPR((_SetTag, _Sndr, variadic _Env)) //
-  ( //
-    typename(completion_signatures_of_t<_Sndr, _Env...>),
-    requires(completion_signatures_of_t<_Sndr, _Env...>::count(_SetTag{}) != 0) //
-  );
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/meta.cuh
+++ b/cudax/include/cuda/experimental/__execution/meta.cuh
@@ -145,24 +145,6 @@ inline constexpr bool __type_contains_error =
 template <class... _Ts>
 using __type_find_error _CCCL_NODEBUG_ALIAS = decltype(+(declval<_Ts&>(), ..., declval<_ERROR<_UNKNOWN>&>()));
 
-template <bool _Error>
-struct __type_self_or_error_with_
-{
-  template <class _Ty, class... _With>
-  using __call _CCCL_NODEBUG_ALIAS = _Ty;
-};
-
-template <>
-struct __type_self_or_error_with_<true>
-{
-  template <class _Ty, class... _With>
-  using __call _CCCL_NODEBUG_ALIAS = decltype(declval<_Ty&>().with(declval<_ERROR<_With...>&>()));
-};
-
-template <class _Ty, class... _With>
-using __type_self_or_error_with _CCCL_NODEBUG_ALIAS =
-  ::cuda::std::__type_call<__type_self_or_error_with_<__type_is_error<_Ty>>, _Ty, _With...>;
-
 template <bool>
 struct __type_try__;
 
@@ -279,7 +261,7 @@ struct __type_self_or
 };
 
 template <template <class...> class _Fn, class _Default, class... _Ts>
-using __type_call_or_q =
+using __type_call_or_quote =
   typename ::cuda::std::_If<__is_instantiable_with<_Fn, _Ts...>,
                             ::cuda::std::__type_quote<_Fn>,
                             ::cuda::std::__type_always<_Default>>::template __call<_Ts...>;

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -49,7 +49,6 @@ namespace cuda::experimental::execution
 {
 struct schedule_from_t
 {
-  _CUDAX_SEMI_PRIVATE:
   template <class _Sndr>
   struct __sndr_t;
 

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -228,14 +228,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t::__sndr_t
     // If _Sndr2 has _SetTag completions but does not know its _SetTag completion scheduler,
     // then we cannot know it either. Delete the function to prevent its use.
     _CCCL_TEMPLATE(class _SetTag, class... _Env)
-    _CCCL_REQUIRES(__has_completions_for<_SetTag, _Sndr2, __env2_t<_Env...>> _CCCL_AND(
+    _CCCL_REQUIRES(__has_completions_for<_Sndr2, _SetTag, __env2_t<_Env...>> _CCCL_AND(
       !__callable<get_completion_scheduler_t<_SetTag>, env_of_t<_Sndr2>, __env2_t<_Env...>>))
     _CCCL_API auto query(get_completion_scheduler_t<_SetTag>, const _Env&...) const = delete;
 
     // If _Sndr2 has _SetTag completions but does not know its _SetTag completion domain,
     // then we cannot know it either. Delete the function to prevent its use.
     _CCCL_TEMPLATE(class _SetTag, class... _Env)
-    _CCCL_REQUIRES(__has_completions_for<_SetTag, _Sndr2, __env2_t<_Env...>> _CCCL_AND(
+    _CCCL_REQUIRES(__has_completions_for<_Sndr2, _SetTag, __env2_t<_Env...>> _CCCL_AND(
       !__callable<get_completion_domain_t<_SetTag>, env_of_t<_Sndr2>, __env2_t<_Env...>>))
     _CCCL_API auto query(get_completion_domain_t<_SetTag>, const _Env&...) const = delete;
 

--- a/cudax/include/cuda/experimental/__execution/sndr_ref.cuh
+++ b/cudax/include/cuda/experimental/__execution/sndr_ref.cuh
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef __CUDAX_EXECUTION_SNDR_REF
+#define __CUDAX_EXECUTION_SNDR_REF
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/experimental/__execution/cpos.cuh>
+#include <cuda/experimental/__execution/env.cuh>
+#include <cuda/experimental/__execution/get_completion_signatures.cuh>
+
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+template <class _Sndr>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_ref
+{
+  using sender_concept = receiver_t;
+
+  _CCCL_API explicit constexpr __sndr_ref(_Sndr&& __sndr) noexcept
+      : __sndr_(static_cast<_Sndr&&>(__sndr))
+  {}
+
+  template <class _Self, class... _Env>
+  _CCCL_API static _CCCL_CONSTEVAL auto get_completion_signatures()
+  {
+    return execution::get_completion_signatures<_Sndr, _Env...>();
+  }
+
+  template <class _Rcvr>
+  _CCCL_API constexpr auto connect(_Rcvr __rcvr) const
+  {
+    return execution::connect(static_cast<_Sndr&&>(__sndr_), static_cast<_Rcvr&&>(__rcvr));
+  }
+
+  [[nodiscard]] _CCCL_API constexpr auto get_env() const noexcept -> env_of_t<_Sndr>
+  {
+    return execution::get_env(__sndr_);
+  }
+
+private:
+  _Sndr&& __sndr_;
+};
+
+template <class _Sndr>
+_CCCL_HOST_DEVICE __sndr_ref(_Sndr&& __sndr) -> __sndr_ref<_Sndr>;
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_SNDR_REF

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -224,9 +224,15 @@ struct __upon_t
                                                        // extended (host/device) lambda
   {
     template <class _Sndr>
-    _CCCL_API constexpr auto operator()(_Sndr __sndr) -> __call_result_t<__upon_tag_t, _Sndr, _Fn>
+    _CCCL_API constexpr auto operator()(_Sndr __sndr) && -> __call_result_t<__upon_tag_t, _Sndr, _Fn>
     {
       return __upon_tag_t{}(static_cast<_Sndr&&>(__sndr), static_cast<_Fn&&>(__fn_));
+    }
+
+    template <class _Sndr>
+    _CCCL_API constexpr auto operator()(_Sndr __sndr) const& -> __call_result_t<__upon_tag_t, _Sndr, _Fn>
+    {
+      return __upon_tag_t{}(static_cast<_Sndr&&>(__sndr), __fn_);
     }
 
     template <class _Sndr>

--- a/cudax/include/cuda/experimental/__execution/transform_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/transform_sender.cuh
@@ -28,6 +28,7 @@
 #include <cuda/experimental/__detail/utility.cuh>
 #include <cuda/experimental/__execution/domain.cuh>
 #include <cuda/experimental/__execution/env.cuh>
+#include <cuda/experimental/__execution/fwd.cuh>
 #include <cuda/experimental/__execution/type_traits.cuh>
 
 #include <cuda/experimental/__execution/prologue.cuh>

--- a/cudax/include/cuda/experimental/__execution/write_attrs.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_attrs.cuh
@@ -49,9 +49,15 @@ struct write_attrs_t
     }
 
     template <class _Sndr>
-    [[nodiscard]] _CCCL_API friend auto operator|(_Sndr __sndr, __closure_t _clsr)
+    [[nodiscard]] _CCCL_API auto operator()(_Sndr __sndr) const&
     {
-      return __sndr_t<_Sndr, _Attrs>{{}, static_cast<_Attrs&&>(_clsr.__attrs_), static_cast<_Sndr&&>(__sndr)};
+      return __sndr_t<_Sndr, _Attrs>{{}, __attrs_, static_cast<_Sndr&&>(__sndr)};
+    }
+
+    template <class _Sndr>
+    [[nodiscard]] _CCCL_API friend auto operator|(_Sndr __sndr, __closure_t __clsr)
+    {
+      return __sndr_t<_Sndr, _Attrs>{{}, static_cast<_Attrs&&>(__clsr.__attrs_), static_cast<_Sndr&&>(__sndr)};
     }
 
     _Attrs __attrs_;
@@ -79,7 +85,7 @@ struct write_attrs_t
   //!
   //! @endrst
   template <class _Sndr, class _Attrs>
-  [[nodiscard]] _CCCL_API auto operator()(_Sndr __sndr, _Attrs __attrs) const -> __sndr_t<_Sndr, _Attrs>
+  [[nodiscard]] _CCCL_API auto operator()(_Sndr __sndr, _Attrs __attrs) const
   {
     return __sndr_t<_Sndr, _Attrs>{{}, static_cast<_Attrs&&>(__attrs), static_cast<_Sndr&&>(__sndr)};
   }

--- a/cudax/include/cuda/experimental/__execution/write_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_env.cuh
@@ -194,15 +194,21 @@ template <class _Env>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__closure_t
 {
   template <class _Sndr>
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Sndr __sndr) const -> __sndr_t<_Sndr, _Env>
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Sndr __sndr) &&
   {
-    return __sndr_t<_Sndr, _Env>{{}, static_cast<_Env&&>(__env_), static_cast<_Sndr&&>(__sndr)};
+    return write_env_t()(static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__env_));
   }
 
   template <class _Sndr>
-  [[nodiscard]] _CCCL_API friend constexpr auto operator|(_Sndr __sndr, __closure_t __self) -> __sndr_t<_Sndr, _Env>
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Sndr __sndr) const&
   {
-    return __sndr_t<_Sndr, _Env>{{}, static_cast<_Env&&>(__self.__env_), static_cast<_Sndr&&>(__sndr)};
+    return write_env_t()(static_cast<_Sndr&&>(__sndr), __env_);
+  }
+
+  template <class _Sndr>
+  [[nodiscard]] _CCCL_API friend constexpr auto operator|(_Sndr __sndr, __closure_t __self)
+  {
+    return write_env_t()(static_cast<_Sndr&&>(__sndr), static_cast<_Env&&>(__self.__env_));
   }
 
   _Env __env_;


### PR DESCRIPTION
## Description

my focus recently has been shoring up `std::execution`'s algorithm customization mechanism ahead of the C++26 release. in that mechanism, the domains on which an operation starts and completes are used to dispatch to the correct algorithm implementation.

a thorny issue has been: what to do when an operation can complete on domain `A` _or_ domain `B`? that can sometimes happen. without the ability to pick _one_ domain, the customization mechanism gives up, and no custom implementation is used.

during last week's committee meeting i had a happy thought. most domains do not customize most algorithms. it shouldn't be an error if `then(sndr, fn)` can complete on domain `A` or domain `B` _if neither domain customizes the `then` algorithm_.

this led me to the idea of using a set of domains as a domain. `indeterminate_domain<A, B>` captures the fact that a sender completes on one of two domains.

dispatching with `indeterminate_domain<A, B>` proceeds as follows:

- compute the types of `D().transform_sender(set_value, sndr, env)` for `D` in `A`, `B`, and `default_domain`.
- if the 3 transformed sender types are the same, then we use the `default_domain` transform.
- otherwise, it is a hard error.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
