### PR TITLE
Run scan benchmark for 2^32 elements

### DIFF
--- a/cub/benchmarks/bench/scan/exclusive/base.cuh
+++ b/cub/benchmarks/bench/scan/exclusive/base.cuh
@@ -64,6 +64,7 @@ struct policy_hub_t
 
 template <typename T, typename OffsetT>
 static void basic(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+try
 {
   using init_t         = T;
   using wrapped_init_t = cub::detail::InputValue<init_t>;
@@ -82,6 +83,11 @@ static void basic(nvbench::state& state, nvbench::type_list<T, OffsetT>)
 #endif
 
   const auto elements = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  if (sizeof(offset_t) == 4 && elements > std::numeric_limits<offset_t>::max())
+  {
+    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
+    return;
+  }
 
   thrust::device_vector<T> input = generate(elements);
   thrust::device_vector<T> output(elements);
@@ -98,8 +104,6 @@ static void basic(nvbench::state& state, nvbench::type_list<T, OffsetT>)
     nullptr, tmp_size, d_input, d_output, op_t{}, wrapped_init_t{T{}}, static_cast<int>(input.size()), 0 /* stream */);
 
   thrust::device_vector<nvbench::uint8_t> tmp(tmp_size);
-  nvbench::uint8_t* d_tmp = thrust::raw_pointer_cast(tmp.data());
-
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
     dispatch_t::Dispatch(
       thrust::raw_pointer_cast(tmp.data()),
@@ -108,12 +112,16 @@ static void basic(nvbench::state& state, nvbench::type_list<T, OffsetT>)
       d_output,
       op_t{},
       wrapped_init_t{T{}},
-      static_cast<int>(input.size()),
+      static_cast<offset_t>(input.size()),
       launch.get_stream());
   });
+}
+catch (const std::bad_alloc&)
+{
+  state.skip("Skipping: out of memory.");
 }
 
 NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(all_types, offset_types))
   .set_name("base")
   .set_type_axes_names({"T{ct}", "OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4));


### PR DESCRIPTION
On RTX 5090. Allocation failures are handled gracefully (although compute-sanitizer would report them):
```
Run:  [1/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.021472ms GPU, 0.023785ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [2/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.014912ms GPU, 0.018295ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [3/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.039680ms GPU, 0.042780ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [4/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 0.437984ms GPU, 0.441203ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [5/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [6/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.018496ms GPU, 0.029967ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [7/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.017312ms GPU, 0.020679ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [8/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.041152ms GPU, 0.044675ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [9/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 0.445088ms GPU, 0.449009ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [10/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [11/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.020320ms GPU, 0.023735ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [12/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.016704ms GPU, 0.020158ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [13/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.055584ms GPU, 0.059002ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [14/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 0.717792ms GPU, 0.721293ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [15/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [16/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.017408ms GPU, 0.020739ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [17/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.016544ms GPU, 0.020278ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [18/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.052800ms GPU, 0.056476ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [19/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 0.713472ms GPU, 0.716924ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [20/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [21/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.018272ms GPU, 0.021871ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [22/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.019424ms GPU, 0.023033ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [23/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.096960ms GPU, 0.100670ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [24/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 1.419936ms GPU, 1.434409ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [25/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [26/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.018464ms GPU, 0.021841ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [27/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.018560ms GPU, 0.021992ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [28/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.094368ms GPU, 0.098076ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [29/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 1.420256ms GPU, 1.424330ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [30/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [31/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.020800ms GPU, 0.023855ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [32/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.029120ms GPU, 0.032983ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [33/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.191008ms GPU, 0.194206ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [34/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 2.830080ms GPU, 2.833642ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [35/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [36/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.018016ms GPU, 0.021631ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [37/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.022400ms GPU, 0.025779ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [38/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.187488ms GPU, 0.191262ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [39/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 2.831488ms GPU, 2.835245ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [40/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [41/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.023584ms GPU, 0.026780ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [42/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.033024ms GPU, 0.036369ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [43/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.373856ms GPU, 0.377403ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [44/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 5.644448ms GPU, 5.648278ms CPU, 0.01s total GPU, 0.01s total wall, 1x 
Run:  [45/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [46/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.042976ms GPU, 0.045937ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [47/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.039808ms GPU, 0.042901ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [48/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.363168ms GPU, 0.366863ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [49/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 5.645760ms GPU, 5.648689ms CPU, 0.01s total GPU, 0.01s total wall, 1x 
Run:  [50/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [51/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.020544ms GPU, 0.023464ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [52/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.019072ms GPU, 0.022502ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [53/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.096352ms GPU, 0.099939ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [54/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 1.422496ms GPU, 1.431805ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [55/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [56/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.026880ms GPU, 0.035717ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [57/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.021824ms GPU, 0.025107ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [58/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.101024ms GPU, 0.104167ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [59/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 1.423008ms GPU, 1.426084ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [60/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [61/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.025984ms GPU, 0.029205ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [62/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.028128ms GPU, 0.031720ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [63/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.186048ms GPU, 0.189598ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [64/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 2.823040ms GPU, 2.826418ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [65/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [66/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.023712ms GPU, 0.027542ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [67/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.027904ms GPU, 0.031359ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [68/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.188224ms GPU, 0.192093ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [69/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 2.828640ms GPU, 2.831348ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [70/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [71/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.027808ms GPU, 0.030618ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [72/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.028320ms GPU, 0.031920ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [73/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.216000ms GPU, 0.219104ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [74/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 3.005856ms GPU, 3.009123ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [75/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [76/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.018272ms GPU, 0.021551ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [77/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.026304ms GPU, 0.030598ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [78/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.206848ms GPU, 0.210217ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [79/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 2.990272ms GPU, 2.993735ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [80/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
```

```
### [0] NVIDIA GeForce RTX 5090

| T{ct} | OffsetT{ct} |   Elements{io}   |    Size     | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil |
|-------|-------------|------------------|-------------|---------|------------|-------|------------|-------|----------|--------------|--------|
|    I8 |         I32 |     2^16 = 65536 |  64.000 KiB |      1x |  23.785 us |  inf% |  21.472 us |  inf% |   3.052G |   6.104 GB/s |  0.34% |
|    I8 |         I32 |   2^20 = 1048576 |   1.000 MiB |      1x |  18.295 us |  inf% |  14.912 us |  inf% |  70.318G | 140.635 GB/s |  7.85% |
|    I8 |         I32 |  2^24 = 16777216 |  16.000 MiB |      1x |  42.780 us |  inf% |  39.680 us |  inf% | 422.813G | 845.626 GB/s | 47.19% |
|    I8 |         I32 | 2^28 = 268435456 | 256.000 MiB |      1x | 441.203 us |  inf% | 437.984 us |  inf% | 612.889G |   1.226 TB/s | 68.40% |
|    I8 |         I64 |     2^16 = 65536 |  64.000 KiB |      1x |  29.967 us |  inf% |  18.496 us |  inf% |   3.543G |   7.087 GB/s |  0.40% |
|    I8 |         I64 |   2^20 = 1048576 |   1.000 MiB |      1x |  20.679 us |  inf% |  17.312 us |  inf% |  60.569G | 121.139 GB/s |  6.76% |
|    I8 |         I64 |  2^24 = 16777216 |  16.000 MiB |      1x |  44.675 us |  inf% |  41.152 us |  inf% | 407.689G | 815.378 GB/s | 45.50% |
|    I8 |         I64 | 2^28 = 268435456 | 256.000 MiB |      1x | 449.009 us |  inf% | 445.088 us |  inf% | 603.106G |   1.206 TB/s | 67.31% |
|   I16 |         I32 |     2^16 = 65536 | 128.000 KiB |      1x |  23.735 us |  inf% |  20.320 us |  inf% |   3.225G |  12.901 GB/s |  0.72% |
|   I16 |         I32 |   2^20 = 1048576 |   2.000 MiB |      1x |  20.158 us |  inf% |  16.704 us |  inf% |  62.774G | 251.096 GB/s | 14.01% |
|   I16 |         I32 |  2^24 = 16777216 |  32.000 MiB |      1x |  59.002 us |  inf% |  55.584 us |  inf% | 301.835G |   1.207 TB/s | 67.37% |
|   I16 |         I32 | 2^28 = 268435456 | 512.000 MiB |      1x | 721.293 us |  inf% | 717.792 us |  inf% | 373.974G |   1.496 TB/s | 83.47% |
|   I16 |         I64 |     2^16 = 65536 | 128.000 KiB |      1x |  20.739 us |  inf% |  17.408 us |  inf% |   3.765G |  15.059 GB/s |  0.84% |
|   I16 |         I64 |   2^20 = 1048576 |   2.000 MiB |      1x |  20.278 us |  inf% |  16.544 us |  inf% |  63.381G | 253.524 GB/s | 14.15% |
|   I16 |         I64 |  2^24 = 16777216 |  32.000 MiB |      1x |  56.476 us |  inf% |  52.800 us |  inf% | 317.750G |   1.271 TB/s | 70.92% |
|   I16 |         I64 | 2^28 = 268435456 | 512.000 MiB |      1x | 716.924 us |  inf% | 713.472 us |  inf% | 376.238G |   1.505 TB/s | 83.98% |
|   I32 |         I32 |     2^16 = 65536 | 256.000 KiB |      1x |  21.871 us |  inf% |  18.272 us |  inf% |   3.587G |  28.694 GB/s |  1.60% |
|   I32 |         I32 |   2^20 = 1048576 |   4.000 MiB |      1x |  23.033 us |  inf% |  19.424 us |  inf% |  53.984G | 431.868 GB/s | 24.10% |
|   I32 |         I32 |  2^24 = 16777216 |  64.000 MiB |      1x | 100.670 us |  inf% |  96.960 us |  inf% | 173.032G |   1.384 TB/s | 77.24% |
|   I32 |         I32 | 2^28 = 268435456 |   1.000 GiB |      1x |   1.434 ms |  inf% |   1.420 ms |  inf% | 189.048G |   1.512 TB/s | 84.39% |
|   I32 |         I64 |     2^16 = 65536 | 256.000 KiB |      1x |  21.841 us |  inf% |  18.464 us |  inf% |   3.549G |  28.395 GB/s |  1.58% |
|   I32 |         I64 |   2^20 = 1048576 |   4.000 MiB |      1x |  21.992 us |  inf% |  18.560 us |  inf% |  56.497G | 451.972 GB/s | 25.22% |
|   I32 |         I64 |  2^24 = 16777216 |  64.000 MiB |      1x |  98.076 us |  inf% |  94.368 us |  inf% | 177.785G |   1.422 TB/s | 79.36% |
|   I32 |         I64 | 2^28 = 268435456 |   1.000 GiB |      1x |   1.424 ms |  inf% |   1.420 ms |  inf% | 189.005G |   1.512 TB/s | 84.37% |
|   I64 |         I32 |     2^16 = 65536 | 512.000 KiB |      1x |  23.855 us |  inf% |  20.800 us |  inf% |   3.151G |  50.412 GB/s |  2.81% |
|   I64 |         I32 |   2^20 = 1048576 |   8.000 MiB |      1x |  32.983 us |  inf% |  29.120 us |  inf% |  36.009G | 576.141 GB/s | 32.15% |
|   I64 |         I32 |  2^24 = 16777216 | 128.000 MiB |      1x | 194.206 us |  inf% | 191.008 us |  inf% |  87.835G |   1.405 TB/s | 78.42% |
|   I64 |         I32 | 2^28 = 268435456 |   2.000 GiB |      1x |   2.834 ms |  inf% |   2.830 ms |  inf% |  94.851G |   1.518 TB/s | 84.68% |
|   I64 |         I64 |     2^16 = 65536 | 512.000 KiB |      1x |  21.631 us |  inf% |  18.016 us |  inf% |   3.638G |  58.202 GB/s |  3.25% |
|   I64 |         I64 |   2^20 = 1048576 |   8.000 MiB |      1x |  25.779 us |  inf% |  22.400 us |  inf% |  46.811G | 748.983 GB/s | 41.79% |
|   I64 |         I64 |  2^24 = 16777216 | 128.000 MiB |      1x | 191.262 us |  inf% | 187.488 us |  inf% |  89.484G |   1.432 TB/s | 79.89% |
|   I64 |         I64 | 2^28 = 268435456 |   2.000 GiB |      1x |   2.835 ms |  inf% |   2.831 ms |  inf% |  94.804G |   1.517 TB/s | 84.64% |
|  I128 |         I32 |     2^16 = 65536 |   1.000 MiB |      1x |  26.780 us |  inf% |  23.584 us |  inf% |   2.779G |  88.923 GB/s |  4.96% |
|  I128 |         I32 |   2^20 = 1048576 |  16.000 MiB |      1x |  36.369 us |  inf% |  33.024 us |  inf% |  31.752G |   1.016 TB/s | 56.70% |
|  I128 |         I32 |  2^24 = 16777216 | 256.000 MiB |      1x | 377.403 us |  inf% | 373.856 us |  inf% |  44.876G |   1.436 TB/s | 80.13% |
|  I128 |         I32 | 2^28 = 268435456 |   4.000 GiB |      1x |   5.648 ms |  inf% |   5.644 ms |  inf% |  47.557G |   1.522 TB/s | 84.92% |
|  I128 |         I64 |     2^16 = 65536 |   1.000 MiB |      1x |  45.937 us |  inf% |  42.976 us |  inf% |   1.525G |  48.798 GB/s |  2.72% |
|  I128 |         I64 |   2^20 = 1048576 |  16.000 MiB |      1x |  42.901 us |  inf% |  39.808 us |  inf% |  26.341G | 842.907 GB/s | 47.03% |
|  I128 |         I64 |  2^24 = 16777216 | 256.000 MiB |      1x | 366.863 us |  inf% | 363.168 us |  inf% |  46.197G |   1.478 TB/s | 82.49% |
|  I128 |         I64 | 2^28 = 268435456 |   4.000 GiB |      1x |   5.649 ms |  inf% |   5.646 ms |  inf% |  47.546G |   1.521 TB/s | 84.90% |
|   F32 |         I32 |     2^16 = 65536 | 256.000 KiB |      1x |  23.464 us |  inf% |  20.544 us |  inf% |   3.190G |  25.520 GB/s |  1.42% |
|   F32 |         I32 |   2^20 = 1048576 |   4.000 MiB |      1x |  22.502 us |  inf% |  19.072 us |  inf% |  54.980G | 439.839 GB/s | 24.54% |
|   F32 |         I32 |  2^24 = 16777216 |  64.000 MiB |      1x |  99.939 us |  inf% |  96.352 us |  inf% | 174.124G |   1.393 TB/s | 77.73% |
|   F32 |         I32 | 2^28 = 268435456 |   1.000 GiB |      1x |   1.432 ms |  inf% |   1.422 ms |  inf% | 188.707G |   1.510 TB/s | 84.24% |
|   F32 |         I64 |     2^16 = 65536 | 256.000 KiB |      1x |  35.717 us |  inf% |  26.880 us |  inf% |   2.438G |  19.505 GB/s |  1.09% |
|   F32 |         I64 |   2^20 = 1048576 |   4.000 MiB |      1x |  25.107 us |  inf% |  21.824 us |  inf% |  48.047G | 384.375 GB/s | 21.45% |
|   F32 |         I64 |  2^24 = 16777216 |  64.000 MiB |      1x | 104.167 us |  inf% | 101.024 us |  inf% | 166.072G |   1.329 TB/s | 74.13% |
|   F32 |         I64 | 2^28 = 268435456 |   1.000 GiB |      1x |   1.426 ms |  inf% |   1.423 ms |  inf% | 188.639G |   1.509 TB/s | 84.21% |
|   F64 |         I32 |     2^16 = 65536 | 512.000 KiB |      1x |  29.205 us |  inf% |  25.984 us |  inf% |   2.522G |  40.355 GB/s |  2.25% |
|   F64 |         I32 |   2^20 = 1048576 |   8.000 MiB |      1x |  31.720 us |  inf% |  28.128 us |  inf% |  37.279G | 596.460 GB/s | 33.28% |
|   F64 |         I32 |  2^24 = 16777216 | 128.000 MiB |      1x | 189.598 us |  inf% | 186.048 us |  inf% |  90.177G |   1.443 TB/s | 80.51% |
|   F64 |         I32 | 2^28 = 268435456 |   2.000 GiB |      1x |   2.826 ms |  inf% |   2.823 ms |  inf% |  95.087G |   1.521 TB/s | 84.89% |
|   F64 |         I64 |     2^16 = 65536 | 512.000 KiB |      1x |  27.542 us |  inf% |  23.712 us |  inf% |   2.764G |  44.221 GB/s |  2.47% |
|   F64 |         I64 |   2^20 = 1048576 |   8.000 MiB |      1x |  31.359 us |  inf% |  27.904 us |  inf% |  37.578G | 601.248 GB/s | 33.55% |
|   F64 |         I64 |  2^24 = 16777216 | 128.000 MiB |      1x | 192.093 us |  inf% | 188.224 us |  inf% |  89.134G |   1.426 TB/s | 79.58% |
|   F64 |         I64 | 2^28 = 268435456 |   2.000 GiB |      1x |   2.831 ms |  inf% |   2.829 ms |  inf% |  94.899G |   1.518 TB/s | 84.73% |
|   C32 |         I32 |     2^16 = 65536 | 512.000 KiB |      1x |  30.618 us |  inf% |  27.808 us |  inf% |   2.357G |  37.708 GB/s |  2.10% |
|   C32 |         I32 |   2^20 = 1048576 |   8.000 MiB |      1x |  31.920 us |  inf% |  28.320 us |  inf% |  37.026G | 592.416 GB/s | 33.06% |
|   C32 |         I32 |  2^24 = 16777216 | 128.000 MiB |      1x | 219.104 us |  inf% | 216.000 us |  inf% |  77.672G |   1.243 TB/s | 69.35% |
|   C32 |         I32 | 2^28 = 268435456 |   2.000 GiB |      1x |   3.009 ms |  inf% |   3.006 ms |  inf% |  89.304G |   1.429 TB/s | 79.73% |
|   C32 |         I64 |     2^16 = 65536 | 512.000 KiB |      1x |  21.551 us |  inf% |  18.272 us |  inf% |   3.587G |  57.387 GB/s |  3.20% |
|   C32 |         I64 |   2^20 = 1048576 |   8.000 MiB |      1x |  30.598 us |  inf% |  26.304 us |  inf% |  39.864G | 637.820 GB/s | 35.59% |
|   C32 |         I64 |  2^24 = 16777216 | 128.000 MiB |      1x | 210.217 us |  inf% | 206.848 us |  inf% |  81.109G |   1.298 TB/s | 72.41% |
|   C32 |         I64 | 2^28 = 268435456 |   2.000 GiB |      1x |   2.994 ms |  inf% |   2.990 ms |  inf% |  89.770G |   1.436 TB/s | 80.15% |
```