### PR TITLE
[libcu++] Leak static CUDA resources and add missing release on memory pool

### DIFF
--- a/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
@@ -128,7 +128,10 @@ struct device_memory_pool : device_memory_pool_ref
 
   ~device_memory_pool() noexcept
   {
-    ::cuda::__driver::__mempoolDestroy(__pool_);
+    if (__pool_ != nullptr)
+    {
+      ::cuda::__driver::__mempoolDestroy(__pool_);
+    }
   }
 
   _CCCL_HOST_API static device_memory_pool from_native_handle(::cudaMemPool_t __pool) noexcept

--- a/libcudacxx/include/cuda/__memory_pool/managed_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/managed_memory_pool.h
@@ -119,7 +119,10 @@ struct managed_memory_pool : managed_memory_pool_ref
 
   ~managed_memory_pool() noexcept
   {
-    ::cuda::__driver::__mempoolDestroy(__pool_);
+    if (__pool_ != nullptr)
+    {
+      ::cuda::__driver::__mempoolDestroy(__pool_);
+    }
   }
 
   _CCCL_HOST_API static managed_memory_pool from_native_handle(::cudaMemPool_t __pool) noexcept

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -527,6 +527,16 @@ public:
     return __pool_;
   }
 
+  //! @brief Retrieve the native `cudaMemPool_t` handle and give up ownership.
+  //!
+  //! @return cudaMemPool_t The native handle being held by the `memory_pool_base` object.
+  //!
+  //! @post The memory pool object is in a moved-from state.
+  _CCCL_HOST_API constexpr cudaMemPool_t release() noexcept
+  {
+    return ::cuda::std::exchange(__pool_, nullptr);
+  }
+
   //! @brief Deallocate memory pointed to by \p __ptr.
   //! @param __ptr Pointer to be deallocated. Must have been allocated through a
   //! call to `allocate`.

--- a/libcudacxx/include/cuda/__stream/internal_streams.h
+++ b/libcudacxx/include/cuda/__stream/internal_streams.h
@@ -33,7 +33,12 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 //! should ever be pushed into it
 inline ::cuda::stream_ref __cccl_allocation_stream()
 {
-  static ::cuda::stream __stream{device_ref{0}};
+  // Intentionally leak the stream here to avoid stream destruction when the program exits, which is not guaraneed to
+  // work.
+  static ::cuda::stream_ref __stream = []() {
+    ::cuda::stream __str{::cuda::device_ref{0}};
+    return __str.release();
+  }();
   return __stream;
 }
 


### PR DESCRIPTION
CUDA Programming Guide explicitly states that calling CUDA APIs before and after main is undefined behavior: https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#initialization

We have two places where we have function-local static objects that hold CUDA handles and we are technically in the UB territory here. It shouldn't make a difference if we just leak the handles to avoid potential issues if CUDA stops handling destroy calls of those objects after main exits correctly.

This PR make those variables just raw CUDA handles to leak them and also adds missing `.release()` member function on the memory pool types