### PR TITLE
Refactor driver APIs

### DIFF
--- a/cudax/include/cuda/experimental/__cufile/exception.cuh
+++ b/cudax/include/cuda/experimental/__cufile/exception.cuh
@@ -102,18 +102,18 @@ public:
 }
 
 //! @brief Macro to call a cuFile API and throw a cufile_error or cuda_error if it fails.
-#define _CCCL_TRY_CUFILE_API(_NAME, _MSG, ...)                                                              \
-  do                                                                                                        \
-  {                                                                                                         \
-    const ::CUfileError_t __cufile_error_status = _NAME(__VA_ARGS__);                                       \
-    switch (__cufile_error_status.err)                                                                      \
-    {                                                                                                       \
-      case ::CU_FILE_SUCCESS:                                                                               \
-        break;                                                                                              \
-      case ::CU_FILE_CUDA_DRIVER_ERROR:                                                                     \
-        ::cuda::__throw_cuda_error(static_cast<::cudaError_t>(__cufile_error_status.cu_err), _MSG, #_NAME); \
-      default:                                                                                              \
-        __throw_cufile_error(__cufile_error_status.err, _MSG, #_NAME);                                      \
-    }                                                                                                       \
+#define _CCCL_TRY_CUFILE_API(_NAME, _MSG, ...)                                  \
+  do                                                                            \
+  {                                                                             \
+    const ::CUfileError_t __cufile_error_status = _NAME(__VA_ARGS__);           \
+    switch (__cufile_error_status.err)                                          \
+    {                                                                           \
+      case ::CU_FILE_SUCCESS:                                                   \
+        break;                                                                  \
+      case ::CU_FILE_CUDA_DRIVER_ERROR:                                         \
+        ::cuda::__throw_cuda_error(__cufile_error_status.cu_err, _MSG, #_NAME); \
+      default:                                                                  \
+        __throw_cufile_error(__cufile_error_status.err, _MSG, #_NAME);          \
+    }                                                                           \
   } while (0)
 } // namespace cuda::experimental

--- a/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
+++ b/cudax/include/cuda/experimental/__green_context/green_ctx.cuh
@@ -47,9 +47,9 @@ struct green_context
       : __dev_id(__device.get())
   {
     // TODO get CUdevice from device
-    auto __dev_handle = ::cuda::__driver::__deviceGet(__dev_id);
-    __green_ctx       = ::cuda::__driver::__greenCtxCreate(__dev_handle);
-    __transformed     = ::cuda::__driver::__ctxFromGreenCtx(__green_ctx);
+    auto __dev_handle = _CCCL_TRY_DRIVER_API(__deviceGet(__dev_id));
+    __green_ctx       = _CCCL_TRY_DRIVER_API(__greenCtxCreate(__dev_handle));
+    __transformed     = _CCCL_TRY_DRIVER_API(__ctxFromGreenCtx(__green_ctx));
   }
 
   green_context(const green_context&)            = delete;
@@ -58,17 +58,17 @@ struct green_context
   // TODO this probably should be the runtime equivalent once available
   [[nodiscard]] static green_context from_native_handle(CUgreenCtx __gctx)
   {
-    CUcontext __transformed = ::cuda::__driver::__ctxFromGreenCtx(__gctx);
-    ::cuda::__driver::__ctxPush(__transformed);
-    CUdevice __device = ::cuda::__driver::__ctxGetDevice();
-    ::cuda::__driver::__ctxPop();
+    CUcontext __transformed = _CCCL_TRY_DRIVER_API(__ctxFromGreenCtx(__gctx));
+    (void) _CCCL_TRY_DRIVER_API(__ctxPush(__transformed));
+    CUdevice __device = _CCCL_TRY_DRIVER_API(__ctxGetDevice());
+    (void) _CCCL_TRY_DRIVER_API(__ctxPop());
     return green_context(::cuda::__driver::__cudevice_to_ordinal(__device), __gctx, __transformed);
   }
 
 #  if _CCCL_CTK_AT_LEAST(13, 0)
   [[nodiscard]] _CCCL_HOST_API green_context_id id() const
   {
-    return green_context_id{::cuda::__driver::__greenCtxGetId(__green_ctx)};
+    return green_context_id{_CCCL_TRY_DRIVER_API(__greenCtxGetId(__green_ctx))};
   }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
@@ -83,7 +83,7 @@ struct green_context
   {
     if (__green_ctx)
     {
-      [[maybe_unused]] cudaError_t __status = ::cuda::__driver::__greenCtxDestroyNoThrow(__green_ctx);
+      _CCCL_ASSERT_DRIVER_API(__greenCtxDestroy(__green_ctx));
     }
   }
 

--- a/cudax/include/cuda/experimental/__kernel/attributes.cuh
+++ b/cudax/include/cuda/experimental/__kernel/attributes.cuh
@@ -47,8 +47,8 @@ struct __kernel_attr_impl
   template <class _Signature>
   [[nodiscard]] type operator()(kernel_ref<_Signature> __kernel, device_ref __dev) const
   {
-    return static_cast<type>(
-      ::cuda::__driver::__kernelGetAttribute(_Attr, __kernel.get(), ::cuda::__driver::__deviceGet(__dev.get())));
+    return static_cast<type>(_CCCL_TRY_DRIVER_API(
+      __kernelGetAttribute(_Attr, __kernel.get(), _CCCL_TRY_DRIVER_API(__deviceGet(__dev.get())))));
   }
 };
 

--- a/cudax/include/cuda/experimental/__kernel/kernel_ref.cuh
+++ b/cudax/include/cuda/experimental/__kernel/kernel_ref.cuh
@@ -95,7 +95,7 @@ public:
   //! @throws cuda_error if the kernel name cannot be obtained
   [[nodiscard]] ::cuda::std::string_view name() const
   {
-    return ::cuda::__driver::__kernelGetName(__kernel_);
+    return _CCCL_TRY_DRIVER_API(__kernelGetName(__kernel_));
   }
 #endif // _CCCL_CTK_AT_LEAST(12, 3)
 

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -60,7 +60,7 @@ __global__ static void __kernel_launcher_no_config(_Kernel __kernel_fn, _Args...
 template <class... _Args>
 [[nodiscard]] _CCCL_HOST_API CUfunction __get_cufunction_of(kernel_ref<void(_Args...)> __kernel)
 {
-  return ::cuda::__driver::__kernelGetFunction(__kernel.get());
+  return _CCCL_TRY_DRIVER_API(__kernelGetFunction(__kernel.get()));
 }
 
 template <class... _Args>
@@ -90,12 +90,12 @@ __do_launch(_GraphInserter&& __inserter, ::CUlaunchConfig& __config, ::CUfunctio
 
   auto __dependencies = __inserter.get_dependencies();
 
-  const auto __node = ::cuda::__driver::__graphAddKernelNode(
-    __inserter.get_graph().get(), __dependencies.data(), __dependencies.size(), __node_params);
+  const auto __node = _CCCL_TRY_DRIVER_API(
+    __graphAddKernelNode(__inserter.get_graph().get(), __dependencies.data(), __dependencies.size(), __node_params));
 
   for (unsigned int __i = 0; __i < __config.numAttrs; ++__i)
   {
-    ::cuda::__driver::__graphKernelNodeSetAttribute(__node, __config.attrs[__i].id, __config.attrs[__i].value);
+    _CCCL_TRY_DRIVER_API(__graphKernelNodeSetAttribute(__node, __config.attrs[__i].id, __config.attrs[__i].value));
   }
 
   // TODO skip the update if called on rvalue?
@@ -111,7 +111,7 @@ _CCCL_HOST_API void inline __do_launch(
 #if defined(_CUDAX_LAUNCH_CONFIG_TEST)
   test_launch_kernel_replacement(__config, __kernel, __args_ptrs);
 #else // ^^^ _CUDAX_LAUNCH_CONFIG_TEST ^^^ / vvv !_CUDAX_LAUNCH_CONFIG_TEST vvv
-  ::cuda::__driver::__launchKernel(__config, __kernel, __args_ptrs);
+  _CCCL_TRY_DRIVER_API(__launchKernel(__config, __kernel, __args_ptrs));
 #endif // ^^^ !_CUDAX_LAUNCH_CONFIG_TEST ^^^
 }
 

--- a/cudax/include/cuda/experimental/__library/library.cuh
+++ b/cudax/include/cuda/experimental/__library/library.cuh
@@ -79,7 +79,7 @@ struct library : public library_ref
   {
     if (__library_ != value_type{})
     {
-      [[maybe_unused]] const auto __status = ::cuda::__driver::__libraryUnloadNoThrow(__library_);
+      _CCCL_ASSERT_DRIVER_API(__libraryUnload(__library_));
     }
   }
 

--- a/cudax/include/cuda/experimental/__library/library_ref.cuh
+++ b/cudax/include/cuda/experimental/__library/library_ref.cuh
@@ -72,15 +72,15 @@ public:
   //! @throws cuda_error if the library could not be queried for the kernel
   [[nodiscard]] bool has_kernel(const char* __name) const
   {
-    ::CUkernel __kernel{};
-    switch (const auto __res = ::cuda::__driver::__libraryGetKernelNoThrow(__kernel, __library_, __name))
+    const auto __status = ::cuda::__driver::__libraryGetKernel(__library_, __name).__error_;
+    switch (__status)
     {
-      case ::cudaSuccess:
+      case ::CUDA_SUCCESS:
         return true;
-      case ::cudaErrorSymbolNotFound:
+      case ::CUDA_ERROR_NOT_FOUND:
         return false;
       default:
-        ::cuda::__throw_cuda_error(__res, "Failed to get the kernel from library");
+        ::cuda::__throw_cuda_error(__status, "Failed to get the kernel from library");
     }
   }
 
@@ -96,13 +96,7 @@ public:
   template <class _Signature>
   [[nodiscard]] kernel_ref<_Signature> kernel(const char* __name) const
   {
-    ::CUkernel __kernel{};
-    if (const auto __res = ::cuda::__driver::__libraryGetKernelNoThrow(__kernel, __library_, __name);
-        __res != ::cudaSuccess)
-    {
-      ::cuda::__throw_cuda_error(__res, "Failed to get the kernel from the library");
-    }
-    return kernel_ref<_Signature>{__kernel};
+    return kernel_ref<_Signature>{_CCCL_TRY_DRIVER_API(__libraryGetKernel(__library_, __name))};
   }
 
   //! @brief Checks if the library contains a global symbol with the given name on a device
@@ -117,16 +111,15 @@ public:
   {
     ::cuda::__ensure_current_context __ctx_guard(__device);
 
-    ::CUdeviceptr __dptr{};
-    ::cuda::std::size_t __size{};
-    switch (const auto __res = ::cuda::__driver::__libraryGetGlobalNoThrow(__dptr, __size, __library_, __name))
+    const auto __status = ::cuda::__driver::__libraryGetGlobal(__library_, __name).__error_;
+    switch (__status)
     {
-      case ::cudaSuccess:
+      case ::CUDA_SUCCESS:
         return true;
-      case ::cudaErrorSymbolNotFound:
+      case ::CUDA_ERROR_NOT_FOUND:
         return false;
       default:
-        ::cuda::__throw_cuda_error(__res, "Failed to get the global symbol from library");
+        ::cuda::__throw_cuda_error(__status, "Failed to get the global symbol from library");
     }
   }
 
@@ -141,15 +134,8 @@ public:
   [[nodiscard]] library_symbol_info global(const char* __name, ::cuda::device_ref __device) const
   {
     ::cuda::__ensure_current_context __ctx_guard(__device);
-
-    ::CUdeviceptr __dptr{};
-    ::cuda::std::size_t __size{};
-    if (const auto __res = ::cuda::__driver::__libraryGetGlobalNoThrow(__dptr, __size, __library_, __name);
-        __res != ::cudaSuccess)
-    {
-      ::cuda::__throw_cuda_error(__res, "Failed to get the global symbol from the library");
-    }
-    return library_symbol_info{reinterpret_cast<void*>(__dptr), __size};
+    auto [__ptr, __size] = _CCCL_TRY_DRIVER_API(__libraryGetGlobal(__library_, __name));
+    return library_symbol_info{__ptr, __size};
   }
 
   //! @brief Checks if the library contains a managed symbol with the given name
@@ -163,16 +149,15 @@ public:
   //! @note Managed memory is shared across devices
   [[nodiscard]] bool has_managed(const char* __name) const
   {
-    ::CUdeviceptr __dptr{};
-    ::cuda::std::size_t __size{};
-    switch (const auto __res = ::cuda::__driver::__libraryGetManagedNoThrow(__dptr, __size, __library_, __name))
+    const auto __status = ::cuda::__driver::__libraryGetManaged(__library_, __name).__error_;
+    switch (__status)
     {
-      case ::cudaSuccess:
+      case ::CUDA_SUCCESS:
         return true;
-      case ::cudaErrorSymbolNotFound:
+      case ::CUDA_ERROR_NOT_FOUND:
         return false;
       default:
-        ::cuda::__throw_cuda_error(__res, "Failed to get the managed symbol from library");
+        ::cuda::__throw_cuda_error(__status, "Failed to get the managed symbol from library");
     }
   }
 
@@ -187,14 +172,8 @@ public:
   //! @note Managed memory is shared across devices
   [[nodiscard]] library_symbol_info managed(const char* __name) const
   {
-    ::CUdeviceptr __dptr{};
-    ::cuda::std::size_t __size{};
-    if (const auto __res = ::cuda::__driver::__libraryGetManagedNoThrow(__dptr, __size, __library_, __name);
-        __res != ::cudaSuccess)
-    {
-      ::cuda::__throw_cuda_error(__res, "Failed to get the managed symbol from the library");
-    }
-    return library_symbol_info{reinterpret_cast<void*>(__dptr), __size};
+    auto [__ptr, __size] = _CCCL_TRY_DRIVER_API(__libraryGetManaged(__library_, __name));
+    return library_symbol_info{__ptr, __size};
   }
 
   //! @brief Gets the CUlibrary handle

--- a/cudax/include/cuda/experimental/__memory_resource/synchronous_resource_adapter.cuh
+++ b/cudax/include/cuda/experimental/__memory_resource/synchronous_resource_adapter.cuh
@@ -85,7 +85,7 @@ struct synchronous_resource_adapter : ::cuda::mr::__copy_default_queries<_Resour
     }
     else
     {
-      ::cuda::__driver::__streamSynchronizeNoThrow(__stream.get());
+      _CCCL_ASSERT_DRIVER_API(__streamSynchronize(__stream.get()));
       __resource.deallocate_sync(__ptr, __bytes, __alignment);
     }
   }

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -95,7 +95,7 @@ struct stream : stream_ref
     {
       // Needs to call driver API in case current device is not set, runtime version would set dev 0 current
       // Alternative would be to store the device and push/pop here
-      [[maybe_unused]] auto status = ::cuda::__driver::__streamDestroyNoThrow(__stream);
+      _CCCL_ASSERT_DRIVER_API(__streamDestroy(__stream));
     }
   }
 

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -75,12 +75,12 @@ struct stream_ref : ::cuda::stream_ref
     CUcontext __stream_ctx;
     ::cuda::experimental::logical_device::kinds __ctx_kind = ::cuda::experimental::logical_device::kinds::device;
 #if _CCCL_CTK_AT_LEAST(12, 5)
-    if (::cuda::__driver::__version_at_least(12, 5))
+    if (_CCCL_TRY_DRIVER_API(__version_at_least(12, 5)))
     {
-      auto __ctx = ::cuda::__driver::__streamGetCtx_v2(__stream);
+      auto __ctx = _CCCL_TRY_DRIVER_API(__streamGetCtx_v2(__stream));
       if (__ctx.__ctx_kind_ == ::cuda::__driver::__ctx_from_stream::__kind::__green)
       {
-        __stream_ctx = ::cuda::__driver::__ctxFromGreenCtx(__ctx.__ctx_green_);
+        __stream_ctx = _CCCL_TRY_DRIVER_API(__ctxFromGreenCtx(__ctx.__ctx_green_));
         __ctx_kind   = ::cuda::experimental::logical_device::kinds::green_context;
       }
       else
@@ -92,7 +92,7 @@ struct stream_ref : ::cuda::stream_ref
     else
 #endif // _CCCL_CTK_AT_LEAST(12, 5)
     {
-      __stream_ctx = ::cuda::__driver::__streamGetCtx(__stream);
+      __stream_ctx = _CCCL_TRY_DRIVER_API(__streamGetCtx(__stream));
       __ctx_kind   = ::cuda::experimental::logical_device::kinds::device;
     }
     // Because the stream can come from_native_handle, we can't just loop over devices comparing contexts,

--- a/cudax/test/common/testing.cuh
+++ b/cudax/test/common/testing.cuh
@@ -98,13 +98,27 @@ namespace
 {
 namespace test
 {
+template <class T>
+[[nodiscard]] inline T ccclrt_check_and_extract_driver_result(cuda::__driver::__driver_call_result<T> result)
+{
+  REQUIRE(result.__error_ == CUDA_SUCCESS);
+  return result.__value_;
+}
+
+inline void ccclrt_check_and_extract_driver_result(cuda::__driver::__driver_call_result<void> result)
+{
+  REQUIRE(result.__error_ == CUDA_SUCCESS);
+}
+
+#define CCCLRT_DRIVER_CALL(call) test::ccclrt_check_and_extract_driver_result(cuda::__driver::call)
+
 inline int count_driver_stack()
 {
-  if (cuda::__driver::__ctxGetCurrent() != nullptr)
+  if (_CCCL_TRY_DRIVER_API(__ctxGetCurrent()) != nullptr)
   {
-    auto ctx    = cuda::__driver::__ctxPop();
+    auto ctx    = _CCCL_TRY_DRIVER_API(__ctxPop());
     auto result = 1 + count_driver_stack();
-    cuda::__driver::__ctxPush(ctx);
+    _CCCL_ASSERT_DRIVER_API(__ctxPush(ctx));
     return result;
   }
   else
@@ -115,15 +129,15 @@ inline int count_driver_stack()
 
 inline void empty_driver_stack()
 {
-  while (cuda::__driver::__ctxGetCurrent() != nullptr)
+  while (_CCCL_TRY_DRIVER_API(__ctxGetCurrent()) != nullptr)
   {
-    cuda::__driver::__ctxPop();
+    _CCCL_ASSERT_DRIVER_API(__ctxPop());
   }
 }
 
 inline int cuda_driver_version()
 {
-  return cuda::__driver::__getVersion();
+  return _CCCL_TRY_DRIVER_API(__getVersion());
 }
 
 // Needs to be a template because we use template catch2 macro

--- a/cudax/test/kernel/kernel_ref.cu
+++ b/cudax/test/kernel/kernel_ref.cu
@@ -176,10 +176,10 @@ template <const auto& Attr, ::CUfunction_attribute ExpectedAttr, class ExpectedR
 
 C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
 {
-  CUlibrary lib = ::cuda::__driver::__libraryLoadData(kernel_ptx_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  CUlibrary lib = CCCLRT_DRIVER_CALL(__libraryLoadData(kernel_ptx_src, nullptr, nullptr, 0, nullptr, nullptr, 0));
 
-  CUkernel kernel_ptx1_handle = ::cuda::__driver::__libraryGetKernel(lib, "kernel_ptx1");
-  CUkernel kernel_ptx2_handle = ::cuda::__driver::__libraryGetKernel(lib, "kernel_ptx2");
+  CUkernel kernel_ptx1_handle = CCCLRT_DRIVER_CALL(__libraryGetKernel(lib, "kernel_ptx1"));
+  CUkernel kernel_ptx2_handle = CCCLRT_DRIVER_CALL(__libraryGetKernel(lib, "kernel_ptx2"));
 
   cuda::device_ref device{0};
   cuda::__ensure_current_context context_guard{device};
@@ -314,5 +314,5 @@ C2H_CCCLRT_TEST("Kernel reference", "[kernel_ref]")
   }
 #endif // _CCCL_CTK_AT_LEAST(12, 1)
 
-  CUDAX_REQUIRE(::cuda::__driver::__libraryUnloadNoThrow(lib) == cudaSuccess);
+  CCCLRT_DRIVER_CALL(__libraryUnload(lib));
 }

--- a/cudax/test/launch/configuration.cu
+++ b/cudax/test/launch/configuration.cu
@@ -76,7 +76,7 @@ void test_launch_kernel_replacement(CUlaunchConfig& config, CUfunction kernel, v
 
   if (!has_cluster || !skip_device_exec(arch_filter<std::less<int>, 90>))
   {
-    return ::cuda::__driver::__launchKernel(config, kernel, args);
+    CCCLRT_DRIVER_CALL(__launchKernel(config, kernel, args));
   }
 }
 

--- a/cudax/test/library/library.cu
+++ b/cudax/test/library/library.cu
@@ -105,8 +105,8 @@ C2H_CCCLRT_TEST("Library", "[library]")
   constexpr char const_symbol_name[]   = "const_data";
   constexpr char managed_symbol_name[] = "managed_data";
 
-  CUlibrary lib1_native = ::cuda::__driver::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
-  CUlibrary lib2_native = ::cuda::__driver::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  CUlibrary lib1_native = CCCLRT_DRIVER_CALL(__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0));
+  CUlibrary lib2_native = CCCLRT_DRIVER_CALL(__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0));
 
   const cuda::device_ref device{0};
 
@@ -202,8 +202,7 @@ C2H_CCCLRT_TEST("Library", "[library]")
     cudax::library lib = cudax::library::from_native_handle(lib1_native);
     auto kernel        = lib.kernel<void(int*, int)>(kernel_name);
 
-    CUkernel kernel_handle;
-    CUDAX_REQUIRE(::cuda::__driver::__libraryGetKernelNoThrow(kernel_handle, lib1_native, kernel_name) == cudaSuccess);
+    CUkernel kernel_handle = CCCLRT_DRIVER_CALL(__libraryGetKernel(lib1_native, kernel_name));
     CUDAX_REQUIRE(kernel.get() == kernel_handle);
 
     (void) lib.release(); // prevent library unload in destructor
@@ -236,13 +235,9 @@ C2H_CCCLRT_TEST("Library", "[library]")
 
       cuda::__ensure_current_context context_guard{device};
 
-      CUdeviceptr global_symbol_ptr;
-      cuda::std::size_t global_symbol_size;
-      CUDAX_REQUIRE(::cuda::__driver::__libraryGetGlobalNoThrow(
-                      global_symbol_ptr, global_symbol_size, lib1_native, global_symbol_name)
-                    == cudaSuccess);
-
-      CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(global_sym.ptr) == global_symbol_ptr);
+      const auto [global_symbol_ptr, global_symbol_size] =
+        CCCLRT_DRIVER_CALL(__libraryGetGlobal(lib1_native, global_symbol_name));
+      CUDAX_REQUIRE(global_sym.ptr == global_symbol_ptr);
       CUDAX_REQUIRE(global_sym.size == global_symbol_size);
       CUDAX_REQUIRE(global_sym.size == sizeof(int));
     }
@@ -253,13 +248,9 @@ C2H_CCCLRT_TEST("Library", "[library]")
 
       cuda::__ensure_current_context context_guard{device};
 
-      CUdeviceptr const_symbol_ptr;
-      cuda::std::size_t const_symbol_size;
-      CUDAX_REQUIRE(
-        ::cuda::__driver::__libraryGetGlobalNoThrow(const_symbol_ptr, const_symbol_size, lib1_native, const_symbol_name)
-        == cudaSuccess);
-
-      CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(const_sym.ptr) == const_symbol_ptr);
+      const auto [const_symbol_ptr, const_symbol_size] =
+        CCCLRT_DRIVER_CALL(__libraryGetGlobal(lib1_native, const_symbol_name));
+      CUDAX_REQUIRE(const_sym.ptr == const_symbol_ptr);
       CUDAX_REQUIRE(const_sym.size == const_symbol_size);
       CUDAX_REQUIRE(const_sym.size == sizeof(int));
     }
@@ -287,13 +278,9 @@ C2H_CCCLRT_TEST("Library", "[library]")
     cudax::library lib = cudax::library::from_native_handle(lib1_native);
     auto managed_sym   = lib.managed(managed_symbol_name);
 
-    CUdeviceptr managed_symbol_ptr;
-    cuda::std::size_t managed_symbol_size;
-    CUDAX_REQUIRE(::cuda::__driver::__libraryGetManagedNoThrow(
-                    managed_symbol_ptr, managed_symbol_size, lib1_native, managed_symbol_name)
-                  == cudaSuccess);
-
-    CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(managed_sym.ptr) == managed_symbol_ptr);
+    auto [managed_symbol_ptr,
+          managed_symbol_size] = CCCLRT_DRIVER_CALL(__libraryGetManaged(lib1_native, managed_symbol_name));
+    CUDAX_REQUIRE(managed_sym.ptr == managed_symbol_ptr);
     CUDAX_REQUIRE(managed_sym.size == managed_symbol_size);
     CUDAX_REQUIRE(managed_sym.size == sizeof(int));
 

--- a/cudax/test/library/library_ref.cu
+++ b/cudax/test/library/library_ref.cu
@@ -105,8 +105,8 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
   constexpr char const_symbol_name[]   = "const_data";
   constexpr char managed_symbol_name[] = "managed_data";
 
-  CUlibrary lib1 = ::cuda::__driver::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
-  CUlibrary lib2 = ::cuda::__driver::__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0);
+  CUlibrary lib1 = CCCLRT_DRIVER_CALL(__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0));
+  CUlibrary lib2 = CCCLRT_DRIVER_CALL(__libraryLoadData(library_src, nullptr, nullptr, 0, nullptr, nullptr, 0));
 
   const cuda::device_ref device{0};
 
@@ -160,8 +160,7 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     cudax::library_ref lib_ref{lib1};
     auto kernel = lib_ref.kernel<void(int*, int)>(kernel_name);
 
-    CUkernel kernel_handle;
-    CUDAX_REQUIRE(::cuda::__driver::__libraryGetKernelNoThrow(kernel_handle, lib1, kernel_name) == cudaSuccess);
+    CUkernel kernel_handle = CCCLRT_DRIVER_CALL(__libraryGetKernel(lib1, kernel_name));
     CUDAX_REQUIRE(kernel.get() == kernel_handle);
   }
 
@@ -191,13 +190,8 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
 
       cuda::__ensure_current_context context_guard{device};
 
-      CUdeviceptr global_symbol_ptr;
-      cuda::std::size_t global_symbol_size;
-      CUDAX_REQUIRE(
-        ::cuda::__driver::__libraryGetGlobalNoThrow(global_symbol_ptr, global_symbol_size, lib1, global_symbol_name)
-        == cudaSuccess);
-
-      CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(global_sym.ptr) == global_symbol_ptr);
+      auto [global_symbol_ptr, global_symbol_size] = CCCLRT_DRIVER_CALL(__libraryGetGlobal(lib1, global_symbol_name));
+      CUDAX_REQUIRE(global_sym.ptr == global_symbol_ptr);
       CUDAX_REQUIRE(global_sym.size == global_symbol_size);
       CUDAX_REQUIRE(global_sym.size == sizeof(int));
     }
@@ -208,13 +202,8 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
 
       cuda::__ensure_current_context context_guard{device};
 
-      CUdeviceptr const_symbol_ptr;
-      cuda::std::size_t const_symbol_size;
-      CUDAX_REQUIRE(
-        ::cuda::__driver::__libraryGetGlobalNoThrow(const_symbol_ptr, const_symbol_size, lib1, const_symbol_name)
-        == cudaSuccess);
-
-      CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(const_sym.ptr) == const_symbol_ptr);
+      auto [const_symbol_ptr, const_symbol_size] = CCCLRT_DRIVER_CALL(__libraryGetGlobal(lib1, const_symbol_name));
+      CUDAX_REQUIRE(const_sym.ptr == const_symbol_ptr);
       CUDAX_REQUIRE(const_sym.size == const_symbol_size);
       CUDAX_REQUIRE(const_sym.size == sizeof(int));
     }
@@ -238,13 +227,8 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     cudax::library_ref lib_ref{lib1};
     auto managed_sym = lib_ref.managed(managed_symbol_name);
 
-    CUdeviceptr managed_symbol_ptr;
-    cuda::std::size_t managed_symbol_size;
-    CUDAX_REQUIRE(
-      ::cuda::__driver::__libraryGetManagedNoThrow(managed_symbol_ptr, managed_symbol_size, lib1, managed_symbol_name)
-      == cudaSuccess);
-
-    CUDAX_REQUIRE(reinterpret_cast<CUdeviceptr>(managed_sym.ptr) == managed_symbol_ptr);
+    auto [managed_symbol_ptr, managed_symbol_size] = CCCLRT_DRIVER_CALL(__libraryGetManaged(lib1, managed_symbol_name));
+    CUDAX_REQUIRE(managed_sym.ptr == managed_symbol_ptr);
     CUDAX_REQUIRE(managed_sym.size == managed_symbol_size);
     CUDAX_REQUIRE(managed_sym.size == sizeof(int));
   }
@@ -266,6 +250,6 @@ C2H_CCCLRT_TEST("Library reference", "[library_ref]")
     CUDAX_REQUIRE(lib_ref1 != lib_ref2);
   }
 
-  CUDAX_REQUIRE(::cuda::__driver::__libraryUnloadNoThrow(lib1) == cudaSuccess);
-  CUDAX_REQUIRE(::cuda::__driver::__libraryUnloadNoThrow(lib2) == cudaSuccess);
+  CCCLRT_DRIVER_CALL(__libraryUnload(lib1));
+  CCCLRT_DRIVER_CALL(__libraryUnload(lib2));
 }

--- a/cudax/test/utility/ensure_current_device.cu
+++ b/cudax/test/utility/ensure_current_device.cu
@@ -21,7 +21,7 @@ void recursive_check_device_setter(int id)
   int cudart_id;
   cudax::__ensure_current_device setter(cuda::device_ref{id});
   CUDAX_REQUIRE(test::count_driver_stack() == cuda::devices.size() - id);
-  auto ctx = driver::__ctxGetCurrent();
+  auto ctx = CCCLRT_DRIVER_CALL(__ctxGetCurrent());
   CUDART(cudaGetDevice(&cudart_id));
   CUDAX_REQUIRE(cudart_id == id);
 
@@ -30,7 +30,7 @@ void recursive_check_device_setter(int id)
     recursive_check_device_setter(id - 1);
 
     CUDAX_REQUIRE(test::count_driver_stack() == cuda::devices.size() - id);
-    CUDAX_REQUIRE(ctx == driver::__ctxGetCurrent());
+    CUDAX_REQUIRE(ctx == CCCLRT_DRIVER_CALL(__ctxGetCurrent()));
     CUDART(cudaGetDevice(&cudart_id));
     CUDAX_REQUIRE(cudart_id == id);
   }

--- a/libcudacxx/include/cuda/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/__algorithm/copy.h
@@ -90,10 +90,10 @@ _CCCL_HOST_API void __copy_bytes_impl(
   __attributes.dstLocHint.type    = static_cast<::CUmemLocationType>(__config.dst_location_hint.type);
 
   ::cuda::__ensure_current_context guard(__stream);
-  ::cuda::__driver::__memcpyAsyncWithAttributes(
-    __dst.data(), __src.data(), __src.size_bytes(), __stream.get(), __attributes);
+  _CCCL_TRY_DRIVER_API(
+    __memcpyAsyncWithAttributes(__dst.data(), __src.data(), __src.size_bytes(), __stream.get(), __attributes));
 #  else
-  ::cuda::__driver::__memcpyAsync(__dst.data(), __src.data(), __src.size_bytes(), __stream.get());
+  _CCCL_TRY_DRIVER_API(__memcpyAsync(__dst.data(), __src.data(), __src.size_bytes(), __stream.get()));
 #  endif // _CCCL_CTK_BELOW(13, 0)
 }
 

--- a/libcudacxx/include/cuda/__algorithm/fill.h
+++ b/libcudacxx/include/cuda/__algorithm/fill.h
@@ -42,7 +42,7 @@ __fill_bytes_impl(stream_ref __stream, ::cuda::std::span<_DstTy, _DstSize> __dst
   static_assert(::cuda::std::is_trivially_copyable_v<_DstTy>);
 
   // TODO do a host callback if not device accessible?
-  ::cuda::__driver::__memsetAsync(__dst.data(), __value, __dst.size_bytes(), __stream.get());
+  _CCCL_TRY_DRIVER_API(__memsetAsync(__dst.data(), __value, __dst.size_bytes(), __stream.get()));
 }
 
 template <typename _DstElem, typename _DstExtents, typename _DstLayout, typename _DstAccessor>

--- a/libcudacxx/include/cuda/__device/attributes.h
+++ b/libcudacxx/include/cuda/__device/attributes.h
@@ -45,8 +45,8 @@ struct __dev_attr_impl
 
   [[nodiscard]] _CCCL_HOST_API type operator()(device_ref __dev) const
   {
-    return static_cast<type>(::cuda::__driver::__deviceGetAttribute(
-      static_cast<::CUdevice_attribute>(_Attr), ::cuda::__driver::__deviceGet(__dev.get())));
+    return static_cast<type>(_CCCL_TRY_DRIVER_API(
+      __deviceGetAttribute(static_cast<::CUdevice_attribute>(_Attr), _CCCL_TRY_DRIVER_API(__deviceGet(__dev.get())))));
   }
 };
 

--- a/libcudacxx/include/cuda/__device/device_ref.h
+++ b/libcudacxx/include/cuda/__device/device_ref.h
@@ -142,8 +142,8 @@ public:
   //! @return true if its possible for this device to access the specified device's memory
   [[nodiscard]] _CCCL_HOST_API bool has_peer_access_to(device_ref __other_dev) const
   {
-    return ::cuda::__driver::__deviceCanAccessPeer(
-      ::cuda::__driver::__deviceGet(get()), ::cuda::__driver::__deviceGet(__other_dev.get()));
+    return _CCCL_TRY_DRIVER_API(__deviceCanAccessPeer(
+      _CCCL_TRY_DRIVER_API(__deviceGet(get())), _CCCL_TRY_DRIVER_API(__deviceGet(__other_dev.get()))));
   }
 
   // TODO this might return some more complex type in the future

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -27,12 +27,54 @@
 #  include <cuda/std/__internal/namespaces.h>
 #  include <cuda/std/__type_traits/always_false.h>
 #  include <cuda/std/__type_traits/is_same.h>
+#  include <cuda/std/__utility/pod_tuple.h>
+#  include <cuda/std/source_location>
 
 #  include <cuda.h>
 
 #  include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_DRIVER
+
+template <class _Tp>
+struct [[nodiscard]] __driver_call_result
+{
+  _Tp __value_;
+  ::CUresult __error_;
+};
+
+template <>
+struct [[nodiscard]] __driver_call_result<void>
+{
+  ::CUresult __error_;
+};
+
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API constexpr _Tp __check_and_extract_result(
+  __driver_call_result<_Tp> __result, ::cuda::std::source_location __loc = ::cuda::std::source_location::current())
+{
+  if (__result.__error_ != ::CUDA_SUCCESS)
+  {
+    ::cuda::__throw_cuda_error(__result.__error_, "", nullptr, __loc);
+  }
+  return __result.__value_;
+}
+
+_CCCL_HOST_API inline void __check_and_extract_result(
+  __driver_call_result<void> __result, ::cuda::std::source_location __loc = ::cuda::std::source_location::current())
+{
+  if (__result.__error_ != ::CUDA_SUCCESS)
+  {
+    ::cuda::__throw_cuda_error(__result.__error_, "", nullptr, __loc);
+  }
+}
+
+#  define _CCCL_TRY_DRIVER_API(...) ::cuda::__driver::__check_and_extract_result(::cuda::__driver::__VA_ARGS__)
+#  define _CCCL_ASSERT_DRIVER_API(...)                                                                     \
+    do                                                                                                     \
+    {                                                                                                      \
+      _CCCL_ASSERT((::cuda::__driver::__VA_ARGS__).__error_ == ::CUDA_SUCCESS, "CUDA Driver call failed"); \
+    } while (0)
 
 // Get the driver function by name using this macro
 #  define _CCCLRT_GET_DRIVER_FUNCTION(function_name) \
@@ -104,23 +146,6 @@ _CCCL_SUPPRESS_DEPRECATED_POP
   return __fn;
 }
 
-//! @brief CUDA Driver API call wrapper. Calls a given CUDA Driver API and checks the return value.
-//!
-//! @param __fn A CUDA Driver function.
-//! @param __err_msg Error message describing the call if the all fails.
-//! @param __args The arguments to the @c __fn call.
-//!
-//! @throws @c cuda::cuda_error if the function call doesn't return CUDA_SUCCESS.
-template <typename Fn, typename... Args>
-_CCCL_HOST_API inline void __call_driver_fn(Fn __fn, const char* __err_msg, Args... __args)
-{
-  ::CUresult __status = __fn(__args...);
-  if (__status != ::CUDA_SUCCESS)
-  {
-    ::cuda::__throw_cuda_error(static_cast<::cudaError_t>(__status), __err_msg);
-  }
-}
-
 //! @brief Initializes the CUDA Driver.
 //!
 //! @param __get_proc_addr_fn The pointer to cuGetProcAddress function.
@@ -132,7 +157,10 @@ _CCCL_HOST_API inline void __call_driver_fn(Fn __fn, const char* __err_msg, Args
 {
   auto __driver_fn = reinterpret_cast<decltype(::cuInit)*>(
     ::cuda::__driver::__get_driver_entry_point_impl(__get_proc_addr_fn, "cuInit", 12, 0));
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to initialize CUDA Driver", 0);
+  if (auto __status = __driver_fn(0); __status != ::CUDA_SUCCESS)
+  {
+    ::cuda::__throw_cuda_error(__status, "Failed to initialize CUDA Driver");
+  }
   return true;
 }
 
@@ -165,142 +193,147 @@ __get_driver_entry_point(const char* __name, [[maybe_unused]] int __major = 12, 
 
 // Version management
 
-[[nodiscard]] _CCCL_HOST_API inline int __getVersion()
+_CCCL_HOST_API inline __driver_call_result<int> __getVersion() noexcept
 {
-  static int __version = []() {
-    int __v;
-    auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDriverGetVersion);
-    ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to check CUDA driver version", &__v);
-    return __v;
-  }();
-  return __version;
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDriverGetVersion);
+  __driver_call_result<int> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline bool __version_at_least(int __major, int __minor)
+_CCCL_HOST_API inline __driver_call_result<bool> __version_at_least(int __major, int __minor) noexcept
 {
-  return ::cuda::__driver::__getVersion() >= ::cuda::__driver::__make_version(__major, __minor);
+  __driver_call_result<bool> __ret{};
+  auto __version = ::cuda::__driver::__getVersion();
+  __ret.__error_ = __version.__error_;
+  if (__ret.__error_ == ::CUDA_SUCCESS)
+  {
+    __ret.__value_ = __version.__value_ >= ::cuda::__driver::__make_version(__major, __minor);
+  }
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline bool __version_below(int __major, int __minor)
+_CCCL_HOST_API inline __driver_call_result<bool> __version_below(int __major, int __minor) noexcept
 {
-  return ::cuda::__driver::__getVersion() < ::cuda::__driver::__make_version(__major, __minor);
+  __driver_call_result<bool> __ret{};
+  auto __version = ::cuda::__driver::__getVersion();
+  __ret.__error_ = __version.__error_;
+  if (__ret.__error_ == ::CUDA_SUCCESS)
+  {
+    __ret.__value_ = __version.__value_ < ::cuda::__driver::__make_version(__major, __minor);
+  }
+  return __ret;
 }
 
 // Device management
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUdevice __deviceGet(int __ordinal)
+_CCCL_HOST_API inline __driver_call_result<::CUdevice> __deviceGet(int __ordinal) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceGet);
-  ::CUdevice __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get device", &__result, __ordinal);
-  return __result;
+  __driver_call_result<::CUdevice> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __ordinal);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUdevice __deviceGetAttribute(::CUdevice_attribute __attr, ::CUdevice __device)
+_CCCL_HOST_API inline __driver_call_result<int>
+__deviceGetAttribute(::CUdevice_attribute __attr, ::CUdevice __device) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceGetAttribute);
-  int __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get device attribute", &__result, __attr, __device);
-  return __result;
+  __driver_call_result<int> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __attr, __device);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline int __deviceGetCount()
+_CCCL_HOST_API inline __driver_call_result<int> __deviceGetCount() noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceGetCount);
-  int __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get device count", &__result);
-  return __result;
+  __driver_call_result<int> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_);
+  return __ret;
 }
 
-_CCCL_HOST_API inline void __deviceGetName(char* __name_out, int __len, int __ordinal)
+_CCCL_HOST_API inline __driver_call_result<void> __deviceGetName(char* __name, int __len, ::CUdevice __device) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceGetName);
-
-  // TODO CUdevice is just an int, we probably could just cast, but for now do the safe thing
-  ::CUdevice __dev = __deviceGet(__ordinal);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to query the name of a device", __name_out, __len, __dev);
+  return {__driver_fn(__name, __len, __device)};
 }
 
 // Primary context management
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUcontext __primaryCtxRetain(::CUdevice __dev)
+_CCCL_HOST_API inline __driver_call_result<::CUcontext> __primaryCtxRetain(::CUdevice __dev) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxRetain);
-  ::CUcontext __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to retain context for a device", &__result, __dev);
-  return __result;
+  __driver_call_result<::CUcontext> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __dev);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __primaryCtxReleaseNoThrow(::CUdevice __dev)
+_CCCL_HOST_API inline __driver_call_result<void> __primaryCtxRelease(::CUdevice __dev) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxRelease);
-  return static_cast<::cudaError_t>(__driver_fn(__dev));
+  return {__driver_fn(__dev)};
 }
 
-[[nodiscard]] _CCCL_HOST_API inline bool __isPrimaryCtxActive(::CUdevice __dev)
+_CCCL_HOST_API inline __driver_call_result<bool> __isPrimaryCtxActive(::CUdevice __dev) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDevicePrimaryCtxGetState);
-  int __result;
-  unsigned int __dummy;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to check the primary ctx state", __dev, &__dummy, &__result);
-  return __result == 1;
+  __driver_call_result<bool> __ret{};
+  int __active{};
+  unsigned __dummy{};
+  __ret.__error_ = __driver_fn(__dev, &__dummy, &__active);
+  __ret.__value_ = __active == 1;
+  return __ret;
 }
 
 // Context management
 
-_CCCL_HOST_API inline void __ctxPush(::CUcontext __ctx)
+_CCCL_HOST_API inline __driver_call_result<void> __ctxPush(::CUcontext __ctx) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuCtxPushCurrent);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to push context", __ctx);
+  return {__driver_fn(__ctx)};
 }
 
-_CCCL_HOST_API inline ::CUcontext __ctxPop()
+_CCCL_HOST_API inline __driver_call_result<::CUcontext> __ctxPop() noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuCtxPopCurrent);
-  ::CUcontext __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to pop context", &__result);
-  return __result;
+  __driver_call_result<::CUcontext> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUcontext __ctxGetCurrent()
+_CCCL_HOST_API inline __driver_call_result<::CUcontext> __ctxGetCurrent() noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuCtxGetCurrent);
-  ::CUcontext __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get current context", &__result);
-  return __result;
+  __driver_call_result<::CUcontext> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUdevice __ctxGetDevice()
+_CCCL_HOST_API inline __driver_call_result<::CUdevice> __ctxGetDevice() noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuCtxGetDevice);
-  ::CUdevice __result{};
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get current context", &__result);
-  return __result;
+  __driver_call_result<::CUdevice> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_);
+  return __ret;
 }
 
 // Memory management
 
-_CCCL_HOST_API inline void __memcpyAsync(void* __dst, const void* __src, size_t __count, ::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<void>
+__memcpyAsync(void* __dst, const void* __src, ::cuda::std::size_t __count, ::CUstream __stream) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemcpyAsync);
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn,
-    "Failed to perform a memcpy",
-    reinterpret_cast<::CUdeviceptr>(__dst),
-    reinterpret_cast<::CUdeviceptr>(__src),
-    __count,
-    __stream);
+  return {
+    __driver_fn(reinterpret_cast<::CUdeviceptr>(__dst), reinterpret_cast<::CUdeviceptr>(__src), __count, __stream)};
 }
 
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-_CCCL_HOST_API inline void __memcpyAsyncWithAttributes(
-  void* __dst, const void* __src, size_t __count, ::CUstream __stream, ::CUmemcpyAttributes __attributes)
+_CCCL_HOST_API inline __driver_call_result<void> __memcpyAsyncWithAttributes(
+  void* __dst, const void* __src, size_t __count, ::CUstream __stream, ::CUmemcpyAttributes __attributes) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuMemcpyBatchAsync, cuMemcpyBatchAsync, 13, 0);
-  size_t __zero           = 0;
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn,
-    "Failed to perform a memcpy with attributes",
+  ::cuda::std::size_t __zero{};
+  return {__driver_fn(
     reinterpret_cast<::CUdeviceptr*>(&__dst),
     reinterpret_cast<::CUdeviceptr*>(&__src),
     &__count,
@@ -308,139 +341,142 @@ _CCCL_HOST_API inline void __memcpyAsyncWithAttributes(
     &__attributes,
     &__zero,
     1,
-    __stream);
+    __stream)};
 }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
-template <typename _Tp>
-_CCCL_HOST_API void __memsetAsync(void* __dst, _Tp __value, size_t __count, ::CUstream __stream)
+template <class _Tp>
+_CCCL_HOST_API __driver_call_result<void>
+__memsetAsync(void* __dst, _Tp __value, size_t __count, ::CUstream __stream) noexcept
 {
   if constexpr (sizeof(_Tp) == 1)
   {
     static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD8Async);
-    ::cuda::__driver::__call_driver_fn(
-      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __value, __count, __stream);
+    return {__driver_fn(reinterpret_cast<::CUdeviceptr>(__dst), __value, __count, __stream)};
   }
   else if constexpr (sizeof(_Tp) == 2)
   {
     static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD16Async);
-    ::cuda::__driver::__call_driver_fn(
-      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __value, __count, __stream);
+    return {__driver_fn(reinterpret_cast<::CUdeviceptr>(__dst), __value, __count, __stream)};
   }
   else if constexpr (sizeof(_Tp) == 4)
   {
     static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD32Async);
-    ::cuda::__driver::__call_driver_fn(
-      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __value, __count, __stream);
+    return {__driver_fn(reinterpret_cast<::CUdeviceptr>(__dst), __value, __count, __stream)};
   }
   else
   {
     static_assert(::cuda::std::__always_false_v<_Tp>, "Unsupported type for memset");
+    return {};
   }
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
-__mempoolCreateNoThrow(::CUmemoryPool* __pool, ::CUmemPoolProps* __props)
+_CCCL_HOST_API inline __driver_call_result<::CUmemoryPool> __mempoolCreate(::CUmemPoolProps* __props) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolCreate);
-  return static_cast<::cudaError_t>(__driver_fn(__pool, __props));
+  __driver_call_result<::CUmemoryPool> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __props);
+  return __ret;
 }
 
-_CCCL_HOST_API inline void __mempoolSetAttribute(::CUmemoryPool __pool, ::CUmemPool_attribute __attr, void* __value)
+_CCCL_HOST_API inline __driver_call_result<void>
+__mempoolSetAttribute(::CUmemoryPool __pool, ::CUmemPool_attribute __attr, void* __value) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolSetAttribute);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to set attribute for a memory pool", __pool, __attr, __value);
+  return {__driver_fn(__pool, __attr, __value)};
 }
 
-_CCCL_HOST_API inline size_t __mempoolGetAttribute(::CUmemoryPool __pool, ::CUmemPool_attribute __attr)
+_CCCL_HOST_API inline __driver_call_result<::cuda::std::size_t>
+__mempoolGetAttribute(::CUmemoryPool __pool, ::CUmemPool_attribute __attr) noexcept
 {
-  size_t __value          = 0;
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolGetAttribute);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get attribute for a memory pool", __pool, __attr, &__value);
-  return __value;
+  __driver_call_result<::cuda::std::size_t> __ret{};
+  __ret.__error_ = __driver_fn(__pool, __attr, &__ret.__value_);
+  return __ret;
 }
 
-_CCCL_HOST_API inline void __mempoolDestroy(::CUmemoryPool __pool)
+_CCCL_HOST_API inline __driver_call_result<void> __mempoolDestroy(::CUmemoryPool __pool) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolDestroy);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to destroy a memory pool", __pool);
+  return {__driver_fn(__pool)};
 }
 
-_CCCL_HOST_API inline ::CUdeviceptr
-__mallocFromPoolAsync(::cuda::std::size_t __bytes, ::CUmemoryPool __pool, ::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<void*>
+__mallocFromPoolAsync(::cuda::std::size_t __bytes, ::CUmemoryPool __pool, ::CUstream __stream) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemAllocFromPoolAsync);
-  ::CUdeviceptr __result  = 0;
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn, "Failed to allocate memory from a memory pool", &__result, __bytes, __pool, __stream);
-  return __result;
+  __driver_call_result<void*> __ret{};
+  __ret.__error_ = __driver_fn(reinterpret_cast<::CUdeviceptr*>(&__ret.__value_), __bytes, __pool, __stream);
+  return __ret;
 }
 
-_CCCL_HOST_API inline void __mempoolTrimTo(::CUmemoryPool __pool, ::cuda::std::size_t __min_bytes_to_keep)
+_CCCL_HOST_API inline __driver_call_result<void>
+__mempoolTrimTo(::CUmemoryPool __pool, ::cuda::std::size_t __min_bytes_to_keep) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolTrimTo);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to trim a memory pool", __pool, __min_bytes_to_keep);
+  return {__driver_fn(__pool, __min_bytes_to_keep)};
 }
 
-_CCCL_HOST_API inline ::cudaError_t __freeAsyncNoThrow(::CUdeviceptr __dptr, ::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<void> __freeAsync(void* __ptr, ::CUstream __stream) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemFreeAsync);
-  return static_cast<::cudaError_t>(__driver_fn(__dptr, __stream));
+  return {__driver_fn(reinterpret_cast<::CUdeviceptr>(__ptr), __stream)};
 }
 
-_CCCL_HOST_API inline void __mempoolSetAccess(::CUmemoryPool __pool, ::CUmemAccessDesc* __descs, ::size_t __count)
+_CCCL_HOST_API inline __driver_call_result<void>
+__mempoolSetAccess(::CUmemoryPool __pool, ::CUmemAccessDesc* __descs, ::cuda::std::size_t __count) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolSetAccess);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to set access of a memory pool", __pool, __descs, __count);
+  return {__driver_fn(__pool, __descs, __count)};
 }
 
-_CCCL_HOST_API inline ::CUmemAccess_flags __mempoolGetAccess(::CUmemoryPool __pool, ::CUmemLocation* __location)
+_CCCL_HOST_API inline __driver_call_result<::CUmemAccess_flags>
+__mempoolGetAccess(::CUmemoryPool __pool, ::CUmemLocation* __location) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemPoolGetAccess);
-  ::CUmemAccess_flags __flags;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get access of a memory pool", &__flags, __pool, __location);
-  return __flags;
+  __driver_call_result<::CUmemAccess_flags> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __pool, __location);
+  return __ret;
 }
 
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-_CCCL_HOST_API inline ::CUmemoryPool
-__getDefaultMemPool(CUmemLocation __location, CUmemAllocationType_enum __allocation_type)
+_CCCL_HOST_API inline __driver_call_result<::CUmemoryPool>
+__getDefaultMemPool(CUmemLocation __location, CUmemAllocationType_enum __allocation_type) noexcept
 {
   static auto __driver_fn =
     _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuMemGetDefaultMemPool, cuMemGetDefaultMemPool, 13, 0);
-  ::CUmemoryPool __result = nullptr;
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn, "Failed to get default memory pool", &__result, &__location, __allocation_type);
-  return __result;
+  __driver_call_result<::CUmemoryPool> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, &__location, __allocation_type);
+  return __ret;
 }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
-_CCCL_HOST_API inline ::CUdeviceptr __mallocManaged(::cuda::std::size_t __bytes, unsigned int __flags)
+_CCCL_HOST_API inline __driver_call_result<void*> __mallocManaged(::cuda::std::size_t __bytes, unsigned __flags) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemAllocManaged);
-  ::CUdeviceptr __result  = 0;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to allocate managed memory", &__result, __bytes, __flags);
-  return __result;
+  __driver_call_result<void*> __ret{};
+  __ret.__error_ = __driver_fn(reinterpret_cast<::CUdeviceptr*>(&__ret.__value_), __bytes, __flags);
+  return __ret;
 }
 
-_CCCL_HOST_API inline void* __mallocHost(::cuda::std::size_t __bytes)
+_CCCL_HOST_API inline __driver_call_result<void*> __mallocHost(::cuda::std::size_t __bytes) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemAllocHost);
-  void* __result          = nullptr;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to allocate host memory", &__result, __bytes);
-  return __result;
+  __driver_call_result<void*> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __bytes);
+  return __ret;
 }
 
-_CCCL_HOST_API inline ::cudaError_t __freeNoThrow(::CUdeviceptr __dptr)
+_CCCL_HOST_API inline __driver_call_result<void> __free(void* __ptr) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemFree);
-  return static_cast<::cudaError_t>(__driver_fn(__dptr));
+  return {__driver_fn(reinterpret_cast<::CUdeviceptr>(__ptr))};
 }
 
-_CCCL_HOST_API inline ::cudaError_t __freeHostNoThrow(void* __dptr)
+_CCCL_HOST_API inline __driver_call_result<void> __freeHost(void* __dptr) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemFreeHost);
-  return static_cast<::cudaError_t>(__driver_fn(__dptr));
+  return {__driver_fn(__dptr)};
 }
 
 // Unified Addressing
@@ -483,72 +519,62 @@ template <::CUpointer_attribute _Attr>
 using __pointer_attribute_value_type_t = decltype(::cuda::__driver::__pointer_attribute_value_type_t_impl<_Attr>());
 
 template <::CUpointer_attribute _Attr>
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
-__pointerGetAttributeNoThrow(__pointer_attribute_value_type_t<_Attr>& __result, const void* __ptr)
+_CCCL_HOST_API inline __driver_call_result<__pointer_attribute_value_type_t<_Attr>>
+__pointerGetAttribute(const void* __ptr) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuPointerGetAttribute);
-  ::cudaError_t __status{};
+  __driver_call_result<__pointer_attribute_value_type_t<_Attr>> __ret{};
   if constexpr (::cuda::std::is_same_v<__pointer_attribute_value_type_t<_Attr>, bool>)
   {
     int __result2{};
-    __status = static_cast<::cudaError_t>(__driver_fn(&__result2, _Attr, reinterpret_cast<::CUdeviceptr>(__ptr)));
-    __result = static_cast<bool>(__result2);
+    __ret.__error_ = __driver_fn(&__result2, _Attr, reinterpret_cast<::CUdeviceptr>(__ptr));
+    __ret.__value_ = static_cast<bool>(__result2);
   }
   else
   {
-    __status =
-      static_cast<::cudaError_t>(__driver_fn((void*) &__result, _Attr, reinterpret_cast<::CUdeviceptr>(__ptr)));
+    __ret.__error_ = __driver_fn((void*) &__ret.__value_, _Attr, reinterpret_cast<::CUdeviceptr>(__ptr));
   }
-  return __status;
+  return __ret;
 }
 
 template <::cuda::std::size_t _Np>
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
-__pointerGetAttributesNoThrow(::CUpointer_attribute (&__attrs)[_Np], void* (&__results)[_Np], const void* __ptr)
+_CCCL_HOST_API inline __driver_call_result<void>
+__pointerGetAttributes(::CUpointer_attribute (&__attrs)[_Np], void* (&__results)[_Np], const void* __ptr) noexcept
 {
-  static const auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuPointerGetAttributes);
-  return static_cast<::cudaError_t>(
-    __driver_fn(static_cast<unsigned>(_Np), __attrs, __results, reinterpret_cast<::CUdeviceptr>(__ptr)));
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuPointerGetAttributes);
+  return {__driver_fn(static_cast<unsigned>(_Np), __attrs, __results, reinterpret_cast<::CUdeviceptr>(__ptr))};
 }
 
 // Stream management
 
-_CCCL_HOST_API inline void
-__streamAddCallback(::CUstream __stream, ::CUstreamCallback __cb, void* __data, unsigned __flags = 0)
+_CCCL_HOST_API inline __driver_call_result<void>
+__streamAddCallback(::CUstream __stream, ::CUstreamCallback __cb, void* __data, unsigned __flags = 0) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamAddCallback);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to add a stream callback", __stream, __cb, __data, __flags);
+  return {__driver_fn(__stream, __cb, __data, __flags)};
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUstream __streamCreateWithPriority(unsigned __flags, int __priority)
+_CCCL_HOST_API inline __driver_call_result<::CUstream>
+__streamCreateWithPriority(unsigned __flags, int __priority) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamCreateWithPriority);
-  ::CUstream __stream;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to create a stream", &__stream, __flags, __priority);
-  return __stream;
+  __driver_call_result<::CUstream> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __flags, __priority);
+  return __ret;
 }
 
-_CCCL_HOST_API inline ::cudaError_t __streamSynchronizeNoThrow(::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<void> __streamSynchronize(::CUstream __stream) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamSynchronize);
-  return static_cast<::cudaError_t>(__driver_fn(__stream));
+  return {__driver_fn(__stream)};
 }
 
-_CCCL_HOST_API inline void __streamSynchronize(::CUstream __stream)
-{
-  cudaError_t __status = __streamSynchronizeNoThrow(__stream);
-  if (__status != cudaSuccess)
-  {
-    ::cuda::__throw_cuda_error(__status, "Failed to synchronize a stream");
-  }
-}
-
-[[nodiscard]] _CCCL_HOST_API inline ::CUcontext __streamGetCtx(::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<::CUcontext> __streamGetCtx(::CUstream __stream) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamGetCtx);
-  ::CUcontext __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get context from a stream", __stream, &__result);
-  return __result;
+  __driver_call_result<::CUcontext> __ret{};
+  __ret.__error_ = __driver_fn(__stream, &__ret.__value_);
+  return __ret;
 }
 
 #  if _CCCL_CTK_AT_LEAST(12, 5)
@@ -568,146 +594,145 @@ struct __ctx_from_stream
   };
 };
 
-[[nodiscard]] _CCCL_HOST_API inline __ctx_from_stream __streamGetCtx_v2(::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<__ctx_from_stream> __streamGetCtx_v2(::CUstream __stream) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetCtx, cuStreamGetCtx_v2, 12, 5);
 
   ::CUcontext __ctx   = nullptr;
   ::CUgreenCtx __gctx = nullptr;
-  __ctx_from_stream __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get context from a stream", __stream, &__ctx, &__gctx);
+  __driver_call_result<__ctx_from_stream> __ret{};
+  __ret.__error_ = __driver_fn(__stream, &__ctx, &__gctx);
   if (__gctx)
   {
-    __result.__ctx_kind_  = __ctx_from_stream::__kind::__green;
-    __result.__ctx_green_ = __gctx;
+    __ret.__value_.__ctx_kind_  = __ctx_from_stream::__kind::__green;
+    __ret.__value_.__ctx_green_ = __gctx;
   }
   else
   {
-    __result.__ctx_kind_   = __ctx_from_stream::__kind::__device;
-    __result.__ctx_device_ = __ctx;
+    __ret.__value_.__ctx_kind_   = __ctx_from_stream::__kind::__device;
+    __ret.__value_.__ctx_device_ = __ctx;
   }
-  return __result;
+  return __ret;
 }
 #  endif // _CCCL_CTK_AT_LEAST(12, 5)
 
 // TODO: make this available since CUDA 12.8
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-[[nodiscard]] _CCCL_HOST_API inline ::CUdevice __streamGetDevice(::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<::CUdevice> __streamGetDevice(::CUstream __stream) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuStreamGetDevice, cuStreamGetDevice, 12, 8);
-  ::CUdevice __result{};
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the device of the stream", __stream, &__result);
-  return __result;
+  __driver_call_result<::CUdevice> __ret{};
+  __ret.__error_ = __driver_fn(__stream, &__ret.__value_);
+  return __ret;
 }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
-_CCCL_HOST_API inline void __streamWaitEvent(::CUstream __stream, ::CUevent __evnt)
+_CCCL_HOST_API inline __driver_call_result<void> __streamWaitEvent(::CUstream __stream, ::CUevent __evnt) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamWaitEvent);
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn, "Failed to make a stream wait for an event", __stream, __evnt, ::CU_EVENT_WAIT_DEFAULT);
+  return {__driver_fn(__stream, __evnt, ::CU_EVENT_WAIT_DEFAULT)};
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __streamQueryNoThrow(::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<void> __streamQuery(::CUstream __stream) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamQuery);
-  return static_cast<::cudaError_t>(__driver_fn(__stream));
+  return {__driver_fn(__stream)};
 }
 
-[[nodiscard]] _CCCL_HOST_API inline int __streamGetPriority(::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<int> __streamGetPriority(::CUstream __stream) noexcept
 {
-  int __priority;
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamGetPriority);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the priority of a stream", __stream, &__priority);
-  return __priority;
+  __driver_call_result<::CUdevice> __ret{};
+  __ret.__error_ = __driver_fn(__stream, &__ret.__value_);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline unsigned long long __streamGetId(::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<unsigned long long> __streamGetId(::CUstream __stream) noexcept
 {
-  unsigned long long __id;
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamGetId);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the ID of a stream", __stream, &__id);
-  return __id;
+  __driver_call_result<unsigned long long> __ret{};
+  __ret.__error_ = __driver_fn(__stream, &__ret.__value_);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __streamDestroyNoThrow(::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<void> __streamDestroy(::CUstream __stream) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuStreamDestroy);
-  return static_cast<::cudaError_t>(__driver_fn(__stream));
+  return {__driver_fn(__stream)};
 }
 
 // Event management
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUevent __eventCreate(unsigned __flags)
+_CCCL_HOST_API inline __driver_call_result<::CUevent> __eventCreate(unsigned __flags) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventCreate);
-  ::CUevent __evnt;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to create a CUDA event", &__evnt, __flags);
-  return __evnt;
+  __driver_call_result<::CUevent> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __flags);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __eventDestroyNoThrow(::CUevent __evnt)
+_CCCL_HOST_API inline __driver_call_result<void> __eventDestroy(::CUevent __evnt) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventDestroy);
-  return static_cast<::cudaError_t>(__driver_fn(__evnt));
+  return {__driver_fn(__evnt)};
 }
 
-[[nodiscard]] _CCCL_HOST_API inline float __eventElapsedTime(::CUevent __start, ::CUevent __end)
+_CCCL_HOST_API inline __driver_call_result<float> __eventElapsedTime(::CUevent __start, ::CUevent __end) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventElapsedTime);
-  float __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get event elapsed time", &__result, __start, __end);
-  return __result;
+  __driver_call_result<float> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __start, __end);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __eventQueryNoThrow(::CUevent __evnt)
+_CCCL_HOST_API inline __driver_call_result<void> __eventQuery(::CUevent __evnt) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventQuery);
-  return static_cast<::cudaError_t>(__driver_fn(__evnt));
+  return {__driver_fn(__evnt)};
 }
 
-_CCCL_HOST_API inline void __eventRecord(::CUevent __evnt, ::CUstream __stream)
+_CCCL_HOST_API inline __driver_call_result<void> __eventRecord(::CUevent __evnt, ::CUstream __stream) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventRecord);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to record an event", __evnt, __stream);
+  return {__driver_fn(__evnt, __stream)};
 }
 
-_CCCL_HOST_API inline void __eventSynchronize(::CUevent __evnt)
+_CCCL_HOST_API inline __driver_call_result<void> __eventSynchronize(::CUevent __evnt) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventSynchronize);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to synchronize an event", __evnt);
+  return {__driver_fn(__evnt)};
 }
 
 // Library management
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUfunction __kernelGetFunction(::CUkernel __kernel)
+_CCCL_HOST_API inline __driver_call_result<::CUfunction> __kernelGetFunction(::CUkernel __kernel) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuKernelGetFunction);
-  ::CUfunction __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get kernel function", &__result, __kernel);
-  return __result;
+  __driver_call_result<::CUfunction> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __kernel);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline int
-__kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdevice __dev)
+_CCCL_HOST_API inline __driver_call_result<int>
+__kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdevice __dev) noexcept
 {
-  int __value;
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuKernelGetAttribute);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get kernel attribute", &__value, __attr, __kernel, __dev);
-  return __value;
+  __driver_call_result<int> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __attr, __kernel, __dev);
+  return __ret;
 }
 
 #  if _CCCL_CTK_AT_LEAST(12, 3)
-[[nodiscard]] _CCCL_HOST_API inline const char* __kernelGetName(::CUkernel __kernel)
+_CCCL_HOST_API inline __driver_call_result<const char*> __kernelGetName(::CUkernel __kernel) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuKernelGetName, cuKernelGetName, 12, 3);
-  const char* __name;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get kernel name", &__name, __kernel);
-  return __name;
+  __driver_call_result<const char*> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __kernel);
+  return __ret;
 }
 #  endif // _CCCL_CTK_AT_LEAST(12, 3)
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUlibrary __libraryLoadData(
+_CCCL_HOST_API inline __driver_call_result<::CUlibrary> __libraryLoadData(
   const void* __code,
   ::CUjit_option* __jit_opts,
   void** __jit_opt_vals,
@@ -717,172 +742,167 @@ __kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdev
   unsigned __nlib_opts)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLibraryLoadData);
-  ::CUlibrary __result;
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn,
-    "Failed to load a library from data",
-    &__result,
-    __code,
-    __jit_opts,
-    __jit_opt_vals,
-    __njit_opts,
-    __lib_opts,
-    __lib_opt_vals,
-    __nlib_opts);
-  return __result;
+  __driver_call_result<::CUlibrary> __ret{};
+  __ret.__error_ = __driver_fn(
+    &__ret.__value_, __code, __jit_opts, __jit_opt_vals, __njit_opts, __lib_opts, __lib_opt_vals, __nlib_opts);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUkernel __libraryGetKernel(::CUlibrary __library, const char* __name)
+_CCCL_HOST_API inline __driver_call_result<::CUkernel>
+__libraryGetKernel(::CUlibrary __library, const char* __name) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLibraryGetKernel);
-  ::CUkernel __result;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get kernel from library", &__result, __library, __name);
-  return __result;
-}
-
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __libraryUnloadNoThrow(::CUlibrary __library)
-{
-  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLibraryUnload);
-  return static_cast<::cudaError_t>(__driver_fn(__library));
+  __driver_call_result<::CUkernel> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __library, __name);
+  return __ret;
 }
 
 #  if _CCCL_CTK_AT_LEAST(12, 5)
-[[nodiscard]] _CCCL_HOST_API inline ::CUlibrary __kernelGetLibrary(::CUkernel __kernel)
+_CCCL_HOST_API inline __driver_call_result<::CUlibrary> __kernelGetLibrary(::CUkernel __kernel) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuKernelGetLibrary, cuKernelGetLibrary, 12, 5);
-  ::CUlibrary __lib;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the library from kernel", &__lib, __kernel);
-  return __lib;
+  __driver_call_result<::CUlibrary> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __kernel);
+  return __ret;
 }
 #  endif // _CCCL_CTK_AT_LEAST(12, 5)
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
-__libraryGetKernelNoThrow(::CUkernel& __kernel, ::CUlibrary __lib, const char* __name)
-{
-  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLibraryGetKernel);
-  return static_cast<cudaError_t>(__driver_fn(&__kernel, __lib, __name));
-}
-
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
-__libraryGetGlobalNoThrow(::CUdeviceptr& __dptr, ::cuda::std::size_t& __nbytes, ::CUlibrary __lib, const char* __name)
+_CCCL_HOST_API inline __driver_call_result<::cuda::std::__tuple<void*, ::cuda::std::size_t>>
+__libraryGetGlobal(::CUlibrary __lib, const char* __name) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLibraryGetGlobal);
-  return static_cast<::cudaError_t>(__driver_fn(&__dptr, &__nbytes, __lib, __name));
+  __driver_call_result<::cuda::std::__tuple<void*, ::cuda::std::size_t>> __ret{};
+  __ret.__error_ =
+    __driver_fn(reinterpret_cast<::CUdeviceptr*>(&__ret.__value_.__val0), &__ret.__value_.__val1, __lib, __name);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
-__libraryGetManagedNoThrow(::CUdeviceptr& __dptr, ::cuda::std::size_t& __nbytes, ::CUlibrary __lib, const char* __name)
+_CCCL_HOST_API inline __driver_call_result<::cuda::std::__tuple<void*, ::cuda::std::size_t>>
+__libraryGetManaged(::CUlibrary __lib, const char* __name) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLibraryGetManaged);
-  return static_cast<::cudaError_t>(__driver_fn(&__dptr, &__nbytes, __lib, __name));
+  __driver_call_result<::cuda::std::__tuple<void*, ::cuda::std::size_t>> __ret{};
+  __ret.__error_ =
+    __driver_fn(reinterpret_cast<::CUdeviceptr*>(&__ret.__value_.__val0), &__ret.__value_.__val1, __lib, __name);
+  return __ret;
+}
+
+_CCCL_HOST_API inline __driver_call_result<void> __libraryUnload(::CUlibrary __lib) noexcept
+{
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLibraryUnload);
+  return {__driver_fn(__lib)};
 }
 
 // Execution control
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
-__functionGetAttributeNoThrow(int& __value, ::CUfunction_attribute __attr, ::CUfunction __kernel)
+_CCCL_HOST_API inline __driver_call_result<int>
+__functionGetAttribute(::CUfunction_attribute __attr, ::CUfunction __kernel) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuFuncGetAttribute);
-  return static_cast<::cudaError_t>(__driver_fn(&__value, __attr, __kernel));
+  __driver_call_result<int> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __attr, __kernel);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __functionLoadNoThrow(::CUfunction __kernel) noexcept
+_CCCL_HOST_API inline __driver_call_result<void> __functionLoad(::CUfunction __kernel) noexcept
 {
   static auto __driver_fn = reinterpret_cast<::CUresult(CUDAAPI*)(::CUfunction)>(
     ::cuda::__driver::__get_driver_entry_point("cuFuncLoad", 12, 4));
-  return static_cast<::cudaError_t>(__driver_fn(__kernel));
+  return {__driver_fn(__kernel)};
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
-__functionSetAttributeNoThrow(::CUfunction __kernel, ::CUfunction_attribute __attr, int __value)
+_CCCL_HOST_API inline __driver_call_result<void>
+__functionSetAttribute(::CUfunction __kernel, ::CUfunction_attribute __attr, int __value) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuFuncSetAttribute);
-  return static_cast<::cudaError_t>(__driver_fn(__kernel, __attr, __value));
+  return {__driver_fn(__kernel, __attr, __value)};
 }
 
-_CCCL_HOST_API inline void __launchHostFunc(::CUstream __stream, ::CUhostFn __fn, void* __data)
+_CCCL_HOST_API inline __driver_call_result<void>
+__launchHostFunc(::CUstream __stream, ::CUhostFn __fn, void* __data) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLaunchHostFunc);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to launch host function", __stream, __fn, __data);
+  return {__driver_fn(__stream, __fn, __data)};
 }
 
-_CCCL_HOST_API inline void
-__launchKernel(::CUlaunchConfig& __config, ::CUfunction __kernel, void* __args[], void* __extra[] = nullptr)
+_CCCL_HOST_API inline __driver_call_result<void>
+__launchKernel(::CUlaunchConfig& __config, ::CUfunction __kernel, void* __args[], void* __extra[] = nullptr) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuLaunchKernelEx);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to launch kernel", &__config, __kernel, __args, __extra);
+  return {__driver_fn(&__config, __kernel, __args, __extra)};
 }
 
 // Graph management
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUgraphNode __graphAddKernelNode(
-  ::CUgraph __graph, const ::CUgraphNode __deps[], ::cuda::std::size_t __ndeps, ::CUDA_KERNEL_NODE_PARAMS& __node_params)
+_CCCL_HOST_API inline __driver_call_result<::CUgraphNode> __graphAddKernelNode(
+  ::CUgraph __graph,
+  const ::CUgraphNode __deps[],
+  ::cuda::std::size_t __ndeps,
+  ::CUDA_KERNEL_NODE_PARAMS& __node_params) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuGraphAddKernelNode);
-  ::CUgraphNode __result;
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn, "Failed to add a node to a graph", &__result, __graph, __deps, __ndeps, &__node_params);
-  return __result;
+  __driver_call_result<::CUgraphNode> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __graph, __deps, __ndeps, &__node_params);
+  return __ret;
 }
 
-_CCCL_HOST_API inline void
-__graphKernelNodeSetAttribute(::CUgraphNode __node, ::CUkernelNodeAttrID __id, const ::CUkernelNodeAttrValue& __value)
+_CCCL_HOST_API inline __driver_call_result<void> __graphKernelNodeSetAttribute(
+  ::CUgraphNode __node, ::CUkernelNodeAttrID __id, const ::CUkernelNodeAttrValue& __value) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuGraphKernelNodeSetAttribute);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to set kernel node parameters", __node, __id, &__value);
+  return {__driver_fn(__node, __id, &__value)};
 }
 
 // Peer Context Memory Access
 
-[[nodiscard]] _CCCL_HOST_API inline bool __deviceCanAccessPeer(::CUdevice __dev, ::CUdevice __peer_dev)
+_CCCL_HOST_API inline __driver_call_result<bool> __deviceCanAccessPeer(::CUdevice __dev, ::CUdevice __peer_dev) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuDeviceCanAccessPeer);
-  int __result;
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn, "Failed to query if device can access peer's memory", &__result, __dev, __peer_dev);
-  return static_cast<bool>(__result);
+  __driver_call_result<bool> __ret{};
+  int __result{};
+  __ret.__error_ = __driver_fn(&__result, __dev, __peer_dev);
+  __ret.__value_ = static_cast<bool>(__result);
+  return __ret;
 }
 
 // Green contexts
 
 #  if _CCCL_CTK_AT_LEAST(12, 5)
 // Add actual resource description input once exposure is ready
-[[nodiscard]] _CCCL_HOST_API inline ::CUgreenCtx __greenCtxCreate(::CUdevice __dev)
+_CCCL_HOST_API inline __driver_call_result<::CUgreenCtx> __greenCtxCreate(::CUdevice __dev) noexcept
 {
-  ::CUgreenCtx __result;
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxCreate, cuGreenCtxCreate, 12, 5);
-  ::cuda::__driver::__call_driver_fn(
-    __driver_fn, "Failed to create a green context", &__result, nullptr, __dev, ::CU_GREEN_CTX_DEFAULT_STREAM);
-  return __result;
+  __driver_call_result<::CUgreenCtx> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, nullptr, __dev, ::CU_GREEN_CTX_DEFAULT_STREAM);
+  return __ret;
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __greenCtxDestroyNoThrow(::CUgreenCtx __green_ctx)
+_CCCL_HOST_API inline __driver_call_result<void> __greenCtxDestroy(::CUgreenCtx __green_ctx) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxDestroy, cuGreenCtxDestroy, 12, 5);
-  return static_cast<::cudaError_t>(__driver_fn(__green_ctx));
+  return {__driver_fn(__green_ctx)};
 }
 
-[[nodiscard]] _CCCL_HOST_API inline ::CUcontext __ctxFromGreenCtx(::CUgreenCtx __green_ctx)
+_CCCL_HOST_API inline __driver_call_result<::CUcontext> __ctxFromGreenCtx(::CUgreenCtx __green_ctx) noexcept
 {
-  ::CUcontext __result;
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuCtxFromGreenCtx, cuCtxFromGreenCtx, 12, 5);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to convert a green context", &__result, __green_ctx);
-  return __result;
+  __driver_call_result<::CUcontext> __ret{};
+  __ret.__error_ = __driver_fn(&__ret.__value_, __green_ctx);
+  return __ret;
 }
 #  endif // _CCCL_CTK_AT_LEAST(12, 5)
 
 #  if _CCCL_CTK_AT_LEAST(13, 0)
-[[nodiscard]] _CCCL_HOST_API inline unsigned long long __greenCtxGetId(::CUgreenCtx __green_ctx)
+_CCCL_HOST_API inline __driver_call_result<unsigned long long> __greenCtxGetId(::CUgreenCtx __green_ctx) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION_VERSIONED(cuGreenCtxGetId, cuGreenCtxGetId, 13, 0);
-  unsigned long long __id;
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get the ID of a green context", __green_ctx, &__id);
-  return __id;
+  __driver_call_result<unsigned long long> __ret{};
+  __ret.__error_ = __driver_fn(__green_ctx, &__ret.__value_);
+  return __ret;
 }
 #  endif // _CCCL_CTK_AT_LEAST(13, 0)
 
-[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __tensorMapEncodeTiledNoThrow(
-  ::CUtensorMap& __tensorMap,
+_CCCL_HOST_API inline __driver_call_result<::CUtensorMap> __tensorMapEncodeTiled(
   ::CUtensorMapDataType __tensorDataType,
   ::cuda::std::uint32_t __tensorRank,
   void* __globalAddress,
@@ -896,8 +916,9 @@ __graphKernelNodeSetAttribute(::CUgraphNode __node, ::CUkernelNodeAttrID __id, c
   ::CUtensorMapFloatOOBfill __oobFill) noexcept
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuTensorMapEncodeTiled);
-  return static_cast<::cudaError_t>(__driver_fn(
-    &__tensorMap,
+  __driver_call_result<::CUtensorMap> __ret{};
+  __ret.__error_ = __driver_fn(
+    &__ret.__value_,
     __tensorDataType,
     __tensorRank,
     __globalAddress,
@@ -908,7 +929,8 @@ __graphKernelNodeSetAttribute(::CUgraphNode __node, ::CUkernelNodeAttrID __id, c
     __interleave,
     __swizzle,
     __l2Promotion,
-    __oobFill));
+    __oobFill);
+  return __ret;
 }
 
 #  undef _CCCLRT_GET_DRIVER_FUNCTION

--- a/libcudacxx/include/cuda/__event/event.h
+++ b/libcudacxx/include/cuda/__event/event.h
@@ -98,7 +98,7 @@ public:
     {
       // Needs to call driver API in case current device is not set, runtime version would set dev 0 current
       // Alternative would be to store the device and push/pop here
-      [[maybe_unused]] auto __status = ::cuda::__driver::__eventDestroyNoThrow(__event_);
+      _CCCL_ASSERT_DRIVER_API(__eventDestroy(__event_));
     }
   }
 
@@ -158,7 +158,7 @@ private:
       : event_ref(::cudaEvent_t{})
   {
     [[maybe_unused]] __ensure_current_context __ctx_setter(__device);
-    __event_ = ::cuda::__driver::__eventCreate(static_cast<unsigned>(__flags));
+    __event_ = _CCCL_TRY_DRIVER_API(__eventCreate(static_cast<unsigned>(__flags)));
   }
 };
 

--- a/libcudacxx/include/cuda/__event/timed_event.h
+++ b/libcudacxx/include/cuda/__event/timed_event.h
@@ -99,7 +99,7 @@ public:
   [[nodiscard]] friend _CCCL_HOST_API ::cuda::std::chrono::nanoseconds
   operator-(const timed_event& __end, const timed_event& __start)
   {
-    const auto __ms = ::cuda::__driver::__eventElapsedTime(__start.get(), __end.get());
+    const auto __ms = _CCCL_TRY_DRIVER_API(__eventElapsedTime(__start.get(), __end.get()));
     return ::cuda::std::chrono::nanoseconds(static_cast<::cuda::std::chrono::nanoseconds::rep>(__ms * 1'000'000.0));
   }
 

--- a/libcudacxx/include/cuda/__launch/host_launch.h
+++ b/libcudacxx/include/cuda/__launch/host_launch.h
@@ -77,7 +77,8 @@ _CCCL_HOST_API void host_launch(stream_ref __stream, _Callable __callable, _Args
   _CallbackData* __callback_data_ptr = new _CallbackData{::cuda::std::move(__callable), {::cuda::std::move(__args)...}};
 
   // We use the callback here to have it execute even on stream error, because it needs to free the above allocation
-  ::cuda::__driver::__streamAddCallback(__stream.get(), __stream_callback_launcher<_CallbackData>, __callback_data_ptr);
+  _CCCL_TRY_DRIVER_API(
+    __streamAddCallback(__stream.get(), __stream_callback_launcher<_CallbackData>, __callback_data_ptr));
 }
 
 template <class _Callable>
@@ -101,8 +102,8 @@ template <class _Callable>
 _CCCL_HOST_API void host_launch(stream_ref __stream, ::cuda::std::reference_wrapper<_Callable> __callable)
 {
   static_assert(::cuda::std::is_invocable_v<_Callable>, "Callable in reference_wrapper can't take any arguments");
-  ::cuda::__driver::__launchHostFunc(
-    __stream.get(), __host_func_launcher<_Callable>, ::cuda::std::addressof(__callable.get()));
+  _CCCL_TRY_DRIVER_API(
+    __launchHostFunc(__stream.get(), __host_func_launcher<_Callable>, ::cuda::std::addressof(__callable.get())));
 }
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__mdspan/host_device_accessor.h
+++ b/libcudacxx/include/cuda/__mdspan/host_device_accessor.h
@@ -114,11 +114,9 @@ class __host_accessor : public _Accessor
     {
       if (!cuda::std::__cccl_default_is_constant_evaluated())
       {
-        auto __p1 = ::cuda::std::to_address(__p);
-        ::CUmemorytype __type{};
-        const auto __status =
-          ::cuda::__driver::__pointerGetAttributeNoThrow<::CU_POINTER_ATTRIBUTE_MEMORY_TYPE>(__type, __p1);
-        return (__status != ::cudaSuccess) || __type == ::CU_MEMORYTYPE_HOST;
+        auto __p1             = ::cuda::std::to_address(__p);
+        const auto __mem_type = ::cuda::__driver::__pointerGetAttribute<::CU_POINTER_ATTRIBUTE_MEMORY_TYPE>(__p1);
+        return (__mem_type.__error_ != ::CUDA_SUCCESS) || __mem_type.__value_ == ::CU_MEMORYTYPE_HOST;
       }
       return true;
     }
@@ -249,11 +247,9 @@ class __device_accessor : public _Accessor
 #if _CCCL_HAS_CTK()
     if constexpr (::cuda::std::contiguous_iterator<__data_handle_type>)
     {
-      auto __p1 = ::cuda::std::to_address(__p);
-      ::CUmemorytype __type{};
-      const auto __status =
-        ::cuda::__driver::__pointerGetAttributeNoThrow<::CU_POINTER_ATTRIBUTE_MEMORY_TYPE>(__type, __p1);
-      return (__status != ::cudaSuccess) || __type == ::CU_MEMORYTYPE_DEVICE;
+      auto __p1             = ::cuda::std::to_address(__p);
+      const auto __mem_type = ::cuda::__driver::__pointerGetAttribute<::CU_POINTER_ATTRIBUTE_MEMORY_TYPE>(__p1);
+      return (__mem_type.__error_ != ::CUDA_SUCCESS) || __mem_type.__value_ == ::CU_MEMORYTYPE_DEVICE;
     }
     else
 #endif // _CCCL_HAS_CTK()
@@ -400,11 +396,9 @@ class __managed_accessor : public _Accessor
 #if _CCCL_HAS_CTK()
     if constexpr (::cuda::std::contiguous_iterator<__data_handle_type>)
     {
-      const auto __p1 = ::cuda::std::to_address(__p);
-      bool __is_managed{};
-      const auto __status =
-        ::cuda::__driver::__pointerGetAttributeNoThrow<::CU_POINTER_ATTRIBUTE_IS_MANAGED>(__is_managed, __p1);
-      return (__status != ::cudaSuccess) || __is_managed;
+      const auto __p1         = ::cuda::std::to_address(__p);
+      const auto __is_managed = ::cuda::__driver::__pointerGetAttribute<::CU_POINTER_ATTRIBUTE_IS_MANAGED>(__p1);
+      return (__is_managed.__error_ != ::CUDA_SUCCESS) || __is_managed.__value_;
     }
     else
 #endif // _CCCL_HAS_CTK()

--- a/libcudacxx/include/cuda/__memory_resource/device_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_resource/device_memory_pool.h
@@ -119,9 +119,9 @@ struct device_memory_pool : device_memory_pool_ref
           ::CU_MEM_ALLOCATION_TYPE_PINNED))
   {}
 
-  ~device_memory_pool() noexcept
+  ~device_memory_pool()
   {
-    ::cuda::__driver::__mempoolDestroy(__pool_);
+    _CCCL_ASSERT_DRIVER_API(__mempoolDestroy(__pool_));
   }
 
   _CCCL_HOST_API static device_memory_pool from_native_handle(::cudaMemPool_t __pool) noexcept

--- a/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
@@ -79,8 +79,7 @@ public:
     }
 
     ::cuda::__ensure_current_context __guard(__device_);
-    ::CUdeviceptr __ptr = ::cuda::__driver::__mallocManaged(__bytes, __flags_);
-    return reinterpret_cast<void*>(__ptr);
+    return _CCCL_TRY_DRIVER_API(__mallocManaged(__bytes, __flags_));
   }
 
   //! @brief Deallocate memory pointed to by \p __ptr.
@@ -95,9 +94,7 @@ public:
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _CCCL_ASSERT(__is_valid_alignment(__alignment),
                  "Invalid alignment passed to legacy_managed_memory_resource::deallocate_sync.");
-    _CCCL_ASSERT_CUDA_API(::cuda::__driver::__freeNoThrow,
-                          "legacy_managed_memory_resource::deallocate_sync failed",
-                          reinterpret_cast<::CUdeviceptr>(__ptr));
+    _CCCL_ASSERT_DRIVER_API(__free(__ptr));
   }
 
   //! @brief Equality comparison with another \c managed_memory_resource.

--- a/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
@@ -70,8 +70,7 @@ public:
     }
 
     ::cuda::__ensure_current_context __guard(__device_);
-    void* __ptr = ::cuda::__driver::__mallocHost(__bytes);
-    return __ptr;
+    return _CCCL_TRY_DRIVER_API(__mallocHost(__bytes));
   }
 
   //! @brief Deallocate memory pointed to by \p __ptr.
@@ -86,8 +85,7 @@ public:
     // We need to ensure that the provided alignment matches the minimal provided alignment
     _CCCL_ASSERT(__is_valid_alignment(__alignment),
                  "Invalid alignment passed to legacy_pinned_memory_resource::deallocate_sync.");
-    _CCCL_ASSERT_CUDA_API(
-      ::cuda::__driver::__freeHostNoThrow, "legacy_pinned_memory_resource::deallocate_sync failed", __ptr);
+    _CCCL_ASSERT_DRIVER_API(__freeHost(__ptr));
   }
 
   //! @brief Equality comparison with another \c legacy_pinned_memory_resource.

--- a/libcudacxx/include/cuda/__memory_resource/managed_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_resource/managed_memory_pool.h
@@ -36,8 +36,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 
 [[nodiscard]] static ::cudaMemPool_t __get_default_managed_pool()
 {
-  return ::cuda::__driver::__getDefaultMemPool(
-    ::CUmemLocation{::CU_MEM_LOCATION_TYPE_NONE, 0}, ::CU_MEM_ALLOCATION_TYPE_MANAGED);
+  return _CCCL_TRY_DRIVER_API(
+    __getDefaultMemPool(::CUmemLocation{::CU_MEM_LOCATION_TYPE_NONE, 0}, ::CU_MEM_ALLOCATION_TYPE_MANAGED));
 }
 
 //! @rst
@@ -112,9 +112,9 @@ struct managed_memory_pool : managed_memory_pool_ref
 
   // TODO add a constructor that accepts memory location one a type for it is added
 
-  ~managed_memory_pool() noexcept
+  ~managed_memory_pool()
   {
-    ::cuda::__driver::__mempoolDestroy(__pool_);
+    _CCCL_ASSERT_DRIVER_API(__mempoolDestroy(__pool_));
   }
 
   _CCCL_HOST_API static managed_memory_pool from_native_handle(::cudaMemPool_t __pool) noexcept

--- a/libcudacxx/include/cuda/__memory_resource/pinned_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_resource/pinned_memory_pool.h
@@ -136,9 +136,9 @@ struct pinned_memory_pool : pinned_memory_pool_ref
     enable_access_from(cuda::devices);
   }
 
-  ~pinned_memory_pool() noexcept
+  ~pinned_memory_pool()
   {
-    ::cuda::__driver::__mempoolDestroy(__pool_);
+    _CCCL_ASSERT_DRIVER_API(__mempoolDestroy(__pool_));
   }
 
   _CCCL_HOST_API static pinned_memory_pool from_native_handle(::cudaMemPool_t __pool) noexcept
@@ -165,8 +165,8 @@ static_assert(::cuda::mr::resource_with<pinned_memory_pool, ::cuda::mr::host_acc
 {
 #  if _CCCL_CTK_AT_LEAST(13, 0)
   static ::cudaMemPool_t __default_pool = []() {
-    ::cudaMemPool_t __pool = ::cuda::__driver::__getDefaultMemPool(
-      ::CUmemLocation{::CU_MEM_LOCATION_TYPE_HOST, 0}, ::CU_MEM_ALLOCATION_TYPE_PINNED);
+    ::cudaMemPool_t __pool = _CCCL_TRY_DRIVER_API(
+      __getDefaultMemPool(::CUmemLocation{::CU_MEM_LOCATION_TYPE_HOST, 0}, ::CU_MEM_ALLOCATION_TYPE_PINNED));
     // TODO should we be more careful with setting access from all devices? Maybe only if it was not set for any device?
     ::cuda::__mempool_set_access(__pool, ::cuda::devices, ::CU_MEM_ACCESS_FLAGS_PROT_READWRITE);
     return __pool;

--- a/libcudacxx/include/cuda/__runtime/ensure_current_context.h
+++ b/libcudacxx/include/cuda/__runtime/ensure_current_context.h
@@ -49,7 +49,7 @@ struct [[maybe_unused]] __ensure_current_context
   _CCCL_HOST_API explicit __ensure_current_context(device_ref __new_device)
   {
     auto __ctx = ::cuda::__physical_devices()[__new_device.get()].__primary_context();
-    ::cuda::__driver::__ctxPush(__ctx);
+    _CCCL_TRY_DRIVER_API(__ctxPush(__ctx));
   }
 
   //! @brief Construct a new `__ensure_current_context` object and switch to the specified
@@ -60,7 +60,7 @@ struct [[maybe_unused]] __ensure_current_context
   //! @throws cuda_error if the context switch fails
   _CCCL_HOST_API explicit __ensure_current_context(::CUcontext __ctx)
   {
-    ::cuda::__driver::__ctxPush(__ctx);
+    _CCCL_TRY_DRIVER_API(__ctxPush(__ctx));
   }
 
   //! @brief Construct a new `__ensure_current_context` object and switch to the context
@@ -84,7 +84,7 @@ struct [[maybe_unused]] __ensure_current_context
   _CCCL_HOST_API ~__ensure_current_context() noexcept(false)
   {
     // TODO would it make sense to assert here that we pushed and popped the same thing?
-    ::cuda::__driver::__ctxPop();
+    (void) _CCCL_TRY_DRIVER_API(__ctxPop());
   }
 };
 

--- a/libcudacxx/include/cuda/__stream/stream.h
+++ b/libcudacxx/include/cuda/__stream/stream.h
@@ -48,7 +48,7 @@ struct stream : stream_ref
       : stream_ref(::cuda::__invalid_stream())
   {
     [[maybe_unused]] __ensure_current_context __ctx_setter(__dev);
-    __stream = ::cuda::__driver::__streamCreateWithPriority(cudaStreamNonBlocking, __priority);
+    __stream = _CCCL_TRY_DRIVER_API(__streamCreateWithPriority(cudaStreamNonBlocking, __priority));
   }
 
   //! @brief Construct a new `stream` object into the moved-from state.
@@ -79,7 +79,7 @@ struct stream : stream_ref
     {
       // Needs to call driver API in case current device is not set, runtime version would set dev 0 current
       // Alternative would be to store the device and push/pop here
-      [[maybe_unused]] auto status = ::cuda::__driver::__streamDestroyNoThrow(__stream);
+      _CCCL_ASSERT_DRIVER_API(__streamDestroy(__stream));
     }
   }
 

--- a/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
+++ b/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
@@ -532,8 +532,7 @@ _CCCL_HOST_API inline void __check_swizzle(tma_interleave_layout __interleave_la
     __box_sizes, __tensor_sizes, __rank, __interleave_layout, __swizzle, __data_type, __tensor.device.device_id);
   const auto __raw_elem_strides =
     ::cuda::__get_elem_strides(__elem_strides, __tensor_sizes, __rank, __interleave_layout);
-  ::CUtensorMap __tensorMap{};
-  const auto __status = ::cuda::__driver::__tensorMapEncodeTiledNoThrow(
+  const auto __tensorMap = ::cuda::__driver::__tensorMapEncodeTiled(
     __tensorMap,
     __data_type,
     __rank,
@@ -546,8 +545,8 @@ _CCCL_HOST_API inline void __check_swizzle(tma_interleave_layout __interleave_la
     __raw_swizzle,
     __raw_l2_fetch_size,
     __raw_oobfill);
-  _CCCL_VERIFY(__status == ::cudaSuccess, "Failed to encode TMA descriptor");
-  return __tensorMap;
+  _CCCL_VERIFY(__tensorMap.__error_ == ::CUDA_SUCCESS, "Failed to encode TMA descriptor");
+  return __tensorMap.__value_;
 }
 
 [[nodiscard]] _CCCL_HOST_API inline ::CUtensorMap make_tma_descriptor(

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -30,6 +30,10 @@
 
 #  include <nv/target>
 
+#  if _CCCL_HAS_CTK()
+#    include <cuda.h>
+#  endif // _CCCL_HAS_CTK()
+
 #  include <cstdio>
 #  include <stdexcept>
 
@@ -108,6 +112,17 @@ private:
 {
   _CCCL_THROW(::cuda::cuda_error(__status, __msg, __api, __loc));
 }
+
+#  if _CCCL_HAS_CTK()
+[[noreturn]] _CCCL_API inline void __throw_cuda_error(
+  [[maybe_unused]] const ::CUresult __status,
+  [[maybe_unused]] const char* __msg,
+  [[maybe_unused]] const char* __api                  = nullptr,
+  [[maybe_unused]] ::cuda::std::source_location __loc = ::cuda::std::source_location::current())
+{
+  _CCCL_THROW(::cuda::cuda_error(static_cast<__cuda_error_t>(__status), __msg, __api, __loc));
+}
+#  endif // _CCCL_HAS_CTK()
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/device_smoke.c2h.cu
@@ -36,7 +36,7 @@ C2H_CCCLRT_TEST("init", "[device]")
 {
   cuda::device_ref dev{0};
   dev.init();
-  CCCLRT_REQUIRE(cuda::__driver::__isPrimaryCtxActive(cuda::__driver::__deviceGet(0)));
+  CCCLRT_REQUIRE(CCCLRT_DRIVER_CALL(__isPrimaryCtxActive(CCCLRT_DRIVER_CALL(__deviceGet(0)))));
 }
 
 C2H_CCCLRT_TEST("Smoke", "[device]")

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/driver_api.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/driver_api.c2h.cu
@@ -15,7 +15,6 @@
 // This test is an exception and shouldn't use C2H_CCCLRT_TEST macro
 C2H_TEST("Call each driver api", "[utility]")
 {
-  namespace driver = ::cuda::__driver;
   cudaStream_t stream;
   // Assumes the ctx stack was empty or had one ctx, should be the case unless some other
   // test leaves 2+ ctxs on the stack
@@ -23,48 +22,48 @@ C2H_TEST("Call each driver api", "[utility]")
   // Pushes the primary context if the stack is empty
   CUDART(cudaStreamCreate(&stream));
 
-  auto ctx = driver::__ctxGetCurrent();
+  auto ctx = CCCLRT_DRIVER_CALL(__ctxGetCurrent());
   CCCLRT_REQUIRE(ctx != nullptr);
 
   // Confirm pop will leave the stack empty
-  driver::__ctxPop();
-  CCCLRT_REQUIRE(driver::__ctxGetCurrent() == nullptr);
+  (void) CCCLRT_DRIVER_CALL(__ctxPop());
+  CCCLRT_REQUIRE(CCCLRT_DRIVER_CALL(__ctxGetCurrent()) == nullptr);
 
   // Confirm we can push multiple times
-  driver::__ctxPush(ctx);
-  CCCLRT_REQUIRE(driver::__ctxGetCurrent() == ctx);
+  (void) CCCLRT_DRIVER_CALL(__ctxPush(ctx));
+  CCCLRT_REQUIRE(CCCLRT_DRIVER_CALL(__ctxGetCurrent()) == ctx);
 
-  driver::__ctxPush(ctx);
-  CCCLRT_REQUIRE(driver::__ctxGetCurrent() == ctx);
+  (void) CCCLRT_DRIVER_CALL(__ctxPush(ctx));
+  CCCLRT_REQUIRE(CCCLRT_DRIVER_CALL(__ctxGetCurrent()) == ctx);
 
-  driver::__ctxPop();
-  CCCLRT_REQUIRE(driver::__ctxGetCurrent() == ctx);
+  (void) CCCLRT_DRIVER_CALL(__ctxPop());
+  CCCLRT_REQUIRE(CCCLRT_DRIVER_CALL(__ctxGetCurrent()) == ctx);
 
   // Confirm stream ctx match
-  auto stream_ctx = driver::__streamGetCtx(stream);
+  auto stream_ctx = CCCLRT_DRIVER_CALL(__streamGetCtx(stream));
   CCCLRT_REQUIRE(ctx == stream_ctx);
 
   CUDART(cudaStreamDestroy(stream));
 
-  CCCLRT_REQUIRE(driver::__deviceGet(0) == 0);
+  CCCLRT_REQUIRE(CCCLRT_DRIVER_CALL(__deviceGet(0)) == 0);
 
   // Confirm we can retain the primary ctx that cudart retained first
-  auto primary_ctx = driver::__primaryCtxRetain(0);
+  auto primary_ctx = CCCLRT_DRIVER_CALL(__primaryCtxRetain(0));
   CCCLRT_REQUIRE(ctx == primary_ctx);
 
-  driver::__ctxPop();
-  CCCLRT_REQUIRE(driver::__ctxGetCurrent() == nullptr);
+  (void) CCCLRT_DRIVER_CALL(__ctxPop());
+  CCCLRT_REQUIRE(CCCLRT_DRIVER_CALL(__ctxGetCurrent()) == nullptr);
 
-  CCCLRT_REQUIRE(driver::__isPrimaryCtxActive(0));
+  CCCLRT_REQUIRE(CCCLRT_DRIVER_CALL(__isPrimaryCtxActive(0)));
   // Confirm we can reset the primary context with double release
-  CCCLRT_REQUIRE(driver::__primaryCtxReleaseNoThrow(0) == cudaSuccess);
-  CCCLRT_REQUIRE(driver::__primaryCtxReleaseNoThrow(0) == cudaSuccess);
+  CCCLRT_DRIVER_CALL(__primaryCtxRelease(0));
+  CCCLRT_DRIVER_CALL(__primaryCtxRelease(0));
 
-  CCCLRT_REQUIRE(!driver::__isPrimaryCtxActive(0));
+  CCCLRT_REQUIRE(!CCCLRT_DRIVER_CALL(__isPrimaryCtxActive(0)));
 
   // Confirm cudart can recover
   CUDART(cudaStreamCreate(&stream));
-  CCCLRT_REQUIRE(driver::__ctxGetCurrent() == ctx);
+  CCCLRT_REQUIRE(CCCLRT_DRIVER_CALL(__ctxGetCurrent()) == ctx);
 
-  CUDART(driver::__streamDestroyNoThrow(stream));
+  CCCLRT_DRIVER_CALL(__streamDestroy(stream));
 }

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/ensure_current_context.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/ensure_current_context.c2h.cu
@@ -20,7 +20,7 @@ void recursive_check_device_setter(int id)
   int cudart_id;
   cuda::__ensure_current_context setter(cuda::device_ref{id});
   CCCLRT_REQUIRE(test::count_driver_stack() == cuda::devices.size() - id);
-  auto ctx = driver::__ctxGetCurrent();
+  auto ctx = CCCLRT_DRIVER_CALL(__ctxGetCurrent());
   CUDART(cudaGetDevice(&cudart_id));
   CCCLRT_REQUIRE(cudart_id == id);
 
@@ -29,7 +29,7 @@ void recursive_check_device_setter(int id)
     recursive_check_device_setter(id - 1);
 
     CCCLRT_REQUIRE(test::count_driver_stack() == cuda::devices.size() - id);
-    CCCLRT_REQUIRE(ctx == driver::__ctxGetCurrent());
+    CCCLRT_REQUIRE(ctx == CCCLRT_DRIVER_CALL(__ctxGetCurrent()));
     CUDART(cudaGetDevice(&cudart_id));
     CCCLRT_REQUIRE(cudart_id == id);
   }


### PR DESCRIPTION
Currently, we have 2 types of CUDA Driver calls:
1. `__meow(...)` and 
2. `__meowNoThrow(...)`

I don't like the design, it forces us to repeat the implementations and forces us to have in/out parameters.

This PR refactors the driver APIs and keeps only 1 definition for each API. Each function is `noexcept` and returns `std::expected`-like type that returns the error + return values.

In case that throwing behaviour is demanded, `_CCCL_TRY_DRIVER_API` macro is provided, which checks the return value of the CUDA call and returns the output parameters. Alternatively, `_CCCL_ASSERT_DRIVER_API` can be used to assert that a call succeeded.