### PR TITLE
In test_device_segmented_scan_api change type from int to unsigned

### DIFF
--- a/cub/test/catch2_test_device_segmented_scan_api.cu
+++ b/cub/test/catch2_test_device_segmented_scan_api.cu
@@ -220,8 +220,8 @@ C2H_TEST("cub::DeviceSegmentedScan::InclusiveSegmentedScanInit API with two offs
 {
   const std::string& algo_name = "cub::DeviceSegmentedScan::InclusiveSegmentedScanInit[2 offsets]";
   // example-begin inclusive-segmented-scan-init-two-offsets
-  unsigned prime  = 7;
-  auto input = thrust::device_vector<unsigned>{
+  unsigned prime = 7;
+  auto input     = thrust::device_vector<unsigned>{
     2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6, 6, 6, 6, 6};
 
   auto row_size    = static_cast<size_t>(prime);


### PR DESCRIPTION
This works-around an issue where scan operator may be invoked on uninitialized value by the algorithm on certain architectures, but the operator value is unused.

Some of these unitialized values trip assertions embedded in fast_mod_div implementation, tripping assertion failures in test runs.

This PR replaces use of signed integral input type with unsigned integral type instead, as all uninitialized values are valid in the eye of fast_mod_div algorithm.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
