### PR TITLE
Add unsupported compiler flag to .clangd

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -104,6 +104,7 @@ CompileFlags:
     - "--expt-relaxed-constexpr"
     - "-forward-unknown-to-host-compiler"
     - "-Werror=cross-execution-space-call"
+    - "-allow-unsupported-compiler"
 Diagnostics:
   Suppress:
     - "variadic_device_fn"


### PR DESCRIPTION
## Description

continuing my never-ending mission to placate clangd, which knows nothing about nvcc's `-allow-unsupported-compiler` flag.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
