### PR TITLE
Backport `cuda::std::reference_wrapper` C++20 features

### DIFF
--- a/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
@@ -41,33 +41,34 @@ public:
   using type = _Tp;
 
 private:
-  type* __f_;
+  type* __f_{};
 
-  static _CCCL_API inline void __fun(_Tp&) noexcept;
+  static _CCCL_API void __fun(_Tp&) noexcept;
   static void __fun(_Tp&&) = delete;
 
 public:
-  template <class _Up,
-            class = enable_if_t<!__is_same_uncvref<_Up, reference_wrapper>::value, decltype(__fun(declval<_Up>()))>>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 reference_wrapper(_Up&& __u) noexcept(noexcept(__fun(declval<_Up>())))
+  template <
+    class _Up,
+    class = enable_if_t<!__is_same_uncvref<_Up, reference_wrapper>::value, decltype(__fun(::cuda::std::declval<_Up>()))>>
+  _CCCL_API constexpr reference_wrapper(_Up&& __u) noexcept(noexcept(__fun(::cuda::std::declval<_Up>())))
   {
     type& __f = static_cast<_Up&&>(__u);
     __f_      = ::cuda::std::addressof(__f);
   }
 
   // access
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 operator type&() const noexcept
+  _CCCL_API constexpr operator type&() const noexcept
   {
     return *__f_;
   }
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 type& get() const noexcept
+  [[nodiscard]] _CCCL_API constexpr type& get() const noexcept
   {
     return *__f_;
   }
 
   // invoke
   template <class... _ArgTypes>
-  _CCCL_API inline _CCCL_CONSTEXPR_CXX20 invoke_result_t<type&, _ArgTypes...> operator()(_ArgTypes&&... __args) const
+  _CCCL_API constexpr invoke_result_t<type&, _ArgTypes...> operator()(_ArgTypes&&... __args) const
     noexcept(is_nothrow_invocable_v<_Tp&, _ArgTypes...>)
   {
     return ::cuda::std::invoke(get(), ::cuda::std::forward<_ArgTypes>(__args)...);
@@ -78,25 +79,25 @@ template <class _Tp>
 _CCCL_HOST_DEVICE reference_wrapper(_Tp&) -> reference_wrapper<_Tp>;
 
 template <class _Tp>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 reference_wrapper<_Tp> ref(_Tp& __t) noexcept
+[[nodiscard]] _CCCL_API constexpr reference_wrapper<_Tp> ref(_Tp& __t) noexcept
 {
   return reference_wrapper<_Tp>(__t);
 }
 
 template <class _Tp>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 reference_wrapper<_Tp> ref(reference_wrapper<_Tp> __t) noexcept
+[[nodiscard]] _CCCL_API constexpr reference_wrapper<_Tp> ref(reference_wrapper<_Tp> __t) noexcept
 {
   return __t;
 }
 
 template <class _Tp>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 reference_wrapper<const _Tp> cref(const _Tp& __t) noexcept
+[[nodiscard]] _CCCL_API constexpr reference_wrapper<const _Tp> cref(const _Tp& __t) noexcept
 {
   return reference_wrapper<const _Tp>(__t);
 }
 
 template <class _Tp>
-_CCCL_API inline _CCCL_CONSTEXPR_CXX20 reference_wrapper<const _Tp> cref(reference_wrapper<_Tp> __t) noexcept
+[[nodiscard]] _CCCL_API constexpr reference_wrapper<const _Tp> cref(reference_wrapper<_Tp> __t) noexcept
 {
   return __t;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.bind_front/bind_front.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.bind_front/bind_front.pass.cpp
@@ -200,11 +200,9 @@ __host__ __device__ constexpr bool test()
     assert(h(2, 2, 2) == 9);
   }
 
-  // Make sure we don't treat cuda::std::reference_wrapper specially.
-#if TEST_STD_VER > 2017
-#  if TEST_COMPILER(NVRTC) // reference_wrapper requires `addressof` which is currently not supported with nvrtc
+#if TEST_COMPILER(NVRTC) // reference_wrapper requires `addressof` which is currently not supported with nvrtc
   if (!TEST_IS_CONSTANT_EVALUATED())
-#  endif // TEST_COMPILER(NVRTC)
+#endif // TEST_COMPILER(NVRTC)
   {
     auto add = [](cuda::std::reference_wrapper<int> a, cuda::std::reference_wrapper<int> b) {
       return a.get() + b.get();
@@ -213,7 +211,6 @@ __host__ __device__ constexpr bool test()
     auto f = cuda::std::bind_front(add, cuda::std::ref(i));
     assert(f(cuda::std::ref(j)) == 3);
   }
-#endif
 
   // Make sure we can call a function that's a pointer to a member function.
   {

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.invoke/invoke.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/func.invoke/invoke.pass.cpp
@@ -203,8 +203,6 @@ __host__ __device__ void bullet_one_two_tests()
     test_b12<int volatile && (NonCopyable&&) volatile&&, int volatile&&>(cuda::std::move(cl));
     test_b12<int const volatile && (NonCopyable&&) const volatile&&, int const volatile&&>(cuda::std::move(cl));
   }
-#ifndef __cuda_std__
-  // uncomment when reenabling reference_wrapper
   {
     TestClass cl_obj(42);
     cuda::std::reference_wrapper<TestClass> cl(cl_obj);
@@ -231,7 +229,6 @@ __host__ __device__ void bullet_one_two_tests()
     test_b12<int volatile&(NonCopyable&&) volatile&, int volatile&>(cuda::std::move(cl));
     test_b12<int const volatile&(NonCopyable&&) const volatile&, int const volatile&>(cuda::std::move(cl));
   }
-#endif
   {
     TestClass cl_obj(42);
     TestClass* cl = &cl_obj;
@@ -278,8 +275,6 @@ __host__ __device__ void bullet_three_four_tests()
     test_b34<int volatile&&>(static_cast<Fn volatile&&>(cl));
     test_b34<int const volatile&&>(static_cast<Fn const volatile&&>(cl));
   }
-#ifndef __cuda_std__
-  // uncomment when reenabling reference_wrapper
   {
     typedef TestClass Fn;
     Fn cl(42);
@@ -296,7 +291,6 @@ __host__ __device__ void bullet_three_four_tests()
     test_b34<int volatile&>(cuda::std::reference_wrapper<Fn volatile>(cl));
     test_b34<int const volatile&>(cuda::std::reference_wrapper<Fn const volatile>(cl));
   }
-#endif
   {
     typedef TestClass Fn;
     Fn cl_obj(42);

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/binder_typedefs.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/binder_typedefs.compile.pass.cpp
@@ -7,7 +7,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// REQUIRES: c++03 || c++11 || c++14 || c++17
+// REQUIRES: c++17
 
 // ADDITIONAL_COMPILE_DEFINITIONS: CCCL_IGNORE_DEPRECATED_API
 

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/ctor.incomplete.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/ctor.incomplete.pass.cpp
@@ -7,13 +7,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++17
-
 // <functional>
 //
 // reference_wrapper<T>
 //
-//  where T is an incomplete type (since C++20)
+//  where T is an incomplete type
 
 // #include <cuda/std/functional>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/type_conv_ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/type_conv_ctor.pass.cpp
@@ -66,9 +66,7 @@ int main(int, char**)
   {
     using Ref = cuda::std::reference_wrapper<int>;
     static_assert(noexcept(Ref(nothrow_convertible<true>())));
-#if !TEST_COMPILER(NVHPC)
     static_assert(!noexcept(Ref(nothrow_convertible<false>())));
-#endif // !TEST_COMPILER(NVHPC)
   }
   {
     meow(0);

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/type_conv_ctor2.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.const/type_conv_ctor2.pass.cpp
@@ -43,18 +43,18 @@ struct A2
 
 __host__ __device__ void implicitly_convert(cuda::std::reference_wrapper<B>) noexcept;
 
-__host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
+__host__ __device__ constexpr bool test()
 {
   {
     A1 a{};
-#if !TEST_COMPILER(NVHPC)
+#if !_CCCL_COMPILER(GCC, <, 8) && !(_CCCL_COMPILER(MSVC, <, 19, 40) && _CCCL_STD_VER < 2020)
     static_assert(!noexcept(implicitly_convert(a)));
-#endif // TEST_COMPILER(NVHPC)
+#endif // !_CCCL_COMPILER(GCC, <, 8) && !(_CCCL_COMPILER(MSVC, <, 19, 40) && _CCCL_STD_VER < 2020)
     cuda::std::reference_wrapper<B> b1 = a;
     assert(&b1.get() == &a.b_);
-#if !TEST_COMPILER(NVHPC)
+#if !_CCCL_COMPILER(GCC, <, 8) && !(_CCCL_COMPILER(MSVC, <, 19, 40) && _CCCL_STD_VER < 2020)
     static_assert(!noexcept(b1 = a));
-#endif // TEST_COMPILER(NVHPC)
+#endif // !_CCCL_COMPILER(GCC, <, 8) && !(_CCCL_COMPILER(MSVC, <, 19, 40) && _CCCL_STD_VER < 2020)
     b1 = a;
     assert(&b1.get() == &a.b_);
   }
@@ -73,9 +73,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
 int main(int, char**)
 {
   test();
-#if TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
   static_assert(test());
-#endif // TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/cref.incomplete.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/cref.incomplete.pass.cpp
@@ -7,15 +7,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++17
-
 // <functional>
 //
 // reference_wrapper
 //
 // template <ObjectType T> reference_wrapper<const T> cref(const T& t);
 //
-//  where T is an incomplete type (since C++20)
+//  where T is an incomplete type
 
 // #include <cuda/std/functional>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/cref_1.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/cref_1.pass.cpp
@@ -19,7 +19,7 @@
 
 #include "test_macros.h"
 
-__host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
+__host__ __device__ constexpr bool test()
 {
   int i                                     = 0;
   cuda::std::reference_wrapper<const int> r = cuda::std::cref(i);
@@ -30,9 +30,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
 int main(int, char**)
 {
   test();
-#if TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
   static_assert(test());
-#endif // TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/cref_2.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/cref_2.pass.cpp
@@ -26,7 +26,7 @@ struct A
 __host__ __device__ void cref(A) {}
 } // namespace adl
 
-__host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
+__host__ __device__ constexpr bool test()
 {
   {
     const int i                                = 0;
@@ -46,9 +46,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
 int main(int, char**)
 {
   test();
-#if TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
   static_assert(test());
-#endif // TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/lwg3146.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/lwg3146.pass.cpp
@@ -20,7 +20,7 @@
 
 #include "test_macros.h"
 
-__host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
+__host__ __device__ constexpr bool test()
 {
   {
     int i = 0;
@@ -63,9 +63,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
 int main(int, char**)
 {
   test();
-#if TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
   static_assert(test());
-#endif // TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/ref.incomplete.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/ref.incomplete.pass.cpp
@@ -7,15 +7,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++17
-
 // <functional>
 //
 // reference_wrapper
 //
 // template <ObjectType T> reference_wrapper<T> ref(T& t);
 //
-//  where T is an incomplete type (since C++20)
+//  where T is an incomplete type
 
 // #include <cuda/std/functional>
 #include <cuda/std/cassert>

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/ref_1.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/ref_1.pass.cpp
@@ -19,7 +19,7 @@
 
 #include "test_macros.h"
 
-__host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
+__host__ __device__ constexpr bool test()
 {
   int i                               = 0;
   cuda::std::reference_wrapper<int> r = cuda::std::ref(i);
@@ -30,9 +30,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
 int main(int, char**)
 {
   test();
-#if TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
   static_assert(test());
-#endif // TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
 
   return 0;
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/ref_2.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.helpers/ref_2.pass.cpp
@@ -38,7 +38,7 @@ struct A
 __host__ __device__ void ref(A) {}
 } // namespace adl
 
-__host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
+__host__ __device__ constexpr bool test()
 {
   {
     int i                                = 0;
@@ -58,9 +58,7 @@ __host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
 int main(int, char**)
 {
   test();
-#if TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
   static_assert(test());
-#endif // TEST_STD_VER > 2017 && !TEST_COMPILER(NVRTC)
 
   {
     unary_counting_predicate<bool (*)(int), int> cp(is5);

--- a/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/invoke.incomplete.compile.fail.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/function.objects/refwrap/refwrap.invoke/invoke.incomplete.compile.fail.cpp
@@ -7,8 +7,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: c++17
-
 // <functional>
 //
 // reference_wrapper
@@ -17,7 +15,7 @@
 //  cuda::std::invoke_result_t<T&, ArgTypes...>
 //      operator()(ArgTypes&&... args) const;
 //
-// Requires T to be a complete type (since C++20).
+// Requires T to be a complete type
 
 // #include <cuda/std/functional>
 #include <cuda/std/utility>


### PR DESCRIPTION
This PR backports `cuda::std::reference_wrapper` C++20 features - making it constexpr and work with incomplete types.