### PR TITLE
[libcu++] Dynamically load CUDA library instead of using the runtime

### DIFF
--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -53,16 +53,17 @@ _CCCL_SUPPRESS_DEPRECATED_PUSH
 //! @brief Gets the cuGetProcAddress function pointer.
 [[nodiscard]] _CCCL_PUBLIC_HOST_API inline auto __getProcAddressFn() -> decltype(cuGetProcAddress)*
 {
+  const char* __fn_name = "cuGetProcAddress_v2";
 #  if _CCCL_OS(WINDOWS)
   static auto __driver_library = ::LoadLibraryExA("nvcuda.dll", nullptr, LOAD_LIBRARY_SEARCH_SYSTEM32);
   if (__driver_library == nullptr)
   {
     ::cuda::__throw_cuda_error(::cudaErrorUnknown, "Failed to load nvcuda.dll");
   }
-  static void* __fn = ::GetProcAddress(__driver_library, "cuGetProcAddress_v2");
+  static void* __fn = ::GetProcAddress(__driver_library, __fn_name);
   if (__fn == nullptr)
   {
-    ::cuda::__throw_cuda_error(::cudaErrorUnknown, "Failed to get cuGetProcAddress_v2 from nvcuda.dll");
+    ::cuda::__throw_cuda_error(::cudaErrorInitializationError, "Failed to get cuGetProcAddress from nvcuda.dll");
   }
 #  else // ^^^ _CCCL_OS(WINDOWS) ^^^ / vvv !_CCCL_OS(WINDOWS) vvv
 #    if _CCCL_OS(ANDROID)
@@ -75,10 +76,10 @@ _CCCL_SUPPRESS_DEPRECATED_PUSH
   {
     ::cuda::__throw_cuda_error(::cudaErrorUnknown, "Failed to load libcuda.so.1");
   }
-  static void* __fn = ::dlsym(__driver_library, "cuGetProcAddress_v2");
+  static void* __fn = ::dlsym(__driver_library, __fn_name);
   if (__fn == nullptr)
   {
-    ::cuda::__throw_cuda_error(::cudaErrorUnknown, "Failed to get cuGetProcAddress_v2 from libcuda.so.1");
+    ::cuda::__throw_cuda_error(::cudaErrorInitializationError, "Failed to get cuGetProcAddress from libcuda.so.1");
   }
 #  endif // ^^^ !_CCCL_OS(WINDOWS) ^^^
   return reinterpret_cast<decltype(cuGetProcAddress)*>(__fn);


### PR DESCRIPTION
We can't support minor version compatibility in 12.X releases without breaking dynamic runtime use case described here: https://github.com/NVIDIA/cccl/issues/5970. Its because in older 12.X releases there is no `cudaGetDriverEntryPointByVersion` and the non versioned one can't support MVC.
This PR switches to instead dynamically load the CUDA library and fetch `cuGetProcAddress` from it, instead of using `cudaGetDriverEntryPoint`
On the windows side it uses `LibraryLoad/GetProcAddress`, which requires `windows.h` include. It's a pretty heavy header, but should also be commonly included anyway. Long term we can think about an alternative