### PR TITLE
accommodate new behavior of clang's `__builtin_structured_binding_size`

### DIFF
--- a/cudax/include/cuda/experimental/__execution/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/bulk.cuh
@@ -452,13 +452,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT bulk_t : __bulk_t<bulk_t>
 _CCCL_GLOBAL_CONSTANT auto bulk = bulk_t{};
 
 template <class _Sndr, class _Policy, class _Shape, class _Fn>
-inline constexpr size_t structured_binding_size<bulk_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
+inline constexpr int structured_binding_size<bulk_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
 
 template <class _Sndr, class _Policy, class _Shape, class _Fn>
-inline constexpr size_t structured_binding_size<bulk_chunked_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
+inline constexpr int structured_binding_size<bulk_chunked_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
 
 template <class _Sndr, class _Policy, class _Shape, class _Fn>
-inline constexpr size_t structured_binding_size<bulk_unchunked_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
+inline constexpr int structured_binding_size<bulk_unchunked_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
 } // namespace cuda::experimental::execution
 
 _CCCL_DIAG_POP

--- a/cudax/include/cuda/experimental/__execution/conditional.cuh
+++ b/cudax/include/cuda/experimental/__execution/conditional.cuh
@@ -304,7 +304,7 @@ _CCCL_API constexpr auto conditional_t::operator()(_Pred __pred, _Then __then, _
 }
 
 template <class _Params, class _Sndr>
-inline constexpr size_t structured_binding_size<conditional_t::__sndr_t<_Params, _Sndr>> = 3;
+inline constexpr int structured_binding_size<conditional_t::__sndr_t<_Params, _Sndr>> = 3;
 
 _CCCL_GLOBAL_CONSTANT conditional_t conditional{};
 } // namespace cuda::experimental::execution

--- a/cudax/include/cuda/experimental/__execution/continues_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/continues_on.cuh
@@ -455,7 +455,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continues_on_t::__sndr_t
 };
 
 template <class _Sch, class _Sndr>
-inline constexpr size_t structured_binding_size<continues_on_t::__sndr_t<_Sch, _Sndr>> = 3;
+inline constexpr int structured_binding_size<continues_on_t::__sndr_t<_Sch, _Sndr>> = 3;
 
 _CCCL_GLOBAL_CONSTANT continues_on_t continues_on{};
 } // namespace cuda::experimental::execution

--- a/cudax/include/cuda/experimental/__execution/just.cuh
+++ b/cudax/include/cuda/experimental/__execution/just.cuh
@@ -166,11 +166,11 @@ _CCCL_API constexpr auto __just_t<_JustTag, _SetTag>::operator()(_Ts... __ts) co
 }
 
 template <class... _Ts>
-inline constexpr size_t structured_binding_size<just_t::__sndr_t<_Ts...>> = 2;
+inline constexpr int structured_binding_size<just_t::__sndr_t<_Ts...>> = 2;
 template <class... _Ts>
-inline constexpr size_t structured_binding_size<just_error_t::__sndr_t<_Ts...>> = 2;
+inline constexpr int structured_binding_size<just_error_t::__sndr_t<_Ts...>> = 2;
 template <class... _Ts>
-inline constexpr size_t structured_binding_size<just_stopped_t::__sndr_t<_Ts...>> = 2;
+inline constexpr int structured_binding_size<just_stopped_t::__sndr_t<_Ts...>> = 2;
 
 _CCCL_GLOBAL_CONSTANT auto just         = just_t{};
 _CCCL_GLOBAL_CONSTANT auto just_error   = just_error_t{};

--- a/cudax/include/cuda/experimental/__execution/just_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/just_from.cuh
@@ -182,11 +182,11 @@ _CCCL_API constexpr auto __just_from_t<_JustFromTag, _SetTag>::operator()(_Fn __
 }
 
 template <class _Fn>
-inline constexpr size_t structured_binding_size<just_from_t::__sndr_t<_Fn>> = 2;
+inline constexpr int structured_binding_size<just_from_t::__sndr_t<_Fn>> = 2;
 template <class _Fn>
-inline constexpr size_t structured_binding_size<just_error_from_t::__sndr_t<_Fn>> = 2;
+inline constexpr int structured_binding_size<just_error_from_t::__sndr_t<_Fn>> = 2;
 template <class _Fn>
-inline constexpr size_t structured_binding_size<just_stopped_from_t::__sndr_t<_Fn>> = 2;
+inline constexpr int structured_binding_size<just_stopped_from_t::__sndr_t<_Fn>> = 2;
 
 _CCCL_GLOBAL_CONSTANT auto just_from         = just_from_t{};
 _CCCL_GLOBAL_CONSTANT auto just_error_from   = just_error_from_t{};

--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -633,11 +633,11 @@ template <>
 constexpr set_stopped_t __let_t::__set_tag<let_stopped_t>{};
 
 template <class _Sndr, class _Fn>
-inline constexpr size_t structured_binding_size<let_value_t::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr int structured_binding_size<let_value_t::__sndr_t<_Sndr, _Fn>> = 3;
 template <class _Sndr, class _Fn>
-inline constexpr size_t structured_binding_size<let_error_t::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr int structured_binding_size<let_error_t::__sndr_t<_Sndr, _Fn>> = 3;
 template <class _Sndr, class _Fn>
-inline constexpr size_t structured_binding_size<let_stopped_t::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr int structured_binding_size<let_stopped_t::__sndr_t<_Sndr, _Fn>> = 3;
 
 _CCCL_GLOBAL_CONSTANT auto let_value   = let_value_t{};
 _CCCL_GLOBAL_CONSTANT auto let_error   = let_error_t{};

--- a/cudax/include/cuda/experimental/__execution/on.cuh
+++ b/cudax/include/cuda/experimental/__execution/on.cuh
@@ -296,13 +296,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT on_t::__sndr_t<_Sch, _Sndr, _Closure>
 _CCCL_GLOBAL_CONSTANT on_t on{};
 
 template <class _Sch, class _Sndr>
-inline constexpr size_t structured_binding_size<on_t::__sndr_t<_Sch, _Sndr>> = 3;
+inline constexpr int structured_binding_size<on_t::__sndr_t<_Sch, _Sndr>> = 3;
 
 template <class _Sch, class _Sndr, class _Closure>
-inline constexpr size_t structured_binding_size<on_t::__sndr_t<_Sch, _Sndr, _Closure>> = 3;
+inline constexpr int structured_binding_size<on_t::__sndr_t<_Sch, _Sndr, _Closure>> = 3;
 
 template <class _Sndr, class _NewSch, class _OldSch, class... _Closure>
-inline constexpr size_t structured_binding_size<on_t::__lowered_sndr_t<_Sndr, _NewSch, _OldSch, _Closure...>> = 3;
+inline constexpr int structured_binding_size<on_t::__lowered_sndr_t<_Sndr, _NewSch, _OldSch, _Closure...>> = 3;
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/read_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/read_env.cuh
@@ -159,7 +159,7 @@ _CCCL_API constexpr read_env_t::__sndr_t<_Query> read_env_t::operator()(_Query _
 }
 
 template <class _Query>
-inline constexpr size_t structured_binding_size<read_env_t::__sndr_t<_Query>> = 2;
+inline constexpr int structured_binding_size<read_env_t::__sndr_t<_Query>> = 2;
 
 _CCCL_GLOBAL_CONSTANT read_env_t read_env{};
 } // namespace cuda::experimental::execution

--- a/cudax/include/cuda/experimental/__execution/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/schedule_from.cuh
@@ -93,7 +93,7 @@ struct schedule_from_t::__sndr_t
 };
 
 template <class _Sndr>
-inline constexpr size_t structured_binding_size<schedule_from_t::__sndr_t<_Sndr>> = 3;
+inline constexpr int structured_binding_size<schedule_from_t::__sndr_t<_Sndr>> = 3;
 
 _CCCL_GLOBAL_CONSTANT schedule_from_t schedule_from{};
 } // namespace cuda::experimental::execution

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -281,7 +281,7 @@ _CCCL_API constexpr auto sequence_t::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) 
 }
 
 template <class _Sndr1, class _Sndr2>
-inline constexpr size_t structured_binding_size<sequence_t::__sndr_t<_Sndr1, _Sndr2>> = 4;
+inline constexpr int structured_binding_size<sequence_t::__sndr_t<_Sndr1, _Sndr2>> = 4;
 
 _CCCL_GLOBAL_CONSTANT sequence_t sequence{};
 } // namespace cuda::experimental::execution

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -202,7 +202,7 @@ template <class _Sch, class _Sndr>
 }
 
 template <class _Sch, class _Sndr>
-inline constexpr size_t structured_binding_size<starts_on_t::__sndr_t<_Sch, _Sndr>> = 3;
+inline constexpr int structured_binding_size<starts_on_t::__sndr_t<_Sch, _Sndr>> = 3;
 
 _CCCL_GLOBAL_CONSTANT starts_on_t starts_on{};
 } // namespace cuda::experimental::execution

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -411,7 +411,7 @@ _CCCL_API constexpr auto __adapt(_Sndr&& __sndr, _GetStream __get_stream) noexce
 } // namespace __stream
 
 template <class _Sndr, class _GetStream>
-inline constexpr size_t structured_binding_size<__stream::__sndr_t<_Sndr, _GetStream>> = 3;
+inline constexpr int structured_binding_size<__stream::__sndr_t<_Sndr, _GetStream>> = 3;
 } // namespace cuda::experimental::execution
 
 _CCCL_DIAG_POP

--- a/cudax/include/cuda/experimental/__execution/stream/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/bulk.cuh
@@ -209,14 +209,13 @@ struct stream_domain::__apply_t<bulk_t> : __stream::__bulk_t
 {};
 
 template <class _Sndr, class _Policy, class _Shape, class _Fn>
-inline constexpr size_t structured_binding_size<__stream::__bulk_chunked_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
+inline constexpr int structured_binding_size<__stream::__bulk_chunked_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
 
 template <class _Sndr, class _Policy, class _Shape, class _Fn>
-inline constexpr size_t structured_binding_size<__stream::__bulk_unchunked_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> =
-  3;
+inline constexpr int structured_binding_size<__stream::__bulk_unchunked_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
 
 template <class _Sndr, class _Policy, class _Shape, class _Fn>
-inline constexpr size_t structured_binding_size<__stream::__bulk_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
+inline constexpr int structured_binding_size<__stream::__bulk_t::__sndr_t<_Sndr, _Policy, _Shape, _Fn>> = 3;
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/stream/schedule_from.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/schedule_from.cuh
@@ -223,7 +223,7 @@ struct stream_domain::__apply_t<schedule_from_t> : __stream::__schedule_from_t
 {};
 
 template <class _Sndr>
-inline constexpr size_t structured_binding_size<__stream::__schedule_from_t::__sndr_t<_Sndr>> = 3;
+inline constexpr int structured_binding_size<__stream::__schedule_from_t::__sndr_t<_Sndr>> = 3;
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/then.cuh
+++ b/cudax/include/cuda/experimental/__execution/then.cuh
@@ -391,11 +391,11 @@ _CCCL_API constexpr auto __upon_t<_UponTag, _SetTag>::operator()(_Fn __fn) const
 }
 
 template <class _Sndr, class _Fn>
-inline constexpr size_t structured_binding_size<then_t::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr int structured_binding_size<then_t::__sndr_t<_Sndr, _Fn>> = 3;
 template <class _Sndr, class _Fn>
-inline constexpr size_t structured_binding_size<upon_error_t::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr int structured_binding_size<upon_error_t::__sndr_t<_Sndr, _Fn>> = 3;
 template <class _Sndr, class _Fn>
-inline constexpr size_t structured_binding_size<upon_stopped_t::__sndr_t<_Sndr, _Fn>> = 3;
+inline constexpr int structured_binding_size<upon_stopped_t::__sndr_t<_Sndr, _Fn>> = 3;
 
 _CCCL_GLOBAL_CONSTANT auto then         = then_t{};
 _CCCL_GLOBAL_CONSTANT auto upon_error   = upon_error_t{};

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -559,7 +559,7 @@ _CCCL_API constexpr auto when_all_t::operator()(_Sndrs... __sndrs) const
 }
 
 template <class... _Sndrs>
-inline constexpr size_t structured_binding_size<when_all_t::__sndr_t<_Sndrs...>> = sizeof...(_Sndrs) + 2;
+inline constexpr int structured_binding_size<when_all_t::__sndr_t<_Sndrs...>> = sizeof...(_Sndrs) + 2;
 
 _CCCL_GLOBAL_CONSTANT when_all_t when_all{};
 } // namespace cuda::experimental::execution

--- a/cudax/include/cuda/experimental/__execution/write_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/write_env.cuh
@@ -215,7 +215,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT write_env_t::__closure_t
 };
 
 template <class _Sndr, class _Env>
-inline constexpr size_t structured_binding_size<write_env_t::__sndr_t<_Sndr, _Env>> = 3;
+inline constexpr int structured_binding_size<write_env_t::__sndr_t<_Sndr, _Env>> = 3;
 
 _CCCL_GLOBAL_CONSTANT write_env_t write_env{};
 } // namespace cuda::experimental::execution

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -509,7 +509,7 @@ _CCCL_API constexpr auto launch(kernel_config<_Dimensions, _Config...> __config,
 namespace execution
 {
 template <class _Config, class _Fn, class... _Args>
-inline constexpr size_t structured_binding_size<__kernel_t::__sndr_t<_Config, _Fn, _Args...>> = 2;
+inline constexpr int structured_binding_size<__kernel_t::__sndr_t<_Config, _Fn, _Args...>> = 2;
 } // namespace execution
 } // namespace cuda::experimental
 


### PR DESCRIPTION
## Description

in pre-release clang-21 builds, `__builtin_structured_binding_size(X)` would be `(size_t)-1` if `X` could not be used to initialize a structured binding. in the final clang-21 release, `__builtin_structured_binding_size(X)` is ill-formed in that case.

in cudax::execution, we were assuming the old behavior. this pr updates the usages of `__builtin_structured_binding_size` to the new behavior.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
