### PR TITLE
Avoid use of cccl namespace macros in cub

### DIFF
--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -39,11 +39,9 @@ struct __return_constant
 } // namespace detail
 CUB_NAMESPACE_END
 
-_CCCL_BEGIN_NAMESPACE_CUDA
 template <typename T>
-struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
+struct ::cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::__return_constant<T>> : ::cuda::std::true_type
 {};
-_CCCL_END_NAMESPACE_CUDA
 
 CUB_NAMESPACE_BEGIN
 //! DeviceTransform provides device-wide, parallel operations for transforming elements tuple-wise from multiple input

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -48,11 +48,10 @@ struct always_true_predicate
 } // namespace detail::transform
 CUB_NAMESPACE_END
 
-_CCCL_BEGIN_NAMESPACE_CUDA
 template <>
-struct proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate> : ::cuda::std::true_type
+struct ::cuda::proclaims_copyable_arguments<CUB_NS_QUALIFIER::detail::transform::always_true_predicate>
+    : ::cuda::std::true_type
 {};
-_CCCL_END_NAMESPACE_CUDA
 
 CUB_NAMESPACE_BEGIN
 namespace detail::transform

--- a/cub/test/catch2_test_device_reduce.cuh
+++ b/cub/test/catch2_test_device_reduce.cuh
@@ -26,10 +26,8 @@
 // Half support is provided by SM53+. We currently test against a few older architectures.
 // The specializations below can be removed once we drop these architectures.
 
-_CCCL_BEGIN_NAMESPACE_CUDA
-
 template <>
-_CCCL_API inline __half minimum<void>::operator()<__half, __half>(const __half& a, const __half& b) const
+_CCCL_API inline __half cuda::minimum<void>::operator()<__half, __half>(const __half& a, const __half& b) const
 {
 #  if defined(__CUDA_NO_HALF_OPERATORS__)
   return ::cuda::std::min(__half2float(a), __half2float(b));
@@ -40,7 +38,7 @@ _CCCL_API inline __half minimum<void>::operator()<__half, __half>(const __half& 
 }
 
 template <>
-_CCCL_API inline __half maximum<void>::operator()<__half, __half>(const __half& a, const __half& b) const
+_CCCL_API inline __half cuda::maximum<void>::operator()<__half, __half>(const __half& a, const __half& b) const
 {
 #  if defined(__CUDA_NO_HALF_OPERATORS__)
   return ::cuda::std::max(__half2float(a), __half2float(b));
@@ -49,8 +47,6 @@ _CCCL_API inline __half maximum<void>::operator()<__half, __half>(const __half& 
     NV_PROVIDES_SM_53, (return ::cuda::std::max(a, b);), (return ::cuda::std::max(__half2float(a), __half2float(b));));
 #  endif // !__CUDA_NO_HALF_OPERATORS__
 }
-
-_CCCL_END_NAMESPACE_CUDA
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -897,9 +897,8 @@ __host__ __device__ __forceinline__ void InitValue(GenMode gen_mode, TestFoo& va
   InitValue(gen_mode, value.w, index);
 }
 
-_CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <>
-class numeric_limits<TestFoo>
+class ::cuda::std::numeric_limits<TestFoo>
 {
 public:
   static constexpr bool is_specialized = true;
@@ -922,7 +921,6 @@ public:
       numeric_limits<char>::lowest());
   }
 };
-_CCCL_END_NAMESPACE_CUDA_STD
 
 //---------------------------------------------------------------------
 // Complex data type TestBar (with optimizations for fence-free warp-synchrony)
@@ -1027,9 +1025,8 @@ __host__ __device__ __forceinline__ void InitValue(GenMode gen_mode, TestBar& va
   InitValue(gen_mode, value.y, index);
 }
 
-_CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <>
-class numeric_limits<TestBar>
+class cuda::std::numeric_limits<TestBar>
 {
 public:
   static constexpr bool is_specialized = true;
@@ -1044,7 +1041,6 @@ public:
     return TestBar(numeric_limits<long long>::lowest(), numeric_limits<int>::lowest());
   }
 };
-_CCCL_END_NAMESPACE_CUDA_STD
 
 /******************************************************************************
  * Helper routines for list comparison and display

--- a/docs/cub/Doxyfile
+++ b/docs/cub/Doxyfile
@@ -154,8 +154,6 @@ PREDEFINED             = __device__= \
                         _CCCL_PUBLIC_API=inline \
                         _CCCL_PUBLIC_DEVICE_API=inline \
                         _CCCL_PUBLIC_HOST_API=inline \
-                        "_CCCL_BEGIN_NAMESPACE_CUDA_STD=namespace cuda::std {" \
-                        "_CCCL_END_NAMESPACE_CUDA_STD=}" \
                         "_CUDAX_CONSTEXPR_FRIEND=friend" \
                         "_LIBCUDACXX_HAS_SPACESHIP_OPERATOR()=1" \
                         "CCCL_DEPRECATED=" \

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -11,8 +11,6 @@
 #ifndef _CUDA___CONTAINER_BUFFER_H
 #define _CUDA___CONTAINER_BUFFER_H
 
-// Temporary workaround to not trigger issues in CUB headers missing prologue
-#define _CCCL_WAIVE_PROLOGUE_INCLUDE_CHECK
 #include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)

--- a/libcudacxx/include/cuda/buffer
+++ b/libcudacxx/include/cuda/buffer
@@ -11,8 +11,6 @@
 #ifndef _CUDA_BUFFER
 #define _CUDA_BUFFER
 
-// Temporary workaround to not trigger issues in CUB headers missing prologue
-#define _CCCL_WAIVE_PROLOGUE_INCLUDE_CHECK
 #include <cuda/std/detail/__config>
 
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)

--- a/libcudacxx/include/cuda/std/__internal/namespaces.h
+++ b/libcudacxx/include/cuda/std/__internal/namespaces.h
@@ -23,7 +23,7 @@
 #include <cuda/std/__internal/version.h>
 
 // During the header testing, we want to check if the code is wrapped by the prologue/epilogue
-#if defined(_CCCL_HEADER_TEST) && !defined(_CCCL_WAIVE_PROLOGUE_INCLUDE_CHECK)
+#if defined(_CCCL_HEADER_TEST)
 #  define _LIBCUDACXX_PROLOGUE_INCLUDE_CHECK() \
     static_assert(_CCCL_PROLOGUE_INCLUDED(), "missing #include <cuda/std/__cccl/prologue.h>");
 #else // ^^^ defined(_CCCL_HEADER_TEST) ^^^ / vvv !defined(_CCCL_HEADER_TEST) vvv


### PR DESCRIPTION
This PR replaces the uses `_CCCL_(BEGIN|END)_NAMESPACE_MEOW` macros in cub so we needn't to find workarounds for libcu++'s prologue/epilogue includes.