### PR TITLE
Increase threads per segment from 16 to 32 for segmented_sort

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
@@ -360,7 +360,7 @@ struct policy_hub
                                   LOAD_LDG>;
     using MediumSegmentPolicy =
       AgentSubWarpMergeSortPolicy<BLOCK_THREADS,
-                                  16 /* Threads per segment */,
+                                  32 /* Threads per segment */,
                                   ITEMS_PER_MEDIUM_THREAD,
                                   WARP_LOAD_TRANSPOSE,
                                   LOAD_LDG>;


### PR DESCRIPTION
On Policy860 (SM 8.6+, Ada/Hopper), MediumSegmentPolicy was using 16 threads per segment, while other architecture policies use a full warp (32 threads). That effectively cuts the “medium” capacity roughly in half:

- Policy860: 16 threads × 7 items/thread = 112 items
- Policy800: 32 threads × 7–11 items/thread = 224–352 items

As a result, segments in the [113, 352] range were classified as “large” and routed to the block-level radix sort instead of the faster warp-level merge sort. This PR changes Policy860 to use 32 threads per segment (full warp), aligning its MediumSegmentPolicy with the other architectures and restoring the intended “medium” cutoff on Ada/Hopper.

On standard industry benchmark using [libcubwt ](https://github.com/IlyaGrebnov/libcubwt) library for Burrows-Wheeler transform construction, throughput improves by ~7% on average, with the best-affected cases (e.g., proteins.001.1, rs.13) speeding up by up to ~50%. A few inputs fluctuate within ~2%, which looks like acceptable variation.

|         dataset |    size (bytes) |          before (time, throughput) |           after (time, throughput) |
|-----------------|----------------:|------------------------------------|------------------------------------|
|          enwik8 |      100000000  |   0.145 sec ( 691.84 MB/s)         |   0.136 sec ( 736.81 MB/s)         |
|          enwik9 |      369098752  |   0.568 sec ( 649.78 MB/s)         |   0.531 sec ( 694.76 MB/s)         |
|       chr22.dna |       34553758  |   0.090 sec ( 382.34 MB/s)         |   0.089 sec ( 386.53 MB/s)         |
|         etext99 |      105277340  |   0.195 sec ( 540.69 MB/s)         |   0.167 sec ( 628.72 MB/s)         |
|     gcc-3.0.tar |       86630400  |   0.215 sec ( 402.98 MB/s)         |   0.215 sec ( 402.60 MB/s)         |
|           howto |       39422105  |   0.064 sec ( 615.49 MB/s)         |   0.061 sec ( 644.09 MB/s)         |
|          jdk13c |       69728899  |   0.170 sec ( 410.05 MB/s)         |   0.158 sec ( 441.78 MB/s)         |
| linux-2.4.5.tar |      116254720  |   0.246 sec ( 473.32 MB/s)         |   0.246 sec ( 471.87 MB/s)         |
|        rctail96 |      114711151  |   0.249 sec ( 460.40 MB/s)         |   0.232 sec ( 493.80 MB/s)         |
|             rfc |      116421901  |   0.223 sec ( 522.74 MB/s)         |   0.222 sec ( 524.79 MB/s)         |
|     sprot34.dat |      109617186  |   0.207 sec ( 530.69 MB/s)         |   0.192 sec ( 570.10 MB/s)         |
|            w3c2 |      104201579  |   0.280 sec ( 372.51 MB/s)         |   0.259 sec ( 402.34 MB/s)         |
|        dblp.xml |      296135874  |   0.546 sec ( 541.99 MB/s)         |   0.509 sec ( 581.30 MB/s)         |
|             dna |      369098752  |   0.582 sec ( 634.39 MB/s)         |   0.572 sec ( 644.78 MB/s)         |
|  english.1024MB |      369098752  |   0.744 sec ( 496.28 MB/s)         |   0.709 sec ( 520.68 MB/s)         |
|         pitches |       55832855  |   0.094 sec ( 591.88 MB/s)         |   0.093 sec ( 598.75 MB/s)         |
|        proteins |      369098752  |   0.726 sec ( 508.49 MB/s)         |   0.681 sec ( 542.03 MB/s)         |
|         sources |      210866607  |   0.383 sec ( 549.86 MB/s)         |   0.357 sec ( 590.10 MB/s)         |
|            cere |      369098752  |   1.735 sec ( 212.68 MB/s)         |   1.774 sec ( 208.05 MB/s)         |
|       coreutils |      205281778  |   0.873 sec ( 235.12 MB/s)         |   0.754 sec ( 272.11 MB/s)         |
| einstein.de.txt |       92758441  |   0.532 sec ( 174.40 MB/s)         |   0.419 sec ( 221.18 MB/s)         |
| einstein.en.txt |      369098752  |   2.132 sec ( 173.10 MB/s)         |   1.700 sec ( 217.13 MB/s)         |
|Escherichia_Coli |      112689515  |   0.296 sec ( 380.28 MB/s)         |   0.296 sec ( 380.39 MB/s)         |
|       influenza |      154808555  |   0.515 sec ( 300.74 MB/s)         |   0.454 sec ( 341.04 MB/s)         |
|          kernel |      257961616  |   1.044 sec ( 247.10 MB/s)         |   1.049 sec ( 245.92 MB/s)         |
|            para |      369098752  |   1.304 sec ( 282.95 MB/s)         |   1.325 sec ( 278.48 MB/s)         |
|   world_leaders |       46968181  |   0.302 sec ( 155.71 MB/s)         |   0.300 sec ( 156.58 MB/s)         |
|dblp.xml.00001.1 |      104857600  |   0.417 sec ( 251.59 MB/s)         |   0.406 sec ( 258.59 MB/s)         |
|dblp.xml.00001.2 |      104857600  |   0.424 sec ( 247.40 MB/s)         |   0.413 sec ( 253.68 MB/s)         |
| dblp.xml.0001.1 |      104857600  |   0.364 sec ( 288.14 MB/s)         |   0.350 sec ( 299.45 MB/s)         |
| dblp.xml.0001.2 |      104857600  |   0.365 sec ( 287.29 MB/s)         |   0.354 sec ( 296.31 MB/s)         |
|       dna.001.1 |      104857600  |   0.270 sec ( 388.41 MB/s)         |   0.270 sec ( 388.90 MB/s)         |
|   english.001.2 |      104857600  |   0.279 sec ( 375.51 MB/s)         |   0.272 sec ( 385.10 MB/s)         |
|  proteins.001.1 |      104857600  |   0.475 sec ( 220.58 MB/s)         |   0.310 sec ( 338.12 MB/s)         |
|   sources.001.2 |      104857600  |   0.295 sec ( 355.87 MB/s)         |   0.280 sec ( 374.89 MB/s)         |
|           fib41 |      267914296  |   2.421 sec ( 110.67 MB/s)         |   2.259 sec ( 118.59 MB/s)         |
|           rs.13 |      216747218  |   2.050 sec ( 105.72 MB/s)         |   1.698 sec ( 127.66 MB/s)         |
|            tm29 |      268435456  |   2.292 sec ( 117.09 MB/s)         |   2.095 sec ( 128.15 MB/s)         |


## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #6173<!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
