### PR TITLE
[cuda.compute]: Fix issue with `get_dtype()` not working anymore for pytorch arrays

### DIFF
--- a/python/cuda_cccl/cuda/compute/_utils/protocols.py
+++ b/python/cuda_cccl/cuda/compute/_utils/protocols.py
@@ -27,7 +27,7 @@ def get_dtype(arr: DeviceArrayLike | GpuStruct | np.ndarray) -> np.dtype:
     # Try the fast path via .dtype attribute (works for np.ndarray, GpuStruct, and most device arrays)
     try:
         return np.dtype(arr.dtype)  # type: ignore
-    except AttributeError:
+    except (AttributeError, TypeError):
         pass
 
     # Fall back to __cuda_array_interface__ for DeviceArrayLike


### PR DESCRIPTION
## Description

Calling `np.dtype()` on a torch datatype results in a TypeError. This was working before because we caught all errors, but a recent change made it so that we catch only AttributeErrors.

## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
