### PR TITLE
cuda.compute: Fix caching of functions that call other functions

### DIFF
--- a/python/cuda_cccl/cuda/compute/_caching.py
+++ b/python/cuda_cccl/cuda/compute/_caching.py
@@ -52,21 +52,24 @@ class CachableFunction:
     """
 
     def __init__(self, func):
-        # if the function is a `@cuda.jit'd` function, use the wrapped
-        # function for caching purposes.
         import numba.cuda.dispatcher
-
-        if isinstance(func, numba.cuda.dispatcher.CUDADispatcher):
-            func = func.py_func
 
         self._func = func
 
         closure = func.__closure__ if func.__closure__ is not None else []
+        contents = []
+        # if any of the contents is a numba.cuda.dispatcher.CUDADispatcher
+        # use the function for caching purposes:
+        for cell in closure:
+            if isinstance(cell.cell_contents, numba.cuda.dispatcher.CUDADispatcher):
+                contents.append(CachableFunction(cell.cell_contents.py_func))
+            else:
+                contents.append(cell.cell_contents)
         self._identity = (
             func.__name__,
             func.__code__.co_code,
             func.__code__.co_consts,
-            tuple(cell.cell_contents for cell in closure),
+            tuple(contents),
             tuple(func.__globals__.get(name, None) for name in func.__code__.co_names),
         )
 

--- a/python/cuda_cccl/tests/compute/test_func_caching.py
+++ b/python/cuda_cccl/tests/compute/test_func_caching.py
@@ -77,17 +77,17 @@ def test_func_caching_with_global_variable():
 def test_func_caching_wrapped_cuda_jit_function():
     import numba.cuda
 
-    @numba.cuda.jit
-    def inner(x):
-        return x
+    def make_func():
+        @numba.cuda.jit
+        def inner(x):
+            return x
 
-    def func(x):
-        return inner(x) + 1
+        def func(x):
+            return inner(x) + 1
 
-    wrapped_func1 = numba.cuda.jit(func)
+        return func
 
-    def func(x):
-        return inner(x) + 1
+    func1 = make_func()
+    func2 = make_func()
 
-    wrapped_func2 = numba.cuda.jit(func)
-    assert CachableFunction(wrapped_func1) == CachableFunction(wrapped_func2)
+    assert CachableFunction(func1) == CachableFunction(func2)


### PR DESCRIPTION
## Description

Merge after #6766 

This is a follow-up to https://github.com/NVIDIA/cccl/pull/6758. 

My implementation there wasn't actually doing the correct thing -- rather than handling top-level `@cuda.jit`'d functions, we need to handle closure variables that are `@cuda.jit`d.

That is, we're not interested in:

```python
@cuda.jit
def foo(x):
    return x + 1

CachableFunction(foo)
```

Rather, we are interested in the case:

```python
@cuda.jit
def inner(x):
    return x + 1

def outer(x):
    return inner(x) > 1

CachableFunction(outer)
```

This second case occurs when the user provides `inner`, and we want to wrap it in our own `outer` function and pass that to `cuda.compute` algorithms. 

I fixed the implementation and test to reflect this.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
