### PR TITLE
fix(readme): Update broken Godbolt example link

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ The sum of each block is then reduced to a single value using an atomic add via 
 
 It then shows how the same reduction can be done using Thrust's `reduce` algorithm and compares the results.
 
-[Try it live on Godbolt!](https://godbolt.org/z/aMx4j9f4T)
+[Try it live on Godbolt!](https://godbolt.org/z/3KaWz3Msf)
 
 ```cpp
 #include <thrust/execution_policy.h>


### PR DESCRIPTION
The Godbolt link in the README https://godbolt.org/z/aMx4j9f4T failed to compile: 
```
/opt/compiler-explorer/libs/cccl/trunk/cub/cub/util_cpp_dialect.cuh:65:8: error: #error CUB requires at least C++17. Define CCCL_IGNORE_DEPRECATED_CPP_DIALECT to suppress this message.
   65 | #      error CUB requires at least C++17. Define CCCL_IGNORE_DEPRECATED_CPP_DIALECT to suppress this message.
      |        ^~~~~
Execution build compiler returned: 1
```

So I added the `-std=c++17` flag and also updated NVCC to the latest version https://godbolt.org/z/3KaWz3Msf

