### PR TITLE
Avoid scaling twice in `ReduceNondeterministicPolicy`

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce.cuh
@@ -213,7 +213,8 @@ struct policy_hub
                         AccumT,
                         ReducePolicy::VECTOR_LOAD_LENGTH,
                         BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
-                        ReducePolicy::LOAD_MODIFIER>;
+                        ReducePolicy::LOAD_MODIFIER,
+                        NoScaling<ReducePolicy::BLOCK_THREADS, ReducePolicy::ITEMS_PER_THREAD>>;
   };
 
   struct Policy600 : ChainedPolicy<600, Policy600, Policy500>
@@ -240,7 +241,8 @@ struct policy_hub
                         AccumT,
                         ReducePolicy::VECTOR_LOAD_LENGTH,
                         BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
-                        ReducePolicy::LOAD_MODIFIER>;
+                        ReducePolicy::LOAD_MODIFIER,
+                        NoScaling<ReducePolicy::BLOCK_THREADS, ReducePolicy::ITEMS_PER_THREAD>>;
   };
 
   struct Policy1000 : ChainedPolicy<1000, Policy1000, Policy600>
@@ -274,7 +276,8 @@ struct policy_hub
                         AccumT,
                         ReducePolicy::VECTOR_LOAD_LENGTH,
                         BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
-                        ReducePolicy::LOAD_MODIFIER>;
+                        ReducePolicy::LOAD_MODIFIER,
+                        NoScaling<ReducePolicy::BLOCK_THREADS, ReducePolicy::ITEMS_PER_THREAD>>;
   };
 
   using MaxPolicy = Policy1000;

--- a/cub/cub/util_arch.cuh
+++ b/cub/cub/util_arch.cuh
@@ -164,7 +164,7 @@ public:
   static constexpr int BLOCK_THREADS    = result.block_threads;
 };
 
-template <int Nominal4ByteBlockThreads, int Nominal4ByteItemsPerThread, typename>
+template <int Nominal4ByteBlockThreads, int Nominal4ByteItemsPerThread, typename = void>
 struct NoScaling
 {
   static constexpr int ITEMS_PER_THREAD = Nominal4ByteItemsPerThread;


### PR DESCRIPTION
`cub.bench.reduce.nondeterministic.base` on `B200`:
```
## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I32   |      I32      |      2^16      |   6.082 us |       3.67% |   6.034 us |       5.47% | -0.047 us |  -0.78% |   SAME   |
|   I32   |      I32      |      2^20      |   8.177 us |       0.55% |   8.118 us |       1.25% | -0.059 us |  -0.73% |   FAST   |
|   I32   |      I32      |      2^24      |  20.326 us |       2.60% |  20.271 us |       2.64% | -0.056 us |  -0.27% |   SAME   |
|   I32   |      I32      |      2^28      | 170.747 us |       0.58% | 170.736 us |       0.58% | -0.011 us |  -0.01% |   SAME   |
|   I32   |      I64      |      2^16      |   6.161 us |       4.13% |   6.260 us |       9.10% |  0.099 us |   1.60% |   SAME   |
|   I32   |      I64      |      2^20      |   8.172 us |       0.67% |   8.130 us |       1.13% | -0.042 us |  -0.51% |   SAME   |
|   I32   |      I64      |      2^24      |  20.466 us |       0.74% |  20.425 us |       0.46% | -0.041 us |  -0.20% |   SAME   |
|   I32   |      I64      |      2^28      | 170.902 us |       0.59% | 170.897 us |       0.58% | -0.004 us |  -0.00% |   SAME   |
|   I64   |      I32      |      2^16      |   6.364 us |      10.27% |   6.695 us |      13.83% |  0.331 us |   5.20% |   SAME   |
|   I64   |      I32      |      2^20      |  10.109 us |       4.41% |   8.681 us |      10.28% | -1.428 us | -14.13% |   FAST   |
|   I64   |      I32      |      2^24      |  36.028 us |       2.78% |  32.662 us |       0.98% | -3.366 us |  -9.34% |   FAST   |
|   I64   |      I32      |      2^28      | 324.731 us |       0.40% | 316.095 us |       0.34% | -8.635 us |  -2.66% |   FAST   |
|   I64   |      I64      |      2^16      |   6.364 us |      11.19% |   6.896 us |      14.49% |  0.532 us |   8.36% |   SAME   |
|   I64   |      I64      |      2^20      |   9.939 us |       5.86% |   8.808 us |      11.03% | -1.131 us | -11.38% |   FAST   |
|   I64   |      I64      |      2^24      |  36.702 us |       0.97% |  32.610 us |       0.28% | -4.092 us | -11.15% |   FAST   |
|   I64   |      I64      |      2^28      | 325.518 us |       0.39% | 316.750 us |       0.33% | -8.767 us |  -2.69% |   FAST   |
|   F32   |      I32      |      2^16      |   6.337 us |       9.46% |   6.308 us |       8.89% | -0.030 us |  -0.47% |   SAME   |
|   F32   |      I32      |      2^20      |   8.182 us |       0.46% |   8.170 us |       0.81% | -0.012 us |  -0.15% |   SAME   |
|   F32   |      I32      |      2^24      |  20.410 us |       1.76% |  20.417 us |       1.55% |  0.007 us |   0.03% |   SAME   |
|   F32   |      I32      |      2^28      | 169.470 us |       0.55% | 169.478 us |       0.51% |  0.008 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   6.228 us |       6.83% |   6.380 us |      10.89% |  0.152 us |   2.45% |   SAME   |
|   F32   |      I64      |      2^20      |   8.177 us |       0.54% |   8.120 us |       1.18% | -0.057 us |  -0.69% |   FAST   |
|   F32   |      I64      |      2^24      |  20.459 us |       0.27% |  20.406 us |       0.51% | -0.053 us |  -0.26% |   SAME   |
|   F32   |      I64      |      2^28      | 171.265 us |       0.57% | 171.216 us |       0.58% | -0.049 us |  -0.03% |   SAME   |
|   F64   |      I32      |      2^16      |   7.230 us |      13.99% |   8.116 us |       1.28% |  0.886 us |  12.25% |   SLOW   |
|   F64   |      I32      |      2^20      |   9.418 us |      10.44% |  10.135 us |       1.79% |  0.717 us |   7.61% |   SLOW   |
|   F64   |      I32      |      2^24      |  34.863 us |       1.02% |  32.695 us |       0.32% | -2.168 us |  -6.22% |   FAST   |
|   F64   |      I32      |      2^28      | 319.312 us |       0.38% | 316.053 us |       0.37% | -3.259 us |  -1.02% |   FAST   |
|   F64   |      I64      |      2^16      |   6.947 us |      14.59% |   6.985 us |      14.81% |  0.037 us |   0.54% |   SAME   |
|   F64   |      I64      |      2^20      |  10.045 us |       4.19% |   9.835 us |       6.27% | -0.210 us |  -2.09% |   SAME   |
|   F64   |      I64      |      2^24      |  36.764 us |       0.27% |  32.680 us |       1.09% | -4.083 us | -11.11% |   FAST   |
|   F64   |      I64      |      2^28      | 325.738 us |       0.39% | 316.639 us |       0.36% | -9.099 us |  -2.79% |   FAST   |
```