### PR TITLE
Optimize `cuda::std::conditional_t`

### DIFF
--- a/c2h/include/c2h/detail/generators.cuh
+++ b/c2h/include/c2h/detail/generators.cuh
@@ -69,7 +69,7 @@ struct random_to_item_t
 template <typename T>
 struct random_to_item_t<T, true>
 {
-  using storage_t = ::cuda::std::_If<(sizeof(T) > 4), double, float>;
+  using storage_t = ::cuda::std::conditional_t<(sizeof(T) > 4), double, float>;
   storage_t m_min;
   storage_t m_max;
 

--- a/cub/benchmarks/bench/radix_sort/keys.cu
+++ b/cub/benchmarks/bench/radix_sort/keys.cu
@@ -26,7 +26,7 @@ struct policy_hub_t
 {
   static constexpr bool KEYS_ONLY = std::is_same_v<ValueT, cub::NullType>;
 
-  using DominantT = ::cuda::std::_If<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
+  using DominantT = ::cuda::std::conditional_t<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
 
   struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
   {

--- a/cub/benchmarks/bench/radix_sort/pairs.cu
+++ b/cub/benchmarks/bench/radix_sort/pairs.cu
@@ -24,7 +24,7 @@ struct policy_hub_t
 {
   static constexpr bool KEYS_ONLY = std::is_same_v<ValueT, cub::NullType>;
 
-  using DominantT = ::cuda::std::_If<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
+  using DominantT = ::cuda::std::conditional_t<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
 
   struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
   {

--- a/cub/benchmarks/bench/transform/common.h
+++ b/cub/benchmarks/bench/transform/common.h
@@ -44,10 +44,10 @@ struct policy_hub_t
 #    error Policy hub does not yet implement the specified value for algorithm
 #  endif
 
-    using algo_policy =
-      ::cuda::std::_If<algorithm == cub::detail::transform::Algorithm::prefetch,
-                       cub::detail::transform::prefetch_policy_t<TUNE_THREADS>,
-                       cub::detail::transform::async_copy_policy_t<TUNE_THREADS, __CUDA_ARCH_LIST__ == 900 ? 128 : 16>>;
+    using algo_policy = ::cuda::std::conditional_t<
+      algorithm == cub::detail::transform::Algorithm::prefetch,
+      cub::detail::transform::prefetch_policy_t<TUNE_THREADS>,
+      cub::detail::transform::async_copy_policy_t<TUNE_THREADS, __CUDA_ARCH_LIST__ == 900 ? 128 : 16>>;
   };
 };
 #endif

--- a/cub/cub/agent/agent_histogram.cuh
+++ b/cub/cub/agent/agent_histogram.cuh
@@ -175,9 +175,9 @@ struct AgentHistogram
   // Wrap the native input pointer with CacheModifiedInputIterator or directly use the supplied input iterator type
   // TODO(bgruber): we can wrap all contiguous iterators, not just pointers
   using WrappedSampleIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<SampleIteratorT>,
-                     CacheModifiedInputIterator<load_modifier, SampleT, OffsetT>,
-                     SampleIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<SampleIteratorT>,
+                               CacheModifiedInputIterator<load_modifier, SampleT, OffsetT>,
+                               SampleIteratorT>;
   using WrappedPixelIteratorT = CacheModifiedInputIterator<load_modifier, PixelT, OffsetT>;
   using WrappedVecsIteratorT  = CacheModifiedInputIterator<load_modifier, VecT, OffsetT>;
   using BlockLoadSampleT = BlockLoad<SampleT, block_threads, samples_per_thread, AgentHistogramPolicyT::LOAD_ALGORITHM>;

--- a/cub/cub/agent/agent_radix_sort_onesweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_onesweep.cuh
@@ -168,10 +168,10 @@ struct AgentRadixSortOnesweep
                   || RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ATOMIC_OR,
                 "for onesweep agent, the ranking algorithm must warp-strided key arrangement");
 
-  using BlockRadixRankT = ::cuda::std::_If<
+  using BlockRadixRankT = ::cuda::std::conditional_t<
     RANK_ALGORITHM == RADIX_RANK_MATCH_EARLY_COUNTS_ATOMIC_OR,
     BlockRadixRankMatchEarlyCounts<BLOCK_THREADS, RADIX_BITS, false, SCAN_ALGORITHM, WARP_MATCH_ATOMIC_OR, RANK_NUM_PARTS>,
-    ::cuda::std::_If<
+    ::cuda::std::conditional_t<
       RANK_ALGORITHM == RADIX_RANK_MATCH,
       BlockRadixRankMatch<BLOCK_THREADS, RADIX_BITS, false, SCAN_ALGORITHM>,
       BlockRadixRankMatchEarlyCounts<BLOCK_THREADS, RADIX_BITS, false, SCAN_ALGORITHM, WARP_MATCH_ANY, RANK_NUM_PARTS>>>;

--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -196,9 +196,9 @@ struct AgentReduceImpl
   // Wrap the native input pointer with CacheModifiedInputIterator
   // or directly use the supplied input iterator type
   using WrappedInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
-                     CacheModifiedInputIterator<AgentReducePolicy::LOAD_MODIFIER, InputT, OffsetT>,
-                     InputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<InputIteratorT>,
+                               CacheModifiedInputIterator<AgentReducePolicy::LOAD_MODIFIER, InputT, OffsetT>,
+                               InputIteratorT>;
 
   /// Constants
   static constexpr int ITEMS_PER_THREAD   = AgentReducePolicy::ITEMS_PER_THREAD;

--- a/cub/cub/agent/agent_reduce_by_key.cuh
+++ b/cub/cub/agent/agent_reduce_by_key.cuh
@@ -212,27 +212,27 @@ struct AgentReduceByKey
   // CacheModifiedValuesInputIterator or directly use the supplied input
   // iterator type
   using WrappedKeysInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<KeysInputIteratorT>,
-                     CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, KeyInputT, OffsetT>,
-                     KeysInputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<KeysInputIteratorT>,
+                               CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, KeyInputT, OffsetT>,
+                               KeysInputIteratorT>;
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier)
   // for values Wrap the native input pointer with
   // CacheModifiedValuesInputIterator or directly use the supplied input
   // iterator type
   using WrappedValuesInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<ValuesInputIteratorT>,
-                     CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, ValueInputT, OffsetT>,
-                     ValuesInputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<ValuesInputIteratorT>,
+                               CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, ValueInputT, OffsetT>,
+                               ValuesInputIteratorT>;
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier)
   // for fixup values Wrap the native input pointer with
   // CacheModifiedValuesInputIterator or directly use the supplied input
   // iterator type
   using WrappedFixupInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<AggregatesOutputIteratorT>,
-                     CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, ValueInputT, OffsetT>,
-                     AggregatesOutputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<AggregatesOutputIteratorT>,
+                               CacheModifiedInputIterator<AgentReduceByKeyPolicyT::LOAD_MODIFIER, ValueInputT, OffsetT>,
+                               AggregatesOutputIteratorT>;
 
   // Reduce-value-by-segment scan operator
   using ReduceBySegmentOpT = ReduceBySegmentOp<ReductionOpT>;

--- a/cub/cub/agent/agent_rle.cuh
+++ b/cub/cub/agent/agent_rle.cuh
@@ -214,9 +214,9 @@ struct AgentRle
   // Wrap the native input pointer with CacheModifiedVLengthnputIterator
   // Directly use the supplied input iterator type
   using WrappedInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
-                     CacheModifiedInputIterator<AgentRlePolicyT::LOAD_MODIFIER, T, OffsetT>,
-                     InputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<InputIteratorT>,
+                               CacheModifiedInputIterator<AgentRlePolicyT::LOAD_MODIFIER, T, OffsetT>,
+                               InputIteratorT>;
 
   // Parameterized BlockLoad type for data
   using BlockLoadT =
@@ -240,7 +240,7 @@ struct AgentRle
   using WarpExchangePairs = WarpExchange<LengthOffsetPair, ITEMS_PER_THREAD>;
 
   using WarpExchangePairsStorage =
-    ::cuda::std::_If<STORE_WARP_TIME_SLICING, typename WarpExchangePairs::TempStorage, NullType>;
+    ::cuda::std::conditional_t<STORE_WARP_TIME_SLICING, typename WarpExchangePairs::TempStorage, NullType>;
 
   using WarpExchangeOffsets = WarpExchange<OffsetT, ITEMS_PER_THREAD>;
   using WarpExchangeLengths = WarpExchange<LengthT, ITEMS_PER_THREAD>;

--- a/cub/cub/agent/agent_scan.cuh
+++ b/cub/cub/agent/agent_scan.cuh
@@ -167,9 +167,9 @@ struct AgentScan
   // Wrap the native input pointer with CacheModifiedInputIterator
   // or directly use the supplied input iterator type
   using WrappedInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
-                     CacheModifiedInputIterator<AgentScanPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
-                     InputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<InputIteratorT>,
+                               CacheModifiedInputIterator<AgentScanPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
+                               InputIteratorT>;
 
   // Inclusive scan if no init_value type is provided
   static constexpr bool HAS_INIT     = !::cuda::std::is_same_v<InitValueT, NullType>;

--- a/cub/cub/agent/agent_scan_by_key.cuh
+++ b/cub/cub/agent/agent_scan_by_key.cuh
@@ -135,14 +135,14 @@ struct AgentScanByKey
   static constexpr int ITEMS_PER_TILE   = BLOCK_THREADS * ITEMS_PER_THREAD;
 
   using WrappedKeysInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<KeysInputIteratorT>,
-                     CacheModifiedInputIterator<AgentScanByKeyPolicyT::LOAD_MODIFIER, KeyT, OffsetT>,
-                     KeysInputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<KeysInputIteratorT>,
+                               CacheModifiedInputIterator<AgentScanByKeyPolicyT::LOAD_MODIFIER, KeyT, OffsetT>,
+                               KeysInputIteratorT>;
 
   using WrappedValuesInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<ValuesInputIteratorT>,
-                     CacheModifiedInputIterator<AgentScanByKeyPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
-                     ValuesInputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<ValuesInputIteratorT>,
+                               CacheModifiedInputIterator<AgentScanByKeyPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
+                               ValuesInputIteratorT>;
 
   using BlockLoadKeysT = BlockLoad<KeyT, BLOCK_THREADS, ITEMS_PER_THREAD, AgentScanByKeyPolicyT::LOAD_ALGORITHM>;
 

--- a/cub/cub/agent/agent_segmented_scan.cuh
+++ b/cub/cub/agent/agent_segmented_scan.cuh
@@ -121,9 +121,9 @@ struct agent_segmented_scan
   // Wrap the native input pointer with CacheModifiedInputIterator
   // or directly use the supplied input iterator type
   using wrapped_input_iterator_t =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
-                     CacheModifiedInputIterator<AgentSegmentedScanPolicyT::load_modifier, input_t, OffsetT>,
-                     InputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<InputIteratorT>,
+                               CacheModifiedInputIterator<AgentSegmentedScanPolicyT::load_modifier, input_t, OffsetT>,
+                               InputIteratorT>;
 
   // Constants
 

--- a/cub/cub/agent/agent_select_if.cuh
+++ b/cub/cub/agent/agent_select_if.cuh
@@ -268,17 +268,17 @@ struct AgentSelectIf
   // Wrap the native input pointer with CacheModifiedValuesInputIterator
   // or directly use the supplied input iterator type
   using WrappedInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
-                     CacheModifiedInputIterator<AgentSelectIfPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
-                     InputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<InputIteratorT>,
+                               CacheModifiedInputIterator<AgentSelectIfPolicyT::LOAD_MODIFIER, InputT, OffsetT>,
+                               InputIteratorT>;
 
   // Cache-modified Input iterator wrapper type (for applying cache modifier) for values
   // Wrap the native input pointer with CacheModifiedValuesInputIterator
   // or directly use the supplied input iterator type
   using WrappedFlagsInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<FlagsInputIteratorT>,
-                     CacheModifiedInputIterator<AgentSelectIfPolicyT::LOAD_MODIFIER, FlagT, OffsetT>,
-                     FlagsInputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<FlagsInputIteratorT>,
+                               CacheModifiedInputIterator<AgentSelectIfPolicyT::LOAD_MODIFIER, FlagT, OffsetT>,
+                               FlagsInputIteratorT>;
 
   // Parameterized BlockLoad type for input data
   using BlockLoadT = BlockLoad<InputT, BLOCK_THREADS, ITEMS_PER_THREAD, AgentSelectIfPolicyT::LOAD_ALGORITHM>;

--- a/cub/cub/agent/agent_three_way_partition.cuh
+++ b/cub/cub/agent/agent_three_way_partition.cuh
@@ -185,9 +185,9 @@ struct AgentThreeWayPartition
   static constexpr int TILE_ITEMS       = BLOCK_THREADS * ITEMS_PER_THREAD;
 
   using WrappedInputIteratorT =
-    ::cuda::std::_If<::cuda::std::is_pointer_v<InputIteratorT>,
-                     cub::CacheModifiedInputIterator<PolicyT::LOAD_MODIFIER, InputT, OffsetT>,
-                     InputIteratorT>;
+    ::cuda::std::conditional_t<::cuda::std::is_pointer_v<InputIteratorT>,
+                               cub::CacheModifiedInputIterator<PolicyT::LOAD_MODIFIER, InputT, OffsetT>,
+                               InputIteratorT>;
 
   // Parameterized BlockLoad type for input data
   using BlockLoadT = cub::BlockLoad<InputT, BLOCK_THREADS, ITEMS_PER_THREAD, PolicyT::LOAD_ALGORITHM>;

--- a/cub/cub/block/block_histogram.cuh
+++ b/cub/cub/block/block_histogram.cuh
@@ -171,9 +171,9 @@ private:
 
   /// Internal specialization.
   using InternalBlockHistogram =
-    ::cuda::std::_If<Algorithm == BLOCK_HISTO_SORT,
-                     detail::BlockHistogramSort<T, BlockDimX, ItemsPerThread, Bins, BlockDimY, BlockDimZ>,
-                     detail::BlockHistogramAtomic<Bins>>;
+    ::cuda::std::conditional_t<Algorithm == BLOCK_HISTO_SORT,
+                               detail::BlockHistogramSort<T, BlockDimX, ItemsPerThread, Bins, BlockDimY, BlockDimZ>,
+                               detail::BlockHistogramAtomic<Bins>>;
 
   /// Shared memory storage layout type for BlockHistogram
   using _TempStorage = typename InternalBlockHistogram::TempStorage;

--- a/cub/cub/block/block_radix_rank.cuh
+++ b/cub/cub/block/block_radix_rank.cuh
@@ -230,7 +230,7 @@ private:
 
   // Integer type for packing DigitCounters into columns of shared memory banks
   using PackedCounter =
-    ::cuda::std::_If<SMemConfig == cudaSharedMemBankSizeEightByte, unsigned long long, unsigned int>;
+    ::cuda::std::conditional_t<SMemConfig == cudaSharedMemBankSizeEightByte, unsigned long long, unsigned int>;
 
   static constexpr DigitCounter max_tile_size = ::cuda::std::numeric_limits<DigitCounter>::max();
 
@@ -1196,16 +1196,16 @@ namespace detail
 // - Support multi-dimensional thread blocks in the rest of implementations
 // - Repurpose BlockRadixRank as an entry name with the algorithm template parameter
 template <RadixRankAlgorithm RankAlgorithm, int BlockDimX, int RadixBits, bool IsDescending, BlockScanAlgorithm ScanAlgorithm>
-using block_radix_rank_t = ::cuda::std::_If<
+using block_radix_rank_t = ::cuda::std::conditional_t<
   RankAlgorithm == RADIX_RANK_BASIC,
   BlockRadixRank<BlockDimX, RadixBits, IsDescending, false, ScanAlgorithm>,
-  ::cuda::std::_If<
+  ::cuda::std::conditional_t<
     RankAlgorithm == RADIX_RANK_MEMOIZE,
     BlockRadixRank<BlockDimX, RadixBits, IsDescending, true, ScanAlgorithm>,
-    ::cuda::std::_If<
+    ::cuda::std::conditional_t<
       RankAlgorithm == RADIX_RANK_MATCH,
       BlockRadixRankMatch<BlockDimX, RadixBits, IsDescending, ScanAlgorithm>,
-      ::cuda::std::_If<
+      ::cuda::std::conditional_t<
         RankAlgorithm == RADIX_RANK_MATCH_EARLY_COUNTS_ANY,
         BlockRadixRankMatchEarlyCounts<BlockDimX, RadixBits, IsDescending, ScanAlgorithm, WARP_MATCH_ANY>,
         BlockRadixRankMatchEarlyCounts<BlockDimX, RadixBits, IsDescending, ScanAlgorithm, WARP_MATCH_ATOMIC_OR>>>>>;

--- a/cub/cub/block/block_reduce.cuh
+++ b/cub/cub/block/block_reduce.cuh
@@ -258,14 +258,14 @@ private:
   using Raking                         = detail::BlockReduceRaking<T, BlockDimX, BlockDimY, BlockDimZ>;
 
   /// Internal specialization type
-  using InternalBlockReduce =
-    ::cuda::std::_If<Algorithm == BLOCK_REDUCE_WARP_REDUCTIONS,
-                     WarpReductions,
-                     ::cuda::std::_If<Algorithm == BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
-                                      WarpReductionsNondeterministic,
-                                      ::cuda::std::_If<Algorithm == BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY,
-                                                       RakingCommutativeOnly,
-                                                       Raking>>>; // BlockReduceRaking
+  using InternalBlockReduce = ::cuda::std::conditional_t<
+    Algorithm == BLOCK_REDUCE_WARP_REDUCTIONS,
+    WarpReductions,
+    ::cuda::std::conditional_t<Algorithm == BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC,
+                               WarpReductionsNondeterministic,
+                               ::cuda::std::conditional_t<Algorithm == BLOCK_REDUCE_RAKING_COMMUTATIVE_ONLY,
+                                                          RakingCommutativeOnly,
+                                                          Raking>>>; // BlockReduceRaking
 
   /// Shared memory storage layout type for BlockReduce
   using _TempStorage = typename InternalBlockReduce::TempStorage;

--- a/cub/cub/block/block_scan.cuh
+++ b/cub/cub/block/block_scan.cuh
@@ -229,7 +229,7 @@ private:
     detail::BlockScanRaking<T, BlockDimX, BlockDimY, BlockDimZ, (SAFE_ALGORITHM == BLOCK_SCAN_RAKING_MEMOIZE)>;
 
   /// Define the delegate type for the desired algorithm
-  using InternalBlockScan = ::cuda::std::_If<SAFE_ALGORITHM == BLOCK_SCAN_WARP_SCANS, WarpScans, Raking>;
+  using InternalBlockScan = ::cuda::std::conditional_t<SAFE_ALGORITHM == BLOCK_SCAN_WARP_SCANS, WarpScans, Raking>;
 
   /// Shared memory storage layout type for BlockScan
   using _TempStorage = typename InternalBlockScan::TempStorage;

--- a/cub/cub/detail/array_utils.cuh
+++ b/cub/cub/detail/array_utils.cuh
@@ -45,7 +45,7 @@ template <typename CastType = void, typename Input>
 to_array(const Input& input)
 {
   using InputType = ::cuda::std::iter_value_t<Input>;
-  using CastType1 = ::cuda::std::_If<::cuda::std::is_same_v<CastType, void>, InputType, CastType>;
+  using CastType1 = ::cuda::std::conditional_t<::cuda::std::is_same_v<CastType, void>, InputType, CastType>;
   return to_array_impl<CastType1>(input, ::cuda::std::make_index_sequence<static_size_v<Input>>{});
 }
 

--- a/cub/cub/detail/choose_offset.cuh
+++ b/cub/cub/detail/choose_offset.cuh
@@ -40,7 +40,7 @@ struct choose_offset
                 "NumItemsT must be an integral type, but not bool");
 
   // Unsigned integer type for global offsets.
-  using type = ::cuda::std::_If<(sizeof(NumItemsT) <= 4), uint32_t, unsigned long long>;
+  using type = ::cuda::std::conditional_t<(sizeof(NumItemsT) <= 4), uint32_t, unsigned long long>;
 };
 
 /**
@@ -63,7 +63,7 @@ struct promote_small_offset
                 "NumItemsT must be an integral type, but not bool");
 
   // Unsigned integer type for global offsets.
-  using type = ::cuda::std::_If<(sizeof(NumItemsT) < 4), int32_t, NumItemsT>;
+  using type = ::cuda::std::conditional_t<(sizeof(NumItemsT) < 4), int32_t, NumItemsT>;
 };
 
 /**
@@ -90,9 +90,10 @@ struct choose_signed_offset
   // uint32 -> int64, else
   // LEQ 4B -> int32, else
   // int64
-  using type = ::cuda::std::_If<(::cuda::std::is_integral_v<NumItemsT> && ::cuda::std::is_unsigned_v<NumItemsT>),
-                                ::cuda::std::int64_t,
-                                ::cuda::std::_If<(sizeof(NumItemsT) <= 4), ::cuda::std::int32_t, ::cuda::std::int64_t>>;
+  using type = ::cuda::std::conditional_t<
+    (::cuda::std::is_integral_v<NumItemsT> && ::cuda::std::is_unsigned_v<NumItemsT>),
+    ::cuda::std::int64_t,
+    ::cuda::std::conditional_t<(sizeof(NumItemsT) <= 4), ::cuda::std::int32_t, ::cuda::std::int64_t>>;
 
   /**
    * Checks if the given num_items can be covered by the selected offset type. If not, returns cudaErrorInvalidValue,

--- a/cub/cub/device/device_scan.cuh
+++ b/cub/cub/device/device_scan.cuh
@@ -132,9 +132,9 @@ struct DeviceScan
     using accum_t =
       ::cuda::std::__accumulator_t<ScanOpT,
                                    cub::detail::it_value_t<InputIteratorT>,
-                                   ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>,
-                                                    cub::detail::it_value_t<InputIteratorT>,
-                                                    typename InitValueT::value_type>>;
+                                   ::cuda::std::conditional_t<::cuda::std::is_same_v<InitValueT, NullType>,
+                                                              cub::detail::it_value_t<InputIteratorT>,
+                                                              typename InitValueT::value_type>>;
 
     using policy_t = typename scan_tuning_t::
       template fn<detail::it_value_t<InputIteratorT>, detail::it_value_t<OutputIteratorT>, accum_t, offset_t, ScanOpT>;

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -387,9 +387,9 @@ struct DispatchBatchMemcpy
     auto max_num_tiles = static_cast<BlockOffsetT>(::cuda::ceil_div(max_num_buffers, TILE_SIZE));
 
     using BlevBufferSrcsOutT =
-      ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, const void*, cub::detail::it_value_t<InputBufferIt>>;
+      ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy, const void*, cub::detail::it_value_t<InputBufferIt>>;
     using BlevBufferDstOutT =
-      ::cuda::std::_If<MemcpyOpt == CopyAlg::Memcpy, void*, cub::detail::it_value_t<OutputBufferIt>>;
+      ::cuda::std::conditional_t<MemcpyOpt == CopyAlg::Memcpy, void*, cub::detail::it_value_t<OutputBufferIt>>;
     using BlevBufferSrcsOutItT        = BlevBufferSrcsOutT*;
     using BlevBufferDstsOutItT        = BlevBufferDstOutT*;
     using BlevBufferSizesOutItT       = BufferSizeT*;

--- a/cub/cub/device/dispatch/dispatch_histogram.cuh
+++ b/cub/cub/device/dispatch/dispatch_histogram.cuh
@@ -397,7 +397,7 @@ public:
    *   CUDA stream to launch kernels within. Default is stream<sub>0</sub>.
    */
   // Should we call DispatchHistogram<....., PolicyHub=void> in DeviceHistogram?
-  template <typename MaxPolicyT = typename ::cuda::std::_If<
+  template <typename MaxPolicyT = typename ::cuda::std::conditional_t<
               ::cuda::std::is_void_v<PolicyHub>,
               /* fallback_policy_hub */
               detail::histogram::policy_hub<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, /* isEven */ 0>,
@@ -581,7 +581,7 @@ public:
    *   CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
    *
    */
-  template <typename MaxPolicyT = typename ::cuda::std::_If<
+  template <typename MaxPolicyT = typename ::cuda::std::conditional_t<
               ::cuda::std::is_void_v<PolicyHub>,
               /* fallback_policy_hub */
               detail::histogram::policy_hub<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, /* isEven */ 0>,
@@ -724,7 +724,7 @@ public:
    *   CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
    *
    */
-  template <typename MaxPolicyT = typename ::cuda::std::_If<
+  template <typename MaxPolicyT = typename ::cuda::std::conditional_t<
               ::cuda::std::is_void_v<PolicyHub>,
               /* fallback_policy_hub */
               detail::histogram::policy_hub<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, /* isEven */ 1>,
@@ -923,7 +923,7 @@ public:
    *   CUDA stream to launch kernels within.  Default is stream<sub>0</sub>.
    *
    */
-  template <typename MaxPolicyT = typename ::cuda::std::_If<
+  template <typename MaxPolicyT = typename ::cuda::std::conditional_t<
               ::cuda::std::is_void_v<PolicyHub>,
               /* fallback_policy_hub */
               detail::histogram::policy_hub<SampleT, CounterT, NUM_CHANNELS, NUM_ACTIVE_CHANNELS, /* isEven */ 1>,

--- a/cub/cub/device/dispatch/dispatch_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan.cuh
@@ -119,9 +119,9 @@ template <
   typename OffsetT,
   typename AccumT                 = ::cuda::std::__accumulator_t<ScanOpT,
                                                                  cub::detail::it_value_t<InputIteratorT>,
-                                                                 ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>,
-                                                                                  cub::detail::it_value_t<InputIteratorT>,
-                                                                                  typename InitValueT::value_type>>,
+                                                                 ::cuda::std::conditional_t<::cuda::std::is_same_v<InitValueT, NullType>,
+                                                                                            cub::detail::it_value_t<InputIteratorT>,
+                                                                                            typename InitValueT::value_type>>,
   ForceInclusive EnforceInclusive = ForceInclusive::No,
   typename PolicyHub              = detail::scan::
     policy_hub<detail::it_value_t<InputIteratorT>, detail::it_value_t<OutputIteratorT>, AccumT, OffsetT, ScanOpT>,

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -209,11 +209,12 @@ template <
   typename ScanOpT,
   typename InitValueT,
   typename OffsetT,
-  typename AccumT = ::cuda::std::__accumulator_t<
-    ScanOpT,
-    cub::detail::it_value_t<ValuesInputIteratorT>,
-    ::cuda::std::
-      _If<::cuda::std::is_same_v<InitValueT, NullType>, cub::detail::it_value_t<ValuesInputIteratorT>, InitValueT>>,
+  typename AccumT =
+    ::cuda::std::__accumulator_t<ScanOpT,
+                                 cub::detail::it_value_t<ValuesInputIteratorT>,
+                                 ::cuda::std::conditional_t<::cuda::std::is_same_v<InitValueT, NullType>,
+                                                            cub::detail::it_value_t<ValuesInputIteratorT>,
+                                                            InitValueT>>,
   typename PolicyHub =
     detail::scan_by_key::policy_hub<KeysInputIteratorT, AccumT, cub::detail::it_value_t<ValuesInputIteratorT>, ScanOpT>>
 struct DispatchScanByKey

--- a/cub/cub/device/dispatch/dispatch_segmented_scan.cuh
+++ b/cub/cub/device/dispatch/dispatch_segmented_scan.cuh
@@ -84,9 +84,9 @@ template <
   typename InitValueT,
   typename AccumT                 = ::cuda::std::__accumulator_t<ScanOpT,
                                                                  cub::detail::it_value_t<InputIteratorT>,
-                                                                 ::cuda::std::_If<::cuda::std::is_same_v<InitValueT, NullType>,
-                                                                                  cub::detail::it_value_t<InputIteratorT>,
-                                                                                  typename InitValueT::value_type>>,
+                                                                 ::cuda::std::conditional_t<::cuda::std::is_same_v<InitValueT, NullType>,
+                                                                                            cub::detail::it_value_t<InputIteratorT>,
+                                                                                            typename InitValueT::value_type>>,
   ForceInclusive EnforceInclusive = ForceInclusive::No,
   typename OffsetT                = typename detail::
     common_iterator_value_t<BeginOffsetIteratorInputT, EndOffsetIteratorInputT, BeginOffsetIteratorOutputT>,

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -56,9 +56,9 @@ struct Transforms
       // Wrap the native input pointer with CacheModifiedInputIterator
       // or Directly use the supplied input iterator type
       using WrappedLevelIteratorT =
-        ::cuda::std::_If<::cuda::std::is_pointer_v<LevelIteratorT>,
-                         CacheModifiedInputIterator<LOAD_MODIFIER, LevelT, OffsetT>,
-                         LevelIteratorT>;
+        ::cuda::std::conditional_t<::cuda::std::is_pointer_v<LevelIteratorT>,
+                                   CacheModifiedInputIterator<LOAD_MODIFIER, LevelT, OffsetT>,
+                                   LevelIteratorT>;
 
       WrappedLevelIteratorT wrapped_levels(d_levels);
 
@@ -100,11 +100,11 @@ struct Transforms
     // rule: 2^l * 2^r = 2^(l + r) to determine a sufficiently large type to hold the
     // multiplication result.
     // If CommonT used to be a 128-bit wide integral type already, we use CommonT's arithmetic
-    using IntArithmeticT = ::cuda::std::_If< //
+    using IntArithmeticT = ::cuda::std::conditional_t< //
       sizeof(SampleT) + sizeof(CommonT) <= sizeof(uint32_t), //
       uint32_t, //
 #  if _CCCL_HAS_INT128()
-      ::cuda::std::_If< //
+      ::cuda::std::conditional_t< //
         (::cuda::std::is_same_v<CommonT, __int128_t> || //
          ::cuda::std::is_same_v<CommonT, __uint128_t>), //
         CommonT, //
@@ -119,9 +119,9 @@ struct Transforms
     template <typename T>
     using is_integral_excl_int128 =
 #if _CCCL_HAS_INT128()
-      ::cuda::std::_If<::cuda::std::is_same_v<T, __int128_t>&& ::cuda::std::is_same_v<T, __uint128_t>,
-                       ::cuda::std::false_type,
-                       ::cuda::std::is_integral<T>>;
+      ::cuda::std::conditional_t<::cuda::std::is_same_v<T, __int128_t>&& ::cuda::std::is_same_v<T, __uint128_t>,
+                                 ::cuda::std::false_type,
+                                 ::cuda::std::is_integral<T>>;
 #else // ^^^ _CCCL_HAS_INT128() ^^^ / vvv !_CCCL_HAS_INT128() vvv
       ::cuda::std::is_integral<T>;
 #endif // !_CCCL_HAS_INT128()

--- a/cub/cub/device/dispatch/kernels/kernel_merge_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_merge_sort.cuh
@@ -101,10 +101,10 @@ private:
     (max_default_size > max_smem_per_block) && (max_fallback_size <= max_smem_per_block);
 
 public:
-  using policy_t = ::cuda::std::_If<uses_fallback_policy, fallback_policy_t, DefaultPolicyT>;
+  using policy_t = ::cuda::std::conditional_t<uses_fallback_policy, fallback_policy_t, DefaultPolicyT>;
   using block_sort_agent_t =
-    ::cuda::std::_If<uses_fallback_policy, fallback_block_sort_agent_t, default_block_sort_agent_t>;
-  using merge_agent_t = ::cuda::std::_If<uses_fallback_policy, fallback_merge_agent_t, default_merge_agent_t>;
+    ::cuda::std::conditional_t<uses_fallback_policy, fallback_block_sort_agent_t, default_block_sort_agent_t>;
+  using merge_agent_t = ::cuda::std::conditional_t<uses_fallback_policy, fallback_merge_agent_t, default_merge_agent_t>;
 };
 
 // TODO: this class should be templated on `typename... Ts` to avoid repetition,

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -92,14 +92,14 @@ __launch_bounds__(int((ALT_DIGIT_BITS) ? int(ChainedPolicyT::ActivePolicy::AltUp
     DecomposerT decomposer = {})
 {
   using ActiveUpsweepPolicyT =
-    ::cuda::std::_If<ALT_DIGIT_BITS,
-                     typename ChainedPolicyT::ActivePolicy::AltUpsweepPolicy,
-                     typename ChainedPolicyT::ActivePolicy::UpsweepPolicy>;
+    ::cuda::std::conditional_t<ALT_DIGIT_BITS,
+                               typename ChainedPolicyT::ActivePolicy::AltUpsweepPolicy,
+                               typename ChainedPolicyT::ActivePolicy::UpsweepPolicy>;
 
   using ActiveDownsweepPolicyT =
-    ::cuda::std::_If<ALT_DIGIT_BITS,
-                     typename ChainedPolicyT::ActivePolicy::AltDownsweepPolicy,
-                     typename ChainedPolicyT::ActivePolicy::DownsweepPolicy>;
+    ::cuda::std::conditional_t<ALT_DIGIT_BITS,
+                               typename ChainedPolicyT::ActivePolicy::AltDownsweepPolicy,
+                               typename ChainedPolicyT::ActivePolicy::DownsweepPolicy>;
 
   static constexpr int TILE_ITEMS =
     ::cuda::std::max(ActiveUpsweepPolicyT::BLOCK_THREADS * ActiveUpsweepPolicyT::ITEMS_PER_THREAD,
@@ -250,14 +250,14 @@ __launch_bounds__(int((ALT_DIGIT_BITS) ? int(ChainedPolicyT::ActivePolicy::AltDo
     DecomposerT decomposer = {})
 {
   using ActiveUpsweepPolicyT =
-    ::cuda::std::_If<ALT_DIGIT_BITS,
-                     typename ChainedPolicyT::ActivePolicy::AltUpsweepPolicy,
-                     typename ChainedPolicyT::ActivePolicy::UpsweepPolicy>;
+    ::cuda::std::conditional_t<ALT_DIGIT_BITS,
+                               typename ChainedPolicyT::ActivePolicy::AltUpsweepPolicy,
+                               typename ChainedPolicyT::ActivePolicy::UpsweepPolicy>;
 
   using ActiveDownsweepPolicyT =
-    ::cuda::std::_If<ALT_DIGIT_BITS,
-                     typename ChainedPolicyT::ActivePolicy::AltDownsweepPolicy,
-                     typename ChainedPolicyT::ActivePolicy::DownsweepPolicy>;
+    ::cuda::std::conditional_t<ALT_DIGIT_BITS,
+                               typename ChainedPolicyT::ActivePolicy::AltDownsweepPolicy,
+                               typename ChainedPolicyT::ActivePolicy::DownsweepPolicy>;
 
   static constexpr int TILE_ITEMS =
     ::cuda::std::max(ActiveUpsweepPolicyT::BLOCK_THREADS * ActiveUpsweepPolicyT::ITEMS_PER_THREAD,

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
@@ -113,9 +113,9 @@ __launch_bounds__(int((ALT_DIGIT_BITS) ? ChainedPolicyT::ActivePolicy::AltSegmen
   //
 
   using SegmentedPolicyT =
-    ::cuda::std::_If<ALT_DIGIT_BITS,
-                     typename ChainedPolicyT::ActivePolicy::AltSegmentedPolicy,
-                     typename ChainedPolicyT::ActivePolicy::SegmentedPolicy>;
+    ::cuda::std::conditional_t<ALT_DIGIT_BITS,
+                               typename ChainedPolicyT::ActivePolicy::AltSegmentedPolicy,
+                               typename ChainedPolicyT::ActivePolicy::SegmentedPolicy>;
 
   static constexpr int BLOCK_THREADS = SegmentedPolicyT::BLOCK_THREADS;
   static constexpr int RADIX_BITS    = SegmentedPolicyT::RADIX_BITS;

--- a/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_radix_sort.cuh
@@ -362,7 +362,7 @@ struct policy_hub
   static constexpr bool KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
   // Dominant-sized key/value type
-  using DominantT = ::cuda::std::_If<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
+  using DominantT = ::cuda::std::conditional_t<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
 
   //------------------------------------------------------------------------------
   // Architecture-specific tuning policies
@@ -944,7 +944,8 @@ struct policy_hub
       RADIX_SORT_STORE_DIRECT,
       ONESWEEP_RADIX_BITS>;
 
-    using OnesweepLargeKeyPolicy = ::cuda::std::_If<sizeof(KeyT) == 4, OnesweepPolicyKey32, OnesweepPolicyKey64>;
+    using OnesweepLargeKeyPolicy =
+      ::cuda::std::conditional_t<sizeof(KeyT) == 4, OnesweepPolicyKey32, OnesweepPolicyKey64>;
 
     using OnesweepSmallKeyPolicy = AgentRadixSortOnesweepPolicy<
       OnesweepSmallKeyPolicySizes::threads,
@@ -957,7 +958,7 @@ struct policy_hub
       8>;
 
   public:
-    using OnesweepPolicy = ::cuda::std::_If<sizeof(KeyT) < 4, OnesweepSmallKeyPolicy, OnesweepLargeKeyPolicy>;
+    using OnesweepPolicy = ::cuda::std::conditional_t<sizeof(KeyT) < 4, OnesweepSmallKeyPolicy, OnesweepLargeKeyPolicy>;
 
     // The Scan, Downsweep and Upsweep policies are never run on SM90, but we have to include them to prevent a
     // compilation error: When we compile e.g. for SM70 **and** SM90, the host compiler will reach calls to those

--- a/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_segmented_sort.cuh
@@ -135,7 +135,7 @@ _CCCL_HOST_DEVICE SegmentedSortPolicyWrapper<PolicyT> MakeSegmentedSortPolicyWra
 template <typename KeyT, typename ValueT>
 struct policy_hub
 {
-  using DominantT                = ::cuda::std::_If<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
+  using DominantT                = ::cuda::std::conditional_t<(sizeof(ValueT) > sizeof(KeyT)), ValueT, KeyT>;
   static constexpr int KEYS_ONLY = ::cuda::std::is_same_v<ValueT, NullType>;
 
   struct Policy500 : ChainedPolicy<500, Policy500, Policy500>

--- a/cub/cub/thread/thread_reduce.cuh
+++ b/cub/cub/thread/thread_reduce.cuh
@@ -396,7 +396,7 @@ ThreadReducePartial(const Input& input, ReductionOp reduction_op, int valid_item
   }
   else
   {
-    using PromT = ::cuda::std::_If<enable_min_max_promotion_v<ReductionOp, ValueT>, int, AccumT>;
+    using PromT = ::cuda::std::conditional_t<enable_min_max_promotion_v<ReductionOp, ValueT>, int, AccumT>;
 
     return cub::detail::ThreadReduceSequentialPartial<PromT>(input, reduction_op, valid_items);
   }
@@ -422,7 +422,7 @@ template <typename Input, typename ReductionOp, typename ValueT, typename AccumT
     return static_cast<AccumT>(input[0]);
   }
 
-  using PromT = ::cuda::std::_If<enable_min_max_promotion_v<ReductionOp, ValueT>, int, AccumT>;
+  using PromT = ::cuda::std::conditional_t<enable_min_max_promotion_v<ReductionOp, ValueT>, int, AccumT>;
   // TODO: should be part of the tuning policy
   if constexpr ((!is_simd_enabled_cuda_operator<ReductionOp, ValueT> && !is_simd_operator_v<ReductionOp>)
                 || sizeof(ValueT) >= 8)

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -720,9 +720,9 @@ private:
 public:
   /// The policy for the active compiler pass
   using ActivePolicy =
-    typename ::cuda::std::_If<(CUB_PTX_ARCH < PolicyPtxVersion && have_previous_policy),
-                              detail::get_active_policy<PrevPolicyT>,
-                              ::cuda::std::type_identity<PolicyT>>::type;
+    typename ::cuda::std::conditional_t<(CUB_PTX_ARCH < PolicyPtxVersion && have_previous_policy),
+                                        detail::get_active_policy<PrevPolicyT>,
+                                        ::cuda::std::type_identity<PolicyT>>::type;
 
 #if !_CCCL_COMPILER(NVRTC)
   /// Specializes and dispatches op in accordance to the first policy in the chain of adequate PTX version

--- a/cub/cub/util_type.cuh
+++ b/cub/cub/util_type.cuh
@@ -82,10 +82,11 @@ struct non_void_value_impl<It, FallbackT, false>
 {
   // we consider thrust::discard_iterator's value_type (`any_assign`) as `void` as well, so users can switch from
   // cub::DiscardInputIterator to thrust::discard_iterator.
-  using type = ::cuda::std::_If<::cuda::std::is_void_v<it_value_t<It>>
-                                  || ::cuda::std::is_same_v<it_value_t<It>, THRUST_NS_QUALIFIER::detail::any_assign>,
-                                FallbackT,
-                                it_value_t<It>>;
+  using type =
+    ::cuda::std::conditional_t<::cuda::std::is_void_v<it_value_t<It>>
+                                 || ::cuda::std::is_same_v<it_value_t<It>, THRUST_NS_QUALIFIER::detail::any_assign>,
+                               FallbackT,
+                               it_value_t<It>>;
 };
 
 /**
@@ -377,20 +378,22 @@ struct UnitWord
   };
 
   /// Largest shuffle word such that sizeof(T) % sizeof(W) == 0 and alignof(W) <= alignof(T)
-  using ShuffleWord =
-    ::cuda::std::_If<IsMultiple<int>::IS_MULTIPLE,
-                     unsigned int,
-                     ::cuda::std::_If<IsMultiple<short>::IS_MULTIPLE, unsigned short, unsigned char>>;
+  using ShuffleWord = ::cuda::std::conditional_t<
+    IsMultiple<int>::IS_MULTIPLE,
+    unsigned int,
+    ::cuda::std::conditional_t<IsMultiple<short>::IS_MULTIPLE, unsigned short, unsigned char>>;
 
   /// Largest volatile word such that sizeof(T) % sizeof(W) == 0 and alignof(W) <= alignof(T)
-  using VolatileWord = ::cuda::std::_If<IsMultiple<long long>::IS_MULTIPLE, unsigned long long, ShuffleWord>;
+  using VolatileWord = ::cuda::std::conditional_t<IsMultiple<long long>::IS_MULTIPLE, unsigned long long, ShuffleWord>;
 
   /// Largest memory-access word such that sizeof(T) % sizeof(W) == 0 and alignof(W) <= alignof(T)
-  using DeviceWord = ::cuda::std::_If<IsMultiple<longlong2>::IS_MULTIPLE, ulonglong2, VolatileWord>;
+  using DeviceWord = ::cuda::std::conditional_t<IsMultiple<longlong2>::IS_MULTIPLE, ulonglong2, VolatileWord>;
 
   /// Biggest texture reference word such that sizeof(T) % sizeof(W) == 0 and alignof(W) <= alignof(T)
-  using TextureWord = ::cuda::std::
-    _If<IsMultiple<int4>::IS_MULTIPLE, uint4, ::cuda::std::_If<IsMultiple<int2>::IS_MULTIPLE, uint2, ShuffleWord>>;
+  using TextureWord =
+    ::cuda::std::conditional_t<IsMultiple<int4>::IS_MULTIPLE,
+                               uint4,
+                               ::cuda::std::conditional_t<IsMultiple<int2>::IS_MULTIPLE, uint2, ShuffleWord>>;
 };
 
 // float2 specialization workaround (for SM10-SM13)

--- a/cub/cub/warp/warp_exchange.cuh
+++ b/cub/cub/warp/warp_exchange.cuh
@@ -38,9 +38,9 @@ namespace detail
 {
 template <typename InputT, int ITEMS_PER_THREAD, int LOGICAL_WARP_THREADS, WarpExchangeAlgorithm WARP_EXCHANGE_ALGORITHM>
 using InternalWarpExchangeImpl =
-  ::cuda::std::_If<WARP_EXCHANGE_ALGORITHM == WARP_EXCHANGE_SMEM,
-                   WarpExchangeSmem<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS>,
-                   WarpExchangeShfl<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS>>;
+  ::cuda::std::conditional_t<WARP_EXCHANGE_ALGORITHM == WARP_EXCHANGE_SMEM,
+                             WarpExchangeSmem<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS>,
+                             WarpExchangeShfl<InputT, ITEMS_PER_THREAD, LOGICAL_WARP_THREADS>>;
 } // namespace detail
 
 /**

--- a/cub/cub/warp/warp_reduce.cuh
+++ b/cub/cub/warp/warp_reduce.cuh
@@ -141,8 +141,10 @@ public:
 
   /// Internal specialization.
   /// Use SHFL-based reduction if LogicalWarpThreads is a power-of-two
-  using InternalWarpReduce = ::cuda::std::
-    _If<is_power_of_two, detail::WarpReduceShfl<T, LogicalWarpThreads>, detail::WarpReduceSmem<T, LogicalWarpThreads>>;
+  using InternalWarpReduce =
+    ::cuda::std::conditional_t<is_power_of_two,
+                               detail::WarpReduceShfl<T, LogicalWarpThreads>,
+                               detail::WarpReduceSmem<T, LogicalWarpThreads>>;
 
 #endif // _CCCL_DOXYGEN_INVOKED
 

--- a/cub/cub/warp/warp_scan.cuh
+++ b/cub/cub/warp/warp_scan.cuh
@@ -155,8 +155,10 @@ private:
 
   /// Internal specialization.
   /// Use SHFL-based scan if LOGICAL_WARP_THREADS is a power-of-two
-  using InternalWarpScan = ::cuda::std::
-    _If<IS_POW_OF_TWO, detail::WarpScanShfl<T, LOGICAL_WARP_THREADS>, detail::WarpScanSmem<T, LOGICAL_WARP_THREADS>>;
+  using InternalWarpScan =
+    ::cuda::std::conditional_t<IS_POW_OF_TWO,
+                               detail::WarpScanShfl<T, LOGICAL_WARP_THREADS>,
+                               detail::WarpScanSmem<T, LOGICAL_WARP_THREADS>>;
 
   /// Shared memory storage layout type for WarpScan
   using _TempStorage = typename InternalWarpScan::TempStorage;

--- a/cub/test/catch2_test_block_run_length_decode.cu
+++ b/cub/test/catch2_test_block_run_length_decode.cu
@@ -137,7 +137,8 @@ public:
   {
     typename BlockLoadRunItemT::TempStorage load_uniques_storage;
     typename BlockLoadRunLengthsT::TempStorage load_run_lengths_storage;
-    cuda::std::_If<TEST_RUN_OFFSETS_, typename BlockRunOffsetScanT::TempStorage, cub::NullType> run_offsets_scan_storage;
+    cuda::std::conditional_t<TEST_RUN_OFFSETS_, typename BlockRunOffsetScanT::TempStorage, cub::NullType>
+      run_offsets_scan_storage;
     struct
     {
       typename BlockRunLengthDecodeT::TempStorage run_length_decode_storage;

--- a/cub/test/catch2_test_warp_merge_sort.cu
+++ b/cub/test/catch2_test_warp_merge_sort.cu
@@ -382,7 +382,7 @@ C2H_TEST(
 {
   using params             = params_t<TestType>;
   using type               = typename params::type;
-  using warp_sort_delegate = cuda::std::_If<params::is_stable, warp_stable_sort_keys_t, warp_sort_keys_t>;
+  using warp_sort_delegate = cuda::std::conditional_t<params::is_stable, warp_stable_sort_keys_t, warp_sort_keys_t>;
 
   // Prepare test data
   c2h::device_vector<type> d_in(params::tile_size);
@@ -413,7 +413,7 @@ C2H_TEST("Warp sort keys-only on partial warp-tile works",
   using params = params_t<TestType>;
   using type   = typename params::type;
   using warp_sort_delegate =
-    cuda::std::_If<params::is_stable, warp_partial_stable_sort_keys_t, warp_partial_sort_keys_t>;
+    cuda::std::conditional_t<params::is_stable, warp_partial_stable_sort_keys_t, warp_partial_sort_keys_t>;
 
   // Prepare test data
   c2h::device_vector<type> d_in(params::tile_size);
@@ -447,7 +447,7 @@ C2H_TEST("Warp sort on keys-value pairs works",
   using params             = params_t<TestType>;
   using key_type           = typename params::type;
   using value_type         = typename c2h::get<4, TestType>;
-  using warp_sort_delegate = cuda::std::_If<params::is_stable, warp_stable_sort_pairs_t, warp_sort_pairs_t>;
+  using warp_sort_delegate = cuda::std::conditional_t<params::is_stable, warp_stable_sort_pairs_t, warp_sort_pairs_t>;
 
   // Prepare test data
   c2h::device_vector<key_type> d_keys_in(params::tile_size);
@@ -490,7 +490,7 @@ C2H_TEST("Warp sort on key-value pairs of a partial warp-tile works",
   using key_type   = typename params::type;
   using value_type = typename c2h::get<4, TestType>;
   using warp_sort_delegate =
-    cuda::std::_If<params::is_stable, warp_partial_stable_sort_pairs_t, warp_partial_sort_pairs_t>;
+    cuda::std::conditional_t<params::is_stable, warp_partial_stable_sort_pairs_t, warp_partial_sort_pairs_t>;
 
   // Prepare test data
   c2h::device_vector<key_type> d_keys_in(params::tile_size);

--- a/cub/test/warp/catch2_test_warp_segmented_reduce.cu
+++ b/cub/test/warp/catch2_test_warp_segmented_reduce.cu
@@ -270,8 +270,8 @@ C2H_TEST("Warp segmented sum works", "[reduce][warp]", full_type_list, logical_w
   constexpr auto segmented_mod = c2h::get<2, TestType>::value;
   static_assert(segmented_mod == reduce_mode::tail_flags || segmented_mod == reduce_mode::head_flags,
                 "Segmented tests must either be head or tail flags");
-  using warp_seg_sum_t =
-    cuda::std::_If<(segmented_mod == reduce_mode::tail_flags), warp_seg_sum_tail_t<type>, warp_seg_sum_head_t<type>>;
+  using warp_seg_sum_t = cuda::std::
+    conditional_t<(segmented_mod == reduce_mode::tail_flags), warp_seg_sum_tail_t<type>, warp_seg_sum_head_t<type>>;
 
   // Prepare test data
   c2h::device_vector<type> d_in(params::tile_size);
@@ -315,9 +315,9 @@ C2H_TEST("Warp segmented reduction works", "[reduce][warp]", builtin_type_list, 
   static_assert(segmented_mod == reduce_mode::tail_flags || segmented_mod == reduce_mode::head_flags,
                 "Segmented tests must either be head or tail flags");
   using warp_seg_reduction_t =
-    cuda::std::_If<(segmented_mod == reduce_mode::tail_flags),
-                   warp_seg_reduce_tail_t<type, red_op_t>,
-                   warp_seg_reduce_head_t<type, red_op_t>>;
+    cuda::std::conditional_t<(segmented_mod == reduce_mode::tail_flags),
+                             warp_seg_reduce_tail_t<type, red_op_t>,
+                             warp_seg_reduce_head_t<type, red_op_t>>;
 
   // Prepare test data
   c2h::device_vector<type> d_in(params::tile_size);

--- a/cudax/include/cuda/experimental/__execution/apply_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/apply_sender.cuh
@@ -45,8 +45,10 @@ private:
   //! @tparam _Domain The domain to check.
   //! @tparam _Args The arguments to validate against the domain.
   template <class _Domain, class... _Args>
-  using __apply_domain_t _CCCL_NODEBUG_ALIAS = ::cuda::std::
-    _If<::cuda::std::_IsValidExpansion<__apply_sender_result_t, _Domain, _Args...>::value, _Domain, default_domain>;
+  using __apply_domain_t _CCCL_NODEBUG_ALIAS =
+    ::cuda::std::conditional_t<::cuda::std::_IsValidExpansion<__apply_sender_result_t, _Domain, _Args...>::value,
+                               _Domain,
+                               default_domain>;
 
 public:
   //! Applies a sender to a domain, tag, and arguments.

--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -295,7 +295,7 @@ struct __remove_sigs
 
 template <class _Fn, class _Sig>
 _CCCL_API _CCCL_CONSTEVAL auto __filer_one() noexcept
-  -> ::cuda::std::_If<_Fn{}(static_cast<_Sig*>(nullptr)), completion_signatures<_Sig>, completion_signatures<>>
+  -> ::cuda::std::conditional_t<_Fn{}(static_cast<_Sig*>(nullptr)), completion_signatures<_Sig>, completion_signatures<>>
 {
   return {};
 }

--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -409,13 +409,13 @@ struct __not_a_domain
 
 template <class... _Domains>
 using __indeterminate_domain_t =
-  ::cuda::std::_If<sizeof...(_Domains) == 1, decltype((_Domains(), ...)), indeterminate_domain<_Domains...>>;
+  ::cuda::std::conditional_t<sizeof...(_Domains) == 1, decltype((_Domains(), ...)), indeterminate_domain<_Domains...>>;
 
 template <class _DomainSet>
 using __domain_from_set_t =
-  ::cuda::std::__type_apply<::cuda::std::_If<::cuda::std::__type_set_contains_v<_DomainSet, __not_a_domain>,
-                                             ::cuda::std::__type_always<__not_a_domain>,
-                                             ::cuda::std::__type_quote<__indeterminate_domain_t>>,
+  ::cuda::std::__type_apply<::cuda::std::conditional_t<::cuda::std::__type_set_contains_v<_DomainSet, __not_a_domain>,
+                                                       ::cuda::std::__type_always<__not_a_domain>,
+                                                       ::cuda::std::__type_quote<__indeterminate_domain_t>>,
                             _DomainSet>;
 
 template <class... _Domains>
@@ -441,16 +441,17 @@ extern __call_result_or_t<get_completion_domain_t<_Tag>, indeterminate_domain<>,
   __compl_domain_v;
 
 template <class _Tag, class _Sndr>
-extern __call_result_or_t<get_completion_domain_t<_Tag>,
-                          // If we ask for the completion domain early (without an env)
-                          // and it cannot be determined, then:
-                          // - if the sender knows it can never complete with _Tag, return
-                          //   indeterminate_domain<>
-                          // - otherwise, return __not_a_domain (indicating that the
-                          //   completion domain may only be knowable later, when an env
-                          //   is available)
-                          ::cuda::std::_If<__never_completes_with<_Sndr, _Tag>, indeterminate_domain<>, __not_a_domain>,
-                          env_of_t<_Sndr>>
+extern __call_result_or_t<
+  get_completion_domain_t<_Tag>,
+  // If we ask for the completion domain early (without an env)
+  // and it cannot be determined, then:
+  // - if the sender knows it can never complete with _Tag, return
+  //   indeterminate_domain<>
+  // - otherwise, return __not_a_domain (indicating that the
+  //   completion domain may only be knowable later, when an env
+  //   is available)
+  ::cuda::std::conditional_t<__never_completes_with<_Sndr, _Tag>, indeterminate_domain<>, __not_a_domain>,
+  env_of_t<_Sndr>>
   __compl_domain_v<_Tag, _Sndr>;
 } // namespace __detail
 

--- a/cudax/include/cuda/experimental/__execution/just_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/just_from.cuh
@@ -62,9 +62,9 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __just_from_t
   {
     template <class... _Ts>
     _CCCL_API auto operator()(_Ts&&... __ts) const noexcept
-      -> ::cuda::std::_If<__detail::__signature_disposition<_SetTag(_Ts...)> != __disposition::__invalid,
-                          completion_signatures<_SetTag(_Ts...)>,
-                          __error_t<_Ts...>>;
+      -> ::cuda::std::conditional_t<__detail::__signature_disposition<_SetTag(_Ts...)> != __disposition::__invalid,
+                                    completion_signatures<_SetTag(_Ts...)>,
+                                    __error_t<_Ts...>>;
   };
 
   template <class _Rcvr>

--- a/cudax/include/cuda/experimental/__execution/meta.cuh
+++ b/cudax/include/cuda/experimental/__execution/meta.cuh
@@ -203,9 +203,9 @@ struct __type_try_quote<_Fn, _Default>
 {
   template <class... _Ts>
   using __call _CCCL_NODEBUG_ALIAS =
-    typename ::cuda::std::_If<__is_instantiable_with<_Fn, _Ts...>, //
-                              __type_try_quote<_Fn>,
-                              ::cuda::std::__type_always<_Default>>::template __call<_Ts...>;
+    typename ::cuda::std::conditional_t<__is_instantiable_with<_Fn, _Ts...>, //
+                                        __type_try_quote<_Fn>,
+                                        ::cuda::std::__type_always<_Default>>::template __call<_Ts...>;
 };
 
 template <class _Return>
@@ -262,15 +262,15 @@ struct __type_self_or
 
 template <template <class...> class _Fn, class _Default, class... _Ts>
 using __type_call_or_quote =
-  typename ::cuda::std::_If<__is_instantiable_with<_Fn, _Ts...>,
-                            ::cuda::std::__type_quote<_Fn>,
-                            ::cuda::std::__type_always<_Default>>::template __call<_Ts...>;
+  typename ::cuda::std::conditional_t<__is_instantiable_with<_Fn, _Ts...>,
+                                      ::cuda::std::__type_quote<_Fn>,
+                                      ::cuda::std::__type_always<_Default>>::template __call<_Ts...>;
 
 template <class _Fn, class _Default, class... _Ts>
 using __type_call_or =
-  typename ::cuda::std::_If<__is_instantiable_with<_Fn::template __call, _Ts...>,
-                            _Fn,
-                            ::cuda::std::__type_always<_Default>>::template __call<_Ts...>;
+  typename ::cuda::std::conditional_t<__is_instantiable_with<_Fn::template __call, _Ts...>,
+                                      _Fn,
+                                      ::cuda::std::__type_always<_Default>>::template __call<_Ts...>;
 } // namespace cuda::experimental::execution
 
 _CCCL_DIAG_POP

--- a/cudax/include/cuda/experimental/__execution/transform_sender.cuh
+++ b/cudax/include/cuda/experimental/__execution/transform_sender.cuh
@@ -47,7 +47,7 @@ template <class _Domain, class _OpTag>
 struct __transform_sender_t
 {
   template <class _Sndr, class _Env>
-  using __domain_for_t = ::cuda::std::_If< //
+  using __domain_for_t = ::cuda::std::conditional_t< //
     __has_transform_sender<_Domain, _OpTag, _Sndr, _Env>,
     _Domain,
     default_domain>;

--- a/cudax/include/cuda/experimental/__execution/utility.cuh
+++ b/cudax/include/cuda/experimental/__execution/utility.cuh
@@ -272,7 +272,7 @@ struct __call_or_t
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Default = __nil,
-            class _Result  = ::cuda::std::_If<__same_as<_Default, __nil>, void, _Default>,
+            class _Result  = ::cuda::std::conditional_t<__same_as<_Default, __nil>, void, _Default>,
             class... _Args>
   [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::std::__ignore_t, _Default&& __default, _Args&&...) const
     noexcept(__nothrow_movable<_Default>) -> _Result

--- a/libcudacxx/include/cuda/__bit/bitfield.h
+++ b/libcudacxx/include/cuda/__bit/bitfield.h
@@ -80,7 +80,7 @@ bitfield_insert(const _Tp __dest, const _Tp __source, int __start, int __width) 
       // clang-format off
       NV_DISPATCH_TARGET( // all SM < 70
         NV_PROVIDES_SM_70, (;),
-        NV_IS_DEVICE,      (using _Up = ::cuda::std::_If<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
+        NV_IS_DEVICE,      (using _Up = ::cuda::std::conditional_t<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
                             return ::cuda::__bfi(static_cast<_Up>(__dest), static_cast<_Up>(__source),
                                                  __start, __width);))
       // clang-format on
@@ -106,7 +106,7 @@ template <typename _Tp>
       // clang-format off
       NV_DISPATCH_TARGET( // all SM < 70
         NV_PROVIDES_SM_70, (;),
-        NV_IS_DEVICE,      (using _Up = ::cuda::std::_If<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
+        NV_IS_DEVICE,      (using _Up = ::cuda::std::conditional_t<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
                             return ::cuda::__bfe(static_cast<_Up>(__value), __start, __width);))
       // clang-format on
     }

--- a/libcudacxx/include/cuda/__bit/bitmask.h
+++ b/libcudacxx/include/cuda/__bit/bitmask.h
@@ -42,7 +42,7 @@ template <typename _Tp>
     if constexpr (sizeof(_Tp) <= sizeof(uint64_t))
     {
       NV_DISPATCH_TARGET(NV_IS_DEVICE,
-                         (using _Up = ::cuda::std::_If<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
+                         (using _Up = ::cuda::std::conditional_t<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
                           return ::cuda::ptx::shl(static_cast<_Up>(__value), __shift);))
     }
   }
@@ -57,7 +57,7 @@ template <typename _Tp>
     if constexpr (sizeof(_Tp) <= sizeof(uint64_t))
     {
       NV_DISPATCH_TARGET(NV_IS_DEVICE,
-                         (using _Up = ::cuda::std::_If<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
+                         (using _Up = ::cuda::std::conditional_t<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
                           return ::cuda::ptx::shr(static_cast<_Up>(__value), __shift);))
     }
   }

--- a/libcudacxx/include/cuda/std/__atomic/api/owned.h
+++ b/libcudacxx/include/cuda/std/__atomic/api/owned.h
@@ -122,12 +122,14 @@ struct __atomic_pointer
 };
 
 template <typename _Tp, thread_scope _Sco = thread_scope_system>
-using __atomic_impl = _If<
-  is_pointer_v<_Tp>,
-  __atomic_pointer<_Tp, __scope_to_tag<_Sco>>,
-  _If<is_floating_point_v<_Tp>,
-      __atomic_arithmetic<_Tp, __scope_to_tag<_Sco>>,
-      _If<is_integral_v<_Tp>, __atomic_bitwise<_Tp, __scope_to_tag<_Sco>>, __atomic_common<_Tp, __scope_to_tag<_Sco>>>>>;
+using __atomic_impl =
+  conditional_t<is_pointer_v<_Tp>,
+                __atomic_pointer<_Tp, __scope_to_tag<_Sco>>,
+                conditional_t<is_floating_point_v<_Tp>,
+                              __atomic_arithmetic<_Tp, __scope_to_tag<_Sco>>,
+                              conditional_t<is_integral_v<_Tp>,
+                                            __atomic_bitwise<_Tp, __scope_to_tag<_Sco>>,
+                                            __atomic_common<_Tp, __scope_to_tag<_Sco>>>>>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__atomic/api/reference.h
+++ b/libcudacxx/include/cuda/std/__atomic/api/reference.h
@@ -103,13 +103,13 @@ struct __atomic_ref_pointer
 
 template <typename _Tp, thread_scope _Sco = thread_scope_system>
 using __atomic_ref_impl =
-  _If<is_pointer_v<_Tp>,
-      __atomic_ref_pointer<_Tp, __scope_to_tag<_Sco>>,
-      _If<is_floating_point_v<_Tp>,
-          __atomic_ref_arithmetic<_Tp, __scope_to_tag<_Sco>>,
-          _If<is_integral_v<_Tp>,
-              __atomic_ref_bitwise<_Tp, __scope_to_tag<_Sco>>,
-              __atomic_ref_common<_Tp, __scope_to_tag<_Sco>>>>>;
+  conditional_t<is_pointer_v<_Tp>,
+                __atomic_ref_pointer<_Tp, __scope_to_tag<_Sco>>,
+                conditional_t<is_floating_point_v<_Tp>,
+                              __atomic_ref_arithmetic<_Tp, __scope_to_tag<_Sco>>,
+                              conditional_t<is_integral_v<_Tp>,
+                                            __atomic_ref_bitwise<_Tp, __scope_to_tag<_Sco>>,
+                                            __atomic_ref_common<_Tp, __scope_to_tag<_Sco>>>>>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated_helper.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_generated_helper.h
@@ -121,42 +121,44 @@ using __atomic_cuda_deduce_bitwise =
                 __type_default<__atomic_cuda_operand_deduction<__atomic_longlong2, __atomic_cuda_operand_b128>>>;
 
 template <class _Type>
-using __atomic_cuda_deduce_arithmetic = _If<
+using __atomic_cuda_deduce_arithmetic = conditional_t<
   is_floating_point_v<_Type>,
-  _If<sizeof(_Type) == 4,
-      __atomic_cuda_operand_deduction<float, __atomic_cuda_operand_f32>,
-      __atomic_cuda_operand_deduction<double, __atomic_cuda_operand_f64>>,
-  _If<is_signed_v<_Type>,
-      __type_switch<sizeof(_Type),
-                    __type_case<1, __atomic_cuda_operand_deduction<int8_t, __atomic_cuda_operand_s8>>,
-                    __type_case<2, __atomic_cuda_operand_deduction<int16_t, __atomic_cuda_operand_s16>>,
-                    __type_case<4, __atomic_cuda_operand_deduction<int32_t, __atomic_cuda_operand_s32>>,
-                    __type_default<__atomic_cuda_operand_deduction<int64_t, __atomic_cuda_operand_u64>>>, // There is no
-                                                                                                          // atom.add.s64
-      __type_switch<sizeof(_Type),
-                    __type_case<1, __atomic_cuda_operand_deduction<uint8_t, __atomic_cuda_operand_u8>>,
-                    __type_case<2, __atomic_cuda_operand_deduction<uint16_t, __atomic_cuda_operand_u16>>,
-                    __type_case<4, __atomic_cuda_operand_deduction<uint32_t, __atomic_cuda_operand_u32>>,
-                    __type_default<__atomic_cuda_operand_deduction<uint64_t, __atomic_cuda_operand_u64>>>>>;
+  conditional_t<sizeof(_Type) == 4,
+                __atomic_cuda_operand_deduction<float, __atomic_cuda_operand_f32>,
+                __atomic_cuda_operand_deduction<double, __atomic_cuda_operand_f64>>,
+  conditional_t<
+    is_signed_v<_Type>,
+    __type_switch<sizeof(_Type),
+                  __type_case<1, __atomic_cuda_operand_deduction<int8_t, __atomic_cuda_operand_s8>>,
+                  __type_case<2, __atomic_cuda_operand_deduction<int16_t, __atomic_cuda_operand_s16>>,
+                  __type_case<4, __atomic_cuda_operand_deduction<int32_t, __atomic_cuda_operand_s32>>,
+                  __type_default<__atomic_cuda_operand_deduction<int64_t, __atomic_cuda_operand_u64>>>, // There is no
+                                                                                                        // atom.add.s64
+    __type_switch<sizeof(_Type),
+                  __type_case<1, __atomic_cuda_operand_deduction<uint8_t, __atomic_cuda_operand_u8>>,
+                  __type_case<2, __atomic_cuda_operand_deduction<uint16_t, __atomic_cuda_operand_u16>>,
+                  __type_case<4, __atomic_cuda_operand_deduction<uint32_t, __atomic_cuda_operand_u32>>,
+                  __type_default<__atomic_cuda_operand_deduction<uint64_t, __atomic_cuda_operand_u64>>>>>;
 
 template <class _Type>
-using __atomic_cuda_deduce_minmax = _If<
+using __atomic_cuda_deduce_minmax = conditional_t<
   is_floating_point_v<_Type>,
-  _If<sizeof(_Type) == 4,
-      __atomic_cuda_operand_deduction<float, __atomic_cuda_operand_f32>,
-      __atomic_cuda_operand_deduction<double, __atomic_cuda_operand_f64>>,
-  _If<is_signed_v<_Type>,
-      __type_switch<sizeof(_Type),
-                    __type_case<1, __atomic_cuda_operand_deduction<int8_t, __atomic_cuda_operand_s8>>,
-                    __type_case<2, __atomic_cuda_operand_deduction<int16_t, __atomic_cuda_operand_s16>>,
-                    __type_case<4, __atomic_cuda_operand_deduction<int32_t, __atomic_cuda_operand_s32>>,
-                    __type_default<__atomic_cuda_operand_deduction<int64_t, __atomic_cuda_operand_s64>>>, // atom.min|max.s64
-                                                                                                          // supported
-      __type_switch<sizeof(_Type),
-                    __type_case<1, __atomic_cuda_operand_deduction<uint8_t, __atomic_cuda_operand_u8>>,
-                    __type_case<2, __atomic_cuda_operand_deduction<uint16_t, __atomic_cuda_operand_u16>>,
-                    __type_case<4, __atomic_cuda_operand_deduction<uint32_t, __atomic_cuda_operand_u32>>,
-                    __type_default<__atomic_cuda_operand_deduction<uint64_t, __atomic_cuda_operand_u64>>>>>;
+  conditional_t<sizeof(_Type) == 4,
+                __atomic_cuda_operand_deduction<float, __atomic_cuda_operand_f32>,
+                __atomic_cuda_operand_deduction<double, __atomic_cuda_operand_f64>>,
+  conditional_t<
+    is_signed_v<_Type>,
+    __type_switch<sizeof(_Type),
+                  __type_case<1, __atomic_cuda_operand_deduction<int8_t, __atomic_cuda_operand_s8>>,
+                  __type_case<2, __atomic_cuda_operand_deduction<int16_t, __atomic_cuda_operand_s16>>,
+                  __type_case<4, __atomic_cuda_operand_deduction<int32_t, __atomic_cuda_operand_s32>>,
+                  __type_default<__atomic_cuda_operand_deduction<int64_t, __atomic_cuda_operand_s64>>>, // atom.min|max.s64
+                                                                                                        // supported
+    __type_switch<sizeof(_Type),
+                  __type_case<1, __atomic_cuda_operand_deduction<uint8_t, __atomic_cuda_operand_u8>>,
+                  __type_case<2, __atomic_cuda_operand_deduction<uint16_t, __atomic_cuda_operand_u16>>,
+                  __type_case<4, __atomic_cuda_operand_deduction<uint32_t, __atomic_cuda_operand_u32>>,
+                  __type_default<__atomic_cuda_operand_deduction<uint64_t, __atomic_cuda_operand_u64>>>>>;
 
 template <class _Type>
 using __atomic_enable_if_native_bitwise = enable_if_t<(sizeof(_Type) < 16), bool>;

--- a/libcudacxx/include/cuda/std/__atomic/types.h
+++ b/libcudacxx/include/cuda/std/__atomic/types.h
@@ -39,10 +39,10 @@ struct __atomic_traits
 };
 
 template <typename _Tp>
-using __atomic_storage_t =
-  _If<__atomic_traits<_Tp>::__atomic_requires_small,
-      __atomic_small_storage<_Tp>,
-      _If<__atomic_traits<_Tp>::__atomic_requires_lock, __atomic_locked_storage<_Tp>, __atomic_storage<_Tp>>>;
+using __atomic_storage_t = conditional_t<
+  __atomic_traits<_Tp>::__atomic_requires_small,
+  __atomic_small_storage<_Tp>,
+  conditional_t<__atomic_traits<_Tp>::__atomic_requires_lock, __atomic_locked_storage<_Tp>, __atomic_storage<_Tp>>>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__atomic/types/small.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/small.h
@@ -36,7 +36,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 // manipulated by PTX without any performance overhead
 template <typename _Tp>
-using __atomic_small_proxy_t = _If<is_signed_v<_Tp>, int32_t, uint32_t>;
+using __atomic_small_proxy_t = conditional_t<is_signed_v<_Tp>, int32_t, uint32_t>;
 
 // Arithmetic conversions to/from proxy types
 template <class _Tp, enable_if_t<is_arithmetic_v<_Tp>, int> = 0>

--- a/libcudacxx/include/cuda/std/__bit/countl.h
+++ b/libcudacxx/include/cuda/std/__bit/countl.h
@@ -151,7 +151,7 @@ _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
 #else // ^^^ _CCCL_BUILTIN_CLZG ^^^ // vvv !_CCCL_BUILTIN_CLZG vvv
   if constexpr (sizeof(_Tp) <= sizeof(uint64_t))
   {
-    using _Sp                    = _If<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
+    using _Sp                    = conditional_t<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
     constexpr auto __digits_diff = numeric_limits<_Sp>::digits - numeric_limits<_Tp>::digits;
     __count                      = ::cuda::std::__cccl_countl_zero_impl(static_cast<_Sp>(__v)) - __digits_diff;
   }

--- a/libcudacxx/include/cuda/std/__bit/countr.h
+++ b/libcudacxx/include/cuda/std/__bit/countr.h
@@ -164,7 +164,7 @@ _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
 #else // ^^^ __CCCL_BUILTIN_CTZG ^^^ / vvv !__CCCL_BUILTIN_CTZG vvv
   if constexpr (sizeof(_Tp) <= sizeof(uint64_t))
   {
-    using _Sp = _If<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
+    using _Sp = conditional_t<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
     __count   = (__v != 0) ? ::cuda::std::__cccl_countr_zero_impl(static_cast<_Sp>(__v)) : numeric_limits<_Tp>::digits;
   }
   else

--- a/libcudacxx/include/cuda/std/__bit/integral.h
+++ b/libcudacxx/include/cuda/std/__bit/integral.h
@@ -45,7 +45,7 @@ _CCCL_API constexpr uint32_t __bit_log2(_Tp __t) noexcept
   {
     if constexpr (sizeof(_Tp) <= 8)
     {
-      using _Up [[maybe_unused]] = _If<sizeof(_Tp) <= 4, uint32_t, uint64_t>;
+      using _Up [[maybe_unused]] = conditional_t<sizeof(_Tp) <= 4, uint32_t, uint64_t>;
       NV_IF_TARGET(NV_IS_DEVICE, (return ::cuda::ptx::bfind(static_cast<_Up>(__t));))
     }
     else
@@ -72,7 +72,7 @@ _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp bit_ceil(_Tp __t) noexcept
 {
-  using _Up = _If<sizeof(_Tp) <= 4, uint32_t, _Tp>;
+  using _Up = conditional_t<sizeof(_Tp) <= 4, uint32_t, _Tp>;
   _CCCL_ASSERT(__t <= numeric_limits<_Tp>::max() / 2, "bit_ceil overflow");
   // if __t == 0, __t - 1 == 0xFFFFFFFF, bit_width(0xFFFFFFFF) returns 32
   auto __width = ::cuda::std::bit_width(static_cast<_Up>(__t) - 1);
@@ -98,7 +98,7 @@ _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
 [[nodiscard]] _CCCL_API constexpr _Tp bit_floor(_Tp __t) noexcept
 {
-  using _Up   = _If<sizeof(_Tp) <= 4, uint32_t, _Tp>;
+  using _Up   = conditional_t<sizeof(_Tp) <= 4, uint32_t, _Tp>;
   auto __log2 = ::cuda::std::__bit_log2(static_cast<_Up>(__t));
   // __bit_log2 returns 0xFFFFFFFF if __t == 0
   if constexpr (sizeof(_Tp) <= 8)

--- a/libcudacxx/include/cuda/std/__bit/popcount.h
+++ b/libcudacxx/include/cuda/std/__bit/popcount.h
@@ -147,7 +147,7 @@ _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
 #else // ^^^ _CCCL_BUILTIN_POPCOUNTG ^^^ / vvv !_CCCL_BUILTIN_POPCOUNTG vvv
   if constexpr (sizeof(_Tp) <= sizeof(uint64_t))
   {
-    using _Sp = _If<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
+    using _Sp = conditional_t<sizeof(_Tp) <= sizeof(uint32_t), uint32_t, uint64_t>;
     __count   = ::cuda::std::__cccl_popcount_impl(static_cast<_Sp>(__v));
   }
   else

--- a/libcudacxx/include/cuda/std/__functional/bind.h
+++ b/libcudacxx/include/cuda/std/__functional/bind.h
@@ -54,7 +54,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
 struct is_bind_expression
-    : _If<is_same_v<_Tp, remove_cvref_t<_Tp>>, false_type, is_bind_expression<remove_cvref_t<_Tp>>>
+    : conditional_t<is_same_v<_Tp, remove_cvref_t<_Tp>>, false_type, is_bind_expression<remove_cvref_t<_Tp>>>
 {};
 
 template <class _Tp>
@@ -62,7 +62,7 @@ inline constexpr size_t is_bind_expression_v = is_bind_expression<_Tp>::value;
 
 template <class _Tp>
 struct is_placeholder
-    : _If<is_same_v<_Tp, remove_cvref_t<_Tp>>, integral_constant<int, 0>, is_placeholder<remove_cvref_t<_Tp>>>
+    : conditional_t<is_same_v<_Tp, remove_cvref_t<_Tp>>, integral_constant<int, 0>, is_placeholder<remove_cvref_t<_Tp>>>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
+++ b/libcudacxx/include/cuda/std/__iterator/iterator_traits.h
@@ -149,9 +149,9 @@ using random_access_iterator_tag = ::std::random_access_iterator_tag;
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __contiguous_iterator_tag_backfill : public ::std::random_access_iterator_tag
 {};
 using contiguous_iterator_tag =
-  _If<::std::__cccl_std_contiguous_iterator_tag_exists::value,
-      ::std::contiguous_iterator_tag,
-      __contiguous_iterator_tag_backfill>;
+  conditional_t<::std::__cccl_std_contiguous_iterator_tag_exists::value,
+                ::std::contiguous_iterator_tag,
+                __contiguous_iterator_tag_backfill>;
 #  else // ^^^ C++20 ^^^ / vvv C++17 vvv
 struct _CCCL_TYPE_VISIBILITY_DEFAULT contiguous_iterator_tag : public random_access_iterator_tag
 {};

--- a/libcudacxx/include/cuda/std/__iterator/move_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/move_iterator.h
@@ -63,9 +63,9 @@ template <class _Iter>
 struct __move_iter_category_base<_Iter>
 {
   using iterator_category =
-    _If<derived_from<typename iterator_traits<_Iter>::iterator_category, random_access_iterator_tag>,
-        random_access_iterator_tag,
-        typename iterator_traits<_Iter>::iterator_category>;
+    conditional_t<derived_from<typename iterator_traits<_Iter>::iterator_category, random_access_iterator_tag>,
+                  random_access_iterator_tag,
+                  typename iterator_traits<_Iter>::iterator_category>;
 };
 
 template <class _Iter, class _Sent>
@@ -85,9 +85,9 @@ template <class _Iter>
 struct __move_iter_category_base<_Iter, enable_if_t<__has_iter_category<iterator_traits<_Iter>>>>
 {
   using iterator_category =
-    _If<derived_from<typename iterator_traits<_Iter>::iterator_category, random_access_iterator_tag>,
-        random_access_iterator_tag,
-        typename iterator_traits<_Iter>::iterator_category>;
+    conditional_t<derived_from<typename iterator_traits<_Iter>::iterator_category, random_access_iterator_tag>,
+                  random_access_iterator_tag,
+                  typename iterator_traits<_Iter>::iterator_category>;
 };
 
 template <class _Iter, class _Sent>

--- a/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
+++ b/libcudacxx/include/cuda/std/__iterator/reverse_iterator.h
@@ -89,14 +89,15 @@ public:
   using iterator_type = _Iter;
 
   using iterator_category =
-    _If<__has_random_access_traversal<_Iter>,
-        random_access_iterator_tag,
-        typename iterator_traits<_Iter>::iterator_category>;
-  using pointer          = typename iterator_traits<_Iter>::pointer;
-  using iterator_concept = _If<random_access_iterator<_Iter>, random_access_iterator_tag, bidirectional_iterator_tag>;
-  using value_type       = iter_value_t<_Iter>;
-  using difference_type  = iter_difference_t<_Iter>;
-  using reference        = iter_reference_t<_Iter>;
+    conditional_t<__has_random_access_traversal<_Iter>,
+                  random_access_iterator_tag,
+                  typename iterator_traits<_Iter>::iterator_category>;
+  using pointer = typename iterator_traits<_Iter>::pointer;
+  using iterator_concept =
+    conditional_t<random_access_iterator<_Iter>, random_access_iterator_tag, bidirectional_iterator_tag>;
+  using value_type      = iter_value_t<_Iter>;
+  using difference_type = iter_difference_t<_Iter>;
+  using reference       = iter_reference_t<_Iter>;
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _It2 = _Iter)

--- a/libcudacxx/include/cuda/std/__ranges/dangling.h
+++ b/libcudacxx/include/cuda/std/__ranges/dangling.h
@@ -39,10 +39,10 @@ struct dangling
 
 #if _CCCL_HAS_CONCEPTS()
 template <range _Rp>
-using borrowed_iterator_t = _If<borrowed_range<_Rp>, iterator_t<_Rp>, dangling>;
+using borrowed_iterator_t = conditional_t<borrowed_range<_Rp>, iterator_t<_Rp>, dangling>;
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Rp>
-using borrowed_iterator_t = enable_if_t<range<_Rp>, _If<borrowed_range<_Rp>, iterator_t<_Rp>, dangling>>;
+using borrowed_iterator_t = enable_if_t<range<_Rp>, conditional_t<borrowed_range<_Rp>, iterator_t<_Rp>, dangling>>;
 #endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
 // borrowed_subrange_t defined in <__ranges/subrange.h>

--- a/libcudacxx/include/cuda/std/__ranges/movable_box.h
+++ b/libcudacxx/include/cuda/std/__ranges/movable_box.h
@@ -381,7 +381,7 @@ struct __mb_base : __mb_move_assign<_Tp>
 };
 
 template <class _Tp>
-using __movable_box_base = _If<__doesnt_need_empty_state<_Tp>(), __mb_base<_Tp>, __mb_optional_base<_Tp>>;
+using __movable_box_base = conditional_t<__doesnt_need_empty_state<_Tp>(), __mb_base<_Tp>, __mb_optional_base<_Tp>>;
 
 // Primary template - uses ::cuda::std::optional and introduces an empty state in case assignment fails.
 template <class _Tp, bool = __movable_box_object<_Tp>>

--- a/libcudacxx/include/cuda/std/__ranges/repeat_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/repeat_view.h
@@ -61,7 +61,8 @@ _CCCL_CONCEPT __integer_like_with_usable_difference_type =
   __signed_integer_like<_Tp> || (__integer_like<_Tp> && weakly_incrementable<_Tp>);
 
 template <class _Tp>
-using __repeat_view_iterator_difference_t _CCCL_NODEBUG_ALIAS = _If<__signed_integer_like<_Tp>, _Tp, _IotaDiffT<_Tp>>;
+using __repeat_view_iterator_difference_t _CCCL_NODEBUG_ALIAS =
+  conditional_t<__signed_integer_like<_Tp>, _Tp, _IotaDiffT<_Tp>>;
 
 #if _CCCL_HAS_CONCEPTS()
 template <move_constructible _Tp, semiregular _Bound = unreachable_sentinel_t>

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -463,7 +463,8 @@ template <class _Ip, class _Sp, subrange_kind _Kp>
 inline constexpr bool enable_borrowed_range<subrange<_Ip, _Sp, _Kp>> = true;
 
 template <class _Rp>
-using borrowed_subrange_t = enable_if_t<range<_Rp>, _If<borrowed_range<_Rp>, subrange<iterator_t<_Rp>>, dangling>>;
+using borrowed_subrange_t =
+  enable_if_t<range<_Rp>, conditional_t<borrowed_range<_Rp>, subrange<iterator_t<_Rp>>, dangling>>;
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -146,9 +146,9 @@ public:
 
   template <class... _Up>
   using __variadic_constraints =
-    _If<!__expands_to_this_tuple<_Up...>::value && sizeof...(_Up) == sizeof...(_Tp),
-        typename __tuple_constraints<_Tp...>::template __variadic_constraints<_Up...>,
-        __invalid_tuple_constraints>;
+    conditional_t<!__expands_to_this_tuple<_Up...>::value && sizeof...(_Up) == sizeof...(_Tp),
+                  typename __tuple_constraints<_Tp...>::template __variadic_constraints<_Up...>,
+                  __invalid_tuple_constraints>;
 
   template <class... _Up,
             class _Constraints                                       = __variadic_constraints<_Up...>,
@@ -166,9 +166,9 @@ public:
 
   template <class... _Up>
   using __variadic_constraints_less_rank =
-    _If<!__expands_to_this_tuple<_Up...>::value,
-        typename __tuple_constraints<_Tp...>::template __variadic_constraints_less_rank<_Up...>,
-        __invalid_tuple_constraints>;
+    conditional_t<!__expands_to_this_tuple<_Up...>::value,
+                  typename __tuple_constraints<_Tp...>::template __variadic_constraints_less_rank<_Up...>,
+                  __invalid_tuple_constraints>;
 
   template <class... _Up,
             class _Constraints                                       = __variadic_constraints_less_rank<_Up...>,
@@ -198,9 +198,9 @@ public:
 
   template <class _Tuple>
   using __tuple_like_constraints =
-    _If<__tuple_like_with_size<_Tuple, sizeof...(_Tp)>,
-        typename __tuple_constraints<_Tp...>::template __tuple_like_constraints<_Tuple>,
-        __invalid_tuple_constraints>;
+    conditional_t<__tuple_like_with_size<_Tuple, sizeof...(_Tp)>,
+                  typename __tuple_constraints<_Tp...>::template __tuple_like_constraints<_Tuple>,
+                  __invalid_tuple_constraints>;
 
   // Horrible hack to make tuple_of_iterator_references work
   template <class _TupleOfIteratorReferences,
@@ -291,9 +291,9 @@ public:
 
   template <class... _Up>
   using __comparison_constraints =
-    _If<(sizeof...(_Tp) == sizeof...(_Up)),
-        typename __tuple_constraints<_Tp...>::template __comparison<_Up...>,
-        __invalid_tuple_constraints>;
+    conditional_t<(sizeof...(_Tp) == sizeof...(_Up)),
+                  typename __tuple_constraints<_Tp...>::template __comparison<_Up...>,
+                  __invalid_tuple_constraints>;
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class... _Up, size_t... _Indices, class _Constraints = __comparison_constraints<_Up...>>

--- a/libcudacxx/include/cuda/std/__type_traits/conditional.h
+++ b/libcudacxx/include/cuda/std/__type_traits/conditional.h
@@ -24,39 +24,32 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
-template <bool>
-struct _IfImpl;
-
-template <>
-struct _IfImpl<true>
-{
-  template <class _IfRes, class _ElseRes>
-  using _Select _CCCL_NODEBUG_ALIAS = _IfRes;
-};
-
-template <>
-struct _IfImpl<false>
-{
-  template <class _IfRes, class _ElseRes>
-  using _Select _CCCL_NODEBUG_ALIAS = _ElseRes;
-};
-
-template <bool _Cond, class _IfRes, class _ElseRes>
-using _If _CCCL_NODEBUG_ALIAS = typename _IfImpl<_Cond>::template _Select<_IfRes, _ElseRes>;
-
-template <bool _Bp, class _If, class _Then>
+template <bool _Bp, class _Tp, class _Fp>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional
 {
-  using type = _If;
+  using type = _Tp;
 };
-template <class _If, class _Then>
-struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional<false, _If, _Then>
+template <class _Tp, class _Fp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT conditional<false, _Tp, _Fp>
 {
-  using type = _Then;
+  using type = _Fp;
 };
 
-template <bool _Bp, class _If, class _Then>
-using conditional_t _CCCL_NODEBUG_ALIAS = typename conditional<_Bp, _If, _Then>::type;
+template <bool>
+struct __conditional_t_impl
+{
+  template <class _Tp, class _Fp>
+  using _Select _CCCL_NODEBUG_ALIAS = _Tp;
+};
+template <>
+struct __conditional_t_impl<false>
+{
+  template <class _Tp, class _Fp>
+  using _Select _CCCL_NODEBUG_ALIAS = _Fp;
+};
+
+template <bool _Bp, class _Tp, class _Fp>
+using conditional_t _CCCL_NODEBUG_ALIAS = typename __conditional_t_impl<_Bp>::template _Select<_Tp, _Fp>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__type_traits/conjunction.h
+++ b/libcudacxx/include/cuda/std/__type_traits/conjunction.h
@@ -54,7 +54,7 @@ struct conjunction<_Arg> : _Arg
 {};
 
 template <class _Arg, class... _Args>
-struct conjunction<_Arg, _Args...> : _If<!bool(_Arg::value), _Arg, conjunction<_Args...>>
+struct conjunction<_Arg, _Args...> : conditional_t<!bool(_Arg::value), _Arg, conjunction<_Args...>>
 {};
 
 template <class... _Args>

--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -444,7 +444,8 @@ template <class _TryFn, class _CatchFn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_try_catch
 {
   template <class... _Ts>
-  using __call _CCCL_NODEBUG_ALIAS = __type_call<_If<__type_callable<_TryFn, _Ts...>::value, _TryFn, _CatchFn>, _Ts...>;
+  using __call _CCCL_NODEBUG_ALIAS =
+    __type_call<conditional_t<__type_callable<_TryFn, _Ts...>::value, _TryFn, _CatchFn>, _Ts...>;
 };
 
 // Implementation for indexing into a list of types:
@@ -967,7 +968,7 @@ template <class _Ty>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_remove_fn
 {
   template <class _Uy>
-  using __call _CCCL_NODEBUG_ALIAS = _If<is_same_v<_Ty, _Uy>, __type_list<>, __type_list<_Uy>>;
+  using __call _CCCL_NODEBUG_ALIAS = conditional_t<is_same_v<_Ty, _Uy>, __type_list<>, __type_list<_Uy>>;
 };
 } // namespace __detail
 
@@ -981,7 +982,7 @@ template <class _Fn>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT __type_remove_if_fn
 {
   template <class _Uy>
-  using __call _CCCL_NODEBUG_ALIAS = _If<__type_call1<_Fn, _Uy>::value, __type_list<>, __type_list<_Uy>>;
+  using __call _CCCL_NODEBUG_ALIAS = conditional_t<__type_call1<_Fn, _Uy>::value, __type_list<>, __type_list<_Uy>>;
 };
 } // namespace __detail
 

--- a/libcudacxx/include/cuda/std/__type_traits/type_set.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_set.h
@@ -66,7 +66,8 @@ struct __tupl<_Ty, _Ts...>
     , __tupl<_Ts...>
 {
   template <class _Uy>
-  using __maybe_insert _CCCL_NODEBUG_ALIAS = _If<__type_set_contains_v<__tupl, _Uy>, __tupl, __tupl<_Uy, _Ty, _Ts...>>;
+  using __maybe_insert _CCCL_NODEBUG_ALIAS =
+    conditional_t<__type_set_contains_v<__tupl, _Uy>, __tupl, __tupl<_Uy, _Ty, _Ts...>>;
 
   _CCCL_API static constexpr size_t __size() noexcept
   {

--- a/libcudacxx/include/cuda/std/inplace_vector
+++ b/libcudacxx/include/cuda/std/inplace_vector
@@ -75,11 +75,11 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <size_t _Capacity>
 using __inplace_vector_size_type =
-  _If<_Capacity <= numeric_limits<uint8_t>::max(),
-      uint8_t,
-      _If<_Capacity <= numeric_limits<uint16_t>::max(),
-          uint16_t,
-          _If<_Capacity <= numeric_limits<uint32_t>::max(), uint32_t, uint64_t>>>;
+  conditional_t<_Capacity <= numeric_limits<uint8_t>::max(),
+                uint8_t,
+                conditional_t<_Capacity <= numeric_limits<uint16_t>::max(),
+                              uint16_t,
+                              conditional_t<_Capacity <= numeric_limits<uint32_t>::max(), uint32_t, uint64_t>>>;
 
 enum class __inplace_vector_specialization
 {

--- a/thrust/thrust/detail/allocator/allocator_traits.h
+++ b/thrust/thrust/detail/allocator/allocator_traits.h
@@ -348,9 +348,10 @@ _CCCL_HOST_DEVICE typename allocator_traits<Alloc>::size_type max_size([[maybe_u
 
 // TODO(bgruber): can be return decltype(auto) here?
 template <typename Alloc>
-_CCCL_HOST_DEVICE ::cuda::std::
-  _If<has_member_system<Alloc>::value, typename allocator_system<Alloc>::type&, typename allocator_system<Alloc>::type>
-  system(Alloc& a)
+_CCCL_HOST_DEVICE ::cuda::std::conditional_t<has_member_system<Alloc>::value,
+                                             typename allocator_system<Alloc>::type&,
+                                             typename allocator_system<Alloc>::type>
+system(Alloc& a)
 {
   if constexpr (has_member_system<Alloc>::value)
   {

--- a/thrust/thrust/iterator/counting_iterator.h
+++ b/thrust/thrust/iterator/counting_iterator.h
@@ -61,8 +61,8 @@ class counting_iterator;
 namespace detail
 {
 template <typename Number>
-using counting_iterator_difference_type =
-  ::cuda::std::_If<::cuda::std::is_integral_v<Number> && sizeof(Number) < sizeof(int), int, ::cuda::std::ptrdiff_t>;
+using counting_iterator_difference_type = ::cuda::std::
+  conditional_t<::cuda::std::is_integral_v<Number> && sizeof(Number) < sizeof(int), int, ::cuda::std::ptrdiff_t>;
 
 template <typename Incrementable, typename System, typename Traversal, typename Difference, typename StrideHolder>
 struct make_counting_iterator_base

--- a/thrust/thrust/iterator/detail/iterator_adaptor_base.h
+++ b/thrust/thrust/iterator/detail/iterator_adaptor_base.h
@@ -53,7 +53,7 @@ namespace detail
 // If T is use_default, return the result of invoking DefaultNullaryFn, otherwise return T.
 template <class T, class DefaultNullaryFn>
 using replace_if_use_default = typename ::cuda::std::
-  _If<::cuda::std::is_same_v<T, use_default>, DefaultNullaryFn, ::cuda::std::type_identity<T>>::type;
+  conditional_t<::cuda::std::is_same_v<T, use_default>, DefaultNullaryFn, ::cuda::std::type_identity<T>>::type;
 
 // A metafunction which computes an iterator_adaptor's base class, a specialization of iterator_facade.
 template <typename Derived,
@@ -71,9 +71,9 @@ private:
   using traversal = replace_if_use_default<Traversal, iterator_traversal<Base>>;
   using reference =
     replace_if_use_default<Reference,
-                           ::cuda::std::_If<::cuda::std::is_same_v<Value, use_default>,
-                                            lazy_trait<it_reference_t, Base>,
-                                            ::cuda::std::add_lvalue_reference<Value>>>;
+                           ::cuda::std::conditional_t<::cuda::std::is_same_v<Value, use_default>,
+                                                      lazy_trait<it_reference_t, Base>,
+                                                      ::cuda::std::add_lvalue_reference<Value>>>;
   using difference = replace_if_use_default<Difference, lazy_trait<it_difference_t, Base>>;
 
 public:

--- a/thrust/thrust/iterator/detail/iterator_category_to_traversal.h
+++ b/thrust/thrust/iterator/detail/iterator_category_to_traversal.h
@@ -53,9 +53,10 @@ _CCCL_HOST_DEVICE auto cat_to_traversal_impl(const output_device_iterator_tag&) 
 template <typename CategoryOrTraversal>
 struct iterator_category_to_traversal
 {
-  using type = ::cuda::std::_If<::cuda::std::is_convertible_v<CategoryOrTraversal, incrementable_traversal_tag>,
-                                CategoryOrTraversal,
-                                decltype(cat_to_traversal_impl(CategoryOrTraversal{}))>;
+  using type =
+    ::cuda::std::conditional_t<::cuda::std::is_convertible_v<CategoryOrTraversal, incrementable_traversal_tag>,
+                               CategoryOrTraversal,
+                               decltype(cat_to_traversal_impl(CategoryOrTraversal{}))>;
 };
 
 template <typename CategoryOrTraversal>

--- a/thrust/thrust/iterator/iterator_facade.h
+++ b/thrust/thrust/iterator/iterator_facade.h
@@ -51,9 +51,9 @@ namespace detail
 // it's legal to access IteratorFacade2::difference_type
 template <typename IteratorFacade1, typename IteratorFacade2>
 using distance_from_result =
-  ::cuda::std::_If<::cuda::std::is_convertible_v<IteratorFacade2, IteratorFacade1>,
-                   typename IteratorFacade1::difference_type,
-                   typename IteratorFacade2::difference_type>;
+  ::cuda::std::conditional_t<::cuda::std::is_convertible_v<IteratorFacade2, IteratorFacade1>,
+                             typename IteratorFacade1::difference_type,
+                             typename IteratorFacade2::difference_type>;
 } // namespace detail
 
 /*! \addtogroup iterators

--- a/thrust/thrust/iterator/shuffle_iterator.h
+++ b/thrust/thrust/iterator/shuffle_iterator.h
@@ -54,7 +54,7 @@ struct make_shuffle_iterator_base
 
   using system     = any_system_tag;
   using traversal  = random_access_traversal_tag;
-  using difference = ::cuda::std::_If<sizeof(IndexType) < sizeof(int), int, ::cuda::std::ptrdiff_t>;
+  using difference = ::cuda::std::conditional_t<sizeof(IndexType) < sizeof(int), int, ::cuda::std::ptrdiff_t>;
 
   using type =
     iterator_adaptor<shuffle_iterator<IndexType, BijectionFunc>,

--- a/thrust/thrust/system/cuda/detail/reduce_by_key.h
+++ b/thrust/thrust/system/cuda/detail/reduce_by_key.h
@@ -957,9 +957,9 @@ template <class Derived, class KeyInputIt, class ValInputIt, class KeyOutputIt, 
   ValOutputIt values_output,
   BinaryPred binary_pred)
 {
-  using value_type = ::cuda::std::_If<thrust::detail::is_output_iterator<ValOutputIt>,
-                                      thrust::detail::it_value_t<ValInputIt>,
-                                      thrust::detail::it_value_t<ValOutputIt>>;
+  using value_type = ::cuda::std::conditional_t<thrust::detail::is_output_iterator<ValOutputIt>,
+                                                thrust::detail::it_value_t<ValInputIt>,
+                                                thrust::detail::it_value_t<ValOutputIt>>;
   return cuda_cub::reduce_by_key(
     policy,
     keys_first,

--- a/thrust/thrust/system/detail/generic/reduce_by_key.inl
+++ b/thrust/thrust/system/detail/generic/reduce_by_key.inl
@@ -171,9 +171,9 @@ _CCCL_HOST_DEVICE ::cuda::std::pair<OutputIterator1, OutputIterator2> reduce_by_
   OutputIterator2 values_output,
   BinaryPredicate binary_pred)
 {
-  using T = ::cuda::std::_If<thrust::detail::is_output_iterator<OutputIterator2>,
-                             thrust::detail::it_value_t<InputIterator2>,
-                             thrust::detail::it_value_t<OutputIterator2>>;
+  using T = ::cuda::std::conditional_t<thrust::detail::is_output_iterator<OutputIterator2>,
+                                       thrust::detail::it_value_t<InputIterator2>,
+                                       thrust::detail::it_value_t<OutputIterator2>>;
 
   // use plus<T> as default BinaryFunction
   return thrust::reduce_by_key(


### PR DESCRIPTION
For `_If` we use an implementation that instantiates less types. This PR uses the implementation for `cuda::std::conditional_t`, too, and removes the `_If` completely.