### PR TITLE
Add internal `cuda::__is_device_or_managed_memory`

### DIFF
--- a/libcudacxx/include/cuda/__memory/is_pointer_accessible.h
+++ b/libcudacxx/include/cuda/__memory/is_pointer_accessible.h
@@ -103,11 +103,15 @@ _CCCL_HOST_API inline bool is_host_accessible(const void* __p)
 /**
  * @brief Checks if a pointer is a device pointer.
  *
+ * This internal-only function can be used when the device id is not known.
+ * The main difference between this function and is_device_accessible() is that this function does not check if the
+ * pointer is peer accessible from a specified device.
+ *
  * @param __p The pointer to check.
  * @return `true` if the pointer is a device pointer, `false` otherwise.
  */
 [[nodiscard]]
-_CCCL_HOST_API inline bool __is_device_memory(const void* __p) noexcept
+_CCCL_HOST_API inline bool __is_device_or_managed_memory(const void* __p) noexcept
 {
   if (__p == nullptr)
   {

--- a/libcudacxx/test/libcudacxx/cuda/memory/is_pointer_accessible.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory/is_pointer_accessible.pass.cpp
@@ -28,13 +28,13 @@ void test_accessible_pointer(
 {
   assert(cuda::is_host_accessible(ptr) == is_host_accessible);
   assert(cuda::is_device_accessible(ptr, device) == is_device_accessible);
-  assert(cuda::__is_device_memory(ptr) == is_device_accessible);
+  assert(cuda::__is_device_or_managed_memory(ptr) == is_device_accessible);
   assert(cuda::is_managed(ptr) == is_managed_accessible);
   if constexpr (!cuda::std::is_same_v<Pointer, const void*> && !cuda::std::is_same_v<Pointer, void*>)
   {
     assert(cuda::is_host_accessible(ptr + 1) == is_host_accessible);
     assert(cuda::is_device_accessible(ptr + 1, device) == is_device_accessible);
-    assert(cuda::__is_device_memory(ptr + 1) == is_device_accessible);
+    assert(cuda::__is_device_or_managed_memory(ptr + 1) == is_device_accessible);
     assert(cuda::is_managed(ptr + 1) == is_managed_accessible);
   }
 }
@@ -151,7 +151,7 @@ bool test_multiple_devices()
 
   /// DEVICE 1 CONTEXT
   cuda::__ensure_current_context ctx1(dev1);
-  assert(cuda::__is_device_memory(device_ptr0) == true);
+  assert(cuda::__is_device_or_managed_memory(device_ptr0) == true);
   assert(cuda::is_device_accessible(device_ptr0, dev0) == true);
   assert(cuda::is_device_accessible(device_ptr0, dev1) == false);
 
@@ -161,7 +161,7 @@ bool test_multiple_devices()
   {
     return true;
   }
-  assert(cuda::__is_device_memory(device_ptr0) == true);
+  assert(cuda::__is_device_or_managed_memory(device_ptr0) == true);
   assert(cuda::is_device_accessible(device_ptr0, dev1) == false);
 
   assert(cudaDeviceEnablePeerAccess(dev1.get(), 0) == cudaSuccess);
@@ -190,7 +190,7 @@ bool test_multiple_devices_from_pool()
     return true;
   }
   assert(cuda::is_device_accessible(ptr, dev1) == false);
-  assert(cuda::__is_device_memory(ptr) == true);
+  assert(cuda::__is_device_or_managed_memory(ptr) == true);
 
   assert(cudaDeviceEnablePeerAccess(dev1.get(), 0) == cudaSuccess);
   assert(cuda::is_device_accessible(ptr, dev0) == true);


### PR DESCRIPTION
## Description

PR https://github.com/NVIDIA/cccl/pull/6733 shows that we also need a relaxed `cuda::is_device_accessible` which doesn't require a device reference. The overall idea is to just check if a pointer is device allocated.