### PR TITLE
portability macro for checking whether an expression satisfies a concept in a `_CCCL_REQUIRES_EXPR` clause

### DIFF
--- a/libcudacxx/include/cuda/std/__concepts/concept_macros.h
+++ b/libcudacxx/include/cuda/std/__concepts/concept_macros.h
@@ -146,12 +146,14 @@ namespace __cccl_unqualified_cuda_std = ::cuda::std; // NOLINT(misc-unused-alias
 // - requires(BOOL-EXPR...)
 // - typename(TYPE...)
 // - _Same_as(TYPE...) EXPR...
+// - _Satisfies(CONCEPT...) EXPR...
 //
 // The last 4 are handled below:
-#define _CCCL_CONCEPT_REQUIREMENT_SWITCH_requires _CCCL_PP_CASE(REQUIRES)
-#define _CCCL_CONCEPT_REQUIREMENT_SWITCH_noexcept _CCCL_PP_CASE(NOEXCEPT)
-#define _CCCL_CONCEPT_REQUIREMENT_SWITCH_typename _CCCL_PP_CASE(TYPENAME)
-#define _CCCL_CONCEPT_REQUIREMENT_SWITCH__Same_as _CCCL_PP_CASE(SAME_AS)
+#define _CCCL_CONCEPT_REQUIREMENT_SWITCH_requires   _CCCL_PP_CASE(REQUIRES)
+#define _CCCL_CONCEPT_REQUIREMENT_SWITCH_noexcept   _CCCL_PP_CASE(NOEXCEPT)
+#define _CCCL_CONCEPT_REQUIREMENT_SWITCH_typename   _CCCL_PP_CASE(TYPENAME)
+#define _CCCL_CONCEPT_REQUIREMENT_SWITCH__Same_as   _CCCL_PP_CASE(SAME_AS)
+#define _CCCL_CONCEPT_REQUIREMENT_SWITCH__Satisfies _CCCL_PP_CASE(SATISFIES)
 
 // Converts "requires(ARGS...)" to "ARGS..."
 #define _CCCL_CONCEPT_EAT_REQUIRES_(...)         _CCCL_PP_CAT(_CCCL_CONCEPT_EAT_REQUIRES_, __VA_ARGS__)
@@ -183,6 +185,18 @@ namespace __cccl_unqualified_cuda_std = ::cuda::std; // NOLINT(misc-unused-alias
                _CCCL_PP_EVAL(_CCCL_PP_FIRST, _CCCL_PP_CAT(_CCCL_CONCEPT_GET_TYPE_FROM_SAME_AS_, __VA_ARGS__)))
 #define _CCCL_CONCEPT_GET_TYPE_FROM_SAME_AS__Same_as(...) EXPAND(__VA_ARGS__),
 
+// Converts "_Satisfies(TYPE) EXPR..." to "EXPR..."
+#define _CCCL_CONCEPT_EAT_SATISFIES_(...) _CCCL_PP_CAT(_CCCL_CONCEPT_EAT_SATISFIES_, __VA_ARGS__)
+#define _CCCL_CONCEPT_EAT_SATISFIES__Satisfies(...)
+
+// Converts "_Satisfies(TYPE) EXPR..." to "TYPE" (The ridiculous concatenation of _CCCL_PP_
+// with EXPAND(__VA_ARGS__) is the only way to get MSVC's broken preprocessor to do macro
+// expansion here.)
+#define _CCCL_CONCEPT_GET_CONCEPT_FROM_SATISFIES_(...) \
+  _CCCL_PP_CAT(_CCCL_PP_,                              \
+               _CCCL_PP_EVAL(_CCCL_PP_FIRST, _CCCL_PP_CAT(_CCCL_CONCEPT_GET_CONCEPT_FROM_SATISFIES_, __VA_ARGS__)))
+#define _CCCL_CONCEPT_GET_CONCEPT_FROM_SATISFIES__Satisfies(...) EXPAND(__VA_ARGS__),
+
 // Here are the implementations of the internal macros, first for when concepts
 // are available, and then for when they're not.
 #if _CCCL_HAS_CONCEPTS() || defined(_CCCL_DOXYGEN_INVOKED)
@@ -207,6 +221,8 @@ namespace __cccl_unqualified_cuda_std = ::cuda::std; // NOLINT(misc-unused-alias
     _CCCL_CONCEPT_TRY_ADD_TYPENAME_(_CCCL_CONCEPT_EAT_TYPENAME_(_REQ))
 #  define _CCCL_CONCEPT_REQUIREMENT_CASE_SAME_AS(_REQ) \
     {_CCCL_CONCEPT_EAT_SAME_AS_(_REQ)}->_CCCL_CONCEPT_VSTD::same_as<_CCCL_CONCEPT_GET_TYPE_FROM_SAME_AS_(_REQ)>
+#  define _CCCL_CONCEPT_REQUIREMENT_CASE_SATISFIES(_REQ) \
+    {_CCCL_CONCEPT_EAT_SATISFIES_(_REQ)}->_CCCL_CONCEPT_GET_CONCEPT_FROM_SATISFIES_(_REQ)
 
 #  define _CCCL_FRAGMENT(_NAME, ...) _NAME<__VA_ARGS__>
 
@@ -251,6 +267,9 @@ namespace __cccl_unqualified_cuda_std = ::cuda::std; // NOLINT(misc-unused-alias
     static_cast<::__cccl_tag<_CCCL_CONCEPT_EAT_TYPENAME_(_REQ)>*>(nullptr)
 #  define _CCCL_CONCEPT_REQUIREMENT_CASE_SAME_AS(_REQ) \
     ::__cccl_requires<::cuda::std::same_as<_CCCL_CONCEPT_SAME_AS_REQUIREMENT_(_REQ)>>
+#  define _CCCL_CONCEPT_REQUIREMENT_CASE_SATISFIES(_REQ)                                                               \
+    ::__cccl_requires < _CCCL_CONCEPT_GET_CONCEPT_FROM_SATISFIES_(_REQ) < decltype(_CCCL_CONCEPT_EAT_SATISFIES_(_REQ)) \
+      >>
 
 // Converts "_Same_as(TYPE) EXPR..." to "TYPE, decltype(EXPR...)"
 #  define _CCCL_CONCEPT_SAME_AS_REQUIREMENT_(_REQ) \

--- a/libcudacxx/include/cuda/std/__concepts/equality_comparable.h
+++ b/libcudacxx/include/cuda/std/__concepts/equality_comparable.h
@@ -65,10 +65,10 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(__make_const_lvalue_ref<_Tp> __t, __make_const_lvalue_ref<_Up> __u)(
     requires(_With_lvalue_reference<_Tp>),
     requires(_With_lvalue_reference<_Up>),
-    requires(__boolean_testable<decltype(__t == __u)>),
-    requires(__boolean_testable<decltype(__t != __u)>),
-    requires(__boolean_testable<decltype(__u == __t)>),
-    requires(__boolean_testable<decltype(__u != __t)>)));
+    _Satisfies(__boolean_testable) __t == __u,
+    _Satisfies(__boolean_testable) __t != __u,
+    _Satisfies(__boolean_testable) __u == __t,
+    _Satisfies(__boolean_testable) __u != __t));
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT __weakly_equality_comparable_with = _CCCL_FRAGMENT(__weakly_equality_comparable_with_, _Tp, _Up);

--- a/libcudacxx/include/cuda/std/__concepts/totally_ordered.h
+++ b/libcudacxx/include/cuda/std/__concepts/totally_ordered.h
@@ -61,14 +61,14 @@ template <class _Tp, class _Up>
 _CCCL_CONCEPT_FRAGMENT(
   __partially_ordered_with_,
   requires(__make_const_lvalue_ref<_Tp> __t, __make_const_lvalue_ref<_Up> __u)(
-    requires(__boolean_testable<decltype(__t < __u)>),
-    requires(__boolean_testable<decltype(__t > __u)>),
-    requires(__boolean_testable<decltype(__t <= __u)>),
-    requires(__boolean_testable<decltype(__t >= __u)>),
-    requires(__boolean_testable<decltype(__u < __t)>),
-    requires(__boolean_testable<decltype(__u > __t)>),
-    requires(__boolean_testable<decltype(__u <= __t)>),
-    requires(__boolean_testable<decltype(__u >= __t)>)));
+    _Satisfies(__boolean_testable)(__t < __u), //
+    _Satisfies(__boolean_testable)(__t > __u), //
+    _Satisfies(__boolean_testable)(__t <= __u), //
+    _Satisfies(__boolean_testable)(__t >= __u), //
+    _Satisfies(__boolean_testable)(__u < __t), //
+    _Satisfies(__boolean_testable)(__u > __t), //
+    _Satisfies(__boolean_testable)(__u <= __t), //
+    _Satisfies(__boolean_testable)(__u >= __t)));
 
 template <class _Tp, class _Up>
 _CCCL_CONCEPT __partially_ordered_with = _CCCL_FRAGMENT(__partially_ordered_with_, _Tp, _Up);


### PR DESCRIPTION
## Description

when writing a concept definition in CCCL today, if you want to portably test whether a particular expression satisfies a given concept, you have to write it like:

```c++
_CCCL_REQUIRES_EXPR((T), T& t)
(
  requires(my_concept<decltype(some-expression)>)
)
```

in c++20, this expands to:

```c++
requires(T& t)
{
  requires my_concept<decltype(some-expression)>;
}
```

but that is not how you would write it in c++20, and the above formulation gives worse diagnostics than the more idiomatic:

```c++
requires(T& t)
{
  {some-expression} -> my_concept;
}
```

this pr adds a new `_Satisfies` requirement kind to CCCL's concept portability macros. it would be used like this:

```c++
_CCCL_REQUIRES_EXPR((T), T& t)
(
  _Satisfies(my_concept) some-expression
)
```

in c++20, this expands to the more idiomatic formulation

this pr also changes the `equality_comparable` and `totally_ordered` concepts to use `_Satisfies`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
