### PR TITLE
Improve charconv test compile times

### DIFF
--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int128.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int128.pass.cpp
@@ -14,7 +14,7 @@
 #include <cuda/std/cstdint>
 #include <cuda/std/cstring>
 #include <cuda/std/type_traits>
-#include <cuda/std/utility>
+#include <cuda/utility>
 
 #include "test_macros.h"
 
@@ -1229,7 +1229,7 @@ __host__ __device__ constexpr void test_to_chars(const TestItem& item)
 }
 
 template <int Base>
-__host__ __device__ constexpr void test_base()
+__host__ __device__ constexpr bool test_base()
 {
   constexpr auto items = get_test_items<Base>();
 
@@ -1238,19 +1238,23 @@ __host__ __device__ constexpr void test_base()
     test_to_chars<__int128_t, Base>(item);
     test_to_chars<__uint128_t, Base>(item);
   }
-}
-
-template <int... Base>
-__host__ __device__ constexpr void test_helper(cuda::std::integer_sequence<int, Base...>)
-{
-  (test_base<Base + first_base>(), ...);
-}
-
-__host__ __device__ constexpr bool test()
-{
-  test_helper(cuda::std::make_integer_sequence<int, last_base - first_base + 1>{});
 
   return true;
+}
+
+struct TestBaseInvoker
+{
+  template <int Base>
+  __host__ __device__ constexpr void operator()(cuda::std::integral_constant<int, Base>) const
+  {
+    test_base<Base>();
+    static_assert(test_base<Base>());
+  }
+};
+
+__host__ __device__ constexpr void test()
+{
+  cuda::static_for<int, first_base, last_base + 1>(TestBaseInvoker{});
 }
 
 #endif // _CCCL_HAS_INT128()
@@ -1259,7 +1263,6 @@ int main(int, char**)
 {
 #if _CCCL_HAS_INT128()
   test();
-  static_assert(test());
 #endif // _CCCL_HAS_INT128()
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int16.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int16.pass.cpp
@@ -14,7 +14,7 @@
 #include <cuda/std/cstdint>
 #include <cuda/std/cstring>
 #include <cuda/std/type_traits>
-#include <cuda/std/utility>
+#include <cuda/utility>
 
 #include "test_macros.h"
 
@@ -1177,7 +1177,7 @@ __host__ __device__ constexpr void test_to_chars(const TestItem& item)
 }
 
 template <int Base>
-__host__ __device__ constexpr void test_base()
+__host__ __device__ constexpr bool test_base()
 {
   constexpr auto items = get_test_items<Base>();
 
@@ -1186,24 +1186,27 @@ __host__ __device__ constexpr void test_base()
     test_to_chars<cuda::std::int16_t, Base>(item);
     test_to_chars<cuda::std::uint16_t, Base>(item);
   }
-}
-
-template <int... Base>
-__host__ __device__ constexpr void test_helper(cuda::std::integer_sequence<int, Base...>)
-{
-  (test_base<Base + first_base>(), ...);
-}
-
-__host__ __device__ constexpr bool test()
-{
-  test_helper(cuda::std::make_integer_sequence<int, last_base - first_base + 1>{});
 
   return true;
+}
+
+struct TestBaseInvoker
+{
+  template <int Base>
+  __host__ __device__ constexpr void operator()(cuda::std::integral_constant<int, Base>) const
+  {
+    test_base<Base>();
+    static_assert(test_base<Base>());
+  }
+};
+
+__host__ __device__ constexpr void test()
+{
+  cuda::static_for<int, first_base, last_base + 1>(TestBaseInvoker{});
 }
 
 int main(int, char**)
 {
   test();
-  static_assert(test());
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int32.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int32.pass.cpp
@@ -14,7 +14,7 @@
 #include <cuda/std/cstdint>
 #include <cuda/std/cstring>
 #include <cuda/std/type_traits>
-#include <cuda/std/utility>
+#include <cuda/utility>
 
 #include "test_macros.h"
 
@@ -1127,7 +1127,7 @@ __host__ __device__ constexpr void test_to_chars(const TestItem& item)
 }
 
 template <int Base>
-__host__ __device__ constexpr void test_base()
+__host__ __device__ constexpr bool test_base()
 {
   constexpr auto items = get_test_items<Base>();
 
@@ -1136,24 +1136,27 @@ __host__ __device__ constexpr void test_base()
     test_to_chars<cuda::std::int32_t, Base>(item);
     test_to_chars<cuda::std::uint32_t, Base>(item);
   }
-}
-
-template <int... Base>
-__host__ __device__ constexpr void test_helper(cuda::std::integer_sequence<int, Base...>)
-{
-  (test_base<Base + first_base>(), ...);
-}
-
-__host__ __device__ constexpr bool test()
-{
-  test_helper(cuda::std::make_integer_sequence<int, last_base - first_base + 1>{});
 
   return true;
+}
+
+struct TestBaseInvoker
+{
+  template <int Base>
+  __host__ __device__ constexpr void operator()(cuda::std::integral_constant<int, Base>) const
+  {
+    test_base<Base>();
+    static_assert(test_base<Base>());
+  }
+};
+
+__host__ __device__ constexpr void test()
+{
+  cuda::static_for<int, first_base, last_base + 1>(TestBaseInvoker{});
 }
 
 int main(int, char**)
 {
   test();
-  static_assert(test());
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int64.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/text/charconv/charconv.to.chars/integral/int64.pass.cpp
@@ -14,7 +14,7 @@
 #include <cuda/std/cstdint>
 #include <cuda/std/cstring>
 #include <cuda/std/type_traits>
-#include <cuda/std/utility>
+#include <cuda/utility>
 
 #include "test_macros.h"
 
@@ -1188,7 +1188,7 @@ __host__ __device__ constexpr void test_to_chars(const TestItem& item)
 }
 
 template <int Base>
-__host__ __device__ constexpr void test_base()
+__host__ __device__ constexpr bool test_base()
 {
   constexpr auto items = get_test_items<Base>();
 
@@ -1197,24 +1197,27 @@ __host__ __device__ constexpr void test_base()
     test_to_chars<cuda::std::int64_t, Base>(item);
     test_to_chars<cuda::std::uint64_t, Base>(item);
   }
-}
-
-template <int... Base>
-__host__ __device__ constexpr void test_helper(cuda::std::integer_sequence<int, Base...>)
-{
-  (test_base<Base + first_base>(), ...);
-}
-
-__host__ __device__ constexpr bool test()
-{
-  test_helper(cuda::std::make_integer_sequence<int, last_base - first_base + 1>{});
 
   return true;
+}
+
+struct TestBaseInvoker
+{
+  template <int Base>
+  __host__ __device__ constexpr void operator()(cuda::std::integral_constant<int, Base>) const
+  {
+    test_base<Base>();
+    static_assert(test_base<Base>());
+  }
+};
+
+__host__ __device__ constexpr void test()
+{
+  cuda::static_for<int, first_base, last_base + 1>(TestBaseInvoker{});
 }
 
 int main(int, char**)
 {
   test();
-  static_assert(test());
   return 0;
 }


### PR DESCRIPTION
`<cuda/std/charconv>` are one of the most expensive tests we have. This PR improves the compile times by reducing number of constexpr steps done at one constexpr evaluation. We use the same design for `from_chars` tests already.