### PR TITLE
Remove unnecessary casts in complex multiplication/division

### DIFF
--- a/libcudacxx/include/cuda/std/__complex/complex.h
+++ b/libcudacxx/include/cuda/std/__complex/complex.h
@@ -292,21 +292,21 @@ template <class _Tp>
                     || (__c == _Tp(0) && ::cuda::std::isnan(__d)));
     if (__z_nan || __w_nan)
     {
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
+      return complex<_Tp>(numeric_limits<_Tp>::quiet_NaN(), _Tp(0));
     }
     if (__z_inf || __w_inf)
     {
       if (__z_zero || __w_zero)
       {
-        return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
+        return complex<_Tp>(numeric_limits<_Tp>::quiet_NaN(), _Tp(0));
       }
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
+      return complex<_Tp>(numeric_limits<_Tp>::infinity(), numeric_limits<_Tp>::infinity());
     }
     bool __z_nonzero_nan = !__z_inf && !__z_nan && (::cuda::std::isnan(__a) || ::cuda::std::isnan(__b));
     bool __w_nonzero_nan = !__w_inf && !__w_nan && (::cuda::std::isnan(__c) || ::cuda::std::isnan(__d));
     if (__z_nonzero_nan || __w_nonzero_nan)
     {
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
+      return complex<_Tp>(numeric_limits<_Tp>::quiet_NaN(), _Tp(0));
     }
   }
 #endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED
@@ -429,7 +429,7 @@ template <class _Tp>
                     || (__c == _Tp(0) && ::cuda::std::isnan(__d)));
     if ((__z_nan || __w_nan) || (__z_inf && __w_inf))
     {
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
+      return complex<_Tp>(numeric_limits<_Tp>::quiet_NaN(), _Tp(0));
     }
     bool __z_nonzero_nan = !__z_inf && !__z_nan && (::cuda::std::isnan(__a) || ::cuda::std::isnan(__b));
     bool __w_nonzero_nan = !__w_inf && !__w_nan && (::cuda::std::isnan(__c) || ::cuda::std::isnan(__d));
@@ -437,9 +437,9 @@ template <class _Tp>
     {
       if (__w_zero)
       {
-        return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
+        return complex<_Tp>(numeric_limits<_Tp>::infinity(), numeric_limits<_Tp>::infinity());
       }
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
+      return complex<_Tp>(numeric_limits<_Tp>::quiet_NaN(), _Tp(0));
     }
     if (__w_inf)
     {
@@ -447,15 +447,15 @@ template <class _Tp>
     }
     if (__z_inf)
     {
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
+      return complex<_Tp>(numeric_limits<_Tp>::infinity(), numeric_limits<_Tp>::infinity());
     }
     if (__w_zero)
     {
       if (__z_zero)
       {
-        return complex<_Tp>(_Tp(numeric_limits<_Tp>::quiet_NaN()), _Tp(0));
+        return complex<_Tp>(numeric_limits<_Tp>::quiet_NaN(), _Tp(0));
       }
-      return complex<_Tp>(_Tp(numeric_limits<_Tp>::infinity()), _Tp(numeric_limits<_Tp>::infinity()));
+      return complex<_Tp>(numeric_limits<_Tp>::infinity(), numeric_limits<_Tp>::infinity());
     }
   }
 #endif // _CCCL_BUILTIN_IS_CONSTANT_EVALUATED

--- a/libcudacxx/include/cuda/std/__complex/exponential_functions.h
+++ b/libcudacxx/include/cuda/std/__complex/exponential_functions.h
@@ -152,8 +152,7 @@ _CCCL_API inline complex<float> exp(const complex<float>& __x)
       // __r == +-INF
       return ::cuda::std::signbit(__r)
              ? complex<float>{}
-             : complex<float>{::cuda::std::numeric_limits<float>::infinity(),
-                              ::cuda::std::numeric_limits<float>::quiet_NaN()};
+             : complex<float>{numeric_limits<float>::infinity(), numeric_limits<float>::quiet_NaN()};
     }
     // __r NaN:
     if (::cuda::std::isnan(__r) && (__i == 0.0f))
@@ -246,8 +245,7 @@ _CCCL_API inline complex<double> exp<double>(const complex<double>& __x)
     {
       return ::cuda::std::signbit(__r)
              ? complex<double>{}
-             : complex<double>{::cuda::std::numeric_limits<double>::infinity(),
-                               ::cuda::std::numeric_limits<double>::quiet_NaN()};
+             : complex<double>{numeric_limits<double>::infinity(), numeric_limits<double>::quiet_NaN()};
     }
     // __r NaN:
     if (::cuda::std::isnan(__r) && (__i == 0.0))

--- a/libcudacxx/include/cuda/std/__complex/logarithms.h
+++ b/libcudacxx/include/cuda/std/__complex/logarithms.h
@@ -239,14 +239,13 @@ template <class _Tp>
   // Fix x == 0.0
   if (__x.real() == _Tp(0.0) && __x.imag() == _Tp(0.0))
   {
-    __abs_rescaled = -::cuda::std::numeric_limits<_Tp>::infinity();
+    __abs_rescaled = -numeric_limits<_Tp>::infinity();
   }
 
   // Fix hypot inf/nan case:
-  if ((__max == ::cuda::std::numeric_limits<_Tp>::infinity())
-      || (__min == ::cuda::std::numeric_limits<_Tp>::infinity()))
+  if ((__max == numeric_limits<_Tp>::infinity()) || (__min == numeric_limits<_Tp>::infinity()))
   {
-    __abs_rescaled = ::cuda::std::numeric_limits<_Tp>::infinity();
+    __abs_rescaled = numeric_limits<_Tp>::infinity();
   }
 
   return complex<_Tp>(__abs_rescaled, ::cuda::std::atan2(__x.imag(), __x.real()));


### PR DESCRIPTION
and fully qualified `::cuda::std::numeric_limits`
