### PR TITLE
Move memory resource into the `cuda::mr` namespace

### DIFF
--- a/cudax/examples/async_buffer_add.cu
+++ b/cudax/examples/async_buffer_add.cu
@@ -55,7 +55,7 @@ int main()
   // The execution policy we want to use to run all work on the same stream
   auto policy = thrust::cuda::par_nosync.on(stream.get());
 
-  cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+  cuda::mr::device_memory_pool_ref device_resource = cuda::mr::device_default_memory_pool(cuda::device_ref{0});
 
   // Allocate the two inputs and output, but do not zero initialize via `cudax::no_init`
   cudax::device_buffer<float> A{stream, device_resource, numElements, cudax::no_init};
@@ -69,7 +69,7 @@ int main()
   // Add the vectors together
   thrust::transform(policy, A.begin(), A.end(), B.begin(), C.begin(), cuda::std::plus<>{});
 
-  cuda::pinned_memory_pool_ref pinned_resource = cuda::pinned_default_memory_pool();
+  cuda::mr::pinned_memory_pool_ref pinned_resource = cuda::mr::pinned_default_memory_pool();
 
   // Verify that the result vector is correct, by copying it to host
   cudax::host_buffer<float> h_A{stream, pinned_resource, A};

--- a/cudax/examples/cub_reduce.cu
+++ b/cudax/examples/cub_reduce.cu
@@ -26,7 +26,7 @@ int main()
 
   // A CUDA stream on which to execute the reduction
   cuda::stream stream{cuda::devices[0]};
-  cuda::device_memory_pool_ref mr = cuda::device_default_memory_pool(cuda::devices[0]);
+  cuda::mr::device_memory_pool_ref mr = cuda::mr::device_default_memory_pool(cuda::devices[0]);
 
   // Allocate input and output, but do not zero initialize output (`cudax::no_init`)
   auto d_in  = cudax::make_buffer<int>(stream, mr, num_items, 1);
@@ -41,7 +41,7 @@ int main()
     exit(EXIT_FAILURE);
   }
 
-  auto h_out = cudax::make_buffer<float>(stream, cuda::pinned_default_memory_pool(), d_out);
+  auto h_out = cudax::make_buffer<float>(stream, cuda::mr::pinned_default_memory_pool(), d_out);
 
   stream.sync();
 

--- a/cudax/examples/simple_p2p.cu
+++ b/cudax/examples/simple_p2p.cu
@@ -120,7 +120,7 @@ void test_cross_device_access_from_kernel(
 
   // This will be a pinned memory vector once available
   cudax::uninitialized_buffer<float, cuda::mr::host_accessible> host_buffer(
-    cuda::legacy_pinned_memory_resource(), dev0_buffer.size());
+    cuda::mr::legacy_pinned_memory_resource(), dev0_buffer.size());
   std::generate(host_buffer.begin(), host_buffer.end(), []() {
     static int i = 0;
     return static_cast<float>((i++) % 4096);
@@ -219,9 +219,9 @@ try
   cuda::stream dev1_stream(peers[1]);
 
   printf("Enabling peer access between GPU%d and GPU%d...\n", peers[0].get(), peers[1].get());
-  cuda::device_memory_pool_ref dev0_resource = cuda::device_default_memory_pool(peers[0]);
+  cuda::mr::device_memory_pool_ref dev0_resource = cuda::mr::device_default_memory_pool(peers[0]);
   dev0_resource.enable_access_from(peers[1]);
-  cuda::device_memory_pool_ref dev1_resource = cuda::device_default_memory_pool(peers[1]);
+  cuda::mr::device_memory_pool_ref dev1_resource = cuda::mr::device_default_memory_pool(peers[1]);
   dev1_resource.enable_access_from(peers[0]);
 
   // Allocate buffers

--- a/cudax/test/algorithm/common.cuh
+++ b/cudax/test/algorithm/common.cuh
@@ -47,7 +47,7 @@ void check_result_and_erase(cudax::stream_ref stream, Result&& result, uint8_t p
 template <typename Layout = cuda::std::layout_right, typename Extents>
 auto make_buffer_for_mdspan(Extents extents, char value = 0)
 {
-  cuda::legacy_pinned_memory_resource host_resource;
+  cuda::mr::legacy_pinned_memory_resource host_resource;
   auto mapping = typename Layout::template mapping<decltype(extents)>{extents};
 
   cudax::uninitialized_buffer<int, cuda::mr::host_accessible> buffer(host_resource, mapping.required_span_size());
@@ -75,11 +75,11 @@ namespace cuda::experimental
 template <typename RelocatableValue = cuda::std::span<int>>
 struct weird_buffer
 {
-  legacy_pinned_memory_resource& resource;
+  cuda::mr::legacy_pinned_memory_resource& resource;
   int* data;
   std::size_t size;
 
-  weird_buffer(legacy_pinned_memory_resource& res, std::size_t s)
+  weird_buffer(cuda::mr::legacy_pinned_memory_resource& res, std::size_t s)
       : resource(res)
       , data((int*) res.allocate_sync(s * sizeof(int)))
       , size(s)

--- a/cudax/test/algorithm/copy.cu
+++ b/cudax/test/algorithm/copy.cu
@@ -16,7 +16,7 @@ C2H_TEST("1d Copy", "[data_manipulation]")
 
   SECTION("Device resource")
   {
-    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    cuda::mr::device_memory_pool_ref device_resource = cuda::mr::device_default_memory_pool(cuda::device_ref{0});
     std::vector<int> host_vector(buffer_size);
 
     {
@@ -46,8 +46,8 @@ C2H_TEST("1d Copy", "[data_manipulation]")
 
   SECTION("Host and managed resource")
   {
-    cuda::legacy_managed_memory_resource managed_resource;
-    cuda::legacy_pinned_memory_resource host_resource;
+    cuda::mr::legacy_managed_memory_resource managed_resource;
+    cuda::mr::legacy_pinned_memory_resource host_resource;
 
     {
       cudax::uninitialized_buffer<int, cuda::mr::host_accessible> host_buffer(host_resource, buffer_size);
@@ -78,7 +78,7 @@ C2H_TEST("1d Copy", "[data_manipulation]")
   }
   SECTION("Launch transform")
   {
-    cuda::legacy_pinned_memory_resource host_resource;
+    cuda::mr::legacy_pinned_memory_resource host_resource;
     cudax::weird_buffer input(host_resource, buffer_size);
     cudax::weird_buffer output(host_resource, buffer_size);
 
@@ -90,7 +90,7 @@ C2H_TEST("1d Copy", "[data_manipulation]")
 
   SECTION("Asymmetric size")
   {
-    cuda::legacy_pinned_memory_resource host_resource;
+    cuda::mr::legacy_pinned_memory_resource host_resource;
     cudax::uninitialized_buffer<int, cuda::mr::host_accessible> host_buffer(host_resource, 1);
     cuda::fill_bytes(_stream, host_buffer, fill_byte);
 
@@ -154,7 +154,7 @@ C2H_TEST("Mdspan copy", "[data_manipulation]")
 
   SECTION("Launch transform")
   {
-    auto host_resource = cuda::legacy_pinned_memory_resource{};
+    auto host_resource = cuda::mr::legacy_pinned_memory_resource{};
     auto mixed_extents =
       cuda::std::extents<size_t, 1024, cuda::std::dynamic_extent, 2, cuda::std::dynamic_extent>(1024, 2);
     [[maybe_unused]] auto static_extents = cuda::std::extents<size_t, 1024, 1024, 2, 2>();

--- a/cudax/test/algorithm/fill.cu
+++ b/cudax/test/algorithm/fill.cu
@@ -15,7 +15,7 @@ C2H_TEST("Fill", "[data_manipulation]")
   cuda::stream _stream{cuda::device_ref{0}};
   SECTION("Host resource")
   {
-    cuda::legacy_pinned_memory_resource host_resource;
+    cuda::mr::legacy_pinned_memory_resource host_resource;
     cudax::uninitialized_buffer<int, cuda::mr::device_accessible> buffer(host_resource, buffer_size);
 
     cuda::fill_bytes(_stream, buffer, fill_byte);
@@ -25,7 +25,7 @@ C2H_TEST("Fill", "[data_manipulation]")
 
   SECTION("Device resource")
   {
-    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    cuda::mr::device_memory_pool_ref device_resource = cuda::mr::device_default_memory_pool(cuda::device_ref{0});
     cudax::uninitialized_buffer<int, cuda::mr::device_accessible> buffer(device_resource, buffer_size);
     cuda::fill_bytes(_stream, buffer, fill_byte);
 
@@ -37,7 +37,7 @@ C2H_TEST("Fill", "[data_manipulation]")
   }
   SECTION("Launch transform")
   {
-    cuda::legacy_pinned_memory_resource host_resource;
+    cuda::mr::legacy_pinned_memory_resource host_resource;
     cudax::weird_buffer buffer(host_resource, buffer_size);
 
     cuda::fill_bytes(_stream, buffer, fill_byte);
@@ -65,7 +65,7 @@ C2H_TEST("Mdspan Fill", "[data_manipulation]")
     check_result_and_erase(stream, cuda::std::span(buffer.data(), buffer.size()));
   }
   {
-    cuda::legacy_pinned_memory_resource host_resource;
+    cuda::mr::legacy_pinned_memory_resource host_resource;
     using static_extents = cuda::std::extents<size_t, 2, 3, 4>;
     auto size            = cuda::std::layout_left::mapping<static_extents>().required_span_size();
     cudax::weird_buffer<cuda::std::mdspan<int, static_extents>> buffer(host_resource, size);

--- a/cudax/test/containers/async_buffer/constructor.cu
+++ b/cudax/test/containers/async_buffer/constructor.cu
@@ -310,7 +310,7 @@ C2H_CCCLRT_TEST("cudax::buffer constructors", "[container][buffer]", test_types)
 C2H_CCCLRT_TEST("cudax::buffer constructors with legacy resource", "[container][buffer]")
 {
   cudax::stream stream{cuda::device_ref{0}};
-  cuda::legacy_pinned_memory_resource resource;
+  cuda::mr::legacy_pinned_memory_resource resource;
   auto input = compare_data_initializer_list;
   cudax::buffer<int, cuda::mr::device_accessible> buffer{stream, resource, input};
   CUDAX_CHECK(equal_range(buffer));
@@ -327,7 +327,7 @@ C2H_CCCLRT_TEST("cudax::buffer constructors with legacy resource", "[container][
 #if _CCCL_CTK_AT_LEAST(12, 6)
 C2H_CCCLRT_TEST("cudax::make_buffer narrowing properties", "[container][buffer]")
 {
-  auto resource = cuda::pinned_default_memory_pool();
+  auto resource = cuda::mr::pinned_default_memory_pool();
   cudax::stream stream{cuda::device_ref{0}};
 
   auto buf = cudax::make_buffer<int>(stream, resource, 0, cudax::no_init);

--- a/cudax/test/containers/async_buffer/copy.cu
+++ b/cudax/test/containers/async_buffer/copy.cu
@@ -161,12 +161,12 @@ C2H_CCCLRT_TEST("make_buffer variants", "[container][buffer]")
   cudax::stream stream{cuda::device_ref{0}};
   const cudax::buffer<int, cuda::mr::device_accessible, other_property> input{
     stream,
-    cuda::device_default_memory_pool(cuda::device_ref{0}),
+    cuda::mr::device_default_memory_pool(cuda::device_ref{0}),
     {int(1), int(42), int(1337), int(0), int(12), int(-1)}};
 
   // straight from a resource
   auto buf =
-    cuda::experimental::make_buffer(input.stream(), cuda::device_default_memory_pool(cuda::device_ref{0}), input);
+    cuda::experimental::make_buffer(input.stream(), cuda::mr::device_default_memory_pool(cuda::device_ref{0}), input);
   CUDAX_CHECK(equal_range(buf));
   static_assert(
     ::cuda::mr::synchronous_resource_with<typename decltype(buf)::__resource_t, cuda::mr::device_accessible>);
@@ -175,7 +175,7 @@ C2H_CCCLRT_TEST("make_buffer variants", "[container][buffer]")
   static_assert(!::cuda::mr::synchronous_resource_with<typename decltype(buf)::__resource_t, other_property>);
 
   auto buf2 = cuda::experimental::make_buffer<int, cuda::mr::device_accessible>(
-    input.stream(), cuda::device_default_memory_pool(cuda::device_ref{0}), input);
+    input.stream(), cuda::mr::device_default_memory_pool(cuda::device_ref{0}), input);
   CUDAX_CHECK(equal_range(buf2));
   static_assert(
     ::cuda::mr::synchronous_resource_with<typename decltype(buf2)::__resource_t, cuda::mr::device_accessible>);
@@ -185,7 +185,7 @@ C2H_CCCLRT_TEST("make_buffer variants", "[container][buffer]")
 
   // from any resource
   auto any_res = cuda::mr::any_resource<cuda::mr::device_accessible, other_property>(
-    cuda::device_default_memory_pool(cuda::device_ref{0}));
+    cuda::mr::device_default_memory_pool(cuda::device_ref{0}));
   auto buf3 = cudax::make_buffer(input.stream(), any_res, input);
   CUDAX_CHECK(equal_range(buf3));
   static_assert(
@@ -220,8 +220,8 @@ C2H_CCCLRT_TEST("make_buffer variants", "[container][buffer]")
   static_assert(
     !::cuda::mr::synchronous_resource_with<typename decltype(buf6)::__resource_t, cuda::mr::host_accessible>);
 
-  auto shared_res =
-    cuda::mr::make_shared_resource<cuda::device_memory_pool_ref>(cuda::device_default_memory_pool(cuda::device_ref{0}));
+  auto shared_res = cuda::mr::make_shared_resource<cuda::mr::device_memory_pool_ref>(
+    cuda::mr::device_default_memory_pool(cuda::device_ref{0}));
   auto buf7 = cudax::make_buffer(input.stream(), shared_res, input);
   CUDAX_CHECK(equal_range(buf7));
   static_assert(
@@ -242,7 +242,7 @@ C2H_CCCLRT_TEST("make_buffer variants", "[container][buffer]")
 C2H_CCCLRT_TEST("make_buffer with legacy resource", "[container][buffer]")
 {
   cudax::stream stream{cuda::device_ref{0}};
-  auto resource = cuda::legacy_pinned_memory_resource{};
+  auto resource = cuda::mr::legacy_pinned_memory_resource{};
   cudax::buffer<int, cuda::mr::host_accessible> input{
     stream, resource, {int(1), int(42), int(1337), int(0), int(12), int(-1)}};
   auto buf = cudax::make_buffer(input.stream(), resource, input);

--- a/cudax/test/containers/async_buffer/helper.h
+++ b/cudax/test/containers/async_buffer/helper.h
@@ -162,14 +162,14 @@ struct extract_properties<cuda::std::tuple<T, Properties...>>
     if constexpr (cuda::mr::__is_host_accessible<Properties...>)
     {
 #if _CCCL_CTK_AT_LEAST(12, 6)
-      return cuda::pinned_default_memory_pool();
+      return cuda::mr::pinned_default_memory_pool();
 #else // ^^^ _CCCL_CTK_AT_LEAST(12, 6) ^^^ / vvv _CCCL_CTK_BELOW(12, 6) vvv
       return;
 #endif // ^^^ _CCCL_CTK_BELOW(12, 6) ^^^
     }
     else
     {
-      return cuda::device_default_memory_pool(cuda::device_ref{0});
+      return cuda::mr::device_default_memory_pool(cuda::device_ref{0});
     }
   }
 

--- a/cudax/test/containers/async_buffer/test_resources.h
+++ b/cudax/test/containers/async_buffer/test_resources.h
@@ -29,10 +29,10 @@ struct other_property
 {};
 
 // make the cudax resources have that property for tests
-inline void get_property(const cuda::device_memory_pool_ref&, other_property) {}
-inline void get_property(const cuda::legacy_pinned_memory_resource&, other_property) {}
+inline void get_property(const cuda::mr::device_memory_pool_ref&, other_property) {}
+inline void get_property(const cuda::mr::legacy_pinned_memory_resource&, other_property) {}
 #if _CCCL_CTK_AT_LEAST(12, 6)
-inline void get_property(const cuda::pinned_memory_pool_ref&, other_property) {}
+inline void get_property(const cuda::mr::pinned_memory_pool_ref&, other_property) {}
 #endif // _CCCL_CTK_AT_LEAST(12, 6)
 
 //! @brief Simple wrapper around a memory resource to ensure that it compares differently and we can test those code

--- a/cudax/test/containers/async_buffer/transform.cu
+++ b/cudax/test/containers/async_buffer/transform.cu
@@ -33,7 +33,7 @@ C2H_TEST("DeviceTransform::Transform cudax::device_buffer", "[device][device_tra
   const int num_items = 1 << 24;
 
   cudax::stream stream{cuda::device_ref{0}};
-  cuda::device_memory_pool_ref resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+  cuda::mr::device_memory_pool_ref resource = cuda::mr::device_default_memory_pool(cuda::device_ref{0});
 
   cudax::device_buffer<type> a{stream, resource, num_items, cudax::no_init};
   cudax::device_buffer<type> b{stream, resource, num_items, cudax::no_init};
@@ -80,7 +80,7 @@ struct add_kernel
 C2H_CCCLRT_TEST("cudax::buffer launch transform", "[container][buffer]")
 {
   cudax::stream stream{cuda::device_ref{0}};
-  cuda::device_memory_pool_ref resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+  cuda::mr::device_memory_pool_ref resource = cuda::mr::device_default_memory_pool(cuda::device_ref{0});
 
   const cuda::std::array array = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10};
 

--- a/cudax/test/containers/uninitialized_buffer.cu
+++ b/cudax/test/containers/uninitialized_buffer.cu
@@ -56,7 +56,7 @@ constexpr int get_property(
 {
   return 42;
 }
-constexpr int get_property(const cuda::device_memory_pool_ref&, my_property)
+constexpr int get_property(const cuda::mr::device_memory_pool_ref&, my_property)
 {
   return 42;
 }
@@ -81,7 +81,7 @@ C2H_TEST_LIST("uninitialized_buffer", "[container]", char, short, int, long, lon
   static_assert(!cuda::std::is_copy_constructible<uninitialized_buffer>::value, "");
   static_assert(!cuda::std::is_copy_assignable<uninitialized_buffer>::value, "");
 
-  cuda::device_memory_pool_ref resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+  cuda::mr::device_memory_pool_ref resource = cuda::mr::device_default_memory_pool(cuda::device_ref{0});
 
   SECTION("construction")
   {
@@ -123,7 +123,7 @@ C2H_TEST_LIST("uninitialized_buffer", "[container]", char, short, int, long, lon
   {
     static_assert(!cuda::std::is_copy_assignable<uninitialized_buffer>::value, "");
     {
-      cuda::legacy_pinned_memory_resource other_resource{};
+      cuda::mr::legacy_pinned_memory_resource other_resource{};
       uninitialized_buffer input{other_resource, 42};
       uninitialized_buffer buf{resource, 1337};
       const auto* old_ptr       = buf.data();
@@ -240,7 +240,7 @@ C2H_TEST("uninitialized_buffer is usable with cudax::launch", "[container]")
   {
     const int grid_size = 4;
     cudax::uninitialized_buffer<int, ::cuda::mr::device_accessible> buffer{
-      cuda::device_default_memory_pool(cuda::device_ref{0}), 1024};
+      cuda::mr::device_default_memory_pool(cuda::device_ref{0}), 1024};
     auto configuration = cudax::make_config(cuda::grid_dims(grid_size), cuda::block_dims<256>());
 
     cudax::stream stream{cuda::device_ref{0}};
@@ -252,7 +252,7 @@ C2H_TEST("uninitialized_buffer is usable with cudax::launch", "[container]")
   {
     const int grid_size = 4;
     const cudax::uninitialized_buffer<int, ::cuda::mr::device_accessible> buffer{
-      cuda::device_default_memory_pool(cuda::device_ref{0}), 1024};
+      cuda::mr::device_default_memory_pool(cuda::device_ref{0}), 1024};
     auto configuration = cudax::make_config(cuda::grid_dims(grid_size), cuda::block_dims<256>());
 
     cudax::stream stream{cuda::device_ref{0}};
@@ -263,18 +263,18 @@ C2H_TEST("uninitialized_buffer is usable with cudax::launch", "[container]")
 
 // A test resource that keeps track of the number of resources are
 // currently alive.
-struct test_device_memory_pool_ref : cuda::device_memory_pool_ref
+struct test_device_memory_pool_ref : cuda::mr::device_memory_pool_ref
 {
   static int count;
 
   test_device_memory_pool_ref()
-      : cuda::device_memory_pool_ref(cuda::device_default_memory_pool(cuda::device_ref{0}))
+      : cuda::mr::device_memory_pool_ref(cuda::mr::device_default_memory_pool(cuda::device_ref{0}))
   {
     ++count;
   }
 
   test_device_memory_pool_ref(const test_device_memory_pool_ref& other)
-      : cuda::device_memory_pool_ref{other}
+      : cuda::mr::device_memory_pool_ref{other}
   {
     ++count;
   }
@@ -290,7 +290,7 @@ int test_device_memory_pool_ref::count = 0;
 C2H_TEST("uninitialized_buffer's memory resource does not dangle", "[container]")
 {
   cudax::uninitialized_buffer<int, ::cuda::mr::device_accessible> buffer{
-    cuda::device_default_memory_pool(cuda::device_ref{0}), 0};
+    cuda::mr::device_default_memory_pool(cuda::device_ref{0}), 0};
 
   {
     CHECK(test_device_memory_pool_ref::count == 0);

--- a/cudax/test/execution/env.cu
+++ b/cudax/test/execution/env.cu
@@ -55,10 +55,10 @@ C2H_TEST("env_t is queryable for all properties we want", "[execution][env]")
 
 C2H_TEST("env_t is default constructible", "[execution][env]")
 {
-  env_t env{cuda::device_default_memory_pool(cuda::device_ref{0})};
+  env_t env{cuda::mr::device_default_memory_pool(cuda::device_ref{0})};
   CHECK(env.query(cuda::get_stream) == cuda::invalid_stream);
   CHECK(env.query(cudax::execution::get_execution_policy) == cudax::execution::any_execution_policy{});
-  CHECK(env.query(cuda::mr::get_memory_resource) == cuda::device_default_memory_pool(cuda::device_ref{0}));
+  CHECK(env.query(cuda::mr::get_memory_resource) == cuda::mr::device_default_memory_pool(cuda::device_ref{0}));
 }
 
 C2H_TEST("env_t is constructible from an any_resource", "[execution][env]")

--- a/cudax/test/execution/test_stream_context.cu
+++ b/cudax/test/execution/test_stream_context.cu
@@ -134,7 +134,7 @@ void bulk_on_stream_scheduler()
   auto sch = sctx.get_scheduler();
 
   using _env_t = cudax::env_t<cuda::mr::device_accessible>;
-  auto mr      = cuda::device_default_memory_pool(_dev);
+  auto mr      = cuda::mr::device_default_memory_pool(_dev);
   auto mr2     = cuda::mr::any_resource<cuda::mr::device_accessible>(mr);
   _env_t env{mr, cuda::get_stream(sch), ex::par_unseq};
   auto buf = cudax::make_buffer<int>(sctx, mr2, 10, 40, env); // a device buffer of 10 integers, initialized to 40

--- a/cudax/test/graph/graph_smoke.cu
+++ b/cudax/test/graph/graph_smoke.cu
@@ -157,7 +157,7 @@ C2H_TEST("graph_node_ref can be copied", "[graph]")
 C2H_TEST("Path builder with kernel nodes", "[graph]")
 {
   cudax::stream s{cuda::device_ref{0}};
-  cuda::legacy_managed_memory_resource mr{};
+  cuda::mr::legacy_managed_memory_resource mr{};
   int* ptr = static_cast<int*>(mr.allocate_sync(sizeof(int)));
   *ptr     = 0;
 
@@ -273,10 +273,10 @@ C2H_TEST("Path builder with kernel nodes", "[graph]")
   {
     SECTION("Multi-device graph")
     {
-      cuda::device_memory_pool_ref dev0_mr = cuda::device_default_memory_pool(cuda::devices[0]);
-      int* dev0_ptr                        = static_cast<int*>(dev0_mr.allocate_sync(sizeof(int)));
-      cuda::device_memory_pool_ref dev1_mr = cuda::device_default_memory_pool(cuda::devices[1]);
-      int* dev1_ptr                        = static_cast<int*>(dev1_mr.allocate_sync(sizeof(int)));
+      cuda::mr::device_memory_pool_ref dev0_mr = cuda::mr::device_default_memory_pool(cuda::devices[0]);
+      int* dev0_ptr                            = static_cast<int*>(dev0_mr.allocate_sync(sizeof(int)));
+      cuda::mr::device_memory_pool_ref dev1_mr = cuda::mr::device_default_memory_pool(cuda::devices[1]);
+      int* dev1_ptr                            = static_cast<int*>(dev1_mr.allocate_sync(sizeof(int)));
 
       cudax::graph_builder g(cuda::devices[0]);
       cudax::path_builder dev0_pb = cudax::start_path(g);

--- a/libcudacxx/include/cuda/__memory_resource/device_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_resource/device_memory_pool.h
@@ -37,7 +37,7 @@
 //! @file
 //! The \c device_memory_pool class provides an asynchronous memory resource
 //! that allocates device memory in stream order.
-_CCCL_BEGIN_NAMESPACE_CUDA
+_CCCL_BEGIN_NAMESPACE_CUDA_MR
 
 //! @rst
 //! .. _cudax-memory-resource-async:
@@ -86,7 +86,7 @@ public:
 //! @returns The default memory pool of the specified device.
 [[nodiscard]] inline device_memory_pool_ref device_default_memory_pool(::cuda::device_ref __device)
 {
-  static ::cudaMemPool_t __pool = ::cuda::__get_default_memory_pool(
+  static ::cudaMemPool_t __pool = ::cuda::mr::__get_default_memory_pool(
     ::CUmemLocation{::CU_MEM_LOCATION_TYPE_DEVICE, __device.get()}, ::CU_MEM_ALLOCATION_TYPE_PINNED);
   return device_memory_pool_ref(__pool);
 }
@@ -149,7 +149,7 @@ static_assert(::cuda::mr::synchronous_resource_with<device_memory_pool_ref, ::cu
 
 static_assert(::cuda::mr::resource_with<device_memory_pool, ::cuda::mr::device_accessible>, "");
 
-_CCCL_END_NAMESPACE_CUDA
+_CCCL_END_NAMESPACE_CUDA_MR
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
@@ -38,7 +38,7 @@
 
 //! @file
 //! The \c managed_memory_resource class provides a memory resource that allocates managed memory.
-_CCCL_BEGIN_NAMESPACE_CUDA
+_CCCL_BEGIN_NAMESPACE_CUDA_MR
 
 //! @brief \c managed_memory_resource uses `cudaMallocManaged` / `cudaFree` for allocation / deallocation.
 class legacy_managed_memory_resource
@@ -141,7 +141,7 @@ private:
 static_assert(::cuda::mr::synchronous_resource_with<legacy_managed_memory_resource, ::cuda::mr::device_accessible>, "");
 static_assert(::cuda::mr::synchronous_resource_with<legacy_managed_memory_resource, ::cuda::mr::host_accessible>, "");
 
-_CCCL_END_NAMESPACE_CUDA
+_CCCL_END_NAMESPACE_CUDA_MR
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
@@ -38,7 +38,7 @@
 
 //! @file
 //! The \c legacy_pinned_memory_resource class provides a memory resource that allocates pinned memory.
-_CCCL_BEGIN_NAMESPACE_CUDA
+_CCCL_BEGIN_NAMESPACE_CUDA_MR
 
 //! @brief legacy_pinned_memory_resource uses `cudaMallocHost` / `cudaFreeAsync` for allocation / deallocation.
 //! @note This memory resource will be deprecated in the future. For CUDA 12.6 and above, use
@@ -134,7 +134,7 @@ private:
 static_assert(::cuda::mr::synchronous_resource_with<legacy_pinned_memory_resource, ::cuda::mr::device_accessible>, "");
 static_assert(::cuda::mr::synchronous_resource_with<legacy_pinned_memory_resource, ::cuda::mr::host_accessible>, "");
 
-_CCCL_END_NAMESPACE_CUDA
+_CCCL_END_NAMESPACE_CUDA_MR
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__memory_resource/managed_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_resource/managed_memory_pool.h
@@ -33,7 +33,7 @@
 //! @file
 //! The \c managed_memory_resource class provides a memory resource that
 //! allocates managed memory.
-_CCCL_BEGIN_NAMESPACE_CUDA
+_CCCL_BEGIN_NAMESPACE_CUDA_MR
 
 //! @rst
 //! .. _cudax-memory-resource-async:
@@ -80,7 +80,7 @@ public:
 //! @returns The default managed memory pool.
 [[nodiscard]] inline managed_memory_pool_ref managed_default_memory_pool()
 {
-  static ::cudaMemPool_t __pool = ::cuda::__get_default_memory_pool(
+  static ::cudaMemPool_t __pool = ::cuda::mr::__get_default_memory_pool(
     ::CUmemLocation{::CU_MEM_LOCATION_TYPE_NONE, 0}, ::CU_MEM_ALLOCATION_TYPE_MANAGED);
   return managed_memory_pool_ref(__pool);
 }
@@ -142,7 +142,7 @@ static_assert(::cuda::mr::resource_with<managed_memory_pool_ref, ::cuda::mr::hos
 static_assert(::cuda::mr::resource_with<managed_memory_pool, ::cuda::mr::device_accessible>, "");
 static_assert(::cuda::mr::resource_with<managed_memory_pool, ::cuda::mr::host_accessible>, "");
 
-_CCCL_END_NAMESPACE_CUDA
+_CCCL_END_NAMESPACE_CUDA_MR
 
 #  include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__memory_resource/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_resource/memory_pool_base.h
@@ -39,7 +39,7 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
-_CCCL_BEGIN_NAMESPACE_CUDA
+_CCCL_BEGIN_NAMESPACE_CUDA_MR
 
 enum class __pool_attr_settable : bool
 {
@@ -119,7 +119,7 @@ struct __pool_attr<::cudaMemPoolAttrReservedMemHigh>
 {
   static void set(::cudaMemPool_t __pool, type __value)
   {
-    ::cuda::__set_attribute_non_zero_only(__pool, ::CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH, __value);
+    ::cuda::mr::__set_attribute_non_zero_only(__pool, ::CU_MEMPOOL_ATTR_RESERVED_MEM_HIGH, __value);
   }
 };
 
@@ -129,7 +129,7 @@ struct __pool_attr<::cudaMemPoolAttrUsedMemHigh>
 {
   static void set(::cudaMemPool_t __pool, type __value)
   {
-    ::cuda::__set_attribute_non_zero_only(__pool, ::CU_MEMPOOL_ATTR_USED_MEM_HIGH, __value);
+    ::cuda::mr::__set_attribute_non_zero_only(__pool, ::CU_MEMPOOL_ATTR_USED_MEM_HIGH, __value);
   }
 };
 
@@ -220,13 +220,13 @@ inline void __verify_device_supports_export_handle_type(
 __get_default_memory_pool(const CUmemLocation __location, [[maybe_unused]] const CUmemAllocationType __allocation_type)
 {
   auto __device = __location.type == ::CU_MEM_LOCATION_TYPE_DEVICE ? __location.id : 0;
-  ::cuda::__verify_device_supports_stream_ordered_allocations(__device);
+  ::cuda::mr::__verify_device_supports_stream_ordered_allocations(__device);
 
 #if _CCCL_CTK_AT_LEAST(13, 0)
   ::cudaMemPool_t __pool = ::cuda::__driver::__getDefaultMemPool(__location, __allocation_type);
-  if (::cuda::memory_pool_attributes::release_threshold(__pool) == 0)
+  if (::cuda::mr::memory_pool_attributes::release_threshold(__pool) == 0)
   {
-    ::cuda::memory_pool_attributes::release_threshold.set(__pool, ::cuda::std::numeric_limits<size_t>::max());
+    ::cuda::mr::memory_pool_attributes::release_threshold.set(__pool, ::cuda::std::numeric_limits<size_t>::max());
   }
 #else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
   _CCCL_ASSERT(__location.type == ::CU_MEM_LOCATION_TYPE_DEVICE,
@@ -327,8 +327,8 @@ struct memory_pool_properties
   {
     auto __device = __location.type == ::CU_MEM_LOCATION_TYPE_DEVICE ? __location.id : 0;
     // Mempool creation failed, lets try to figure out why
-    ::cuda::__verify_device_supports_stream_ordered_allocations(__device);
-    ::cuda::__verify_device_supports_export_handle_type(__device, __properties.allocation_handle_type, __location);
+    ::cuda::mr::__verify_device_supports_stream_ordered_allocations(__device);
+    ::cuda::mr::__verify_device_supports_export_handle_type(__device, __properties.allocation_handle_type, __location);
 
     // Could not find the reason, throw a generic error
     ::cuda::__throw_cuda_error(__error, "Failed to create a memory pool");
@@ -557,7 +557,8 @@ public:
   //! for
   _CCCL_HOST_API void enable_access_from(::cuda::std::span<const device_ref> __devices)
   {
-    ::cuda::__mempool_set_access(__pool_, {__devices.data(), __devices.size()}, ::CU_MEM_ACCESS_FLAGS_PROT_READWRITE);
+    ::cuda::mr::__mempool_set_access(
+      __pool_, {__devices.data(), __devices.size()}, ::CU_MEM_ACCESS_FLAGS_PROT_READWRITE);
   }
 
   //! @brief Enable access to memory allocated through this memory resource by
@@ -570,7 +571,7 @@ public:
   //! be enabled
   _CCCL_HOST_API void enable_access_from(device_ref __device)
   {
-    ::cuda::__mempool_set_access(__pool_, {&__device, 1}, ::CU_MEM_ACCESS_FLAGS_PROT_READWRITE);
+    ::cuda::mr::__mempool_set_access(__pool_, {&__device, 1}, ::CU_MEM_ACCESS_FLAGS_PROT_READWRITE);
   }
 
   //! @brief Disable access to memory allocated through this memory resource by
@@ -585,7 +586,7 @@ public:
   //! for
   _CCCL_HOST_API void disable_access_from(::cuda::std::span<const device_ref> __devices)
   {
-    ::cuda::__mempool_set_access(__pool_, {__devices.data(), __devices.size()}, ::CU_MEM_ACCESS_FLAGS_PROT_NONE);
+    ::cuda::mr::__mempool_set_access(__pool_, {__devices.data(), __devices.size()}, ::CU_MEM_ACCESS_FLAGS_PROT_NONE);
   }
 
   //! @brief Disable access to memory allocated through this memory resource by
@@ -598,7 +599,7 @@ public:
   //! be disabled
   _CCCL_HOST_API void disable_access_from(device_ref __device)
   {
-    ::cuda::__mempool_set_access(__pool_, {&__device, 1}, ::CU_MEM_ACCESS_FLAGS_PROT_NONE);
+    ::cuda::mr::__mempool_set_access(__pool_, {&__device, 1}, ::CU_MEM_ACCESS_FLAGS_PROT_NONE);
   }
 
   //! @brief Query if memory allocated through this memory resource is
@@ -607,7 +608,7 @@ public:
   //! @param __device device for which the access is queried
   [[nodiscard]] _CCCL_HOST_API bool is_accessible_from(device_ref __device)
   {
-    return ::cuda::__mempool_get_access(__pool_, __device);
+    return ::cuda::mr::__mempool_get_access(__pool_, __device);
   }
 
   //! @brief Equality comparison with another __memory_pool_base.
@@ -627,7 +628,7 @@ public:
 #endif // _CCCL_STD_VER <= 2017
 };
 
-_CCCL_END_NAMESPACE_CUDA
+_CCCL_END_NAMESPACE_CUDA_MR
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__memory_resource/pinned_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_resource/pinned_memory_pool.h
@@ -37,7 +37,7 @@
 //! @file
 //! The \c pinned_memory_resource class provides a memory resource that
 //! allocates pinned memory.
-_CCCL_BEGIN_NAMESPACE_CUDA
+_CCCL_BEGIN_NAMESPACE_CUDA_MR
 
 #if _CCCL_CTK_AT_LEAST(12, 6)
 
@@ -89,7 +89,7 @@ public:
 //! @returns The default pinned memory pool.
 [[nodiscard]] inline pinned_memory_pool_ref pinned_default_memory_pool()
 {
-  return pinned_memory_pool_ref{::cuda::__get_default_host_pinned_pool()};
+  return pinned_memory_pool_ref{::cuda::mr::__get_default_host_pinned_pool()};
 }
 
 //! @rst
@@ -182,11 +182,11 @@ static_assert(::cuda::mr::resource_with<pinned_memory_pool, ::cuda::mr::host_acc
 {
 #  if _CCCL_CTK_AT_LEAST(13, 0)
   static ::cudaMemPool_t __default_pool = []() {
-    ::cudaMemPool_t __pool = ::cuda::__get_default_memory_pool(
+    ::cudaMemPool_t __pool = ::cuda::mr::__get_default_memory_pool(
       ::CUmemLocation{::CU_MEM_LOCATION_TYPE_HOST, 0}, ::CU_MEM_ALLOCATION_TYPE_PINNED);
     // TODO should we be more careful with setting access from all devices?
     // Maybe only if it was not set for any device?
-    ::cuda::__mempool_set_access(__pool, ::cuda::devices, ::CU_MEM_ACCESS_FLAGS_PROT_READWRITE);
+    ::cuda::mr::__mempool_set_access(__pool, ::cuda::devices, ::CU_MEM_ACCESS_FLAGS_PROT_READWRITE);
     return __pool;
   }();
 
@@ -199,7 +199,7 @@ static_assert(::cuda::mr::resource_with<pinned_memory_pool, ::cuda::mr::host_acc
 
 #endif // _CCCL_CTK_AT_LEAST(12, 6)
 
-_CCCL_END_NAMESPACE_CUDA
+_CCCL_END_NAMESPACE_CUDA_MR
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__memory_resource/resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource.h
@@ -128,10 +128,6 @@ _CCCL_CONCEPT __non_polymorphic_resources = _CCCL_REQUIRES_EXPR((_Resource, _Oth
   requires(::cuda::__non_polymorphic<_Resource>),
   requires(::cuda::__non_polymorphic<_OtherResource>));
 
-_CCCL_END_NAMESPACE_CUDA_MR
-
-_CCCL_BEGIN_NAMESPACE_CUDA
-
 //! @brief Equality comparison between two resources of different types. Always returns false.
 _CCCL_TEMPLATE(class _Resource, class _OtherResource)
 _CCCL_REQUIRES((!::cuda::std::is_same_v<_Resource, _OtherResource>)
@@ -152,7 +148,7 @@ _CCCL_REQUIRES((!::cuda::std::is_same_v<_Resource, _OtherResource>)
 }
 #endif // _CCCL_STD_VER <= 2017
 
-_CCCL_END_NAMESPACE_CUDA
+_CCCL_END_NAMESPACE_CUDA_MR
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
@@ -40,7 +40,7 @@ constexpr int get_property(const cuda::__uninitialized_async_buffer<int, cuda::m
 {
   return 42;
 }
-constexpr int get_property(const cuda::device_memory_pool_ref&, my_property)
+constexpr int get_property(const cuda::mr::device_memory_pool_ref&, my_property)
 {
   return 42;
 }
@@ -53,7 +53,7 @@ C2H_TEST_LIST(
   static_assert(!cuda::std::is_copy_constructible<__uninitialized_async_buffer>::value, "");
   static_assert(!cuda::std::is_copy_assignable<__uninitialized_async_buffer>::value, "");
 
-  cuda::device_memory_pool_ref resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+  cuda::mr::device_memory_pool_ref resource = cuda::mr::device_default_memory_pool(cuda::device_ref{0});
   cuda::stream stream{cuda::device_ref{0}};
 
   SECTION("construction")
@@ -222,18 +222,18 @@ C2H_TEST_LIST(
 
 // A test resource that keeps track of the number of resources are
 // currently alive.
-struct test_async_device_memory_pool_ref : cuda::device_memory_pool_ref
+struct test_async_device_memory_pool_ref : cuda::mr::device_memory_pool_ref
 {
   static int count;
 
   test_async_device_memory_pool_ref()
-      : cuda::device_memory_pool_ref(cuda::device_default_memory_pool(cuda::device_ref{0}))
+      : cuda::mr::device_memory_pool_ref(cuda::mr::device_default_memory_pool(cuda::device_ref{0}))
   {
     ++count;
   }
 
   test_async_device_memory_pool_ref(const test_async_device_memory_pool_ref& other)
-      : cuda::device_memory_pool_ref{other}
+      : cuda::mr::device_memory_pool_ref{other}
   {
     ++count;
   }
@@ -250,7 +250,7 @@ C2H_TEST("__uninitialized_async_buffer's memory resource does not dangle", "[con
 {
   cuda::stream stream{cuda::device_ref{0}};
   cuda::__uninitialized_async_buffer<int, ::cuda::mr::device_accessible> buffer{
-    cuda::device_default_memory_pool(cuda::device_ref{0}), stream, 0};
+    cuda::mr::device_default_memory_pool(cuda::device_ref{0}), stream, 0};
 
   {
     CHECK(test_async_device_memory_pool_ref::count == 0);

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/managed_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/managed_memory_resource.cu
@@ -17,9 +17,9 @@
 #include <utility.cuh>
 
 #if _CCCL_CTK_AT_LEAST(13, 0)
-#  define TEST_TYPES cuda::legacy_managed_memory_resource, cuda::managed_memory_pool_ref
+#  define TEST_TYPES cuda::mr::legacy_managed_memory_resource, cuda::mr::managed_memory_pool_ref
 #else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
-#  define TEST_TYPES cuda::legacy_managed_memory_resource
+#  define TEST_TYPES cuda::mr::legacy_managed_memory_resource
 #endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
 
 template <typename Resource>
@@ -35,18 +35,18 @@ void resource_static_asserts()
   static_assert(!cuda::std::is_empty<Resource>::value, "");
 }
 
-template void resource_static_asserts<cuda::legacy_managed_memory_resource>();
+template void resource_static_asserts<cuda::mr::legacy_managed_memory_resource>();
 #if _CCCL_CTK_AT_LEAST(13, 0)
-template void resource_static_asserts<cuda::managed_memory_pool_ref>();
+template void resource_static_asserts<cuda::mr::managed_memory_pool_ref>();
 #endif // _CCCL_CTK_AT_LEAST(13, 0)
 
 template <class Resource>
 Resource get_resource()
 {
 #if _CCCL_CTK_AT_LEAST(13, 0)
-  if constexpr (cuda::std::is_same_v<Resource, cuda::managed_memory_pool_ref>)
+  if constexpr (cuda::std::is_same_v<Resource, cuda::mr::managed_memory_pool_ref>)
   {
-    return cuda::managed_default_memory_pool();
+    return cuda::mr::managed_default_memory_pool();
   }
   else
 #endif // _CCCL_CTK_AT_LEAST(13, 0)
@@ -69,7 +69,7 @@ C2H_CCCLRT_TEST_LIST("managed_memory_resource construction", "[memory_resource]"
   using managed_resource = TestType;
   SECTION("Default construction")
   {
-    if constexpr (cuda::std::is_same_v<managed_resource, cuda::legacy_managed_memory_resource>)
+    if constexpr (cuda::std::is_same_v<managed_resource, cuda::mr::legacy_managed_memory_resource>)
     {
       STATIC_REQUIRE(cuda::std::is_default_constructible_v<managed_resource>);
     }
@@ -203,9 +203,9 @@ static_assert(cuda::mr::resource<test_resource<AccessibilityType::Host>>, "");
 static_assert(cuda::mr::resource<test_resource<AccessibilityType::Device>>, "");
 
 // test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
-struct derived_managed_resource : cuda::legacy_managed_memory_resource
+struct derived_managed_resource : cuda::mr::legacy_managed_memory_resource
 {
-  using cuda::legacy_managed_memory_resource::legacy_managed_memory_resource;
+  using cuda::mr::legacy_managed_memory_resource::legacy_managed_memory_resource;
 };
 static_assert(cuda::mr::synchronous_resource<derived_managed_resource>, "");
 
@@ -219,9 +219,9 @@ C2H_CCCLRT_TEST_LIST("managed_memory_resource comparison", "[memory_resource]", 
     CHECK(!(first != second));
   }
 
-  if constexpr (cuda::std::is_same_v<managed_resource, cuda::legacy_managed_memory_resource>)
+  if constexpr (cuda::std::is_same_v<managed_resource, cuda::mr::legacy_managed_memory_resource>)
   { // comparison against a plain legacy_managed_memory_resource with a different flags
-    managed_resource second = cuda::legacy_managed_memory_resource{cudaMemAttachHost};
+    managed_resource second = cuda::mr::legacy_managed_memory_resource{cudaMemAttachHost};
     CHECK((first != second));
     CHECK(!(first == second));
   }
@@ -229,7 +229,7 @@ C2H_CCCLRT_TEST_LIST("managed_memory_resource comparison", "[memory_resource]", 
   else
   {
     // comparison against a managed_memory_pool_ref with a different pool
-    cuda::managed_memory_pool second{};
+    cuda::mr::managed_memory_pool second{};
     CHECK((first != second));
     CHECK(!(first == second));
   }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pinned_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/pinned_memory_resource.cu
@@ -19,9 +19,9 @@
 #include "common_tests.cuh"
 
 #if _CCCL_CTK_AT_LEAST(12, 6)
-#  define TEST_TYPES cuda::legacy_pinned_memory_resource, cuda::pinned_memory_pool_ref
+#  define TEST_TYPES cuda::mr::legacy_pinned_memory_resource, cuda::mr::pinned_memory_pool_ref
 #else // ^^^ _CCCL_CTK_AT_LEAST(12, 6) ^^^ / vvv _CCCL_CTK_BELOW(12, 6) vvv
-#  define TEST_TYPES cuda::legacy_pinned_memory_resource
+#  define TEST_TYPES cuda::mr::legacy_pinned_memory_resource
 #endif // ^^^ _CCCL_CTK_BELOW(12, 6) ^^^
 
 template <typename Resource>
@@ -34,24 +34,24 @@ void resource_static_asserts()
   static_assert(cuda::std::is_trivially_copy_assignable_v<Resource>, "");
   static_assert(cuda::std::is_trivially_move_assignable_v<Resource>, "");
   static_assert(cuda::std::is_trivially_destructible_v<Resource>, "");
-  if constexpr (cuda::std::is_same_v<Resource, cuda::legacy_pinned_memory_resource>)
+  if constexpr (cuda::std::is_same_v<Resource, cuda::mr::legacy_pinned_memory_resource>)
   {
     static_assert(cuda::std::is_default_constructible_v<Resource>, "");
   }
 }
 
-template void resource_static_asserts<cuda::legacy_pinned_memory_resource>();
+template void resource_static_asserts<cuda::mr::legacy_pinned_memory_resource>();
 #if _CCCL_CTK_AT_LEAST(12, 6)
-template void resource_static_asserts<cuda::pinned_memory_pool_ref>();
+template void resource_static_asserts<cuda::mr::pinned_memory_pool_ref>();
 #endif // _CCCL_CTK_AT_LEAST(12, 6)
 
 template <class Resource>
 Resource get_resource()
 {
 #if _CCCL_CTK_AT_LEAST(12, 6)
-  if constexpr (cuda::std::is_same_v<Resource, cuda::pinned_memory_pool_ref>)
+  if constexpr (cuda::std::is_same_v<Resource, cuda::mr::pinned_memory_pool_ref>)
   {
-    return cuda::pinned_default_memory_pool();
+    return cuda::mr::pinned_default_memory_pool();
   }
   else
 #endif // _CCCL_CTK_AT_LEAST(12, 6)
@@ -224,7 +224,7 @@ static_assert(cuda::mr::resource<test_resource<AccessibilityType::Host>>, "");
 static_assert(cuda::mr::resource<test_resource<AccessibilityType::Device>>, "");
 
 // test for cccl#2214: https://github.com/NVIDIA/cccl/issues/2214
-struct derived_pinned_resource : cuda::legacy_pinned_memory_resource
+struct derived_pinned_resource : cuda::mr::legacy_pinned_memory_resource
 {
   using legacy_pinned_memory_resource::legacy_pinned_memory_resource;
 };
@@ -293,7 +293,7 @@ C2H_CCCLRT_TEST_LIST("pinned_memory_resource comparison", "[memory_resource]", T
 #if _CCCL_CTK_AT_LEAST(12, 6)
 C2H_CCCLRT_TEST("pinned_memory_resource async.deallocate_sync", "[memory_resource]")
 {
-  cuda::pinned_memory_pool_ref resource = cuda::pinned_default_memory_pool();
+  cuda::mr::pinned_memory_pool_ref resource = cuda::mr::pinned_default_memory_pool();
   test_deallocate_async(resource);
 }
 #endif // _CCCL_CTK_AT_LEAST(12, 6)


### PR DESCRIPTION
We previously had all memory resource in the `cuda::mr` namespace

This improves discoverability of memory resources and their related machinery. It also greatly simplifies teaching, by always referencing the same namespace.

This concerns the following resources:
* `device_memory_pool` and `device_memory_pool_ref`
* `managed_memory_pool` and `managed_memory_pool_ref`
* `pinned_memory_pool` and `pinned_memory_pool_ref`
* `legacy_managed_memory_resource` 
* `legacy_pinned_memory_resource`

It also concerns attributes like:
* `memory_pool_attributes::release_threshold_t`
* `memory_pool_attributes::reuse_follow_event_dependencies_t`
* `memory_pool_attributes::reuse_allow_opportunistic_t`
* `memory_pool_attributes::reuse_allow_internal_dependencies_t`
* `memory_pool_attributes::reserved_mem_current_t`
* `memory_pool_attributes::reserved_mem_high_t`
* `memory_pool_attributes::used_mem_current_t`
* `memory_pool_attributes::used_mem_high_t`
* `memory_pool_properties`

Affected fucntions are:
* `device_default_memory_pool`
* `managed_default_memory_pool`
* `pinned_default_memory_pool`