### PR TITLE
Add missing `thrust::find_end` algorithm 

### DIFF
--- a/thrust/testing/catch2_test_find_end.cu
+++ b/thrust/testing/catch2_test_find_end.cu
@@ -147,4 +147,3 @@ TEST_CASE("FindEndDispatchImplicit", "[find_end]")
     CHECK(vec.front() == 42);
   }
 }
-

--- a/thrust/testing/catch2_test_find_end.cu
+++ b/thrust/testing/catch2_test_find_end.cu
@@ -1,0 +1,150 @@
+#include <thrust/find_end.h>
+#include <thrust/iterator/retag.h>
+
+#include "catch2_test_helper.h"
+#include "unittest/special_types.h"
+
+TEMPLATE_LIST_TEST_CASE("FindEndSimple", "[find_end]", vector_list)
+{
+  using Vector = TestType;
+  Vector data{1, 2, 3, 4, 2, 3, 4, 5};
+
+  {
+    // Test with a pattern that exists in the data
+    Vector pattern{3, 4, 5};
+    auto result = thrust::find_end(data.begin(), data.end(), pattern.begin(), pattern.end());
+    CHECK(result == data.begin() + 5);
+  }
+
+  {
+    // Test with a pattern that appears multiple times in the data
+    Vector pattern{2, 3, 4};
+    auto result = thrust::find_end(data.begin(), data.end(), pattern.begin(), pattern.end());
+    CHECK(result == data.begin() + 4);
+  }
+
+  {
+    // Test with a pattern that does not exist in the data
+    Vector pattern{7, 8};
+    auto result = thrust::find_end(data.begin(), data.end(), pattern.begin(), pattern.end());
+    CHECK(result == data.end());
+  }
+
+  {
+    // Test with an empty pattern
+    Vector pattern{};
+    auto result = thrust::find_end(data.begin(), data.end(), pattern.begin(), pattern.end());
+    CHECK(result == data.end());
+  }
+
+  {
+    // Test with a pattern longer than the data
+    Vector pattern{1, 2, 3, 4, 2, 3, 4, 5, 6};
+    auto result = thrust::find_end(data.begin(), data.end(), pattern.begin(), pattern.end());
+    CHECK(result == data.end());
+  }
+
+  {
+    // Test with a pattern that matches the entire data
+    Vector pattern{1, 2, 3, 4, 2, 3, 4, 5};
+    auto result = thrust::find_end(data.begin(), data.end(), pattern.begin(), pattern.end());
+    CHECK(result == data.begin());
+  }
+}
+
+template <typename T>
+struct negate_equal
+{
+  _CCCL_HOST_DEVICE bool operator()(const T& a, const T& b) const
+  {
+    return -a == b;
+  }
+};
+
+TEMPLATE_LIST_TEST_CASE("FindEndWithCustomPredicate", "[find_end]", integral_vector_list)
+{
+  using Vector = TestType;
+  using T      = typename Vector::value_type;
+
+  Vector data    = {1, 2, 3, 4, 2, 3, 4, 5};
+  Vector pattern = {-3, -4, -5};
+  auto result    = thrust::find_end(data.begin(), data.end(), pattern.begin(), pattern.end(), negate_equal<T>());
+  CHECK(result == data.begin() + 5);
+}
+
+template <typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
+ForwardIterator1 find_end(
+  my_system& system, ForwardIterator1 first1, ForwardIterator1, ForwardIterator2, ForwardIterator2, BinaryPredicate)
+{
+  system.validate_dispatch();
+  return first1;
+}
+
+template <typename ForwardIterator1, typename ForwardIterator2>
+ForwardIterator1
+find_end(my_system& system, ForwardIterator1 first1, ForwardIterator1, ForwardIterator2, ForwardIterator2)
+{
+  system.validate_dispatch();
+  return first1 + 2;
+}
+
+TEST_CASE("FindEndDispatchExplicit", "[find_end]")
+{
+  thrust::device_vector<int> vec{1, 2, 3, 4};
+  thrust::device_vector<int> pattern{2, 3};
+
+  {
+    my_system sys(0);
+    auto result =
+      thrust::find_end(sys, vec.begin(), vec.end(), pattern.begin(), pattern.end(), ::cuda::std::equal_to<int>());
+    CHECK(sys.is_valid());
+    CHECK(result == vec.begin());
+  }
+
+  {
+    my_system sys(0);
+    auto result = thrust::find_end(sys, vec.begin(), vec.end(), pattern.begin(), pattern.end());
+    CHECK(sys.is_valid());
+    CHECK(result == vec.begin() + 2);
+  }
+}
+
+template <typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
+ForwardIterator1
+find_end(my_tag, ForwardIterator1 first1, ForwardIterator1, ForwardIterator2, ForwardIterator2, BinaryPredicate)
+{
+  *first1 = 13;
+  return first1;
+}
+
+template <typename ForwardIterator1, typename ForwardIterator2>
+ForwardIterator1 find_end(my_tag, ForwardIterator1 first1, ForwardIterator1, ForwardIterator2, ForwardIterator2)
+{
+  *first1 = 42;
+  return first1;
+}
+
+TEST_CASE("FindEndDispatchImplicit", "[find_end]")
+{
+  thrust::device_vector<int> vec{1, 2, 3, 4};
+  thrust::device_vector<int> pattern{2, 3};
+
+  {
+    thrust::find_end(
+      thrust::retag<my_tag>(vec.begin()),
+      thrust::retag<my_tag>(vec.end()),
+      thrust::retag<my_tag>(pattern.begin()),
+      thrust::retag<my_tag>(pattern.end()),
+      ::cuda::std::equal_to<int>());
+    CHECK(vec.front() == 13);
+  }
+
+  {
+    thrust::find_end(thrust::retag<my_tag>(vec.begin()),
+                     thrust::retag<my_tag>(vec.end()),
+                     thrust::retag<my_tag>(pattern.begin()),
+                     thrust::retag<my_tag>(pattern.end()));
+    CHECK(vec.front() == 42);
+  }
+}
+

--- a/thrust/thrust/detail/find_end.inl
+++ b/thrust/thrust/detail/find_end.inl
@@ -1,0 +1,97 @@
+/*
+ *  Copyright 2025 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+#include <thrust/iterator/iterator_traits.h>
+#include <thrust/system/detail/generic/select_system.h>
+
+// Include all active backend system implementations (generic, sequential, host and device)
+#include <thrust/system/detail/generic/find_end.h>
+
+THRUST_NAMESPACE_BEGIN
+
+_CCCL_EXEC_CHECK_DISABLE
+template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2>
+_CCCL_HOST_DEVICE ForwardIterator1 find_end(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  ForwardIterator1 first1,
+  ForwardIterator1 last1,
+  ForwardIterator2 first2,
+  ForwardIterator2 last2)
+{
+  _CCCL_NVTX_RANGE_SCOPE("thrust::find_end");
+  using thrust::system::detail::generic::find_end;
+  return find_end(thrust::detail::derived_cast(thrust::detail::strip_const(exec)), first1, last1, first2, last2);
+}
+
+_CCCL_EXEC_CHECK_DISABLE
+template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
+_CCCL_HOST_DEVICE ForwardIterator1 find_end(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  ForwardIterator1 first1,
+  ForwardIterator1 last1,
+  ForwardIterator2 first2,
+  ForwardIterator2 last2,
+  BinaryPredicate pred)
+{
+  _CCCL_NVTX_RANGE_SCOPE("thrust::find_end");
+  using thrust::system::detail::generic::find_end;
+  return find_end(thrust::detail::derived_cast(thrust::detail::strip_const(exec)), first1, last1, first2, last2, pred);
+}
+
+template <typename ForwardIterator1, typename ForwardIterator2>
+ForwardIterator1
+find_end(ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2)
+{
+  _CCCL_NVTX_RANGE_SCOPE("thrust::find_end");
+  using thrust::system::detail::generic::select_system;
+
+  using System1 = typename thrust::iterator_system<ForwardIterator1>::type;
+  using System2 = typename thrust::iterator_system<ForwardIterator2>::type;
+
+  System1 system1;
+  System2 system2;
+
+  return thrust::find_end(select_system(system1, system2), first1, last1, first2, last2);
+}
+
+template <typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
+ForwardIterator1 find_end(
+  ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, BinaryPredicate pred)
+{
+  _CCCL_NVTX_RANGE_SCOPE("thrust::find_end");
+  using thrust::system::detail::generic::select_system;
+
+  using System1 = typename thrust::iterator_system<ForwardIterator1>::type;
+  using System2 = typename thrust::iterator_system<ForwardIterator2>::type;
+
+  System1 system1;
+  System2 system2;
+
+  return thrust::find_end(select_system(system1, system2), first1, last1, first2, last2, pred);
+}
+
+THRUST_NAMESPACE_END

--- a/thrust/thrust/find_end.h
+++ b/thrust/thrust/find_end.h
@@ -87,7 +87,8 @@ THRUST_NAMESPACE_BEGIN
  *  \endcode
  *
  *  \see find
- *  \see search
+ *  \see find_if
+ *  \see mismatch
  */
 template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2>
 _CCCL_HOST_DEVICE ForwardIterator1 find_end(
@@ -121,7 +122,7 @@ _CCCL_HOST_DEVICE ForwardIterator1 find_end(
  * Iterator</a>.
  *  \tparam ForwardIterator2 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
  * Iterator</a>.
- *  \tparam BinaryPredicate is a model of <a href="https://en.cppreference.com/w/cpp/concepts/predicate">Binary
+ *  \tparam BinaryPredicate is a model of <a href="https://en.cppreference.com/w/cpp/named_req/BinaryPredicate">Binary
  * Predicate</a>.
  *
  *  \code
@@ -156,7 +157,8 @@ _CCCL_HOST_DEVICE ForwardIterator1 find_end(
  *  \endcode
  *
  *  \see find
- *  \see search
+ *  \see find_if
+ *  \see mismatch
  */
 template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
 _CCCL_HOST_DEVICE ForwardIterator1 find_end(
@@ -208,7 +210,8 @@ _CCCL_HOST_DEVICE ForwardIterator1 find_end(
  *  \endcode
  *
  *  \see find
- *  \see search
+ *  \see find_if
+ *  \see mismatch
  */
 template <typename ForwardIterator1, typename ForwardIterator2>
 ForwardIterator1
@@ -234,7 +237,7 @@ find_end(ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first
  * Iterator</a>.
  *  \tparam ForwardIterator2 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
  * Iterator</a>.
- *  \tparam BinaryPredicate is a model of <a href="https://en.cppreference.com/w/cpp/concepts/predicate">Binary
+ *  \tparam BinaryPredicate is a model of <a href="https://en.cppreference.com/w/cpp/named_req/BinaryPredicate">Binary
  * Predicate</a>.
  *
  *  \code
@@ -269,7 +272,8 @@ find_end(ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first
  *  \endcode
  *
  *  \see find
- *  \see search
+ *  \see find_if
+ *  \see mismatch
  */
 template <typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
 ForwardIterator1 find_end(

--- a/thrust/thrust/find_end.h
+++ b/thrust/thrust/find_end.h
@@ -1,0 +1,287 @@
+/*
+ *  Copyright 2025 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/*! \file find_end.h
+ *  \brief Locating the last occurrence of a subsequence in a range
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+#include <thrust/detail/execution_policy.h>
+
+THRUST_NAMESPACE_BEGIN
+
+/*! \addtogroup algorithms
+ */
+
+/*! \addtogroup searching
+ *  \ingroup algorithms
+ *  \{
+ */
+
+/*! \p find_end finds the last occurrence of the subsequence <tt>[first2, last2)</tt>
+ *  in the range <tt>[first1, last1)</tt>. Specifically, \p find_end returns the last
+ *  iterator \c i in <tt>[first1, last1 - (last2 - first2))</tt> such that for every
+ *  iterator \c j in <tt>[first2, last2)</tt>, <tt>*(i + (j - first2)) == *j</tt>.
+ *  If no such iterator exists, \c last1 is returned.
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param first1 The beginning of the sequence to search.
+ *  \param last1 The end of the sequence to search.
+ *  \param first2 The beginning of the subsequence to find.
+ *  \param last2 The end of the subsequence to find.
+ *  \return The last iterator \c i in <tt>[first1, last1 - (last2 - first2))</tt>
+ *          such that the subsequence <tt>[first2, last2)</tt> matches
+ *          <tt>[i, i + (last2 - first2))</tt>, or \c last1 if no such iterator exists.
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam ForwardIterator1 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
+ * Iterator</a>.
+ *  \tparam ForwardIterator2 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
+ * Iterator</a>.
+ *  \tparam ForwardIterator1's \c value_type is equality comparable to \p ForwardIterator2's \c value_type.
+ *
+ *  \code
+ *  #include <thrust/find_end.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *
+ *  thrust::device_vector<int> data(10);
+ *  data[0] = 0; data[1] = 1; data[2] = 2;
+ *  data[3] = 0; data[4] = 1; data[5] = 2;
+ *  data[6] = 3; data[7] = 4; data[8] = 5; data[9] = 6;
+ *
+ *  thrust::device_vector<int> pattern(3);
+ *  pattern[0] = 0; pattern[1] = 1; pattern[2] = 2;
+ *
+ *  // Find the last occurrence of pattern in data
+ *  thrust::device_vector<int>::iterator iter;
+ *  iter = thrust::find_end(thrust::device, data.begin(), data.end(),
+ *                          pattern.begin(), pattern.end());
+ *
+ *  // iter points to data[3] (the last occurrence starting at index 3)
+ *  \endcode
+ *
+ *  \see find
+ *  \see search
+ */
+template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2>
+_CCCL_HOST_DEVICE ForwardIterator1 find_end(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  ForwardIterator1 first1,
+  ForwardIterator1 last1,
+  ForwardIterator2 first2,
+  ForwardIterator2 last2);
+
+/*! \p find_end finds the last occurrence of the subsequence <tt>[first2, last2)</tt>
+ *  in the range <tt>[first1, last1)</tt>. Specifically, \p find_end returns the last
+ *  iterator \c i in <tt>[first1, last1 - (last2 - first2))</tt> such that for every
+ *  iterator \c j in <tt>[first2, last2)</tt>, <tt>pred(*(i + (j - first2)), *j)</tt>
+ *  is \c true. If no such iterator exists, \c last1 is returned.
+ *
+ *  The algorithm's execution is parallelized as determined by \p exec.
+ *
+ *  \param exec The execution policy to use for parallelization.
+ *  \param first1 The beginning of the sequence to search.
+ *  \param last1 The end of the sequence to search.
+ *  \param first2 The beginning of the subsequence to find.
+ *  \param last2 The end of the subsequence to find.
+ *  \param pred The binary predicate used for comparison.
+ *  \return The last iterator \c i in <tt>[first1, last1 - (last2 - first2))</tt>
+ *          such that the subsequence <tt>[first2, last2)</tt> matches
+ *          <tt>[i, i + (last2 - first2))</tt> according to \p pred,
+ *          or \c last1 if no such iterator exists.
+ *
+ *  \tparam DerivedPolicy The name of the derived execution policy.
+ *  \tparam ForwardIterator1 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
+ * Iterator</a>.
+ *  \tparam ForwardIterator2 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
+ * Iterator</a>.
+ *  \tparam BinaryPredicate is a model of <a href="https://en.cppreference.com/w/cpp/concepts/predicate">Binary
+ * Predicate</a>.
+ *
+ *  \code
+ *  #include <thrust/find_end.h>
+ *  #include <thrust/device_vector.h>
+ *  #include <thrust/execution_policy.h>
+ *
+ *  struct compare_modulo_2
+ *  {
+ *    __host__ __device__
+ *    bool operator()(int a, int b) const
+ *    {
+ *      return (a % 2) == (b % 2);
+ *    }
+ *  };
+ *
+ *  thrust::device_vector<int> data(10);
+ *  data[0] = 0; data[1] = 1; data[2] = 2;
+ *  data[3] = 2; data[4] = 3; data[5] = 4;
+ *  data[6] = 3; data[7] = 4; data[8] = 5; data[9] = 6;
+ *
+ *  thrust::device_vector<int> pattern(3);
+ *  pattern[0] = 0; pattern[1] = 1; pattern[2] = 2;
+ *
+ *  // Find the last occurrence where elements match modulo 2
+ *  thrust::device_vector<int>::iterator iter;
+ *  iter = thrust::find_end(thrust::device, data.begin(), data.end(),
+ *                          pattern.begin(), pattern.end(),
+ *                          compare_modulo_2());
+ *
+ *  // iter points to data[3] (elements at [3,4,5] are [2,3,4] which match [0,1,2] modulo 2)
+ *  \endcode
+ *
+ *  \see find
+ *  \see search
+ */
+template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
+_CCCL_HOST_DEVICE ForwardIterator1 find_end(
+  const thrust::detail::execution_policy_base<DerivedPolicy>& exec,
+  ForwardIterator1 first1,
+  ForwardIterator1 last1,
+  ForwardIterator2 first2,
+  ForwardIterator2 last2,
+  BinaryPredicate pred);
+
+/*! \p find_end finds the last occurrence of the subsequence <tt>[first2, last2)</tt>
+ *  in the range <tt>[first1, last1)</tt>. Specifically, \p find_end returns the last
+ *  iterator \c i in <tt>[first1, last1 - (last2 - first2))</tt> such that for every
+ *  iterator \c j in <tt>[first2, last2)</tt>, <tt>*(i + (j - first2)) == *j</tt>.
+ *  If no such iterator exists, \c last1 is returned.
+ *
+ *  \param first1 The beginning of the sequence to search.
+ *  \param last1 The end of the sequence to search.
+ *  \param first2 The beginning of the subsequence to find.
+ *  \param last2 The end of the subsequence to find.
+ *  \return The last iterator \c i in <tt>[first1, last1 - (last2 - first2))</tt>
+ *          such that the subsequence <tt>[first2, last2)</tt> matches
+ *          <tt>[i, i + (last2 - first2))</tt>, or \c last1 if no such iterator exists.
+ *
+ *  \tparam ForwardIterator1 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
+ * Iterator</a>.
+ *  \tparam ForwardIterator2 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
+ * Iterator</a>.
+ *  \tparam ForwardIterator1's \c value_type is equality comparable to \p ForwardIterator2's \c value_type.
+ *
+ *  \code
+ *  #include <thrust/find_end.h>
+ *  #include <thrust/device_vector.h>
+ *  ...
+ *  thrust::device_vector<int> data(10);
+ *  data[0] = 0; data[1] = 1; data[2] = 2;
+ *  data[3] = 0; data[4] = 1; data[5] = 2;
+ *  data[6] = 3; data[7] = 4; data[8] = 5; data[9] = 6;
+ *
+ *  thrust::device_vector<int> pattern(3);
+ *  pattern[0] = 0; pattern[1] = 1; pattern[2] = 2;
+ *
+ *  // Find the last occurrence of pattern in data
+ *  thrust::device_vector<int>::iterator iter;
+ *  iter = thrust::find_end(data.begin(), data.end(),
+ *                          pattern.begin(), pattern.end());
+ *
+ *  // iter points to data[3] (the last occurrence starting at index 3)
+ *  \endcode
+ *
+ *  \see find
+ *  \see search
+ */
+template <typename ForwardIterator1, typename ForwardIterator2>
+ForwardIterator1
+find_end(ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2);
+
+/*! \p find_end finds the last occurrence of the subsequence <tt>[first2, last2)</tt>
+ *  in the range <tt>[first1, last1)</tt>. Specifically, \p find_end returns the last
+ *  iterator \c i in <tt>[first1, last1 - (last2 - first2))</tt> such that for every
+ *  iterator \c j in <tt>[first2, last2)</tt>, <tt>pred(*(i + (j - first2)), *j)</tt>
+ *  is \c true. If no such iterator exists, \c last1 is returned.
+ *
+ *  \param first1 The beginning of the sequence to search.
+ *  \param last1 The end of the sequence to search.
+ *  \param first2 The beginning of the subsequence to find.
+ *  \param last2 The end of the subsequence to find.
+ *  \param pred The binary predicate used for comparison.
+ *  \return The last iterator \c i in <tt>[first1, last1 - (last2 - first2))</tt>
+ *          such that the subsequence <tt>[first2, last2)</tt> matches
+ *          <tt>[i, i + (last2 - first2))</tt> according to \p pred,
+ *          or \c last1 if no such iterator exists.
+ *
+ *  \tparam ForwardIterator1 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
+ * Iterator</a>.
+ *  \tparam ForwardIterator2 is a model of <a href="https://en.cppreference.com/w/cpp/iterator/forward_iterator">Forward
+ * Iterator</a>.
+ *  \tparam BinaryPredicate is a model of <a href="https://en.cppreference.com/w/cpp/concepts/predicate">Binary
+ * Predicate</a>.
+ *
+ *  \code
+ *  #include <thrust/find_end.h>
+ *  #include <thrust/device_vector.h>
+ *
+ *  struct compare_modulo_2
+ *  {
+ *    __host__ __device__
+ *    bool operator()(int a, int b) const
+ *    {
+ *      return (a % 2) == (b % 2);
+ *    }
+ *  };
+ *
+ *  ...
+ *  thrust::device_vector<int> data(10);
+ *  data[0] = 0; data[1] = 1; data[2] = 2;
+ *  data[3] = 2; data[4] = 3; data[5] = 4;
+ *  data[6] = 3; data[7] = 4; data[8] = 5; data[9] = 6;
+ *
+ *  thrust::device_vector<int> pattern(3);
+ *  pattern[0] = 0; pattern[1] = 1; pattern[2] = 2;
+ *
+ *  // Find the last occurrence where elements match modulo 2
+ *  thrust::device_vector<int>::iterator iter;
+ *  iter = thrust::find_end(data.begin(), data.end(),
+ *                          pattern.begin(), pattern.end(),
+ *                          compare_modulo_2());
+ *
+ *  // iter points to data[3] (elements at [3,4,5] are [2,3,4] which match [0,1,2] modulo 2)
+ *  \endcode
+ *
+ *  \see find
+ *  \see search
+ */
+template <typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
+ForwardIterator1 find_end(
+  ForwardIterator1 first1,
+  ForwardIterator1 last1,
+  ForwardIterator2 first2,
+  ForwardIterator2 last2,
+  BinaryPredicate pred);
+
+/*! \} // end searching
+ */
+
+THRUST_NAMESPACE_END
+
+#include <thrust/detail/find_end.inl>

--- a/thrust/thrust/system/detail/generic/find_end.h
+++ b/thrust/thrust/system/detail/generic/find_end.h
@@ -1,0 +1,52 @@
+/*
+ *  Copyright 2008-2013 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+#include <thrust/system/detail/generic/tag.h>
+
+THRUST_NAMESPACE_BEGIN
+namespace system::detail::generic
+{
+template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2>
+_CCCL_HOST_DEVICE ForwardIterator1 find_end(
+  thrust::execution_policy<DerivedPolicy>& exec,
+  ForwardIterator1 first1,
+  ForwardIterator1 last1,
+  ForwardIterator2 first2,
+  ForwardIterator2 last2);
+
+template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
+_CCCL_HOST_DEVICE ForwardIterator1 find_end(
+  thrust::execution_policy<DerivedPolicy>& exec,
+  ForwardIterator1 first1,
+  ForwardIterator1 last1,
+  ForwardIterator2 first2,
+  ForwardIterator2 last2,
+  BinaryPredicate pred);
+} // namespace system::detail::generic
+THRUST_NAMESPACE_END
+
+#include <thrust/system/detail/generic/find_end.inl>

--- a/thrust/thrust/system/detail/generic/find_end.inl
+++ b/thrust/thrust/system/detail/generic/find_end.inl
@@ -1,0 +1,149 @@
+/*
+ *  Copyright 2008-2013 NVIDIA Corporation
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+#pragma once
+
+#include <thrust/detail/config.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+#include <thrust/find_end.h>
+#include <thrust/iterator/counting_iterator.h>
+#include <thrust/iterator/transform_iterator.h>
+#include <thrust/reduce.h>
+
+THRUST_NAMESPACE_BEGIN
+namespace system::detail::generic
+{
+template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2>
+_CCCL_HOST_DEVICE ForwardIterator1 find_end(
+  thrust::execution_policy<DerivedPolicy>& exec,
+  ForwardIterator1 first1,
+  ForwardIterator1 last1,
+  ForwardIterator2 first2,
+  ForwardIterator2 last2)
+{
+  return thrust::find_end(exec, first1, last1, first2, last2, ::cuda::std::equal_to<>());
+}
+
+template <typename TupleType>
+struct find_end_reduce_functor
+{
+  _CCCL_HOST_DEVICE TupleType operator()(const TupleType& lhs, const TupleType& rhs) const
+  {
+    // select the smallest index among true results
+    if (thrust::get<0>(lhs) && thrust::get<0>(rhs))
+    {
+      return TupleType(true, (::cuda::std::max) (thrust::get<1>(lhs), thrust::get<1>(rhs)));
+    }
+    else if (thrust::get<0>(lhs))
+    {
+      return lhs;
+    }
+    else
+    {
+      return rhs;
+    }
+  }
+};
+
+// Functor that checks whether pattern [first2, last2) matches
+// starting at position i in [first1, last1).
+template <typename ForwardIterator1, typename ForwardIterator2, typename difference_type, typename BinaryPredicate>
+struct find_end_match_functor
+{
+  ForwardIterator1 first1;
+  ForwardIterator2 first2;
+  difference_type n2;
+  BinaryPredicate pred;
+  using result_type = thrust::tuple<bool, difference_type>;
+
+  _CCCL_HOST_DEVICE
+  find_end_match_functor(ForwardIterator1 a, ForwardIterator2 b, difference_type len, BinaryPredicate p)
+      : first1(a)
+      , first2(b)
+      , n2(len)
+      , pred(p)
+  {}
+
+  _CCCL_HOST_DEVICE result_type operator()(difference_type i) const
+  {
+    for (difference_type j = 0; j < n2; ++j)
+    {
+      if (!pred(*(first1 + (i + j)), *(first2 + j)))
+      {
+        return thrust::make_tuple(false, i);
+      }
+    }
+    return thrust::make_tuple(true, i);
+  }
+};
+
+template <typename DerivedPolicy, typename ForwardIterator1, typename ForwardIterator2, typename BinaryPredicate>
+_CCCL_HOST_DEVICE ForwardIterator1 find_end(
+  thrust::execution_policy<DerivedPolicy>& exec,
+  ForwardIterator1 first1,
+  ForwardIterator1 last1,
+  ForwardIterator2 first2,
+  ForwardIterator2 last2,
+  BinaryPredicate pred)
+{
+  using difference_type = thrust::detail::it_difference_t<ForwardIterator1>;
+  using result_type     = thrust::tuple<bool, difference_type>;
+
+  if (first2 == last2)
+  {
+    return last1;
+  }
+
+  const difference_type n1 = ::cuda::std::distance(first1, last1);
+  const difference_type n2 = ::cuda::std::distance(first2, last2);
+
+  if (n1 < n2)
+  {
+    return last1;
+  }
+
+  using MatchType = find_end_match_functor<ForwardIterator1, ForwardIterator2, difference_type, BinaryPredicate>;
+  MatchType match_at_index(first1, first2, n2, pred);
+
+  // Build transform iterator over counting_iterator(0..n1-n2)
+  auto count_begin     = thrust::counting_iterator<difference_type>(0);
+  auto transform_begin = thrust::make_transform_iterator(count_begin, match_at_index);
+  auto transform_end   = transform_begin + (n1 - n2 + 1);
+
+  // If no match found, index set to -1 (signed difference_type)
+  result_type init = thrust::make_tuple(false, static_cast<difference_type>(-1));
+
+  // reduce across transformed values to pick the last match
+  result_type result =
+    thrust::reduce(exec, transform_begin, transform_end, init, find_end_reduce_functor<result_type>());
+
+  if (thrust::get<0>(result))
+  {
+    // found: return iterator to start position
+    return first1 + thrust::get<1>(result);
+  }
+
+  return last1;
+}
+} // namespace system::detail::generic
+THRUST_NAMESPACE_END


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
related to [#5160](https://github.com/NVIDIA/cccl/issues/5160)

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] thrust::find_end
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
