### PR TITLE
[libcu++] Use resource test fixture members through this

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_resource.cu
@@ -88,12 +88,12 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      void* ptr = mr.allocate_sync(bytes(50), align(8));
+      void* ptr = mr.allocate_sync(this->bytes(50), this->align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
 
-      mr.deallocate_sync(ptr, bytes(50), align(8));
+      mr.deallocate_sync(ptr, this->bytes(50), this->align(8));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -117,12 +117,12 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      void* ptr = mr.allocate(::cuda::stream_ref{stream}, bytes(50), align(8));
+      void* ptr = mr.allocate(::cuda::stream_ref{stream}, this->bytes(50), this->align(8));
       CHECK(ptr == this);
       ++expected.allocate_async_count;
       CHECK(this->counts == expected);
 
-      mr.deallocate(::cuda::stream_ref{stream}, ptr, bytes(50), align(8));
+      mr.deallocate(::cuda::stream_ref{stream}, ptr, this->bytes(50), this->align(8));
       ++expected.deallocate_async_count;
       CHECK(this->counts == expected);
     }
@@ -147,11 +147,11 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "any_resource", "[container][resource]",
       cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible> ref = mr;
 
       CHECK(this->counts == expected);
-      auto* ptr = ref.allocate_sync(bytes(100), align(8));
+      auto* ptr = ref.allocate_sync(this->bytes(100), this->align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
-      ref.deallocate_sync(ptr, bytes(0), align(0));
+      ref.deallocate_sync(ptr, this->bytes(0), this->align(0));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -187,18 +187,18 @@ TEMPLATE_TEST_CASE_METHOD(
 {
   big_resource mr{42, this};
   cuda::mr::resource_ref<::cuda::mr::host_accessible, get_data> ref{mr};
-  CHECK(ref.allocate_sync(bytes(100), align(8)) == this);
+  CHECK(ref.allocate_sync(this->bytes(100), this->align(8)) == this);
   CHECK(get_property(ref, get_data{}) == 42);
 
   big_resource mr2{43, this};
   cuda::mr::resource_ref<::cuda::mr::host_accessible, get_data> ref2{mr2};
   ref = ref2;
-  CHECK(ref.allocate_sync(bytes(100), align(8)) == this);
+  CHECK(ref.allocate_sync(this->bytes(100), this->align(8)) == this);
   CHECK(get_property(ref, get_data{}) == 43);
 
   cuda::mr::resource_ref<::cuda::mr::host_accessible, get_data, extra_property> ref3{mr};
   ref = ref3;
-  CHECK(ref.allocate_sync(bytes(100), align(8)) == this);
+  CHECK(ref.allocate_sync(this->bytes(100), this->align(8)) == this);
   CHECK(get_property(ref, get_data{}) == 42);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_synchronous_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_synchronous_resource.cu
@@ -97,12 +97,12 @@ TEMPLATE_TEST_CASE_METHOD(
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      void* ptr = mr.allocate_sync(bytes(50), align(8));
+      void* ptr = mr.allocate_sync(this->bytes(50), this->align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
 
-      mr.deallocate_sync(ptr, bytes(50), align(8));
+      mr.deallocate_sync(ptr, this->bytes(50), this->align(8));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -143,7 +143,8 @@ TEMPLATE_TEST_CASE_METHOD(
   // Reset the counters:
   this->counts = Counts();
 
-  SECTION("conversion from any_synchronous_resource to cuda::mr::synchronous_resource_ref")
+  SECTION("conversion from any_synchronous_resource to "
+          "cuda::mr::synchronous_resource_ref")
   {
     Counts expected{};
     {
@@ -153,19 +154,21 @@ TEMPLATE_TEST_CASE_METHOD(
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      // conversion from any_synchronous_resource to cuda::mr::synchronous_synchronous_resource_ref:
+      // conversion from any_synchronous_resource to
+      // cuda::mr::synchronous_synchronous_resource_ref:
       cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data> ref = mr;
 
-      // conversion from any_synchronous_resource to cuda::mr::synchronous_synchronous_resource_ref with narrowing:
+      // conversion from any_synchronous_resource to
+      // cuda::mr::synchronous_synchronous_resource_ref with narrowing:
       cuda::mr::synchronous_resource_ref<cuda::mr::host_accessible, get_data> ref2 = mr;
       CHECK(get_property(ref2, get_data{}) == 42);
 
       CHECK(this->counts == expected);
-      auto* ptr = ref.allocate_sync(bytes(100), align(8));
+      auto* ptr = ref.allocate_sync(this->bytes(100), this->align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
-      ref.deallocate_sync(ptr, bytes(0), align(0));
+      ref.deallocate_sync(ptr, this->bytes(0), this->align(0));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -174,7 +177,8 @@ TEMPLATE_TEST_CASE_METHOD(
     CHECK(this->counts == expected);
   }
 
-  SECTION("conversion from any_synchronous_resource to cuda::mr::synchronous_resource_ref")
+  SECTION("conversion from any_synchronous_resource to "
+          "cuda::mr::synchronous_resource_ref")
   {
     Counts expected{};
     {
@@ -184,19 +188,21 @@ TEMPLATE_TEST_CASE_METHOD(
       ++expected.move_count;
       CHECK(this->counts == expected);
 
-      // conversion from any_synchronous_resource to cuda::mr::synchronous_resource_ref:
+      // conversion from any_synchronous_resource to
+      // cuda::mr::synchronous_resource_ref:
       cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data> ref = mr;
 
-      // conversion from any_synchronous_resource to cuda::mr::synchronous_resource_ref with narrowing:
+      // conversion from any_synchronous_resource to
+      // cuda::mr::synchronous_resource_ref with narrowing:
       cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data> ref2 = mr;
       CHECK(get_property(ref2, get_data{}) == 42);
 
       CHECK(this->counts == expected);
-      auto* ptr = ref.allocate_sync(bytes(100), align(8));
+      auto* ptr = ref.allocate_sync(this->bytes(100), this->align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
-      ref.deallocate_sync(ptr, bytes(0), align(0));
+      ref.deallocate_sync(ptr, this->bytes(0), this->align(0));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -223,11 +229,11 @@ TEMPLATE_TEST_CASE_METHOD(
       ++expected.copy_count;
       CHECK(this->counts == expected);
 
-      auto* ptr = ref.allocate_sync(bytes(100), align(8));
+      auto* ptr = ref.allocate_sync(this->bytes(100), this->align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
-      ref.deallocate_sync(ptr, bytes(0), align(0));
+      ref.deallocate_sync(ptr, this->bytes(0), this->align(0));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -303,17 +309,17 @@ TEMPLATE_TEST_CASE_METHOD(
 {
   big_resource mr{42, this};
   cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data> ref{mr};
-  CHECK(ref.allocate_sync(bytes(100), align(8)) == this);
+  CHECK(ref.allocate_sync(this->bytes(100), this->align(8)) == this);
   CHECK(get_property(ref, get_data{}) == 42);
 
   big_resource mr2{43, this};
   cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data> ref2{mr2};
   ref = ref2;
-  CHECK(ref.allocate_sync(bytes(100), align(8)) == this);
+  CHECK(ref.allocate_sync(this->bytes(100), this->align(8)) == this);
   CHECK(get_property(ref, get_data{}) == 43);
 
   cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible, get_data, extra_property> ref3{mr};
   ref = ref3;
-  CHECK(ref.allocate_sync(bytes(100), align(8)) == this);
+  CHECK(ref.allocate_sync(this->bytes(100), this->align(8)) == this);
   CHECK(get_property(ref, get_data{}) == 42);
 }

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_resource.cu
@@ -87,12 +87,12 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       ++expected.object_count;
       CHECK(this->counts == expected);
 
-      void* ptr = mr.allocate_sync(bytes(50), align(8));
+      void* ptr = mr.allocate_sync(this->bytes(50), this->align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
 
-      mr.deallocate_sync(ptr, bytes(50), align(8));
+      mr.deallocate_sync(ptr, this->bytes(50), this->align(8));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -115,11 +115,11 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       cuda::mr::synchronous_resource_ref<::cuda::mr::host_accessible> ref = mr;
 
       CHECK(this->counts == expected);
-      auto* ptr = ref.allocate_sync(bytes(100), align(8));
+      auto* ptr = ref.allocate_sync(this->bytes(100), this->align(8));
       CHECK(ptr == this);
       ++expected.allocate_count;
       CHECK(this->counts == expected);
-      ref.deallocate_sync(ptr, bytes(0), align(0));
+      ref.deallocate_sync(ptr, this->bytes(0), this->align(0));
       ++expected.deallocate_count;
       CHECK(this->counts == expected);
     }
@@ -133,9 +133,9 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
   SECTION("basic sanity test about shared resource handling")
   {
     Counts expected{};
-    align(alignof(int) * 4);
+    this->align(alignof(int) * 4);
     {
-      bytes(42 * sizeof(int));
+      this->bytes(42 * sizeof(int));
       cuda::stream stream{cuda::device_ref{0}};
       cuda::__uninitialized_async_buffer<int, ::cuda::mr::host_accessible> buffer{
         cuda::mr::shared_resource<TestResource>(cuda::std::in_place_type<TestResource>, 42, this), stream, 42};
@@ -146,15 +146,16 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
       // copying the shared_resource should not copy the stored resource
       {
         // accounting for new storage
-        bytes(1337 * sizeof(int));
+        this->bytes(1337 * sizeof(int));
         cuda::__uninitialized_async_buffer<int, ::cuda::mr::host_accessible> other_buffer{
           buffer.memory_resource(), stream, 1337};
         ++expected.allocate_async_count;
         CHECK(this->counts == expected);
       }
 
-      // The original resource is still alive, but the second allocation was released
-      bytes(42 * sizeof(int));
+      // The original resource is still alive, but the second allocation was
+      // released
+      this->bytes(42 * sizeof(int));
       ++expected.deallocate_async_count;
       CHECK(this->counts == expected);
 
@@ -164,7 +165,8 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
         CHECK(this->counts == expected);
       }
 
-      // The original shared_resource has been moved from so everything is gone already
+      // The original shared_resource has been moved from so everything is gone
+      // already
       --expected.object_count;
       ++expected.deallocate_async_count;
       CHECK(this->counts == expected);


### PR DESCRIPTION
NVBUG 5676106

For some reason on gcc 15 resource fixture member function `bytes` and `align` come up as undefined. Use them through `this->` to fix that issue