### PR TITLE
[libcu++] Add sm_62 arch traits

### DIFF
--- a/libcudacxx/include/cuda/__device/arch_id.h
+++ b/libcudacxx/include/cuda/__device/arch_id.h
@@ -37,6 +37,7 @@ enum class arch_id : int
 {
   sm_60   = 60,
   sm_61   = 61,
+  sm_62   = 62,
   sm_70   = 70,
   sm_75   = 75,
   sm_80   = 80,
@@ -64,6 +65,7 @@ enum class arch_id : int
   {
     case ::cuda::std::to_underlying(arch_id::sm_60):
     case ::cuda::std::to_underlying(arch_id::sm_61):
+    case ::cuda::std::to_underlying(arch_id::sm_62):
     case ::cuda::std::to_underlying(arch_id::sm_70):
     case ::cuda::std::to_underlying(arch_id::sm_75):
     case ::cuda::std::to_underlying(arch_id::sm_80):

--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -228,6 +228,20 @@ template <>
 };
 
 template <>
+[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_62>() noexcept
+{
+  auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_62);
+  __traits.max_shared_memory_per_multiprocessor = 64 * 1024;
+  __traits.max_blocks_per_multiprocessor        = 32;
+  __traits.max_threads_per_multiprocessor       = 2048;
+  __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
+  __traits.max_shared_memory_per_block_optin    = 48 * 1024;
+  __traits.max_registers_per_block              = 32 * 1024;
+
+  return __traits;
+};
+
+template <>
 [[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_70>() noexcept
 {
   auto __traits                                 = ::cuda::__common_arch_traits(arch_id::sm_70);
@@ -452,6 +466,8 @@ template <>
       return ::cuda::arch_traits<arch_id::sm_60>();
     case arch_id::sm_61:
       return ::cuda::arch_traits<arch_id::sm_61>();
+    case arch_id::sm_62:
+      return ::cuda::arch_traits<arch_id::sm_62>();
     case arch_id::sm_70:
       return ::cuda::arch_traits<arch_id::sm_70>();
     case arch_id::sm_75:

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id.c2h.cu
@@ -29,6 +29,7 @@ C2H_CCCLRT_TEST("Architecture id", "[device]")
   STATIC_REQUIRE(cuda::std::is_same_v<cuda::std::underlying_type_t<cuda::arch_id>, int>);
   STATIC_REQUIRE(cuda::std::to_underlying(cuda::arch_id::sm_60) == 60);
   STATIC_REQUIRE(cuda::std::to_underlying(cuda::arch_id::sm_61) == 61);
+  STATIC_REQUIRE(cuda::std::to_underlying(cuda::arch_id::sm_62) == 62);
   STATIC_REQUIRE(cuda::std::to_underlying(cuda::arch_id::sm_70) == 70);
   STATIC_REQUIRE(cuda::std::to_underlying(cuda::arch_id::sm_75) == 75);
   STATIC_REQUIRE(cuda::std::to_underlying(cuda::arch_id::sm_80) == 80);


### PR DESCRIPTION
CUB has tunings for `sm_62`, we should also expose arch traits for it, until all sm_6X traits are removed in the future

Fixes https://github.com/NVIDIA/cccl/issues/6743

Latest programming guide doesn't have information about sm_6X, older version needs to be used for validation https://docs.nvidia.com/cuda/archive/12.9.1/cuda-c-programming-guide/index.html#features-and-technical-specifications