### PR TITLE
[libcu++] Waive hierarchy constexpr testing on GCC8

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/hierarchy/hierarchy_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/hierarchy/hierarchy_smoke.cu
@@ -486,8 +486,8 @@ __global__ void examples_kernel(Hierarchy hierarchy)
 // Test examples from the inline rst documentation
 C2H_TEST("Examples", "[hierarchy]")
 {
-  // GCC 7 complains here that the hierarchy was not declared constexpr
-#if !_CCCL_COMPILER(GCC) || _CCCL_COMPILER(GCC, >, 7)
+  // GCC 7 and 8 complains here that the hierarchy was not declared constexpr
+#if !_CCCL_COMPILER(GCC) || _CCCL_COMPILER(GCC, >, 8)
   {
     auto hierarchy = cuda::make_hierarchy(cuda::grid_dims(256), cuda::cluster_dims<4>(), cuda::block_dims<8, 8, 8>());
     auto fragment  = hierarchy.fragment(cuda::block, cuda::grid);


### PR DESCRIPTION
GCC 8 same as GCC 7 complains when we test partially static hierarchy queries. The test is already waived on GCC7, this PR waives it on GCC 8 as well