### PR TITLE
[cuda.compute]: Add fast path to extract PyTorch array pointer

### DIFF
--- a/python/cuda_cccl/cuda/compute/_utils/protocols.py
+++ b/python/cuda_cccl/cuda/compute/_utils/protocols.py
@@ -15,12 +15,23 @@ from ..typing import DeviceArrayLike, GpuStruct
 
 
 def get_data_pointer(arr: DeviceArrayLike) -> int:
+    # TODO: these are fast paths for CuPy and PyTorch until
+    # we have a more general solution.
+
+    # Fast path for PyTorch (arr.data_ptr())
     try:
-        # TODO: this is a fast path for CuPy until
-        # we have a more general solution.
+        return arr.data_ptr()  # type: ignore
+    except AttributeError:
+        pass
+
+    # Fast path for CuPy (arr.data.ptr)
+    try:
         return arr.data.ptr  # type: ignore
     except AttributeError:
-        return arr.__cuda_array_interface__["data"][0]
+        pass
+
+    # Fall back to __cuda_array_interface__
+    return arr.__cuda_array_interface__["data"][0]
 
 
 def get_dtype(arr: DeviceArrayLike | GpuStruct | np.ndarray) -> np.dtype:


### PR DESCRIPTION
## Description

Should be merged after #6882

## Checklist
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
