### PR TITLE
Use conventional order of `_CCCL_API friend` consistently

### DIFF
--- a/libcudacxx/include/cuda/__device/compute_capability.h
+++ b/libcudacxx/include/cuda/__device/compute_capability.h
@@ -106,37 +106,37 @@ public:
   }
 
   //! @brief Equality operator.
-  [[nodiscard]] friend _CCCL_API constexpr bool operator==(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_API friend constexpr bool operator==(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ == __rhs.__cc_;
   }
 
   //! @brief Inequality operator.
-  [[nodiscard]] friend _CCCL_API constexpr bool operator!=(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_API friend constexpr bool operator!=(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ != __rhs.__cc_;
   }
 
   //! @brief Less than operator.
-  [[nodiscard]] friend _CCCL_API constexpr bool operator<(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_API friend constexpr bool operator<(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ < __rhs.__cc_;
   }
 
   //! @brief Less than or equal to operator.
-  [[nodiscard]] friend _CCCL_API constexpr bool operator<=(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_API friend constexpr bool operator<=(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ <= __rhs.__cc_;
   }
 
   //! @brief Greater than operator.
-  [[nodiscard]] friend _CCCL_API constexpr bool operator>(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_API friend constexpr bool operator>(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ > __rhs.__cc_;
   }
 
   //! @brief Greater than or equal to operator.
-  [[nodiscard]] friend _CCCL_API constexpr bool operator>=(compute_capability __lhs, compute_capability __rhs) noexcept
+  [[nodiscard]] _CCCL_API friend constexpr bool operator>=(compute_capability __lhs, compute_capability __rhs) noexcept
   {
     return __lhs.__cc_ >= __rhs.__cc_;
   }

--- a/libcudacxx/include/cuda/pipeline
+++ b/libcudacxx/include/cuda/pipeline
@@ -70,17 +70,17 @@ private:
   friend class pipeline;
 
   template <class _Group, thread_scope _Pipeline_scope, uint8_t _Pipeline_stages_count>
-  friend _CCCL_API inline pipeline<_Pipeline_scope>
+  _CCCL_API friend inline pipeline<_Pipeline_scope>
   make_pipeline(const _Group& __group, pipeline_shared_state<_Pipeline_scope, _Pipeline_stages_count>* __shared_state);
 
   template <class _Group, thread_scope _Pipeline_scope, uint8_t _Pipeline_stages_count>
-  friend _CCCL_API inline pipeline<_Pipeline_scope>
+  _CCCL_API friend inline pipeline<_Pipeline_scope>
   make_pipeline(const _Group& __group,
                 pipeline_shared_state<_Pipeline_scope, _Pipeline_stages_count>* __shared_state,
                 size_t __producer_count);
 
   template <class _Group, thread_scope _Pipeline_scope, uint8_t _Pipeline_stages_count>
-  friend _CCCL_API inline pipeline<_Pipeline_scope>
+  _CCCL_API friend inline pipeline<_Pipeline_scope>
   make_pipeline(const _Group& __group,
                 pipeline_shared_state<_Pipeline_scope, _Pipeline_stages_count>* __shared_state,
                 pipeline_role __role);
@@ -220,17 +220,17 @@ private:
   }
 
   template <class _Group, thread_scope _Pipeline_scope, uint8_t _Pipeline_stages_count>
-  friend _CCCL_API inline pipeline<_Pipeline_scope>
+  _CCCL_API friend inline pipeline<_Pipeline_scope>
   make_pipeline(const _Group& __group, pipeline_shared_state<_Pipeline_scope, _Pipeline_stages_count>* __shared_state);
 
   template <class _Group, thread_scope _Pipeline_scope, uint8_t _Pipeline_stages_count>
-  friend _CCCL_API inline pipeline<_Pipeline_scope>
+  _CCCL_API friend inline pipeline<_Pipeline_scope>
   make_pipeline(const _Group& __group,
                 pipeline_shared_state<_Pipeline_scope, _Pipeline_stages_count>* __shared_state,
                 size_t __producer_count);
 
   template <class _Group, thread_scope _Pipeline_scope, uint8_t _Pipeline_stages_count>
-  friend _CCCL_API inline pipeline<_Pipeline_scope>
+  _CCCL_API friend inline pipeline<_Pipeline_scope>
   make_pipeline(const _Group& __group,
                 pipeline_shared_state<_Pipeline_scope, _Pipeline_stages_count>* __shared_state,
                 pipeline_role __role);
@@ -402,13 +402,13 @@ private:
       , __tail(0)
   {}
 
-  friend _CCCL_API inline pipeline<thread_scope_thread> make_pipeline();
+  _CCCL_API friend inline pipeline<thread_scope_thread> make_pipeline();
 
   template <uint8_t _Prior>
-  friend _CCCL_API inline void pipeline_consumer_wait_prior(pipeline<thread_scope_thread>& __pipeline);
+  _CCCL_API friend inline void pipeline_consumer_wait_prior(pipeline<thread_scope_thread>& __pipeline);
 
   template <class _Group, thread_scope _Pipeline_scope, uint8_t _Pipeline_stages_count>
-  friend _CCCL_API inline pipeline<_Pipeline_scope> __make_pipeline(
+  _CCCL_API friend inline pipeline<_Pipeline_scope> __make_pipeline(
     const _Group& __group, pipeline_shared_state<_Pipeline_scope, _Pipeline_stages_count>* __shared_state);
 };
 

--- a/libcudacxx/include/cuda/std/__bit/reference.h
+++ b/libcudacxx/include/cuda/std/__bit/reference.h
@@ -111,7 +111,7 @@ public:
     return __bit_iterator<_Cp, false>(__seg_, static_cast<unsigned>(::cuda::std::countr_zero(__mask_)));
   }
 
-  friend _CCCL_API constexpr void swap(__bit_reference<_Cp> __x, __bit_reference<_Cp> __y) noexcept
+  _CCCL_API friend constexpr void swap(__bit_reference<_Cp> __x, __bit_reference<_Cp> __y) noexcept
   {
     bool __t = __x;
     __x      = __y;
@@ -119,21 +119,21 @@ public:
   }
 
   template <class _Dp>
-  friend _CCCL_API constexpr void swap(__bit_reference<_Cp> __x, __bit_reference<_Dp> __y) noexcept
+  _CCCL_API friend constexpr void swap(__bit_reference<_Cp> __x, __bit_reference<_Dp> __y) noexcept
   {
     bool __t = __x;
     __x      = __y;
     __y      = __t;
   }
 
-  friend _CCCL_API constexpr void swap(__bit_reference<_Cp> __x, bool& __y) noexcept
+  _CCCL_API friend constexpr void swap(__bit_reference<_Cp> __x, bool& __y) noexcept
   {
     bool __t = __x;
     __x      = __y;
     __y      = __t;
   }
 
-  friend _CCCL_API constexpr void swap(bool& __x, __bit_reference<_Cp> __y) noexcept
+  _CCCL_API friend constexpr void swap(bool& __x, __bit_reference<_Cp> __y) noexcept
   {
     bool __t = __x;
     __x      = __y;

--- a/libcudacxx/include/cuda/std/__expected/expected.h
+++ b/libcudacxx/include/cuda/std/__expected/expected.h
@@ -439,7 +439,7 @@ public:
   }
 
   template <class _Tp2 = _Tp, class _Err2 = _Err>
-  friend _CCCL_API inline _CCCL_CONSTEXPR_CXX20 auto swap(expected& __x, expected& __y) noexcept(
+  _CCCL_API friend inline _CCCL_CONSTEXPR_CXX20 auto swap(expected& __x, expected& __y) noexcept(
     is_nothrow_move_constructible_v<_Tp2> && is_nothrow_swappable_v<_Tp2> && is_nothrow_move_constructible_v<_Err2>
     && is_nothrow_swappable_v<_Err2>) _CCCL_TRAILING_REQUIRES(void)(__expected::__can_swap<_Tp2, _Err2>)
   {
@@ -1035,7 +1035,7 @@ public:
 
   // [expected.object.eq], equality operators
   _CCCL_EXEC_CHECK_DISABLE
-  friend _CCCL_API constexpr bool operator==(const expected& __x, const expected& __y)
+  _CCCL_API friend constexpr bool operator==(const expected& __x, const expected& __y)
   {
     if (__x.__has_val_ != __y.has_value())
     {
@@ -1056,7 +1056,7 @@ public:
 
 #if _CCCL_STD_VER < 2020
   _CCCL_EXEC_CHECK_DISABLE
-  friend _CCCL_API constexpr bool operator!=(const expected& __x, const expected& __y)
+  _CCCL_API friend constexpr bool operator!=(const expected& __x, const expected& __y)
   {
     return !(__x == __y);
   }
@@ -1065,7 +1065,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T2, class _E2)
   _CCCL_REQUIRES((!is_void_v<_T2>) )
-  friend _CCCL_API constexpr bool operator==(const expected& __x, const expected<_T2, _E2>& __y)
+  _CCCL_API friend constexpr bool operator==(const expected& __x, const expected<_T2, _E2>& __y)
   {
     if (__x.__has_val_ != __y.has_value())
     {
@@ -1088,7 +1088,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T2, class _E2)
   _CCCL_REQUIRES((!is_void_v<_T2>) )
-  friend _CCCL_API constexpr bool operator!=(const expected& __x, const expected<_T2, _E2>& __y)
+  _CCCL_API friend constexpr bool operator!=(const expected& __x, const expected<_T2, _E2>& __y)
   {
     return !(__x == __y);
   }
@@ -1097,7 +1097,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T2)
   _CCCL_REQUIRES((!__is_cuda_std_expected_nonvoid_v<_T2>) )
-  friend _CCCL_API constexpr bool operator==(const expected& __x, const _T2& __v)
+  _CCCL_API friend constexpr bool operator==(const expected& __x, const _T2& __v)
   {
     return __x.__has_val_ && static_cast<bool>(__x.__union_.__val_ == __v);
   }
@@ -1105,21 +1105,21 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T2)
   _CCCL_REQUIRES((!__is_cuda_std_expected_nonvoid_v<_T2>) )
-  friend _CCCL_API constexpr bool operator==(const _T2& __v, const expected& __x)
+  _CCCL_API friend constexpr bool operator==(const _T2& __v, const expected& __x)
   {
     return __x.__has_val_ && static_cast<bool>(__x.__union_.__val_ == __v);
   }
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T2)
   _CCCL_REQUIRES((!__is_cuda_std_expected_nonvoid_v<_T2>) )
-  friend _CCCL_API constexpr bool operator!=(const expected& __x, const _T2& __v)
+  _CCCL_API friend constexpr bool operator!=(const expected& __x, const _T2& __v)
   {
     return !__x.__has_val_ || static_cast<bool>(__x.__union_.__val_ != __v);
   }
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _T2)
   _CCCL_REQUIRES((!__is_cuda_std_expected_nonvoid_v<_T2>) )
-  friend _CCCL_API constexpr bool operator!=(const _T2& __v, const expected& __x)
+  _CCCL_API friend constexpr bool operator!=(const _T2& __v, const expected& __x)
   {
     return !__x.__has_val_ || static_cast<bool>(__x.__union_.__val_ != __v);
   }
@@ -1127,26 +1127,26 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _E2>
-  friend _CCCL_API constexpr bool operator==(const expected& __x, const unexpected<_E2>& __e)
+  _CCCL_API friend constexpr bool operator==(const expected& __x, const unexpected<_E2>& __e)
   {
     return !__x.__has_val_ && static_cast<bool>(__x.__union_.__unex_ == __e.error());
   }
 #if _CCCL_STD_VER < 2020
   _CCCL_EXEC_CHECK_DISABLE
   template <class _E2>
-  friend _CCCL_API constexpr bool operator==(const unexpected<_E2>& __e, const expected& __x)
+  _CCCL_API friend constexpr bool operator==(const unexpected<_E2>& __e, const expected& __x)
   {
     return !__x.__has_val_ && static_cast<bool>(__x.__union_.__unex_ == __e.error());
   }
   _CCCL_EXEC_CHECK_DISABLE
   template <class _E2>
-  friend _CCCL_API constexpr bool operator!=(const expected& __x, const unexpected<_E2>& __e)
+  _CCCL_API friend constexpr bool operator!=(const expected& __x, const unexpected<_E2>& __e)
   {
     return __x.__has_val_ || static_cast<bool>(__x.__union_.__unex_ != __e.error());
   }
   _CCCL_EXEC_CHECK_DISABLE
   template <class _E2>
-  friend _CCCL_API constexpr bool operator!=(const unexpected<_E2>& __e, const expected& __x)
+  _CCCL_API friend constexpr bool operator!=(const unexpected<_E2>& __e, const expected& __x)
   {
     return __x.__has_val_ || static_cast<bool>(__x.__union_.__unex_ != __e.error());
   }
@@ -1373,7 +1373,7 @@ public:
   }
 
   template <class _Err2 = _Err>
-  friend _CCCL_API inline _CCCL_CONSTEXPR_CXX20 auto
+  _CCCL_API friend inline _CCCL_CONSTEXPR_CXX20 auto
   swap(expected& __x, expected& __y) noexcept(is_nothrow_move_constructible_v<_Err2> && is_nothrow_swappable_v<_Err2>)
     _CCCL_TRAILING_REQUIRES(void)(__expected::__can_swap<void, _Err2>)
   {
@@ -1865,7 +1865,7 @@ public:
 
   // [expected.void.eq], equality operators
   _CCCL_EXEC_CHECK_DISABLE
-  friend _CCCL_API constexpr bool operator==(const expected& __x, const expected& __y) noexcept
+  _CCCL_API friend constexpr bool operator==(const expected& __x, const expected& __y) noexcept
   {
     if (__x.__has_val_ != __y.has_value())
     {
@@ -1878,7 +1878,7 @@ public:
   }
 #if _CCCL_STD_VER < 2020
   _CCCL_EXEC_CHECK_DISABLE
-  friend _CCCL_API constexpr bool operator!=(const expected& __x, const expected& __y) noexcept
+  _CCCL_API friend constexpr bool operator!=(const expected& __x, const expected& __y) noexcept
   {
     return !(__x == __y);
   }
@@ -1886,7 +1886,7 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _E2>
-  friend _CCCL_API constexpr bool operator==(const expected& __x, const expected<void, _E2>& __y) noexcept
+  _CCCL_API friend constexpr bool operator==(const expected& __x, const expected<void, _E2>& __y) noexcept
   {
     if (__x.__has_val_ != __y.has_value())
     {
@@ -1900,7 +1900,7 @@ public:
 #if _CCCL_STD_VER < 2020
   _CCCL_EXEC_CHECK_DISABLE
   template <class _E2>
-  friend _CCCL_API constexpr bool operator!=(const expected& __x, const expected<void, _E2>& __y) noexcept
+  _CCCL_API friend constexpr bool operator!=(const expected& __x, const expected<void, _E2>& __y) noexcept
   {
     return !(__x == __y);
   }
@@ -1908,14 +1908,14 @@ public:
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _E2>
-  friend _CCCL_API constexpr bool operator==(const expected& __x, const unexpected<_E2>& __y) noexcept
+  _CCCL_API friend constexpr bool operator==(const expected& __x, const unexpected<_E2>& __y) noexcept
   {
     return !__x.__has_val_ && static_cast<bool>(__x.__union_.__unex_ == __y.error());
   }
 #if _CCCL_STD_VER < 2020
   _CCCL_EXEC_CHECK_DISABLE
   template <class _E2>
-  friend _CCCL_API constexpr bool operator==(const unexpected<_E2>& __y, const expected& __x) noexcept
+  _CCCL_API friend constexpr bool operator==(const unexpected<_E2>& __y, const expected& __x) noexcept
   {
     return !__x.__has_val_ && static_cast<bool>(__x.__union_.__unex_ == __y.error());
   }

--- a/libcudacxx/include/cuda/std/__expected/unexpected.h
+++ b/libcudacxx/include/cuda/std/__expected/unexpected.h
@@ -124,7 +124,7 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Err2 = _Err)
   _CCCL_REQUIRES(is_swappable_v<_Err2>)
-  friend _CCCL_API constexpr void swap(unexpected& __lhs, unexpected& __rhs) noexcept(is_nothrow_swappable_v<_Err2>)
+  _CCCL_API friend constexpr void swap(unexpected& __lhs, unexpected& __rhs) noexcept(is_nothrow_swappable_v<_Err2>)
   {
     __lhs.swap(__rhs);
     return;

--- a/libcudacxx/include/cuda/std/__floating_point/cccl_fp.h
+++ b/libcudacxx/include/cuda/std/__floating_point/cccl_fp.h
@@ -100,9 +100,9 @@ public:
   }
 
   template <class _Tp>
-  friend _CCCL_API constexpr _Tp __fp_from_storage(__fp_storage_of_t<_Tp> __v) noexcept;
+  _CCCL_API friend constexpr _Tp __fp_from_storage(__fp_storage_of_t<_Tp> __v) noexcept;
   template <class _Tp>
-  friend _CCCL_API constexpr __fp_storage_of_t<_Tp> __fp_get_storage(_Tp __v) noexcept;
+  _CCCL_API friend constexpr __fp_storage_of_t<_Tp> __fp_get_storage(_Tp __v) noexcept;
 };
 
 template <__fp_format _Fmt>

--- a/libcudacxx/include/cuda/std/__iterator/bounded_iter.h
+++ b/libcudacxx/include/cuda/std/__iterator/bounded_iter.h
@@ -90,7 +90,7 @@ private:
   }
 
   template <class _It>
-  friend _CCCL_API constexpr __bounded_iter<_It> __make_bounded_iter(_It, _It, _It);
+  _CCCL_API friend constexpr __bounded_iter<_It> __make_bounded_iter(_It, _It, _It);
 
 public:
   // Dereference and indexing operations.


### PR DESCRIPTION
We put attributes at the front conventionallly