### PR TITLE
port the `trampoline_scheduler` from stdexec to cudax::execution

### DIFF
--- a/cudax/include/cuda/experimental/__execution/continues_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/continues_on.cuh
@@ -204,6 +204,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continues_on_t
     using __rcvr_t       = continues_on_t::__rcvr_t<_Rcvr, __results_t>;
     using __stash_rcvr_t = continues_on_t::__stash_rcvr_t<_Sch, _Rcvr, __results_t>;
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_API constexpr explicit __opstate_t(_CvSndr&& __sndr, _Sch __sch, _Rcvr __rcvr)
         : __state_{{static_cast<_Rcvr&&>(__rcvr), {}}, execution::connect(schedule(__sch), __rcvr_t{&__state_})}
         , __opstate1_{execution::connect(static_cast<_CvSndr&&>(__sndr), __stash_rcvr_t{&__state_})}
@@ -230,6 +231,7 @@ public:
   template <class _Sch>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __closure_t
   {
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Sndr>
     [[nodiscard]]
     _CCCL_API constexpr auto operator()(_Sndr __sndr) const -> __sndr_t<_Sch, __call_result_t<schedule_from_t, _Sndr>>
@@ -239,6 +241,7 @@ public:
       return __sndr_t<_Sch, __child_t>{{}, __sch_, schedule_from(static_cast<_Sndr&&>(__sndr))};
     }
 
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _Sndr>
     [[nodiscard]]
     _CCCL_API constexpr friend auto operator|(_Sndr __sndr, __closure_t __clsur)
@@ -252,6 +255,7 @@ public:
     _Sch __sch_;
   };
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sch>
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Sch __sch) const -> __closure_t<_Sch>
   {
@@ -259,6 +263,7 @@ public:
     return __closure_t<_Sch>{__sch};
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sch, class _Sndr>
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Sndr __sndr, _Sch __sch) const
     -> __sndr_t<_Sch, __call_result_t<schedule_from_t, _Sndr>>
@@ -318,6 +323,7 @@ public:
   //! Otherwise, if the scheduler's sender never completes with @c _SetTag, then a
   //! @c _SetTag completion can only come from the original sender, so return the
   //! original sender's completion scheduler.
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _SetTag, class... _Env)
   _CCCL_REQUIRES((__same_as<_SetTag, set_value_t> || __never_completes_with<_Sndr, _SetTag, __fwd_env_t<_Env>...>)
                    _CCCL_AND(!__has_decay_copy_errors<_SetTag, _Env...>()))
@@ -328,6 +334,7 @@ public:
   }
 
   //! @overload
+  _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _SetTag, class... _Env)
   _CCCL_REQUIRES(__never_completes_with<schedule_result_t<_Sch>, _SetTag, __fwd_env_t<_Env>...>)
   [[nodiscard]] _CCCL_API constexpr auto query(get_completion_scheduler_t<_SetTag>, const _Env&... __env) const noexcept
@@ -432,12 +439,14 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continues_on_t::__sndr_t
     _CCCL_UNREACHABLE();
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Rcvr>
   [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) && -> __opstate_t<_Sch, _Sndr, _Rcvr>
   {
     return __opstate_t<_Sch, _Sndr, _Rcvr>{static_cast<_Sndr&&>(__sndr_), __sch_, static_cast<_Rcvr&&>(__rcvr)};
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Rcvr>
   [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const& -> __opstate_t<_Sch, const _Sndr&, _Rcvr>
   {

--- a/cudax/include/cuda/experimental/__execution/sequence.cuh
+++ b/cudax/include/cuda/experimental/__execution/sequence.cuh
@@ -48,6 +48,7 @@ namespace cuda::experimental::execution
 {
 namespace __detail
 {
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Attrs, class... _Env>
 [[nodiscard]] _CCCL_API constexpr auto __mk_seq_env_next(const _Attrs& __attrs, const _Env&... __env) noexcept
 {
@@ -98,6 +99,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t
   template <class _Attrs, class... _Env>
   using __env2_t = __join_env_t<__detail::__seq_env_next_t<_Attrs, __fwd_env_t<_Env>...>, __fwd_env_t<_Env>...>;
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Attrs, class... _Env>
   [[nodiscard]] _CCCL_API static constexpr auto __mk_env2(const _Attrs& __attrs, const _Env&... __env) noexcept
     -> __env2_t<_Attrs, _Env...>
@@ -154,11 +156,13 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t
     using __env2_t _CCCL_NODEBUG_ALIAS = __detail::__seq_env_next_t<env_of_t<_Sndr1>, env_of_t<_Rcvr>>;
 
     // The moves from lvalues here is intentional:
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_API constexpr __opstate_t(_Sndr1& __sndr1, _Sndr2& __sndr2, _Rcvr& __rcvr, __env2_t __env2)
         : __state_(static_cast<_Rcvr&&>(__rcvr), static_cast<__env2_t&&>(__env2), static_cast<_Sndr2&&>(__sndr2))
         , __opstate1_(execution::connect(static_cast<_Sndr1&&>(__sndr1), __rcvr_t<_Rcvr, __env2_t, _Sndr2>{&__state_}))
     {}
 
+    _CCCL_EXEC_CHECK_DISABLE
     _CCCL_API constexpr __opstate_t(_Sndr1&& __sndr1, _Sndr2&& __sndr2, _Rcvr&& __rcvr)
         : __opstate_t(__sndr1, __sndr2, __rcvr, __detail::__mk_seq_env_next(get_env(__sndr1), get_env(__rcvr)))
     {}
@@ -181,6 +185,7 @@ public:
   template <class _Sndr1, class _Sndr2>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr1, class _Sndr2>
   _CCCL_API constexpr auto operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const;
 };
@@ -207,6 +212,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t::__sndr_t
     _CCCL_UNREACHABLE();
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Rcvr>
   [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) && //
     -> sequence_t::__opstate_t<_Rcvr, _Sndr1, _Sndr2>
@@ -215,6 +221,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t::__sndr_t
     return __opstate_t{static_cast<_Sndr1&&>(__sndr1_), static_cast<_Sndr2>(__sndr2_), static_cast<_Rcvr&&>(__rcvr)};
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Rcvr>
   [[nodiscard]] _CCCL_API constexpr auto connect(_Rcvr __rcvr) const& //
     -> sequence_t::__opstate_t<_Rcvr, const _Sndr1&, const _Sndr2&>
@@ -273,6 +280,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT sequence_t::__sndr_t
   _Sndr2 __sndr2_;
 };
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Sndr1, class _Sndr2>
 _CCCL_API constexpr auto sequence_t::operator()(_Sndr1 __sndr1, _Sndr2 __sndr2) const
 {

--- a/cudax/include/cuda/experimental/__execution/starts_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/starts_on.cuh
@@ -99,6 +99,7 @@ public:
   template <class _Sch, class _Sndr>
   struct _CCCL_TYPE_VISIBILITY_DEFAULT __sndr_t;
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sndr>
   [[nodiscard]] static _CCCL_API constexpr auto transform_sender(start_t, _Sndr&& __sndr, ::cuda::std::__ignore_t)
   {
@@ -106,6 +107,7 @@ public:
     return sequence(continues_on(just(), __sch), ::cuda::std::forward_like<_Sndr>(__child));
   }
 
+  _CCCL_EXEC_CHECK_DISABLE
   template <class _Sch, class _Sndr>
   _CCCL_API constexpr auto operator()(_Sch __sch, _Sndr __sndr) const;
 };
@@ -130,6 +132,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT starts_on_t::__sndr_t
   {
     // If the sender has a _SetTag completion, then the completion scheduler for _SetTag
     // is the sender's.
+    _CCCL_EXEC_CHECK_DISABLE
     template <class _SetTag, class... _Env>
     [[nodiscard]] _CCCL_API constexpr auto query(get_completion_scheduler_t<_SetTag>, _Env&&... __env) const noexcept
       -> __call_result_t<get_completion_scheduler_t<_SetTag>, env_of_t<_Sndr>, __env2_t<_Sch, _Env>...>
@@ -195,6 +198,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT starts_on_t::__sndr_t
   _Sndr __sndr_;
 };
 
+_CCCL_EXEC_CHECK_DISABLE
 template <class _Sch, class _Sndr>
 [[nodiscard]] _CCCL_API constexpr auto starts_on_t::operator()(_Sch __sch, _Sndr __sndr) const
 {

--- a/cudax/include/cuda/experimental/__execution/trampoline_scheduler.cuh
+++ b/cudax/include/cuda/experimental/__execution/trampoline_scheduler.cuh
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) 2025 NVIDIA Corporation
+ *
+ * Licensed under the Apache License Version 2.0 with LLVM Exceptions
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *   https://llvm.org/LICENSE.txt
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef __CUDAX_EXECUTION_TRAMPOLINE_SCHEDULER
+#define __CUDAX_EXECUTION_TRAMPOLINE_SCHEDULER
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__cmath/abs.h>
+#include <cuda/std/__tuple_dir/ignore.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__utility/exchange.h>
+#include <cuda/std/cstdint>
+
+#include <cuda/experimental/__execution/completion_signatures.cuh>
+#include <cuda/experimental/__execution/concepts.cuh>
+#include <cuda/experimental/__execution/cpos.cuh>
+#include <cuda/experimental/__execution/env.cuh>
+#include <cuda/experimental/__execution/fwd.cuh>
+#include <cuda/experimental/__execution/stop_token.cuh>
+
+// include this last:
+#include <cuda/experimental/__execution/prologue.cuh>
+
+namespace cuda::experimental::execution
+{
+namespace __detail
+{
+template <class _Operation>
+struct __trampoline_state
+{
+  static thread_local __trampoline_state* __current_;
+
+  _CCCL_HOST_API __trampoline_state(size_t __max_recursion_depth, size_t __max_recursion_size) noexcept
+      : __max_recursion_size_(__max_recursion_size)
+      , __max_recursion_depth_(__max_recursion_depth)
+  {
+    __current_ = this;
+  }
+
+  _CCCL_HOST_API ~__trampoline_state()
+  {
+    __current_ = nullptr;
+  }
+
+  _CCCL_HOST_API void __drain() noexcept;
+
+  // these origin schedule frame limits will apply to all
+  // nested trampoline instances on this thread
+  const size_t __max_recursion_size_;
+  const size_t __max_recursion_depth_;
+
+  // track state of origin schedule frame
+  intptr_t __recursion_origin_ = 0;
+  size_t __recursion_depth_    = 1;
+  _Operation* __head_          = nullptr;
+  _Operation* __tail_          = nullptr;
+};
+} // namespace __detail
+
+class trampoline_scheduler
+{
+  struct __schedule_sender;
+
+public:
+  using scheduler_concept = scheduler_t;
+
+  _CCCL_HOST_API trampoline_scheduler() noexcept
+      : __max_recursion_size_(4096)
+      , __max_recursion_depth_(16)
+  {}
+
+  _CCCL_HOST_API explicit trampoline_scheduler(size_t __max_recursion_depth) noexcept
+      : __max_recursion_size_(4096)
+      , __max_recursion_depth_(__max_recursion_depth)
+  {}
+
+  _CCCL_HOST_API explicit trampoline_scheduler(size_t __max_recursion_depth, size_t __max_recursion_size) noexcept
+      : __max_recursion_size_(__max_recursion_size)
+      , __max_recursion_depth_(__max_recursion_depth)
+  {}
+
+  [[nodiscard]]
+  _CCCL_HOST_API auto schedule() const noexcept -> __schedule_sender
+  {
+    return __schedule_sender{__max_recursion_size_, __max_recursion_depth_};
+  }
+
+#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+
+  _CCCL_HOST_API auto operator==(const trampoline_scheduler&) const noexcept -> bool = default;
+
+#else
+
+  [[nodiscard]]
+  _CCCL_HOST_API friend constexpr bool
+  operator==(const trampoline_scheduler& __a, const trampoline_scheduler& __b) noexcept
+  {
+    return __a.__max_recursion_size_ == __b.__max_recursion_size_
+        && __a.__max_recursion_depth_ == __b.__max_recursion_depth_;
+  }
+
+  [[nodiscard]]
+  _CCCL_HOST_API friend constexpr bool
+  operator!=(const trampoline_scheduler& __a, const trampoline_scheduler& __b) noexcept
+  {
+    return !(__a == __b);
+  }
+
+#endif // _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
+
+private:
+  struct __operation_base
+  {
+    using operation_state_concept = operation_state_t;
+    using __execute_fn            = void(__operation_base*) noexcept;
+
+    _CCCL_HOST_API explicit __operation_base(__execute_fn* __execute, size_t __max_size, size_t __max_depth) noexcept
+        : __execute_(__execute)
+        , __max_recursion_size_(__max_size)
+        , __max_recursion_depth_(__max_depth)
+    {}
+
+    _CCCL_HOST_API void __execute() noexcept
+    {
+      __execute_(this);
+    }
+
+    _CCCL_HOST_API void start() & noexcept
+    {
+      auto* __current_state = __detail::__trampoline_state<__operation_base>::__current_;
+
+      if (__current_state == nullptr)
+      {
+        // origin schedule frame on this thread
+        __detail::__trampoline_state<__operation_base> __state{__max_recursion_depth_, __max_recursion_size_};
+        __execute();
+        __state.__drain();
+      }
+      else
+      {
+        // recursive schedule frame on this thread
+
+        // calculate stack consumption for this schedule
+        size_t __current_size =
+          ::cuda::std::abs(reinterpret_cast<intptr_t>(&__current_state) - __current_state->__recursion_origin_);
+
+        if (__current_size < __current_state->__max_recursion_size_
+            && __current_state->__recursion_depth_ < __current_state->__max_recursion_depth_)
+        {
+          // inline this recursive schedule
+          ++__current_state->__recursion_depth_;
+          __execute();
+        }
+        else
+        {
+          // Exceeded recursion limit.
+
+          // push this recursive schedule to list tail
+          __prev_ = ::cuda::std::exchange(__current_state->__tail_, static_cast<__operation_base*>(this));
+          if (__prev_ != nullptr)
+          {
+            // was not empty
+            ::cuda::std::exchange(__prev_->__next_, static_cast<__operation_base*>(this));
+          }
+          else
+          {
+            // was empty
+            ::cuda::std::exchange(__current_state->__head_, static_cast<__operation_base*>(this));
+          }
+        }
+      }
+    }
+
+    __operation_base* __prev_ = nullptr;
+    __operation_base* __next_ = nullptr;
+    __execute_fn* __execute_;
+    const size_t __max_recursion_size_;
+    const size_t __max_recursion_depth_;
+  };
+
+  template <class _Rcvr>
+  struct __operation : __operation_base
+  {
+    _CCCL_HOST_API explicit __operation(_Rcvr __rcvr, size_t __max_size, size_t __max_depth) noexcept
+        : __operation_base(&__operation::__execute_impl, __max_size, __max_depth)
+        , __rcvr_(static_cast<_Rcvr&&>(__rcvr))
+    {}
+
+    _CCCL_HOST_API static void __execute_impl(__operation_base* __op) noexcept
+    {
+      auto& __self = *static_cast<__operation*>(__op);
+      if constexpr (unstoppable_token<stop_token_of_t<env_of_t<_Rcvr&>>>)
+      {
+        execution::set_value(static_cast<_Rcvr&&>(__self.__rcvr_));
+      }
+      else
+      {
+        if (execution::get_stop_token(get_env(__self.__rcvr_)).stop_requested())
+        {
+          execution::set_stopped(static_cast<_Rcvr&&>(__self.__rcvr_));
+        }
+        else
+        {
+          execution::set_value(static_cast<_Rcvr&&>(__self.__rcvr_));
+        }
+      }
+    }
+
+  private:
+    _Rcvr __rcvr_;
+  };
+
+  struct __schedule_sender
+  {
+    using sender_concept = sender_t;
+    template <class _Env>
+    using __completions_in_t =
+      ::cuda::std::_If<unstoppable_token<stop_token_of_t<_Env>>,
+                       completion_signatures<set_value_t()>,
+                       completion_signatures<set_value_t(), set_stopped_t()>>;
+
+    _CCCL_HOST_API explicit __schedule_sender(size_t __max_size, size_t __max_depth) noexcept
+        : __max_recursion_size_(__max_size)
+        , __max_recursion_depth_(__max_depth)
+    {}
+
+    _CCCL_TEMPLATE(class _Rcvr)
+    _CCCL_REQUIRES(receiver_of<_Rcvr, __completions_in_t<env_of_t<_Rcvr&>>>)
+    [[nodiscard]]
+    _CCCL_HOST_API auto connect(_Rcvr __rcvr) const noexcept -> __operation<_Rcvr>
+    {
+      return __operation<_Rcvr>{static_cast<_Rcvr&&>(__rcvr), __max_recursion_size_, __max_recursion_depth_};
+    }
+
+    template <class _Self, class _Env>
+    _CCCL_HOST_API static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept -> __completions_in_t<_Env>
+    {
+      return {};
+    }
+
+    [[nodiscard]]
+    _CCCL_HOST_API auto query(get_completion_scheduler_t<set_value_t>, ::cuda::std::__ignore_t = {}) const noexcept
+      -> trampoline_scheduler
+    {
+      return trampoline_scheduler{__max_recursion_depth_};
+    }
+
+    [[nodiscard]]
+    _CCCL_HOST_API auto get_env() const noexcept -> const __schedule_sender&
+    {
+      return *this;
+    }
+
+    const size_t __max_recursion_size_;
+    const size_t __max_recursion_depth_;
+  };
+
+  size_t __max_recursion_size_;
+  size_t __max_recursion_depth_;
+};
+
+namespace __detail
+{
+template <class _Operation>
+thread_local __trampoline_state<_Operation>* __trampoline_state<_Operation>::__current_ = nullptr;
+
+template <class _Operation>
+_CCCL_HOST_API void __trampoline_state<_Operation>::__drain() noexcept
+{
+  while (__head_ != nullptr)
+  {
+    // pop the head of the list
+    _Operation* __op = ::cuda::std::exchange(__head_, __head_->__next_);
+    __op->__next_    = nullptr;
+    __op->__prev_    = nullptr;
+    if (__head_ != nullptr)
+    {
+      // is not empty
+      __head_->__prev_ = nullptr;
+    }
+    else
+    {
+      // is empty
+      __tail_ = nullptr;
+    }
+
+    // reset the origin schedule frame state
+    __recursion_origin_ = reinterpret_cast<intptr_t>(&__op);
+    __recursion_depth_  = 1;
+
+    __op->__execute();
+  }
+}
+} // namespace __detail
+} // namespace cuda::experimental::execution
+
+#include <cuda/experimental/__execution/epilogue.cuh>
+
+#endif // __CUDAX_EXECUTION_TRAMPOLINE_SCHEDULER

--- a/cudax/include/cuda/experimental/execution.cuh
+++ b/cudax/include/cuda/experimental/execution.cuh
@@ -39,6 +39,7 @@
 #include <cuda/experimental/__execution/sync_wait.cuh>
 #include <cuda/experimental/__execution/then.cuh>
 #include <cuda/experimental/__execution/thread_context.cuh>
+#include <cuda/experimental/__execution/trampoline_scheduler.cuh>
 #include <cuda/experimental/__execution/transform_completion_signatures.cuh>
 #include <cuda/experimental/__execution/transform_sender.cuh>
 #include <cuda/experimental/__execution/visit.cuh>

--- a/cudax/test/CMakeLists.txt
+++ b/cudax/test/CMakeLists.txt
@@ -56,6 +56,7 @@ cudax_add_catch2_test(test_target execution ${cudax_target}
     execution/test_starts_on.cu
     execution/test_stream_context.cu
     execution/test_then.cu
+    execution/test_trampoline_scheduler.cu
     execution/test_visit.cu
     execution/test_when_all.cu
     execution/test_write_attrs.cu

--- a/cudax/test/execution/common/retry.cuh
+++ b/cudax/test/execution/common/retry.cuh
@@ -1,0 +1,190 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cuda/std/concepts>
+#include <cuda/std/optional>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include <cuda/experimental/execution.cuh>
+
+namespace _retry_detail
+{
+namespace ex = ::cuda::experimental::execution;
+
+template <class From, class To>
+using _copy_cvref_t = ::cuda::std::__copy_cvref_t<From, To>;
+
+// _conv needed so we can emplace construct non-movable types into
+// a cuda::std::optional.
+template <class F>
+struct _conv
+{
+  using result_type = decltype(::cuda::std::declval<F>()());
+
+  operator result_type() &&
+  {
+    return static_cast<F&&>(f_)();
+  }
+
+  F f_;
+};
+
+template <class F>
+_conv(F) -> _conv<F>;
+
+///////////////////////////////////////////////////////////////////////////////
+// retry algorithm:
+template <class S, class R>
+struct _opstate;
+
+// pass through all customizations except set_error, which retries the operation.
+template <class S, class R>
+struct _retry_receiver
+{
+  using receiver_concept = ex::receiver_t;
+
+  template <class... Ts>
+  void set_value(Ts&&... ts) && noexcept
+  {
+    ex::set_value(::cuda::std::move(o_->r_), static_cast<Ts&&>(ts)...);
+  }
+
+  template <class Error>
+  void set_error(Error&&) && noexcept
+  {
+    o_->_retry(); // This causes the op to be retried
+  }
+
+  void set_stopped() && noexcept
+  {
+    ex::set_stopped(static_cast<R&&>(o_->r_));
+  }
+
+  [[nodiscard]]
+  auto get_env() const noexcept -> ex::env_of_t<R>
+  {
+    return ex::get_env(o_->r_);
+  }
+
+  _opstate<S, R>* o_;
+};
+
+// Hold the nested operation state in an optional so we can
+// re-construct and re-start it if the operation fails.
+template <class S, class R>
+struct _opstate
+{
+  using operation_state_concept = ex::operation_state_t;
+  using _nested_op_t            = ex::connect_result_t<S&, _retry_receiver<S, R>>;
+
+  explicit _opstate(S s, R r)
+      : s_(static_cast<S&&>(s))
+      , r_(static_cast<R&&>(r))
+      , o_{_connect()}
+  {}
+
+  _opstate(_opstate&&) = delete;
+
+  [[nodiscard]] auto _connect() noexcept
+  {
+    return _conv{[this] {
+      return ex::connect(s_, _retry_receiver<S, R>{this});
+    }};
+  }
+
+  void _retry() noexcept
+  {
+    _CCCL_TRY
+    {
+      o_.emplace(_connect()); // potentially throwing
+      ex::start(*o_);
+    }
+    _CCCL_CATCH_ALL
+    {
+      ex::set_error(static_cast<R&&>(r_), ex::current_exception());
+    }
+  }
+
+  void start() & noexcept
+  {
+    ex::start(*o_);
+  }
+
+private:
+  friend struct _retry_receiver<S, R>;
+  S s_;
+  R r_;
+  ::cuda::std::optional<_nested_op_t> o_;
+};
+
+struct _swallow_signature
+{
+  template <class... _Ts>
+  _CCCL_CONSTEVAL auto operator()() const noexcept
+  {
+    return ex::completion_signatures{};
+  }
+};
+
+template <class S>
+struct _retry_sender
+{
+  using sender_concept = ex::sender_t;
+
+  explicit _retry_sender(S s)
+      : s_(static_cast<S&&>(s))
+  {}
+
+  template <class Self, class... Env>
+  static _CCCL_CONSTEVAL auto get_completion_signatures()
+  {
+    return ex::transform_completion_signatures(
+      ex::get_child_completion_signatures<Self&, S, Env...>(),
+      {},
+      _swallow_signature{},
+      {},
+      ex::completion_signatures<ex::set_error_t(ex::exception_ptr)>{});
+  }
+
+  template <class R>
+  [[nodiscard]] auto connect(R r) && -> _opstate<S, R>
+  {
+    return _opstate<S, R>{::cuda::std::move(*this).s_, ::cuda::std::move(r)};
+  }
+
+  template <class R>
+  [[nodiscard]] auto connect(R r) const& -> _opstate<S, R>
+  {
+    return _opstate<S, R>{s_, ::cuda::std::move(r)};
+  }
+
+  auto get_env() const noexcept -> ex::env_of_t<S>
+  {
+    return ex::get_env(s_);
+  }
+
+private:
+  S s_;
+};
+} // namespace _retry_detail
+
+struct retry_t
+{
+  template <class S>
+  [[nodiscard]] auto operator()(S s) const -> _retry_detail::_retry_sender<S>
+  {
+    return _retry_detail::_retry_sender<S>{static_cast<S&&>(s)};
+  }
+};
+
+inline constexpr retry_t retry{};

--- a/cudax/test/execution/test_trampoline_scheduler.cu
+++ b/cudax/test/execution/test_trampoline_scheduler.cu
@@ -1,0 +1,97 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/experimental/execution.cuh>
+
+#include "./common/retry.cuh"
+#include "testing.cuh"
+
+namespace ex = ::cuda::experimental::execution;
+
+#if !_CCCL_DEVICE_COMPILATION()
+
+namespace
+{
+struct try_again
+{};
+
+class fails_alot
+{
+  template <class Receiver>
+  struct operation;
+
+public:
+  using sender_concept = ex::sender_t;
+
+  fails_alot() = default;
+
+  __host__ fails_alot(fails_alot&& other) noexcept
+      : counter_(std::move(other.counter_))
+  {}
+
+  __host__ fails_alot(const fails_alot& other) noexcept
+      : counter_(other.counter_)
+  {}
+
+  template <class Receiver>
+  [[nodiscard]] auto connect(Receiver rcvr) const noexcept -> operation<Receiver>
+  {
+    return operation<Receiver>{static_cast<Receiver&&>(rcvr), --*counter_};
+  }
+
+  template <class...>
+  static _CCCL_CONSTEVAL auto get_completion_signatures() noexcept
+  {
+    return ex::completion_signatures<ex::set_value_t(), ex::set_error_t(try_again)>{};
+  }
+
+private:
+  template <class Receiver>
+  struct operation
+  {
+    void start() & noexcept
+    {
+      if (counter_ == 0)
+      {
+        ex::set_value(static_cast<Receiver&&>(rcvr_));
+      }
+      else
+      {
+        ex::set_error(static_cast<Receiver&&>(rcvr_), try_again{});
+      }
+    }
+
+    Receiver rcvr_;
+    int counter_;
+  };
+
+  std::shared_ptr<int> counter_ = std::make_shared<int>(1'000'000);
+};
+
+// #if defined(REQUIRE_TERMINATE)
+// // For some reason, when compiling with nvc++, the forked process dies with SIGSEGV
+// // but the error code returned from ::wait reports success, so this test fails.
+// TEST_CASE("running deeply recursing algo blows the stack", "[schedulers][trampoline_scheduler]") {
+
+//   auto recurse_deeply = retry(fails_alot{});
+//   REQUIRE_TERMINATE([&] { sync_wait(std::move(recurse_deeply)); });
+// }
+// #endif
+
+TEST_CASE("running deeply recursing algo on trampoline_scheduler doesn't blow the stack",
+          "[scheduler][trampoline_scheduler]")
+{
+  ex::trampoline_scheduler sched;
+  auto recurse_deeply = retry(ex::on(sched, fails_alot{}));
+  ex::sync_wait(std::move(recurse_deeply));
+}
+} // namespace
+
+#endif // !_CCCL_DEVICE_COMPILATION()


### PR DESCRIPTION
## Description

the `trampoline_scheduler` is basically like the `inline_scheduler`, except that it detects deep recursion caused by too many consecutive synchronous completions, and then unwinds the stack.

`trampoline_scheduler` is necessary before we can have any repeating algorithms in cudax::execution. for an as-yet hypothetical `repeat` algorithm, `sync_wait(repeat(just())` would blow the stack. but `sync_wait(repeat(on(trampoline_scheduler{}, just())))` would run forever and never blow the stack.

once `trampoline_scheduler` lands, i will add a `repeat_n` algorithm, and then finally i will be able to port georgii's excellent `maxwell` example to cudax::execution.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
