### PR TITLE
Address pending comments for `make_tma_descriptor`

### DIFF
--- a/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
+++ b/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
@@ -12,8 +12,6 @@
 
 #include <cuda/std/detail/__config>
 
-#include <cuda/__memory/is_pointer_accessible.h>
-
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)


### PR DESCRIPTION
https://github.com/NVIDIA/cccl/pull/6237 was closed with automatic merge, leaving two issue opened:

- Adds pointer accessibility verification.
- Refines compute capability conditions.