### PR TITLE
Temporarily add upper bound to numba-cuda dependency

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,7 +213,7 @@ Requirements:
 * Python 3.9+
 * CUDA Toolkit 12.x
 * NVIDIA GPU (CC 6.0+)
-* Dependencies: `numba>=0.60.0`, `numpy`, `cuda-bindings>=12.9.1`, `cuda-core`, `numba-cuda>=0.18.0`
+* Dependencies: `numba>=0.60.0`, `numpy`, `cuda-bindings>=12.9.1`, `cuda-core`, `numba-cuda>=0.18.0,<0.21.2`
 
 ### Usage Examples
 

--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "numpy",
   "cuda-pathfinder>=1.2.3",
   "cuda-core",
-  "numba-cuda>=0.20.0",
+  "numba-cuda>=0.20.0,<0.21.2",
   "typing_extensions",
 ]
 
@@ -42,12 +42,12 @@ readme = { file = "README.md", content-type = "text/markdown" }
 cu12 = [
   "cuda-bindings>=12.9.1,<13.0.0",
   "cuda-toolkit[nvrtc,nvjitlink,cudart,nvcc]==12.*",
-  "numba-cuda[cu12]",
+  "numba-cuda[cu12]>=0.20.0,<0.21.2",
 ]
 cu13 = [
   "cuda-bindings>=13.0.0,<14.0.0",
   "cuda-toolkit[nvrtc,nvjitlink,cudart,nvcc]==13.*",
-  "numba-cuda[cu13]",
+  "numba-cuda[cu13]>=0.20.0,<0.21.2",
 ]
 test-cu12 = [
   # an undocumented way to inherit the dependencies of the cu12 extra.


### PR DESCRIPTION
## Description

CI is currently failing and I've determined that upgrading from numba-cuda 0.21.1 -> 0.21.2 causes the failure. I'll be able to investigate more tomorrow, but until then this should hopefully unblock CI.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
