### PR TITLE
Remove upper bound on numba-cuda

### DIFF
--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
   "numpy",
   "cuda-pathfinder>=1.2.3",
   "cuda-core",
-  "numba-cuda>=0.20.0,<0.21.2",
+  "numba-cuda>=0.20.0,!=0.21.2",
   "typing_extensions",
 ]
 
@@ -42,12 +42,12 @@ readme = { file = "README.md", content-type = "text/markdown" }
 cu12 = [
   "cuda-bindings>=12.9.1,<13.0.0",
   "cuda-toolkit[nvrtc,nvjitlink,cudart,nvcc]==12.*",
-  "numba-cuda[cu12]>=0.20.0,<0.21.2",
+  "numba-cuda[cu12]>=0.20.0,!=0.21.2",
 ]
 cu13 = [
   "cuda-bindings>=13.0.0,<14.0.0",
   "cuda-toolkit[nvrtc,nvjitlink,cudart,nvcc]==13.*",
-  "numba-cuda[cu13]>=0.20.0,<0.21.2",
+  "numba-cuda[cu13]>=0.20.0,!=0.21.2",
 ]
 test-cu12 = [
   # an undocumented way to inherit the dependencies of the cu12 extra.


### PR DESCRIPTION
## Description

In https://github.com/NVIDIA/cccl/pull/6815, we constrained the numba-cuda version to unblock CI. The issue has since been fixed in upstream numba-cuda.

This PR unconstrains the numba-cuda version, while excluding the offending version (0.21.2).  

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
