### PR TITLE
Extend transform benchmarks to 2^32 elements

### DIFF
--- a/cub/benchmarks/bench/transform/babelstream.cu
+++ b/cub/benchmarks/bench/transform/babelstream.cu
@@ -29,7 +29,7 @@ using element_types =
 // 2^21 chars / 2^17 int128 saturate A100 (min_bif =16 * SM count =108)
 // 2^23 chars / 2^19 int128 saturate H100/H200 HBM3 (min_bif =32or48 * SM count =132)
 // inline auto array_size_powers = std::vector<nvbench::int64_t>{28};
-inline auto array_size_powers = nvbench::range(16, 28, 4);
+inline auto array_size_powers = nvbench::range(16, 32, 4);
 
 // Modified from BabelStream to also work for integers and to make nstream maintain a consistent workload since it
 // overwrites one input array. If the data changed at each iteration, the performance would be unstable.
@@ -42,8 +42,15 @@ static_assert(startA == (startA + startB + startScalar * startC), "nstream must 
 
 template <typename T, typename OffsetT>
 static void mul(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+try
 {
-  const auto n = cuda::narrow<OffsetT>(state.get_int64("Elements{io}"));
+  const auto n = state.get_int64("Elements{io}");
+  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
+  {
+    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
+    return;
+  }
+
   thrust::device_vector<T> b(n, startB);
   thrust::device_vector<T> c(n, startC);
 
@@ -52,9 +59,14 @@ static void mul(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_writes<T>(n);
 
   const T scalar = startScalar;
-  bench_transform(state, ::cuda::std::tuple{c.begin()}, b.begin(), n, [=] _CCCL_DEVICE(const T& ci) {
-    return ci * scalar;
-  });
+  bench_transform(
+    state, ::cuda::std::tuple{c.begin()}, b.begin(), static_cast<OffsetT>(n), [=] _CCCL_DEVICE(const T& ci) {
+      return ci * scalar;
+    });
+}
+catch (const std::bad_alloc&)
+{
+  state.skip("Skipping: out of memory.");
 }
 
 NVBENCH_BENCH_TYPES(mul, NVBENCH_TYPE_AXES(element_types, offset_types))
@@ -64,8 +76,15 @@ NVBENCH_BENCH_TYPES(mul, NVBENCH_TYPE_AXES(element_types, offset_types))
 
 template <typename T, typename OffsetT>
 static void add(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+try
 {
-  const auto n = cuda::narrow<OffsetT>(state.get_int64("Elements{io}"));
+  const auto n = state.get_int64("Elements{io}");
+  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
+  {
+    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
+    return;
+  }
+
   thrust::device_vector<T> a(n, startA);
   thrust::device_vector<T> b(n, startB);
   thrust::device_vector<T> c(n, startC);
@@ -74,9 +93,17 @@ static void add(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_reads<T>(2 * n);
   state.add_global_memory_writes<T>(n);
   bench_transform(
-    state, ::cuda::std::tuple{a.begin(), b.begin()}, c.begin(), n, [] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
+    state,
+    ::cuda::std::tuple{a.begin(), b.begin()},
+    c.begin(),
+    static_cast<OffsetT>(n),
+    [] _CCCL_DEVICE(const T& ai, const T& bi) -> T {
       return ai + bi;
     });
+}
+catch (const std::bad_alloc&)
+{
+  state.skip("Skipping: out of memory.");
 }
 
 NVBENCH_BENCH_TYPES(add, NVBENCH_TYPE_AXES(element_types, offset_types))
@@ -86,8 +113,15 @@ NVBENCH_BENCH_TYPES(add, NVBENCH_TYPE_AXES(element_types, offset_types))
 
 template <typename T, typename OffsetT>
 static void triad(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+try
 {
-  const auto n = cuda::narrow<OffsetT>(state.get_int64("Elements{io}"));
+  const auto n = state.get_int64("Elements{io}");
+  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
+  {
+    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
+    return;
+  }
+
   thrust::device_vector<T> a(n, startA);
   thrust::device_vector<T> b(n, startB);
   thrust::device_vector<T> c(n, startC);
@@ -97,9 +131,17 @@ static void triad(nvbench::state& state, nvbench::type_list<T, OffsetT>)
   state.add_global_memory_writes<T>(n);
   const T scalar = startScalar;
   bench_transform(
-    state, ::cuda::std::tuple{b.begin(), c.begin()}, a.begin(), n, [=] _CCCL_DEVICE(const T& bi, const T& ci) {
+    state,
+    ::cuda::std::tuple{b.begin(), c.begin()},
+    a.begin(),
+    static_cast<OffsetT>(n),
+    [=] _CCCL_DEVICE(const T& bi, const T& ci) {
       return bi + scalar * ci;
     });
+}
+catch (const std::bad_alloc&)
+{
+  state.skip("Skipping: out of memory.");
 }
 
 NVBENCH_BENCH_TYPES(triad, NVBENCH_TYPE_AXES(element_types, offset_types))
@@ -109,8 +151,15 @@ NVBENCH_BENCH_TYPES(triad, NVBENCH_TYPE_AXES(element_types, offset_types))
 
 template <typename T, typename OffsetT>
 static void nstream(nvbench::state& state, nvbench::type_list<T, OffsetT>)
+try
 {
-  const auto n = cuda::narrow<OffsetT>(state.get_int64("Elements{io}"));
+  const auto n = state.get_int64("Elements{io}");
+  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
+  {
+    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
+    return;
+  }
+
   thrust::device_vector<T> a(n, startA);
   thrust::device_vector<T> b(n, startB);
   thrust::device_vector<T> c(n, startC);
@@ -123,10 +172,14 @@ static void nstream(nvbench::state& state, nvbench::type_list<T, OffsetT>)
     state,
     ::cuda::std::tuple{a.begin(), b.begin(), c.begin()},
     a.begin(),
-    n,
+    static_cast<OffsetT>(n),
     [=] _CCCL_DEVICE(const T& ai, const T& bi, const T& ci) {
       return ai + bi + scalar * ci;
     });
+}
+catch (const std::bad_alloc&)
+{
+  state.skip("Skipping: out of memory.");
 }
 
 NVBENCH_BENCH_TYPES(nstream, NVBENCH_TYPE_AXES(element_types, offset_types))

--- a/cub/benchmarks/bench/transform/complex_cmp.cu
+++ b/cub/benchmarks/bench/transform/complex_cmp.cu
@@ -13,8 +13,15 @@
 
 template <typename OffsetT>
 static void compare_complex(nvbench::state& state, nvbench::type_list<OffsetT>)
+try
 {
-  const auto n                      = cuda::narrow<OffsetT>(state.get_int64("Elements{io}"));
+  const auto n = state.get_int64("Elements{io}");
+  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
+  {
+    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
+    return;
+  }
+
   thrust::device_vector<complex> in = generate(n);
   thrust::device_vector<bool> out(n - 1);
 
@@ -24,11 +31,16 @@ static void compare_complex(nvbench::state& state, nvbench::type_list<OffsetT>)
 
   // the complex comparison needs lots of compute and transform reads from overlapping input
   using compare_op = less_t;
-  bench_transform(state, ::cuda::std::tuple{in.begin(), in.begin() + 1}, out.begin(), n - 1, compare_op{});
+  bench_transform(
+    state, ::cuda::std::tuple{in.begin(), in.begin() + 1}, out.begin(), static_cast<OffsetT>(n) - 1, compare_op{});
+}
+catch (const std::bad_alloc&)
+{
+  state.skip("Skipping: out of memory.");
 }
 
 // TODO(bgruber): hardcode OffsetT?
 NVBENCH_BENCH_TYPES(compare_complex, NVBENCH_TYPE_AXES(offset_types))
   .set_name("compare_complex")
   .set_type_axes_names({"OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4));

--- a/cub/benchmarks/bench/transform/fib.cu
+++ b/cub/benchmarks/bench/transform/fib.cu
@@ -42,10 +42,17 @@ struct fib_t
 };
 template <typename OffsetT>
 static void fibonacci(nvbench::state& state, nvbench::type_list<OffsetT>)
+try
 {
-  using index_t                     = int64_t;
-  using output_t                    = uint32_t;
-  const auto n                      = cuda::narrow<OffsetT>(state.get_int64("Elements{io}"));
+  using index_t  = int64_t;
+  using output_t = uint32_t;
+  const auto n   = state.get_int64("Elements{io}");
+  if (sizeof(OffsetT) == 4 && n > std::numeric_limits<OffsetT>::max())
+  {
+    state.skip("Skipping: input size exceeds 32-bit offset type capacity.");
+    return;
+  }
+
   thrust::device_vector<index_t> in = generate(n, bit_entropy::_1_000, index_t{0}, index_t{42});
   thrust::device_vector<output_t> out(n);
 
@@ -53,10 +60,15 @@ static void fibonacci(nvbench::state& state, nvbench::type_list<OffsetT>)
   state.add_global_memory_reads<index_t>(n);
   state.add_global_memory_writes<output_t>(n);
 
-  bench_transform(state, ::cuda::std::tuple{in.begin()}, out.begin(), n, fib_t<index_t, output_t>{});
+  bench_transform(
+    state, ::cuda::std::tuple{in.begin()}, out.begin(), static_cast<OffsetT>(n), fib_t<index_t, output_t>{});
+}
+catch (const std::bad_alloc&)
+{
+  state.skip("Skipping: out of memory.");
 }
 
 NVBENCH_BENCH_TYPES(fibonacci, NVBENCH_TYPE_AXES(offset_types))
   .set_name("fibonacci")
   .set_type_axes_names({"OffsetT{ct}"})
-  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 32, 4));


### PR DESCRIPTION
Confirmed that the benchmark runs successfully on a B200 and an RTX 5090. Here is an example log:
```
Run:  [1/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.017344ms GPU, 0.020118ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [2/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.014752ms GPU, 0.017784ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [3/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.041248ms GPU, 0.044404ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [4/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 0.418432ms GPU, 0.422039ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [5/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [6/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.015200ms GPU, 0.018485ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [7/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.013696ms GPU, 0.017092ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [8/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.039232ms GPU, 0.042481ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [9/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 0.430784ms GPU, 0.434322ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [10/80] base [Device=0 T{ct}=I8 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [11/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.016192ms GPU, 0.019256ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [12/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.017472ms GPU, 0.020800ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [13/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.053952ms GPU, 0.057629ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [14/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 0.716480ms GPU, 0.720453ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [15/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [16/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.021120ms GPU, 0.024527ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [17/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.019136ms GPU, 0.022863ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [18/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.052544ms GPU, 0.055966ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [19/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 0.710464ms GPU, 0.713971ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [20/80] base [Device=0 T{ct}=I16 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [21/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.017024ms GPU, 0.020038ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [22/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.017888ms GPU, 0.021821ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [23/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.093472ms GPU, 0.097144ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [24/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 1.418624ms GPU, 1.422412ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [25/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [26/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.018624ms GPU, 0.022001ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [27/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.017440ms GPU, 0.020850ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [28/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.093088ms GPU, 0.096443ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [29/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 1.419040ms GPU, 1.422783ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [30/80] base [Device=0 T{ct}=I32 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [31/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.018912ms GPU, 0.021841ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [32/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.024736ms GPU, 0.028033ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [33/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.183328ms GPU, 0.186913ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [34/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 2.821536ms GPU, 2.825217ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [35/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [36/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.015712ms GPU, 0.019216ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [37/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.021792ms GPU, 0.025388ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [38/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.184320ms GPU, 0.187666ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [39/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 2.828864ms GPU, 2.832430ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [40/80] base [Device=0 T{ct}=I64 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [41/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.021312ms GPU, 0.024696ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [42/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.033376ms GPU, 0.036870ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [43/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.358176ms GPU, 0.361384ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [44/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 5.634912ms GPU, 5.638402ms CPU, 0.01s total GPU, 0.01s total wall, 1x 
Run:  [45/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [46/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.020384ms GPU, 0.024617ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [47/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.031712ms GPU, 0.034996ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [48/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.358112ms GPU, 0.361414ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [49/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 5.635808ms GPU, 5.639163ms CPU, 0.01s total GPU, 0.01s total wall, 1x 
Run:  [50/80] base [Device=0 T{ct}=I128 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [51/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.020576ms GPU, 0.023534ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [52/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.020192ms GPU, 0.023414ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [53/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.092416ms GPU, 0.095982ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [54/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 1.420256ms GPU, 1.423635ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [55/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [56/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.018464ms GPU, 0.021722ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [57/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.019168ms GPU, 0.022553ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [58/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.094880ms GPU, 0.098536ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [59/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 1.418464ms GPU, 1.422212ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [60/80] base [Device=0 T{ct}=F32 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [61/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.023520ms GPU, 0.026430ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [62/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.028448ms GPU, 0.031790ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [63/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.183552ms GPU, 0.187265ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [64/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 2.815936ms GPU, 2.819627ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [65/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [66/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.017504ms GPU, 0.020759ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [67/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.023648ms GPU, 0.026871ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [68/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.182272ms GPU, 0.185721ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [69/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 2.820864ms GPU, 2.824145ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [70/80] base [Device=0 T{ct}=F64 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
Run:  [71/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I32 Elements{io}=2^16]
Pass: Cold: 0.020256ms GPU, 0.023494ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [72/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I32 Elements{io}=2^20]
Pass: Cold: 0.027552ms GPU, 0.030868ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [73/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I32 Elements{io}=2^24]
Pass: Cold: 0.206080ms GPU, 0.209306ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [74/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I32 Elements{io}=2^28]
Pass: Cold: 2.997600ms GPU, 3.001110ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [75/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I32 Elements{io}=2^32]
Skip: Skipping: input size exceeds 32-bit offset type capacity.
Run:  [76/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I64 Elements{io}=2^16]
Pass: Cold: 0.016704ms GPU, 0.020649ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [77/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I64 Elements{io}=2^20]
Pass: Cold: 0.027808ms GPU, 0.031219ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [78/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I64 Elements{io}=2^24]
Pass: Cold: 0.203904ms GPU, 0.207392ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [79/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I64 Elements{io}=2^28]
Pass: Cold: 3.000032ms GPU, 3.003505ms CPU, 0.00s total GPU, 0.00s total wall, 1x 
Run:  [80/80] base [Device=0 T{ct}=C32 OffsetT{ct}=I64 Elements{io}=2^32]
Skip: Skipping: out of memory.
```