### PR TITLE
[cuda.compute] Add dependency on nvidia-nvvm

### DIFF
--- a/python/cuda_cccl/pyproject.toml
+++ b/python/cuda_cccl/pyproject.toml
@@ -46,7 +46,7 @@ cu12 = [
 ]
 cu13 = [
   "cuda-bindings>=13.0.0,<14.0.0",
-  "cuda-toolkit[nvrtc,nvjitlink,cudart,nvcc]==13.*",
+  "cuda-toolkit[nvrtc,nvjitlink,cudart,nvcc,nvvm]==13.*",
   "numba-cuda[cu13]>=0.20.0,!=0.21.2",
 ]
 test-cu12 = [


### PR DESCRIPTION
## Description

Adding this dependency explicitly should help ensure that `nvidia-nvvm` has the same minor version as all the other dependencies.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
