### PR TITLE
Fix arch related `cuda::device::` APIs for nvhpc in CUDA mode

### DIFF
--- a/libcudacxx/include/cuda/__device/arch_id.h
+++ b/libcudacxx/include/cuda/__device/arch_id.h
@@ -141,7 +141,7 @@ _CCCL_DEVICE_API ::cuda::arch_id __unknown_cuda_architecture();
 //!
 //! @note This API cannot be used in constexpr context when compiling with nvc++ in CUDA mode.
 template <class _Dummy = void>
-[[nodiscard]] _CCCL_DEVICE_API _CCCL_TARGET_CONSTEXPR ::cuda::arch_id current_arch_id() noexcept
+[[nodiscard]] _CCCL_DEVICE_API inline _CCCL_TARGET_CONSTEXPR ::cuda::arch_id current_arch_id() noexcept
 {
 #  if _CCCL_CUDA_COMPILER(NVHPC)
   const auto __cc = ::cuda::device::current_compute_capability();

--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -533,7 +533,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 //!
 //! @note This API cannot be used in constexpr context when compiling with nvc++ in CUDA mode.
 template <class _Dummy = void>
-[[nodiscard]] _CCCL_DEVICE_API _CCCL_TARGET_CONSTEXPR ::cuda::arch_traits_t current_arch_traits() noexcept
+[[nodiscard]] _CCCL_DEVICE_API inline _CCCL_TARGET_CONSTEXPR ::cuda::arch_traits_t current_arch_traits() noexcept
 {
 #    if _CCCL_DEVICE_COMPILATION()
   return ::cuda::arch_traits_for(::cuda::device::current_arch_id<_Dummy>());

--- a/libcudacxx/include/cuda/__device/compute_capability.h
+++ b/libcudacxx/include/cuda/__device/compute_capability.h
@@ -151,7 +151,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 //! @brief Returns the \c cuda::compute_capability that is currently being compiled.
 //!
 //! @note This API cannot be used in constexpr context when compiling with nvc++ in CUDA mode.
-[[nodiscard]] _CCCL_DEVICE_API _CCCL_TARGET_CONSTEXPR ::cuda::compute_capability current_compute_capability() noexcept
+[[nodiscard]] _CCCL_DEVICE_API inline _CCCL_TARGET_CONSTEXPR ::cuda::compute_capability
+current_compute_capability() noexcept
 {
 #  if _CCCL_CUDA_COMPILER(NVHPC)
   return ::cuda::compute_capability{__builtin_current_device_sm()};


### PR DESCRIPTION
We miss `inline` if `_CCCL_TARGET_CONSTEXPR` doesn't expand to `constexpr`.
