### PR TITLE
Use vectorized transform kernel for sizeof(T) < 4 workloads of arity >1 on Hopper

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -435,8 +435,8 @@ struct policy_hub<RequiresStableAddress,
 
     // on Hopper, the vectorized kernel performs better for 1 and 2 byte values
     static constexpr bool use_vector_kernel_on_hopper =
-      ((sizeof(it_value_t<RandomAccessIteratorsIn>) < 4) && ...) && sizeof...(RandomAccessIteratorsIn) > 1
-      && sizeof(it_value_t<RandomAccessIteratorOut>) < 4;
+      ((size_of<it_value_t<RandomAccessIteratorsIn>> < 4) && ...) && sizeof...(RandomAccessIteratorsIn) > 1
+      && size_of<it_value_t<RandomAccessIteratorOut>> < 4;
 
     // if each tile size is a multiple of the bulk copy and maximum value type alignments, the alignment is retained if
     // the base pointer is sufficiently aligned (the correct check would be if it's a multiple of all value types


### PR DESCRIPTION
looks good on H200
```
# mul

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   3.935 us |       3.15% |   3.925 us |       3.54% | -0.010 us |  -0.25% |   SAME   |
|   I8    |      I32      |      2^20      |   4.798 us |       3.56% |   4.797 us |       3.43% | -0.001 us |  -0.01% |   SAME   |
|   I8    |      I32      |      2^24      |  14.408 us |       1.78% |  14.439 us |       1.91% |  0.031 us |   0.22% |   SAME   |
|   I8    |      I32      |      2^28      | 141.096 us |       0.54% | 141.259 us |       0.54% |  0.163 us |   0.12% |   SAME   |
|   I8    |      I64      |      2^16      |   4.094 us |       3.03% |   4.108 us |       3.28% |  0.014 us |   0.33% |   SAME   |
|   I8    |      I64      |      2^20      |   5.034 us |       3.29% |   5.029 us |       3.23% | -0.004 us |  -0.08% |   SAME   |
|   I8    |      I64      |      2^24      |  14.481 us |       1.78% |  14.454 us |       1.67% | -0.028 us |  -0.19% |   SAME   |
|   I8    |      I64      |      2^28      | 141.850 us |       0.54% | 141.927 us |       0.52% |  0.076 us |   0.05% |   SAME   |
|   I8    |      I64      |      2^32      |   2.219 ms |       1.94% |   2.251 ms |       3.36% | 32.265 us |   1.45% |   SAME   |
|   I16   |      I32      |      2^16      |   4.198 us |       3.67% |   4.252 us |       4.42% |  0.054 us |   1.29% |   SAME   |
|   I16   |      I32      |      2^20      |   5.678 us |       3.48% |   5.707 us |       3.55% |  0.028 us |   0.50% |   SAME   |
|   I16   |      I32      |      2^24      |  21.108 us |       2.46% |  21.099 us |       2.48% | -0.009 us |  -0.04% |   SAME   |
|   I16   |      I32      |      2^28      | 253.092 us |       0.42% | 253.099 us |       0.44% |  0.007 us |   0.00% |   SAME   |
|   I16   |      I64      |      2^16      |   4.141 us |       3.24% |   4.145 us |       3.20% |  0.003 us |   0.08% |   SAME   |
|   I16   |      I64      |      2^20      |   5.624 us |       3.42% |   5.602 us |       3.48% | -0.023 us |  -0.40% |   SAME   |
|   I16   |      I64      |      2^24      |  21.231 us |       2.56% |  21.202 us |       2.34% | -0.029 us |  -0.14% |   SAME   |
|   I16   |      I64      |      2^28      | 253.069 us |       0.42% | 253.025 us |       0.42% | -0.044 us |  -0.02% |   SAME   |
|   I16   |      I64      |      2^32      |   3.975 ms |       0.04% |   3.975 ms |       0.03% | -0.006 us |  -0.00% |   SAME   |
|   F16   |      I32      |      2^16      |   4.239 us |       4.52% |   4.234 us |       4.63% | -0.004 us |  -0.11% |   SAME   |
|   F16   |      I32      |      2^20      |   5.465 us |       3.78% |   5.460 us |       3.60% | -0.004 us |  -0.08% |   SAME   |
|   F16   |      I32      |      2^24      |  21.119 us |       2.43% |  21.136 us |       2.53% |  0.017 us |   0.08% |   SAME   |
|   F16   |      I32      |      2^28      | 253.105 us |       0.42% | 253.113 us |       0.44% |  0.008 us |   0.00% |   SAME   |
|   F16   |      I64      |      2^16      |   4.007 us |       3.36% |   4.014 us |       3.08% |  0.007 us |   0.18% |   SAME   |
|   F16   |      I64      |      2^20      |   5.522 us |       3.46% |   5.508 us |       3.06% | -0.015 us |  -0.26% |   SAME   |
|   F16   |      I64      |      2^24      |  21.220 us |       2.42% |  21.250 us |       2.44% |  0.030 us |   0.14% |   SAME   |
|   F16   |      I64      |      2^28      | 253.205 us |       0.44% | 253.196 us |       0.41% | -0.008 us |  -0.00% |   SAME   |
|   F16   |      I64      |      2^32      |   3.977 ms |       0.04% |   3.977 ms |       0.04% |  0.061 us |   0.00% |   SAME   |
|   F32   |      I32      |      2^16      |   4.229 us |       5.03% |   4.244 us |       4.64% |  0.015 us |   0.36% |   SAME   |
|   F32   |      I32      |      2^20      |   6.297 us |       3.12% |   6.316 us |       3.55% |  0.019 us |   0.31% |   SAME   |
|   F32   |      I32      |      2^24      |  36.536 us |       1.87% |  36.519 us |       1.88% | -0.017 us |  -0.05% |   SAME   |
|   F32   |      I32      |      2^28      | 508.256 us |       0.19% | 508.277 us |       0.20% |  0.020 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   4.168 us |       4.37% |   4.162 us |       4.20% | -0.006 us |  -0.13% |   SAME   |
|   F32   |      I64      |      2^20      |   6.345 us |       3.20% |   6.353 us |       3.43% |  0.007 us |   0.11% |   SAME   |
|   F32   |      I64      |      2^24      |  36.570 us |       1.89% |  36.792 us |      13.55% |  0.221 us |   0.60% |   SAME   |
|   F32   |      I64      |      2^28      | 508.219 us |       0.17% | 508.369 us |       0.20% |  0.150 us |   0.03% |   SAME   |
|   F32   |      I64      |      2^32      |   8.075 ms |       0.05% |   8.075 ms |       0.05% |  0.094 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   4.406 us |       4.31% |   4.396 us |       4.33% | -0.011 us |  -0.24% |   SAME   |
|   F64   |      I32      |      2^20      |   8.432 us |       2.62% |   8.426 us |       2.74% | -0.006 us |  -0.07% |   SAME   |
|   F64   |      I32      |      2^24      |  67.579 us |       1.07% |  67.611 us |       1.09% |  0.033 us |   0.05% |   SAME   |
|   F64   |      I32      |      2^28      |   1.010 ms |       0.13% |   1.010 ms |       0.12% |  0.057 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   4.416 us |      11.55% |   4.404 us |       4.71% | -0.013 us |  -0.29% |   SAME   |
|   F64   |      I64      |      2^20      |   8.472 us |       2.71% |   8.465 us |       2.57% | -0.007 us |  -0.09% |   SAME   |
|   F64   |      I64      |      2^24      |  67.715 us |       1.16% |  67.773 us |       1.09% |  0.059 us |   0.09% |   SAME   |
|   F64   |      I64      |      2^28      |   1.010 ms |       0.12% |   1.010 ms |       0.13% | -0.074 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^32      |  16.140 ms |       0.03% |  16.139 ms |       0.04% | -0.316 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   4.799 us |       4.94% |   4.806 us |       5.44% |  0.007 us |   0.14% |   SAME   |
|  I128   |      I32      |      2^20      |  12.850 us |       2.75% |  12.846 us |       2.66% | -0.004 us |  -0.03% |   SAME   |
|  I128   |      I32      |      2^24      | 133.040 us |       0.63% | 133.002 us |       0.60% | -0.037 us |  -0.03% |   SAME   |
|  I128   |      I32      |      2^28      |   2.051 ms |       0.08% |   2.051 ms |       0.08% | -0.115 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   4.816 us |       4.29% |   4.830 us |       4.98% |  0.015 us |   0.30% |   SAME   |
|  I128   |      I64      |      2^20      |  12.935 us |       2.64% |  12.909 us |       2.49% | -0.026 us |  -0.20% |   SAME   |
|  I128   |      I64      |      2^24      | 133.182 us |       0.63% | 133.191 us |       0.62% |  0.009 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   2.051 ms |       0.08% |   2.051 ms |       0.08% | -0.090 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^32      |  32.764 ms |       0.02% |  32.763 ms |       0.02% | -1.273 us |  -0.00% |   SAME   |

# add

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I32      |      2^16      |   4.169 us |       5.04% |   4.018 us |       5.13% |  -0.150 us |  -3.61% |   SAME   |
|   I8    |      I32      |      2^20      |   5.439 us |       3.30% |   5.154 us |       3.03% |  -0.285 us |  -5.25% |   FAST   |
|   I8    |      I32      |      2^24      |  18.703 us |       2.18% |  18.347 us |       1.96% |  -0.356 us |  -1.91% |   SAME   |
|   I8    |      I32      |      2^28      | 197.202 us |       0.24% | 194.357 us |       0.26% |  -2.845 us |  -1.44% |   FAST   |
|   I8    |      I64      |      2^16      |   4.260 us |       3.10% |   4.105 us |       3.35% |  -0.154 us |  -3.62% |   FAST   |
|   I8    |      I64      |      2^20      |   5.613 us |       2.60% |   5.239 us |       3.33% |  -0.374 us |  -6.67% |   FAST   |
|   I8    |      I64      |      2^24      |  18.911 us |       2.04% |  18.452 us |       2.07% |  -0.458 us |  -2.42% |   FAST   |
|   I8    |      I64      |      2^28      | 198.258 us |       0.21% | 194.846 us |       0.24% |  -3.413 us |  -1.72% |   FAST   |
|   I8    |      I64      |      2^32      |   3.061 ms |       0.28% |   2.989 ms |       0.02% | -72.021 us |  -2.35% |   FAST   |
|   I16   |      I32      |      2^16      |   4.427 us |       4.98% |   4.220 us |       4.76% |  -0.207 us |  -4.67% |   SAME   |
|   I16   |      I32      |      2^20      |   6.405 us |       3.06% |   6.018 us |       2.93% |  -0.387 us |  -6.04% |   FAST   |
|   I16   |      I32      |      2^24      |  30.245 us |       1.90% |  29.679 us |       1.93% |  -0.566 us |  -1.87% |   SAME   |
|   I16   |      I32      |      2^28      | 371.395 us |       0.22% | 371.865 us |       0.25% |   0.470 us |   0.13% |   SAME   |
|   I16   |      I64      |      2^16      |   4.356 us |       3.22% |   4.179 us |       3.00% |  -0.176 us |  -4.05% |   FAST   |
|   I16   |      I64      |      2^20      |   6.547 us |       3.37% |   6.120 us |       2.90% |  -0.427 us |  -6.52% |   FAST   |
|   I16   |      I64      |      2^24      |  30.340 us |       1.79% |  29.697 us |       1.97% |  -0.643 us |  -2.12% |   FAST   |
|   I16   |      I64      |      2^28      | 371.890 us |       0.21% | 371.865 us |       0.25% |  -0.025 us |  -0.01% |   SAME   |
|   I16   |      I64      |      2^32      |   5.820 ms |       0.01% |   5.869 ms |       0.06% |  48.569 us |   0.83% |   SLOW   |
|   F16   |      I32      |      2^16      |   4.393 us |       5.11% |   4.265 us |       5.82% |  -0.128 us |  -2.92% |   SAME   |
|   F16   |      I32      |      2^20      |   6.409 us |       3.36% |   6.058 us |       3.55% |  -0.351 us |  -5.48% |   FAST   |
|   F16   |      I32      |      2^24      |  30.392 us |       1.87% |  29.791 us |       2.00% |  -0.602 us |  -1.98% |   FAST   |
|   F16   |      I32      |      2^28      | 373.332 us |       0.22% | 371.770 us |       0.25% |  -1.563 us |  -0.42% |   FAST   |
|   F16   |      I64      |      2^16      |   4.345 us |       3.38% |   4.170 us |       4.00% |  -0.175 us |  -4.04% |   FAST   |
|   F16   |      I64      |      2^20      |   6.428 us |       3.38% |   6.021 us |       3.00% |  -0.407 us |  -6.32% |   FAST   |
|   F16   |      I64      |      2^24      |  30.387 us |       1.87% |  29.754 us |       1.99% |  -0.633 us |  -2.08% |   FAST   |
|   F16   |      I64      |      2^28      | 374.813 us |       0.22% | 371.653 us |       0.25% |  -3.160 us |  -0.84% |   FAST   |
|   F16   |      I64      |      2^32      |   5.862 ms |       0.02% |   5.869 ms |       0.05% |   7.153 us |   0.12% |   SLOW   |
|   F32   |      I32      |      2^16      |   4.452 us |       4.86% |   4.453 us |       4.63% |   0.002 us |   0.04% |   SAME   |
|   F32   |      I32      |      2^20      |   7.717 us |       3.82% |   7.642 us |       1.77% |  -0.075 us |  -0.97% |   SAME   |
|   F32   |      I32      |      2^24      |  52.878 us |       1.37% |  52.893 us |       1.38% |   0.015 us |   0.03% |   SAME   |
|   F32   |      I32      |      2^28      | 730.670 us |       0.11% | 730.676 us |       0.11% |   0.006 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   4.337 us |       4.09% |   4.339 us |       3.76% |   0.002 us |   0.04% |   SAME   |
|   F32   |      I64      |      2^20      |   7.691 us |       3.25% |   7.808 us |       4.75% |   0.117 us |   1.53% |   SAME   |
|   F32   |      I64      |      2^24      |  52.952 us |       1.38% |  52.971 us |       1.46% |   0.019 us |   0.04% |   SAME   |
|   F32   |      I64      |      2^28      | 730.846 us |       0.11% | 730.845 us |       0.11% |  -0.001 us |  -0.00% |   SAME   |
|   F32   |      I64      |      2^32      |  11.601 ms |       0.10% |  11.601 ms |       0.10% |   0.121 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   4.720 us |       4.12% |   4.741 us |       4.17% |   0.021 us |   0.45% |   SAME   |
|   F64   |      I32      |      2^20      |  11.041 us |       2.55% |  11.043 us |       2.43% |   0.002 us |   0.02% |   SAME   |
|   F64   |      I32      |      2^24      |  97.284 us |       0.44% |  97.289 us |       0.47% |   0.005 us |   0.01% |   SAME   |
|   F64   |      I32      |      2^28      |   1.466 ms |       0.11% |   1.466 ms |       0.11% |  -0.022 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   4.633 us |       5.12% |   4.622 us |       4.89% |  -0.011 us |  -0.25% |   SAME   |
|   F64   |      I64      |      2^20      |  10.995 us |       2.53% |  10.985 us |       2.52% |  -0.010 us |  -0.09% |   SAME   |
|   F64   |      I64      |      2^24      |  97.409 us |       0.39% |  97.455 us |       0.46% |   0.046 us |   0.05% |   SAME   |
|   F64   |      I64      |      2^28      |   1.466 ms |       0.11% |   1.466 ms |       0.11% |  -0.014 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^32      |  23.442 ms |       0.06% |  23.441 ms |       0.06% |  -0.747 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.249 us |       4.26% |   5.275 us |       4.46% |   0.026 us |   0.49% |   SAME   |
|  I128   |      I32      |      2^20      |  17.842 us |       2.17% |  17.825 us |       2.16% |  -0.016 us |  -0.09% |   SAME   |
|  I128   |      I32      |      2^24      | 188.154 us |       0.32% | 188.165 us |       0.31% |   0.011 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   2.929 ms |       0.06% |   2.929 ms |       0.06% |   0.157 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   5.410 us |       4.79% |   5.393 us |       5.16% |  -0.017 us |  -0.31% |   SAME   |
|  I128   |      I64      |      2^20      |  17.879 us |       2.16% |  17.915 us |       2.25% |   0.036 us |   0.20% |   SAME   |
|  I128   |      I64      |      2^24      | 188.248 us |       0.32% | 188.237 us |       0.33% |  -0.011 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   2.929 ms |       0.07% |   2.929 ms |       0.06% |   0.158 us |   0.01% |   SAME   |

# triad

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   4.288 us |       4.62% |   4.131 us |       4.71% |   -0.158 us |  -3.68% |   SAME   |
|   I8    |      I32      |      2^20      |   5.588 us |       3.34% |   5.134 us |       3.21% |   -0.454 us |  -8.12% |   FAST   |
|   I8    |      I32      |      2^24      |  19.141 us |       1.93% |  17.873 us |       1.99% |   -1.268 us |  -6.62% |   FAST   |
|   I8    |      I32      |      2^28      | 204.938 us |       0.13% | 195.208 us |       0.25% |   -9.730 us |  -4.75% |   FAST   |
|   I8    |      I64      |      2^16      |   4.214 us |       3.20% |   4.050 us |       3.59% |   -0.165 us |  -3.91% |   FAST   |
|   I8    |      I64      |      2^20      |   5.683 us |       3.00% |   5.159 us |       3.37% |   -0.523 us |  -9.21% |   FAST   |
|   I8    |      I64      |      2^24      |  19.228 us |       1.91% |  17.916 us |       2.14% |   -1.312 us |  -6.82% |   FAST   |
|   I8    |      I64      |      2^28      | 206.255 us |       0.18% | 195.590 us |       0.26% |  -10.665 us |  -5.17% |   FAST   |
|   I8    |      I64      |      2^32      |   3.206 ms |       0.42% |   2.995 ms |       0.02% | -211.136 us |  -6.59% |   FAST   |
|   I16   |      I32      |      2^16      |   4.464 us |       4.79% |   4.267 us |       4.42% |   -0.197 us |  -4.41% |   SAME   |
|   I16   |      I32      |      2^20      |   6.358 us |       3.30% |   6.023 us |       2.90% |   -0.336 us |  -5.28% |   FAST   |
|   I16   |      I32      |      2^24      |  30.313 us |       1.87% |  29.478 us |       2.00% |   -0.834 us |  -2.75% |   FAST   |
|   I16   |      I32      |      2^28      | 373.139 us |       0.21% | 372.178 us |       0.23% |   -0.961 us |  -0.26% |   FAST   |
|   I16   |      I64      |      2^16      |   4.349 us |       3.66% |   4.171 us |       3.62% |   -0.178 us |  -4.10% |   FAST   |
|   I16   |      I64      |      2^20      |   6.426 us |       3.06% |   6.041 us |       3.15% |   -0.385 us |  -6.00% |   FAST   |
|   I16   |      I64      |      2^24      |  30.623 us |       1.86% |  29.622 us |       1.89% |   -1.000 us |  -3.27% |   FAST   |
|   I16   |      I64      |      2^28      | 373.672 us |       0.21% | 372.218 us |       0.24% |   -1.454 us |  -0.39% |   FAST   |
|   I16   |      I64      |      2^32      |   5.858 ms |       0.02% |   5.872 ms |       0.05% |   14.072 us |   0.24% |   SLOW   |
|   F16   |      I32      |      2^16      |   4.427 us |       5.01% |   4.281 us |       5.78% |   -0.146 us |  -3.31% |   SAME   |
|   F16   |      I32      |      2^20      |   6.311 us |       3.05% |   6.030 us |       3.33% |   -0.280 us |  -4.44% |   FAST   |
|   F16   |      I32      |      2^24      |  30.422 us |       1.85% |  29.639 us |       1.95% |   -0.782 us |  -2.57% |   FAST   |
|   F16   |      I32      |      2^28      | 373.320 us |       0.21% | 372.152 us |       0.23% |   -1.168 us |  -0.31% |   FAST   |
|   F16   |      I64      |      2^16      |   4.308 us |       3.10% |   4.171 us |       3.07% |   -0.137 us |  -3.18% |   FAST   |
|   F16   |      I64      |      2^20      |   6.365 us |       2.98% |   6.019 us |       3.20% |   -0.346 us |  -5.44% |   FAST   |
|   F16   |      I64      |      2^24      |  30.545 us |       1.84% |  29.631 us |       1.94% |   -0.915 us |  -2.99% |   FAST   |
|   F16   |      I64      |      2^28      | 374.419 us |       0.21% | 372.228 us |       0.25% |   -2.190 us |  -0.59% |   FAST   |
|   F16   |      I64      |      2^32      |   5.891 ms |       0.02% |   5.872 ms |       0.05% |  -18.383 us |  -0.31% |   FAST   |
|   F32   |      I32      |      2^16      |   4.501 us |       4.34% |   4.497 us |       4.37% |   -0.004 us |  -0.10% |   SAME   |
|   F32   |      I32      |      2^20      |   7.980 us |       3.19% |   7.917 us |       2.30% |   -0.063 us |  -0.79% |   SAME   |
|   F32   |      I32      |      2^24      |  52.804 us |       1.37% |  52.800 us |       1.36% |   -0.003 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^28      | 730.978 us |       0.12% | 731.002 us |       0.12% |    0.024 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   4.453 us |       3.81% |   4.441 us |       3.41% |   -0.012 us |  -0.27% |   SAME   |
|   F32   |      I64      |      2^20      |   7.992 us |       2.41% |   7.985 us |       2.15% |   -0.007 us |  -0.09% |   SAME   |
|   F32   |      I64      |      2^24      |  52.864 us |       1.36% |  52.908 us |       1.37% |    0.044 us |   0.08% |   SAME   |
|   F32   |      I64      |      2^28      | 731.113 us |       0.11% | 731.114 us |       0.12% |    0.001 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^32      |  11.624 ms |       0.06% |  11.623 ms |       0.06% |   -0.476 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   4.666 us |       5.68% |   4.623 us |       3.81% |   -0.043 us |  -0.93% |   SAME   |
|   F64   |      I32      |      2^20      |  11.102 us |       2.43% |  11.110 us |       2.45% |    0.007 us |   0.07% |   SAME   |
|   F64   |      I32      |      2^24      |  97.704 us |       0.40% |  97.666 us |       0.44% |   -0.038 us |  -0.04% |   SAME   |
|   F64   |      I32      |      2^28      |   1.466 ms |       0.10% |   1.466 ms |       0.10% |   -0.018 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   4.619 us |       3.97% |   4.636 us |       4.36% |    0.017 us |   0.37% |   SAME   |
|   F64   |      I64      |      2^20      |  11.210 us |       2.29% |  11.222 us |       2.48% |    0.012 us |   0.11% |   SAME   |
|   F64   |      I64      |      2^24      |  97.718 us |       0.45% |  97.702 us |       0.46% |   -0.016 us |  -0.02% |   SAME   |
|   F64   |      I64      |      2^28      |   1.466 ms |       0.10% |   1.466 ms |       0.10% |   -0.060 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^32      |  23.446 ms |       0.07% |  23.446 ms |       0.07% |   -0.117 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.367 us |       4.28% |   5.363 us |       4.51% |   -0.004 us |  -0.08% |   SAME   |
|  I128   |      I32      |      2^20      |  17.278 us |       2.21% |  17.282 us |       2.18% |    0.004 us |   0.03% |   SAME   |
|  I128   |      I32      |      2^24      | 188.003 us |       0.33% | 187.991 us |       0.33% |   -0.012 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   2.932 ms |       0.06% |   2.932 ms |       0.06% |    0.054 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   5.366 us |       4.04% |   5.349 us |       3.77% |   -0.017 us |  -0.32% |   SAME   |
|  I128   |      I64      |      2^20      |  17.341 us |       2.28% |  17.338 us |       2.28% |   -0.004 us |  -0.02% |   SAME   |
|  I128   |      I64      |      2^24      | 187.986 us |       0.34% | 188.000 us |       0.33% |    0.014 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   2.932 ms |       0.06% |   2.932 ms |       0.06% |   -0.001 us |  -0.00% |   SAME   |

# nstream

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   4.329 us |       4.52% |   4.188 us |       4.19% |   -0.141 us |  -3.26% |   SAME   |
|   I8    |      I32      |      2^20      |   5.798 us |       2.98% |   5.425 us |       3.57% |   -0.372 us |  -6.42% |   FAST   |
|   I8    |      I32      |      2^24      |  22.792 us |       1.77% |  22.034 us |       1.89% |   -0.758 us |  -3.33% |   FAST   |
|   I8    |      I32      |      2^28      | 259.922 us |       0.35% | 248.154 us |       0.39% |  -11.769 us |  -4.53% |   FAST   |
|   I8    |      I64      |      2^16      |   4.233 us |       3.26% |   4.095 us |       3.17% |   -0.139 us |  -3.27% |   FAST   |
|   I8    |      I64      |      2^20      |   5.908 us |       2.79% |   5.408 us |       3.02% |   -0.500 us |  -8.46% |   FAST   |
|   I8    |      I64      |      2^24      |  22.991 us |       1.90% |  21.911 us |       1.94% |   -1.079 us |  -4.70% |   FAST   |
|   I8    |      I64      |      2^28      | 263.844 us |       0.37% | 248.114 us |       0.39% |  -15.730 us |  -5.96% |   FAST   |
|   I8    |      I64      |      2^32      |   4.092 ms |       0.38% |   3.847 ms |       0.03% | -244.249 us |  -5.97% |   FAST   |
|   I16   |      I32      |      2^16      |   4.408 us |       4.33% |   4.258 us |       3.97% |   -0.150 us |  -3.40% |   SAME   |
|   I16   |      I32      |      2^20      |   6.878 us |       2.59% |   6.515 us |       3.38% |   -0.363 us |  -5.27% |   FAST   |
|   I16   |      I32      |      2^24      |  38.205 us |       1.76% |  37.155 us |       1.78% |   -1.050 us |  -2.75% |   FAST   |
|   I16   |      I32      |      2^28      | 492.228 us |       0.08% | 489.074 us |       0.14% |   -3.154 us |  -0.64% |   FAST   |
|   I16   |      I64      |      2^16      |   4.308 us |       3.04% |   4.194 us |       3.41% |   -0.114 us |  -2.64% |   SAME   |
|   I16   |      I64      |      2^20      |   7.116 us |       3.41% |   6.723 us |       3.12% |   -0.393 us |  -5.52% |   FAST   |
|   I16   |      I64      |      2^24      |  38.190 us |       1.74% |  37.189 us |       1.76% |   -1.000 us |  -2.62% |   FAST   |
|   I16   |      I64      |      2^28      | 492.258 us |       0.13% | 489.126 us |       0.14% |   -3.133 us |  -0.64% |   FAST   |
|   I16   |      I64      |      2^32      |   7.755 ms |       0.01% |   7.715 ms |       0.07% |  -40.067 us |  -0.52% |   FAST   |
|   F16   |      I32      |      2^16      |   4.434 us |       4.48% |   4.314 us |       4.19% |   -0.121 us |  -2.72% |   SAME   |
|   F16   |      I32      |      2^20      |   7.059 us |       3.25% |   6.624 us |       3.21% |   -0.435 us |  -6.16% |   FAST   |
|   F16   |      I32      |      2^24      |  38.228 us |       1.70% |  37.184 us |       1.77% |   -1.044 us |  -2.73% |   FAST   |
|   F16   |      I32      |      2^28      | 493.859 us |       0.11% | 489.051 us |       0.15% |   -4.809 us |  -0.97% |   FAST   |
|   F16   |      I64      |      2^16      |   4.353 us |       5.46% |   4.219 us |       5.77% |   -0.135 us |  -3.10% |   SAME   |
|   F16   |      I64      |      2^20      |   7.057 us |       3.16% |   6.627 us |       3.23% |   -0.431 us |  -6.10% |   FAST   |
|   F16   |      I64      |      2^24      |  38.339 us |       1.72% |  37.178 us |       1.80% |   -1.161 us |  -3.03% |   FAST   |
|   F16   |      I64      |      2^28      | 496.047 us |       0.10% | 489.243 us |       0.14% |   -6.804 us |  -1.37% |   FAST   |
|   F16   |      I64      |      2^32      |   7.820 ms |       0.02% |   7.716 ms |       0.07% | -104.356 us |  -1.33% |   FAST   |
|   F32   |      I32      |      2^16      |   4.632 us |       4.77% |   4.627 us |       4.44% |   -0.005 us |  -0.11% |   SAME   |
|   F32   |      I32      |      2^20      |   9.230 us |       2.48% |   9.230 us |       2.54% |   -0.000 us |  -0.00% |   SAME   |
|   F32   |      I32      |      2^24      |  68.121 us |       1.01% |  68.130 us |       1.02% |    0.010 us |   0.01% |   SAME   |
|   F32   |      I32      |      2^28      | 969.156 us |       0.09% | 969.170 us |       0.09% |    0.014 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   4.548 us |       4.11% |   4.561 us |       4.31% |    0.013 us |   0.29% |   SAME   |
|   F32   |      I64      |      2^20      |   9.330 us |       2.39% |   9.345 us |       2.59% |    0.015 us |   0.16% |   SAME   |
|   F32   |      I64      |      2^24      |  68.177 us |       1.03% |  68.170 us |       1.02% |   -0.006 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^28      | 969.222 us |       0.09% | 969.252 us |       0.09% |    0.029 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^32      |  15.404 ms |       0.00% |  15.404 ms |       0.00% |    0.005 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   5.103 us |       4.50% |   5.122 us |       5.02% |    0.020 us |   0.39% |   SAME   |
|   F64   |      I32      |      2^20      |  13.474 us |       2.34% |  13.487 us |       2.38% |    0.013 us |   0.10% |   SAME   |
|   F64   |      I32      |      2^24      | 128.017 us |       0.61% | 128.017 us |       0.58% |    0.000 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^28      |   1.930 ms |       0.04% |   1.930 ms |       0.04% |   -0.007 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   4.983 us |       4.17% |   5.006 us |       4.20% |    0.023 us |   0.46% |   SAME   |
|   F64   |      I64      |      2^20      |  13.559 us |       2.30% |  13.567 us |       2.35% |    0.008 us |   0.06% |   SAME   |
|   F64   |      I64      |      2^24      | 128.086 us |       0.58% | 128.113 us |       0.59% |    0.027 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^28      |   1.930 ms |       0.04% |   1.930 ms |       0.04% |   -0.092 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^32      |  30.845 ms |       0.00% |  30.844 ms |       0.00% |   -0.265 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   5.802 us |       4.45% |   5.789 us |       3.84% |   -0.013 us |  -0.23% |   SAME   |
|  I128   |      I32      |      2^20      |  21.310 us |       2.02% |  21.313 us |       2.04% |    0.002 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^24      | 247.890 us |       0.37% | 247.911 us |       0.36% |    0.021 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   3.860 ms |       0.04% |   3.860 ms |       0.04% |    0.160 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   5.845 us |       4.92% |   5.799 us |       3.87% |   -0.046 us |  -0.79% |   SAME   |
|  I128   |      I64      |      2^20      |  21.347 us |       2.05% |  21.350 us |       2.01% |    0.003 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^24      | 248.012 us |       0.36% | 248.026 us |       0.36% |    0.015 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   3.860 ms |       0.04% |   3.860 ms |       0.04% |    0.155 us |   0.00% |   SAME   |
```

perf advantage is less strong on H100, with tiny regressions, but still ok:
```
# mul

## [0] NVIDIA H100 PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.361 us |       2.38% |   4.380 us |       2.55% |  0.020 us |   0.45% |   SAME   |
|   I8    |      I32      |      2^20      |   6.252 us |       2.70% |   6.259 us |       2.89% |  0.007 us |   0.11% |   SAME   |
|   I8    |      I32      |      2^24      |  23.899 us |       1.51% |  23.874 us |       1.51% | -0.025 us |  -0.11% |   SAME   |
|   I8    |      I32      |      2^28      | 296.496 us |       0.27% | 296.494 us |       0.25% | -0.002 us |  -0.00% |   SAME   |
|   I8    |      I64      |      2^16      |   4.614 us |       2.82% |   4.610 us |       2.74% | -0.004 us |  -0.08% |   SAME   |
|   I8    |      I64      |      2^20      |   6.354 us |       2.67% |   6.351 us |       2.59% | -0.003 us |  -0.05% |   SAME   |
|   I8    |      I64      |      2^24      |  24.022 us |       1.45% |  24.086 us |       1.43% |  0.065 us |   0.27% |   SAME   |
|   I8    |      I64      |      2^28      | 296.451 us |       0.24% | 296.449 us |       0.28% | -0.002 us |  -0.00% |   SAME   |
|   I8    |      I64      |      2^32      |   4.628 ms |       0.07% |   4.628 ms |       0.07% |  0.044 us |   0.00% |   SAME   |
|   I16   |      I32      |      2^16      |   4.735 us |       4.57% |   4.719 us |       3.98% | -0.016 us |  -0.33% |   SAME   |
|   I16   |      I32      |      2^20      |   7.671 us |       2.21% |   7.665 us |       1.98% | -0.006 us |  -0.08% |   SAME   |
|   I16   |      I32      |      2^24      |  42.288 us |       0.70% |  42.324 us |       1.43% |  0.036 us |   0.09% |   SAME   |
|   I16   |      I32      |      2^28      | 586.356 us |       0.16% | 586.348 us |       0.17% | -0.009 us |  -0.00% |   SAME   |
|   I16   |      I64      |      2^16      |   4.713 us |       3.00% |   4.708 us |       2.54% | -0.005 us |  -0.10% |   SAME   |
|   I16   |      I64      |      2^20      |   7.473 us |       2.15% |   7.456 us |       1.96% | -0.017 us |  -0.23% |   SAME   |
|   I16   |      I64      |      2^24      |  42.160 us |       0.76% |  42.194 us |       0.81% |  0.034 us |   0.08% |   SAME   |
|   I16   |      I64      |      2^28      | 586.281 us |       0.17% | 586.246 us |       0.16% | -0.035 us |  -0.01% |   SAME   |
|   I16   |      I64      |      2^32      |   9.267 ms |       0.05% |   9.267 ms |       0.05% | -0.101 us |  -0.00% |   SAME   |
|   F16   |      I32      |      2^16      |   4.712 us |       4.28% |   4.730 us |       4.92% |  0.018 us |   0.38% |   SAME   |
|   F16   |      I32      |      2^20      |   7.366 us |       2.13% |   7.365 us |       2.01% | -0.001 us |  -0.02% |   SAME   |
|   F16   |      I32      |      2^24      |  42.067 us |       0.74% |  42.085 us |       0.77% |  0.018 us |   0.04% |   SAME   |
|   F16   |      I32      |      2^28      | 586.295 us |       0.16% | 586.289 us |       0.17% | -0.006 us |  -0.00% |   SAME   |
|   F16   |      I64      |      2^16      |   4.544 us |       3.12% |   4.541 us |       3.10% | -0.003 us |  -0.07% |   SAME   |
|   F16   |      I64      |      2^20      |   7.583 us |       2.11% |   7.603 us |       2.24% |  0.020 us |   0.26% |   SAME   |
|   F16   |      I64      |      2^24      |  42.226 us |       0.76% |  42.242 us |       0.74% |  0.016 us |   0.04% |   SAME   |
|   F16   |      I64      |      2^28      | 586.265 us |       0.17% | 586.280 us |       0.16% |  0.015 us |   0.00% |   SAME   |
|   F16   |      I64      |      2^32      |   9.268 ms |       0.05% |   9.268 ms |       0.05% | -0.048 us |  -0.00% |   SAME   |
|   F32   |      I32      |      2^16      |   4.829 us |       4.62% |   4.810 us |       4.49% | -0.019 us |  -0.40% |   SAME   |
|   F32   |      I32      |      2^20      |   9.142 us |       1.81% |   9.155 us |       2.04% |  0.014 us |   0.15% |   SAME   |
|   F32   |      I32      |      2^24      |  77.519 us |       0.46% |  77.508 us |       0.49% | -0.010 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^28      |   1.170 ms |       0.13% |   1.170 ms |       0.13% | -0.011 us |  -0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   4.714 us |       3.76% |   4.708 us |       3.90% | -0.005 us |  -0.11% |   SAME   |
|   F32   |      I64      |      2^20      |   9.205 us |       1.99% |   9.216 us |       1.78% |  0.011 us |   0.12% |   SAME   |
|   F32   |      I64      |      2^24      |  77.578 us |       0.45% |  77.635 us |       0.48% |  0.058 us |   0.07% |   SAME   |
|   F32   |      I64      |      2^28      |   1.171 ms |       0.13% |   1.170 ms |       0.13% | -0.057 us |  -0.00% |   SAME   |
|   F32   |      I64      |      2^32      |  18.602 ms |       0.03% |  18.602 ms |       0.02% |  0.035 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   5.348 us |       4.67% |   5.370 us |       4.55% |  0.021 us |   0.39% |   SAME   |
|   F64   |      I32      |      2^20      |  13.324 us |       1.91% |  13.310 us |       1.89% | -0.014 us |  -0.11% |   SAME   |
|   F64   |      I32      |      2^24      | 152.097 us |       0.45% | 152.085 us |       0.41% | -0.012 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^28      |   2.332 ms |       0.09% |   2.332 ms |       0.10% | -0.098 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   5.145 us |       5.08% |   5.133 us |       4.83% | -0.012 us |  -0.23% |   SAME   |
|   F64   |      I64      |      2^20      |  13.391 us |       1.98% |  13.425 us |       2.04% |  0.033 us |   0.25% |   SAME   |
|   F64   |      I64      |      2^24      | 152.160 us |       0.38% | 152.177 us |       0.41% |  0.017 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^28      |   2.332 ms |       0.10% |   2.332 ms |       0.10% |  0.002 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^32      |  37.122 ms |       0.02% |  37.123 ms |       0.02% |  0.908 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   6.273 us |       4.22% |   6.268 us |       3.73% | -0.005 us |  -0.09% |   SAME   |
|  I128   |      I32      |      2^20      |  23.328 us |       1.34% |  23.299 us |       1.25% | -0.030 us |  -0.13% |   SAME   |
|  I128   |      I32      |      2^24      | 299.636 us |       0.30% | 299.668 us |       0.31% |  0.032 us |   0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   4.669 ms |       0.17% |   4.669 ms |       0.17% | -0.140 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   6.088 us |       5.73% |   6.056 us |       5.58% | -0.032 us |  -0.53% |   SAME   |
|  I128   |      I64      |      2^20      |  23.374 us |       1.24% |  23.371 us |       1.26% | -0.004 us |  -0.02% |   SAME   |
|  I128   |      I64      |      2^24      | 299.766 us |       0.30% | 299.835 us |       0.33% |  0.070 us |   0.02% |   SAME   |
|  I128   |      I64      |      2^28      |   4.670 ms |       0.18% |   4.669 ms |       0.16% | -0.781 us |  -0.02% |   SAME   |

# add

## [0] NVIDIA H100 PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.894 us |       4.19% |   4.670 us |       4.04% | -0.224 us |  -4.58% |   FAST   |
|   I8    |      I32      |      2^20      |   7.304 us |       1.93% |   6.793 us |       1.97% | -0.511 us |  -7.00% |   FAST   |
|   I8    |      I32      |      2^24      |  34.081 us |       0.69% |  33.483 us |       0.64% | -0.598 us |  -1.75% |   FAST   |
|   I8    |      I32      |      2^28      | 430.875 us |       0.25% | 431.295 us |       0.24% |  0.420 us |   0.10% |   SAME   |
|   I8    |      I64      |      2^16      |   4.642 us |       2.51% |   4.428 us |       3.00% | -0.214 us |  -4.62% |   FAST   |
|   I8    |      I64      |      2^20      |   7.200 us |       2.07% |   6.636 us |       1.98% | -0.564 us |  -7.83% |   FAST   |
|   I8    |      I64      |      2^24      |  34.026 us |       0.69% |  33.401 us |       0.71% | -0.625 us |  -1.84% |   FAST   |
|   I8    |      I64      |      2^28      | 430.877 us |       0.27% | 431.124 us |       0.22% |  0.247 us |   0.06% |   SAME   |
|   I8    |      I64      |      2^32      |   6.794 ms |       0.08% |   6.805 ms |       0.09% | 11.521 us |   0.17% |   SLOW   |
|   I16   |      I32      |      2^16      |   4.828 us |       3.98% |   4.637 us |       3.94% | -0.191 us |  -3.96% |   FAST   |
|   I16   |      I32      |      2^20      |   9.076 us |       2.00% |   8.438 us |       1.96% | -0.637 us |  -7.02% |   FAST   |
|   I16   |      I32      |      2^24      |  60.078 us |       0.56% |  60.018 us |       0.48% | -0.060 us |  -0.10% |   SAME   |
|   I16   |      I32      |      2^28      | 856.642 us |       0.17% | 860.989 us |       0.11% |  4.347 us |   0.51% |   SLOW   |
|   I16   |      I64      |      2^16      |   4.761 us |       2.42% |   4.538 us |       3.03% | -0.224 us |  -4.70% |   FAST   |
|   I16   |      I64      |      2^20      |   9.135 us |       1.88% |   8.628 us |       1.86% | -0.507 us |  -5.55% |   FAST   |
|   I16   |      I64      |      2^24      |  60.164 us |       0.55% |  60.018 us |       0.47% | -0.146 us |  -0.24% |   SAME   |
|   I16   |      I64      |      2^28      | 856.548 us |       0.16% | 861.071 us |       0.12% |  4.523 us |   0.53% |   SLOW   |
|   I16   |      I64      |      2^32      |  13.601 ms |       0.09% |  13.671 ms |       0.09% | 70.270 us |   0.52% |   SLOW   |
|   F16   |      I32      |      2^16      |   4.837 us |       4.53% |   4.657 us |       4.02% | -0.180 us |  -3.73% |   SAME   |
|   F16   |      I32      |      2^20      |   8.797 us |       1.76% |   8.358 us |       1.69% | -0.439 us |  -4.99% |   FAST   |
|   F16   |      I32      |      2^24      |  60.068 us |       0.53% |  60.000 us |       0.45% | -0.067 us |  -0.11% |   SAME   |
|   F16   |      I32      |      2^28      | 856.519 us |       0.17% | 861.065 us |       0.12% |  4.545 us |   0.53% |   SLOW   |
|   F16   |      I64      |      2^16      |   4.728 us |       2.63% |   4.536 us |       3.04% | -0.192 us |  -4.06% |   FAST   |
|   F16   |      I64      |      2^20      |   9.191 us |       1.84% |   8.658 us |       1.78% | -0.532 us |  -5.79% |   FAST   |
|   F16   |      I64      |      2^24      |  60.137 us |       0.53% |  60.043 us |       0.48% | -0.094 us |  -0.16% |   SAME   |
|   F16   |      I64      |      2^28      | 856.519 us |       0.17% | 861.038 us |       0.12% |  4.519 us |   0.53% |   SLOW   |
|   F16   |      I64      |      2^32      |  13.603 ms |       0.09% |  13.672 ms |       0.09% | 69.486 us |   0.51% |   SLOW   |
|   F32   |      I32      |      2^16      |   5.336 us |       4.77% |   5.398 us |      10.07% |  0.062 us |   1.17% |   SAME   |
|   F32   |      I32      |      2^20      |  12.464 us |       1.68% |  12.477 us |       1.68% |  0.013 us |   0.10% |   SAME   |
|   F32   |      I32      |      2^24      | 114.746 us |       0.67% | 114.764 us |       0.72% |  0.017 us |   0.01% |   SAME   |
|   F32   |      I32      |      2^28      |   1.707 ms |       0.10% |   1.707 ms |       0.10% | -0.088 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   5.135 us |       4.55% |   5.126 us |       4.30% | -0.009 us |  -0.18% |   SAME   |
|   F32   |      I64      |      2^20      |  12.626 us |       1.63% |  12.646 us |       1.64% |  0.020 us |   0.16% |   SAME   |
|   F32   |      I64      |      2^24      | 115.080 us |       0.72% | 115.074 us |       0.68% | -0.006 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^28      |   1.707 ms |       0.11% |   1.707 ms |       0.11% |  0.117 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^32      |  27.219 ms |       0.05% |  27.218 ms |       0.05% | -0.323 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   6.055 us |       4.09% |   6.061 us |       4.40% |  0.006 us |   0.10% |   SAME   |
|   F64   |      I32      |      2^20      |  19.902 us |       1.25% |  19.902 us |       1.21% | -0.000 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^24      | 221.187 us |       0.25% | 221.172 us |       0.26% | -0.015 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^28      |   3.410 ms |       0.08% |   3.410 ms |       0.08% |  0.044 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   5.802 us |       6.10% |   5.800 us |       5.87% | -0.002 us |  -0.04% |   SAME   |
|   F64   |      I64      |      2^20      |  19.486 us |       2.10% |  19.482 us |       1.38% | -0.004 us |  -0.02% |   SAME   |
|   F64   |      I64      |      2^24      | 221.272 us |       0.26% | 221.254 us |       0.26% | -0.018 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^28      |   3.410 ms |       0.08% |   3.410 ms |       0.09% |  0.097 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   7.243 us |       3.97% |   7.223 us |       3.64% | -0.020 us |  -0.27% |   SAME   |
|  I128   |      I32      |      2^20      |  33.060 us |       0.83% |  33.051 us |       0.80% | -0.009 us |  -0.03% |   SAME   |
|  I128   |      I32      |      2^24      | 432.208 us |       0.21% | 432.287 us |       0.22% |  0.079 us |   0.02% |   SAME   |
|  I128   |      I32      |      2^28      |   6.814 ms |       0.11% |   6.814 ms |       0.10% |  0.024 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   7.159 us |       3.48% |   7.133 us |       3.62% | -0.027 us |  -0.37% |   SAME   |
|  I128   |      I64      |      2^20      |  33.037 us |       0.84% |  33.012 us |       0.83% | -0.025 us |  -0.07% |   SAME   |
|  I128   |      I64      |      2^24      | 432.320 us |       0.21% | 432.325 us |       0.23% |  0.004 us |   0.00% |   SAME   |
|  I128   |      I64      |      2^28      |   6.814 ms |       0.11% |   6.814 ms |       0.11% |  0.160 us |   0.00% |   SAME   |

# triad

## [0] NVIDIA H100 PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   4.767 us |       4.83% |   4.574 us |       4.79% | -0.193 us |  -4.05% |   SAME   |
|   I8    |      I32      |      2^20      |   7.100 us |       1.83% |   6.537 us |       1.75% | -0.563 us |  -7.93% |   FAST   |
|   I8    |      I32      |      2^24      |  34.282 us |       0.68% |  33.688 us |       0.71% | -0.594 us |  -1.73% |   FAST   |
|   I8    |      I32      |      2^28      | 430.830 us |       0.25% | 431.373 us |       0.23% |  0.543 us |   0.13% |   SAME   |
|   I8    |      I64      |      2^16      |   4.679 us |       2.65% |   4.435 us |       2.84% | -0.244 us |  -5.22% |   FAST   |
|   I8    |      I64      |      2^20      |   7.388 us |       2.01% |   6.782 us |       1.91% | -0.606 us |  -8.20% |   FAST   |
|   I8    |      I64      |      2^24      |  34.265 us |       0.83% |  33.728 us |       0.64% | -0.537 us |  -1.57% |   FAST   |
|   I8    |      I64      |      2^28      | 430.937 us |       0.24% | 431.347 us |       0.22% |  0.410 us |   0.10% |   SAME   |
|   I8    |      I64      |      2^32      |   6.792 ms |       0.08% |   6.806 ms |       0.09% | 13.995 us |   0.21% |   SLOW   |
|   I16   |      I32      |      2^16      |   4.867 us |       3.68% |   4.646 us |       4.17% | -0.221 us |  -4.54% |   FAST   |
|   I16   |      I32      |      2^20      |   9.207 us |       1.88% |   8.704 us |       1.83% | -0.503 us |  -5.47% |   FAST   |
|   I16   |      I32      |      2^24      |  60.328 us |       0.47% |  60.072 us |       0.53% | -0.256 us |  -0.42% |   SAME   |
|   I16   |      I32      |      2^28      | 856.542 us |       0.18% | 861.296 us |       0.13% |  4.754 us |   0.55% |   SLOW   |
|   I16   |      I64      |      2^16      |   4.748 us |       3.24% |   4.532 us |       3.02% | -0.215 us |  -4.54% |   FAST   |
|   I16   |      I64      |      2^20      |   9.188 us |       1.90% |   8.728 us |       2.02% | -0.460 us |  -5.01% |   FAST   |
|   I16   |      I64      |      2^24      |  60.092 us |       0.52% |  59.990 us |       0.47% | -0.102 us |  -0.17% |   SAME   |
|   I16   |      I64      |      2^28      | 856.690 us |       0.17% | 861.363 us |       0.13% |  4.673 us |   0.55% |   SLOW   |
|   I16   |      I64      |      2^32      |  13.604 ms |       0.08% |  13.673 ms |       0.09% | 69.402 us |   0.51% |   SLOW   |
|   F16   |      I32      |      2^16      |   4.928 us |       4.53% |   4.759 us |       4.57% | -0.168 us |  -3.42% |   SAME   |
|   F16   |      I32      |      2^20      |   8.962 us |       1.92% |   8.468 us |       1.78% | -0.494 us |  -5.51% |   FAST   |
|   F16   |      I32      |      2^24      |  60.321 us |       0.50% |  60.184 us |       0.49% | -0.137 us |  -0.23% |   SAME   |
|   F16   |      I32      |      2^28      | 856.791 us |       0.17% | 861.292 us |       0.12% |  4.501 us |   0.53% |   SLOW   |
|   F16   |      I64      |      2^16      |   4.818 us |       2.31% |   4.603 us |       3.81% | -0.215 us |  -4.46% |   FAST   |
|   F16   |      I64      |      2^20      |   9.088 us |       1.78% |   8.501 us |       1.88% | -0.587 us |  -6.45% |   FAST   |
|   F16   |      I64      |      2^24      |  60.429 us |       0.71% |  60.264 us |       0.48% | -0.165 us |  -0.27% |   SAME   |
|   F16   |      I64      |      2^28      | 856.770 us |       0.18% | 861.442 us |       0.13% |  4.672 us |   0.55% |   SLOW   |
|   F16   |      I64      |      2^32      |  13.604 ms |       0.08% |  13.675 ms |       0.09% | 70.880 us |   0.52% |   SLOW   |
|   F32   |      I32      |      2^16      |   5.320 us |       4.71% |   5.281 us |       4.77% | -0.038 us |  -0.72% |   SAME   |
|   F32   |      I32      |      2^20      |  12.196 us |       1.53% |  12.147 us |       1.48% | -0.049 us |  -0.40% |   SAME   |
|   F32   |      I32      |      2^24      | 114.635 us |       0.85% | 114.521 us |       0.84% | -0.113 us |  -0.10% |   SAME   |
|   F32   |      I32      |      2^28      |   1.708 ms |       0.11% |   1.708 ms |       0.10% | -0.243 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   5.121 us |       3.38% |   5.095 us |       3.73% | -0.026 us |  -0.51% |   SAME   |
|   F32   |      I64      |      2^20      |  12.255 us |       1.49% |  12.222 us |       1.49% | -0.033 us |  -0.27% |   SAME   |
|   F32   |      I64      |      2^24      | 114.697 us |       0.83% | 114.730 us |       0.84% |  0.032 us |   0.03% |   SAME   |
|   F32   |      I64      |      2^28      |   1.708 ms |       0.10% |   1.708 ms |       0.11% | -0.355 us |  -0.02% |   SAME   |
|   F32   |      I64      |      2^32      |  27.228 ms |       0.05% |  27.221 ms |       0.05% | -6.200 us |  -0.02% |   SAME   |
|   F64   |      I32      |      2^16      |   6.138 us |       4.06% |   6.094 us |       4.08% | -0.045 us |  -0.73% |   SAME   |
|   F64   |      I32      |      2^20      |  19.476 us |       1.28% |  19.436 us |       1.35% | -0.040 us |  -0.21% |   SAME   |
|   F64   |      I32      |      2^24      | 220.977 us |       0.25% | 220.979 us |       0.25% |  0.003 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^28      |   3.413 ms |       0.08% |   3.412 ms |       0.08% | -0.865 us |  -0.03% |   SAME   |
|   F64   |      I64      |      2^16      |   5.778 us |       4.93% |   5.706 us |       4.54% | -0.071 us |  -1.24% |   SAME   |
|   F64   |      I64      |      2^20      |  19.476 us |       1.30% |  19.442 us |       1.28% | -0.033 us |  -0.17% |   SAME   |
|   F64   |      I64      |      2^24      | 221.014 us |       0.24% | 220.950 us |       0.26% | -0.064 us |  -0.03% |   SAME   |
|   F64   |      I64      |      2^28      |   3.413 ms |       0.08% |   3.412 ms |       0.08% | -0.947 us |  -0.03% |   SAME   |
|  I128   |      I32      |      2^16      |   7.427 us |       3.49% |   7.433 us |       4.00% |  0.006 us |   0.09% |   SAME   |
|  I128   |      I32      |      2^20      |  32.749 us |       0.90% |  32.689 us |       0.90% | -0.060 us |  -0.18% |   SAME   |
|  I128   |      I32      |      2^24      | 432.336 us |       0.20% | 432.241 us |       0.21% | -0.095 us |  -0.02% |   SAME   |
|  I128   |      I32      |      2^28      |   6.816 ms |       0.10% |   6.815 ms |       0.11% | -1.432 us |  -0.02% |   SAME   |
|  I128   |      I64      |      2^16      |   7.477 us |       3.72% |   7.105 us |       5.46% | -0.372 us |  -4.98% |   FAST   |
|  I128   |      I64      |      2^20      |  32.806 us |       0.85% |  32.796 us |       0.86% | -0.010 us |  -0.03% |   SAME   |
|  I128   |      I64      |      2^24      | 432.352 us |       0.22% | 432.323 us |       0.20% | -0.029 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   6.815 ms |       0.11% |   6.815 ms |       0.11% |  0.041 us |   0.00% |   SAME   |

# nstream

## [0] NVIDIA H100 PCIe

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I32      |      2^16      |   4.856 us |       4.29% |   4.677 us |       4.43% |   -0.180 us |  -3.70% |   SAME   |
|   I8    |      I32      |      2^20      |   7.783 us |       1.85% |   7.362 us |       1.92% |   -0.421 us |  -5.41% |   FAST   |
|   I8    |      I32      |      2^24      |  42.331 us |       0.56% |  41.887 us |       0.50% |   -0.444 us |  -1.05% |   FAST   |
|   I8    |      I32      |      2^28      | 584.333 us |       0.15% | 576.653 us |       0.10% |   -7.681 us |  -1.31% |   FAST   |
|   I8    |      I64      |      2^16      |   4.723 us |       2.43% |   4.527 us |       2.37% |   -0.195 us |  -4.14% |   FAST   |
|   I8    |      I64      |      2^20      |   8.035 us |       1.60% |   7.444 us |       2.05% |   -0.591 us |  -7.36% |   FAST   |
|   I8    |      I64      |      2^24      |  42.989 us |       0.42% |  42.413 us |       0.43% |   -0.576 us |  -1.34% |   FAST   |
|   I8    |      I64      |      2^28      | 584.714 us |       0.15% | 576.563 us |       0.10% |   -8.152 us |  -1.39% |   FAST   |
|   I8    |      I64      |      2^32      |   9.239 ms |       0.04% |   9.078 ms |       0.02% | -160.194 us |  -1.73% |   FAST   |
|   I16   |      I32      |      2^16      |   4.992 us |       3.89% |   4.872 us |       4.49% |   -0.120 us |  -2.41% |   SAME   |
|   I16   |      I32      |      2^20      |  10.256 us |       1.71% |   9.685 us |       1.67% |   -0.570 us |  -5.56% |   FAST   |
|   I16   |      I32      |      2^24      |  78.240 us |       0.26% |  77.438 us |       0.34% |   -0.802 us |  -1.02% |   FAST   |
|   I16   |      I32      |      2^28      |   1.154 ms |       0.08% |   1.129 ms |       0.04% |  -25.417 us |  -2.20% |   FAST   |
|   I16   |      I64      |      2^16      |   4.915 us |       2.73% |   4.713 us |       3.30% |   -0.202 us |  -4.11% |   FAST   |
|   I16   |      I64      |      2^20      |  10.349 us |       1.75% |   9.758 us |       1.71% |   -0.591 us |  -5.71% |   FAST   |
|   I16   |      I64      |      2^24      |  78.092 us |       0.23% |  77.367 us |       0.34% |   -0.725 us |  -0.93% |   FAST   |
|   I16   |      I64      |      2^28      |   1.154 ms |       0.08% |   1.129 ms |       0.04% |  -25.237 us |  -2.19% |   FAST   |
|   I16   |      I64      |      2^32      |  18.342 ms |       0.02% |  17.887 ms |       0.01% | -454.701 us |  -2.48% |   FAST   |
|   F16   |      I32      |      2^16      |   5.037 us |       4.20% |   4.877 us |       5.21% |   -0.160 us |  -3.17% |   SAME   |
|   F16   |      I32      |      2^20      |  10.274 us |       1.43% |   9.698 us |       1.67% |   -0.577 us |  -5.61% |   FAST   |
|   F16   |      I32      |      2^24      |  77.971 us |       0.28% |  77.336 us |       0.35% |   -0.635 us |  -0.81% |   FAST   |
|   F16   |      I32      |      2^28      |   1.154 ms |       0.08% |   1.129 ms |       0.04% |  -25.355 us |  -2.20% |   FAST   |
|   F16   |      I64      |      2^16      |   4.877 us |       2.97% |   4.683 us |       3.06% |   -0.194 us |  -3.97% |   FAST   |
|   F16   |      I64      |      2^20      |  10.380 us |       1.63% |   9.729 us |       1.71% |   -0.651 us |  -6.27% |   FAST   |
|   F16   |      I64      |      2^24      |  78.055 us |       0.26% |  77.384 us |       0.35% |   -0.671 us |  -0.86% |   FAST   |
|   F16   |      I64      |      2^28      |   1.154 ms |       0.09% |   1.129 ms |       0.04% |  -25.504 us |  -2.21% |   FAST   |
|   F16   |      I64      |      2^32      |  18.348 ms |       0.02% |  17.888 ms |       0.01% | -460.236 us |  -2.51% |   FAST   |
|   F32   |      I32      |      2^16      |   5.591 us |       4.30% |   5.572 us |       4.43% |   -0.019 us |  -0.34% |   SAME   |
|   F32   |      I32      |      2^20      |  15.097 us |       1.18% |  15.065 us |       1.17% |   -0.031 us |  -0.21% |   SAME   |
|   F32   |      I32      |      2^24      | 151.833 us |       0.36% | 151.797 us |       0.39% |   -0.036 us |  -0.02% |   SAME   |
|   F32   |      I32      |      2^28      |   2.296 ms |       0.06% |   2.295 ms |       0.05% |   -0.691 us |  -0.03% |   SAME   |
|   F32   |      I64      |      2^16      |   5.457 us |       5.30% |   5.438 us |       4.58% |   -0.018 us |  -0.34% |   SAME   |
|   F32   |      I64      |      2^20      |  15.193 us |       1.12% |  15.145 us |       1.04% |   -0.048 us |  -0.32% |   SAME   |
|   F32   |      I64      |      2^24      | 151.947 us |       0.39% | 151.892 us |       0.39% |   -0.054 us |  -0.04% |   SAME   |
|   F32   |      I64      |      2^28      |   2.296 ms |       0.05% |   2.295 ms |       0.06% |   -0.665 us |  -0.03% |   SAME   |
|   F32   |      I64      |      2^32      |  36.608 ms |       0.01% |  36.595 ms |       0.01% |  -12.684 us |  -0.03% |   FAST   |
|   F64   |      I32      |      2^16      |   6.735 us |       4.23% |   6.703 us |       4.55% |   -0.032 us |  -0.48% |   SAME   |
|   F64   |      I32      |      2^20      |  24.696 us |       0.86% |  24.649 us |       0.78% |   -0.048 us |  -0.19% |   SAME   |
|   F64   |      I32      |      2^24      | 294.731 us |       0.24% | 294.640 us |       0.22% |   -0.091 us |  -0.03% |   SAME   |
|   F64   |      I32      |      2^28      |   4.581 ms |       0.04% |   4.579 ms |       0.04% |   -1.798 us |  -0.04% |   FAST   |
|   F64   |      I64      |      2^16      |   6.329 us |       5.67% |   6.313 us |       5.82% |   -0.016 us |  -0.25% |   SAME   |
|   F64   |      I64      |      2^20      |  24.859 us |       0.85% |  24.836 us |       0.83% |   -0.023 us |  -0.09% |   SAME   |
|   F64   |      I64      |      2^24      | 294.715 us |       0.22% | 294.735 us |       0.23% |    0.019 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^28      |   4.580 ms |       0.04% |   4.579 ms |       0.04% |   -1.616 us |  -0.04% |   SAME   |
|  I128   |      I32      |      2^16      |   8.271 us |       3.68% |   8.235 us |       3.63% |   -0.035 us |  -0.43% |   SAME   |
|  I128   |      I32      |      2^20      |  41.934 us |       0.51% |  41.902 us |       0.56% |   -0.032 us |  -0.08% |   SAME   |
|  I128   |      I32      |      2^24      | 570.361 us |       0.07% | 570.292 us |       0.07% |   -0.069 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   8.957 ms |       0.01% |   8.955 ms |       0.01% |   -1.231 us |  -0.01% |   FAST   |
|  I128   |      I64      |      2^16      |   7.918 us |       5.39% |   8.252 us |       3.71% |    0.334 us |   4.22% |   SLOW   |
|  I128   |      I64      |      2^20      |  41.975 us |       0.53% |  41.939 us |       0.51% |   -0.035 us |  -0.08% |   SAME   |
|  I128   |      I64      |      2^24      | 570.362 us |       0.07% | 570.190 us |       0.07% |   -0.172 us |  -0.03% |   SAME   |
|  I128   |      I64      |      2^28      |   8.957 ms |       0.01% |   8.955 ms |       0.01% |   -1.327 us |  -0.01% |   FAST   |
```

There is no benefit on B200, so I am staying with UBLKCP:
```
## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   5.790 us |      12.14% |   5.615 us |      14.03% | -0.175 us |  -3.03% |   SAME   |
|   I8    |      I32      |      2^20      |   6.097 us |       1.34% |   6.050 us |       1.67% | -0.047 us |  -0.77% |   SAME   |
|   I8    |      I32      |      2^24      |  14.299 us |       0.46% |  14.242 us |       0.73% | -0.058 us |  -0.40% |   SAME   |
|   I8    |      I32      |      2^28      | 122.841 us |       0.11% | 122.764 us |       0.20% | -0.077 us |  -0.06% |   SAME   |
|   I8    |      I64      |      2^16      |   5.556 us |      16.14% |   5.673 us |      13.46% |  0.118 us |   2.12% |   SAME   |
|   I8    |      I64      |      2^20      |   6.111 us |       1.09% |   6.054 us |       1.82% | -0.057 us |  -0.94% |   SAME   |
|   I8    |      I64      |      2^24      |  14.298 us |       0.49% |  14.250 us |       0.72% | -0.048 us |  -0.34% |   SAME   |
|   I8    |      I64      |      2^28      | 123.518 us |       0.75% | 123.748 us |       0.76% |  0.229 us |   0.19% |   SAME   |
|   I8    |      I64      |      2^32      |   1.866 ms |       0.05% |   1.866 ms |       0.05% | -0.095 us |  -0.01% |   SAME   |
|   I16   |      I32      |      2^16      |   6.104 us |       1.17% |   6.096 us |       1.41% | -0.008 us |  -0.12% |   SAME   |
|   I16   |      I32      |      2^20      |   6.106 us |       1.13% |   6.079 us |       1.55% | -0.027 us |  -0.44% |   SAME   |
|   I16   |      I32      |      2^24      |  16.390 us |       2.28% |  16.376 us |       2.31% | -0.013 us |  -0.08% |   SAME   |
|   I16   |      I32      |      2^28      | 165.852 us |       0.04% | 165.817 us |       0.06% | -0.035 us |  -0.02% |   SAME   |
|   I16   |      I64      |      2^16      |   6.094 us |       1.32% |   6.061 us |       1.64% | -0.033 us |  -0.54% |   SAME   |
|   I16   |      I64      |      2^20      |   6.107 us |       1.12% |   6.060 us |       2.39% | -0.047 us |  -0.77% |   SAME   |
|   I16   |      I64      |      2^24      |  16.444 us |       2.98% |  16.512 us |       3.56% |  0.068 us |   0.41% |   SAME   |
|   I16   |      I64      |      2^28      | 165.852 us |       0.04% | 165.819 us |       0.06% | -0.033 us |  -0.02% |   SAME   |
|   I16   |      I64      |      2^32      |   2.534 ms |       0.03% |   2.534 ms |       0.04% |  0.226 us |   0.01% |   SAME   |
|   F32   |      I32      |      2^16      |   5.646 us |      14.86% |   5.779 us |      11.77% |  0.133 us |   2.35% |   SAME   |
|   F32   |      I32      |      2^20      |   6.783 us |      13.05% |   6.858 us |      12.95% |  0.075 us |   1.11% |   SAME   |
|   F32   |      I32      |      2^24      |  25.289 us |       3.88% |  25.341 us |       3.96% |  0.052 us |   0.21% |   SAME   |
|   F32   |      I32      |      2^28      | 313.104 us |       0.31% | 313.109 us |       0.29% |  0.005 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   6.093 us |       1.30% |   6.070 us |       1.53% | -0.023 us |  -0.38% |   SAME   |
|   F32   |      I64      |      2^20      |   7.523 us |      11.81% |   7.551 us |      11.32% |  0.028 us |   0.37% |   SAME   |
|   F32   |      I64      |      2^24      |  25.306 us |       3.92% |  25.415 us |       3.97% |  0.109 us |   0.43% |   SAME   |
|   F32   |      I64      |      2^28      | 313.041 us |       0.34% | 313.132 us |       0.33% |  0.092 us |   0.03% |   SAME   |
|   F32   |      I64      |      2^32      |   4.913 ms |       0.10% |   4.913 ms |       0.10% | -0.045 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   6.069 us |       2.48% |   6.076 us |       2.53% |  0.007 us |   0.11% |   SAME   |
|   F64   |      I32      |      2^20      |   8.150 us |       0.93% |   8.111 us |       1.25% | -0.039 us |  -0.48% |   SAME   |
|   F64   |      I32      |      2^24      |  45.460 us |       1.89% |  45.516 us |       1.98% |  0.056 us |   0.12% |   SAME   |
|   F64   |      I32      |      2^28      | 620.037 us |       0.22% | 619.845 us |       0.21% | -0.192 us |  -0.03% |   SAME   |
|   F64   |      I64      |      2^16      |   6.075 us |       2.34% |   6.044 us |       3.05% | -0.030 us |  -0.50% |   SAME   |
|   F64   |      I64      |      2^20      |   8.155 us |       0.84% |   8.117 us |       2.31% | -0.038 us |  -0.46% |   SAME   |
|   F64   |      I64      |      2^24      |  45.852 us |       2.20% |  45.683 us |       2.13% | -0.169 us |  -0.37% |   SAME   |
|   F64   |      I64      |      2^28      | 619.997 us |       0.21% | 619.921 us |       0.22% | -0.077 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^32      |   9.829 ms |       0.15% |   9.829 ms |       0.15% |  0.355 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   6.116 us |       1.19% |   6.062 us |       1.76% | -0.054 us |  -0.89% |   SAME   |
|  I128   |      I32      |      2^20      |  10.465 us |       6.59% |  10.498 us |       7.09% |  0.033 us |   0.31% |   SAME   |
|  I128   |      I32      |      2^24      |  83.515 us |       0.99% |  83.503 us |       0.96% | -0.012 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   1.234 ms |       0.15% |   1.235 ms |       0.14% |  0.352 us |   0.03% |   SAME   |
|  I128   |      I64      |      2^16      |   6.102 us |       1.18% |   6.059 us |       1.71% | -0.043 us |  -0.71% |   SAME   |
|  I128   |      I64      |      2^20      |  10.467 us |       6.52% |  10.514 us |       7.22% |  0.047 us |   0.45% |   SAME   |
|  I128   |      I64      |      2^24      |  83.369 us |       1.10% |  83.397 us |       1.07% |  0.028 us |   0.03% |   SAME   |
|  I128   |      I64      |      2^28      |   1.234 ms |       0.15% |   1.234 ms |       0.15% | -0.116 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^32      |  19.667 ms |       0.11% |  19.666 ms |       0.10% | -1.039 us |  -0.01% |   SAME   |

# add

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   6.111 us |       1.39% |   6.073 us |       1.70% | -0.038 us |  -0.62% |   SAME   |
|   I8    |      I32      |      2^20      |   6.084 us |       1.11% |   6.037 us |       1.62% | -0.047 us |  -0.78% |   SAME   |
|   I8    |      I32      |      2^24      |  16.306 us |       0.92% |  16.294 us |       1.08% | -0.013 us |  -0.08% |   SAME   |
|   I8    |      I32      |      2^28      | 149.473 us |       0.04% | 149.428 us |       0.07% | -0.045 us |  -0.03% |   SAME   |
|   I8    |      I64      |      2^16      |   6.097 us |       1.37% |   6.045 us |       1.73% | -0.051 us |  -0.84% |   SAME   |
|   I8    |      I64      |      2^20      |   6.102 us |       2.26% |   6.045 us |       1.71% | -0.057 us |  -0.93% |   SAME   |
|   I8    |      I64      |      2^24      |  16.315 us |       0.89% |  16.384 us |       0.00% |  0.069 us |   0.42% |   SLOW   |
|   I8    |      I64      |      2^28      | 151.275 us |       0.44% | 151.262 us |       0.41% | -0.013 us |  -0.01% |   SAME   |
|   I8    |      I64      |      2^32      |   2.301 ms |       0.03% |   2.300 ms |       0.03% | -0.194 us |  -0.01% |   SAME   |
|   I16   |      I32      |      2^16      |   6.099 us |       1.33% |   6.078 us |       1.52% | -0.021 us |  -0.34% |   SAME   |
|   I16   |      I32      |      2^20      |   6.692 us |      12.86% |   6.682 us |      12.36% | -0.010 us |  -0.15% |   SAME   |
|   I16   |      I32      |      2^24      |  22.486 us |       0.33% |  22.450 us |       0.43% | -0.035 us |  -0.16% |   SAME   |
|   I16   |      I32      |      2^28      | 240.109 us |       0.38% | 240.098 us |       0.37% | -0.012 us |  -0.00% |   SAME   |
|   I16   |      I64      |      2^16      |   5.743 us |      13.01% |   5.839 us |      10.09% |  0.095 us |   1.66% |   SAME   |
|   I16   |      I64      |      2^20      |   6.824 us |      13.25% |   6.947 us |      13.07% |  0.123 us |   1.81% |   SAME   |
|   I16   |      I64      |      2^24      |  22.467 us |       0.32% |  22.428 us |       0.43% | -0.039 us |  -0.17% |   SAME   |
|   I16   |      I64      |      2^28      | 242.072 us |       0.34% | 242.218 us |       0.38% |  0.146 us |   0.06% |   SAME   |
|   I16   |      I64      |      2^32      |   3.738 ms |       0.02% |   3.738 ms |       0.02% | -0.122 us |  -0.00% |   SAME   |
|   F32   |      I32      |      2^16      |   6.068 us |       2.45% |   6.067 us |       2.59% | -0.001 us |  -0.02% |   SAME   |
|   F32   |      I32      |      2^20      |   8.153 us |       0.91% |   8.105 us |       1.27% | -0.047 us |  -0.58% |   SAME   |
|   F32   |      I32      |      2^24      |  36.810 us |       0.43% |  36.774 us |       0.41% | -0.036 us |  -0.10% |   SAME   |
|   F32   |      I32      |      2^28      | 453.811 us |       0.22% | 453.870 us |       0.21% |  0.059 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   6.057 us |       2.69% |   6.065 us |       2.60% |  0.008 us |   0.14% |   SAME   |
|   F32   |      I64      |      2^20      |   8.148 us |       0.92% |   8.110 us |       1.25% | -0.039 us |  -0.47% |   SAME   |
|   F32   |      I64      |      2^24      |  36.818 us |       0.20% |  36.773 us |       0.39% | -0.045 us |  -0.12% |   SAME   |
|   F32   |      I64      |      2^28      | 454.627 us |       0.01% | 454.598 us |       0.02% | -0.029 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^32      |   7.113 ms |       0.32% |   7.115 ms |       0.36% |  1.892 us |   0.03% |   SAME   |
|   F64   |      I32      |      2^16      |   6.102 us |       1.28% |   6.093 us |       1.40% | -0.010 us |  -0.16% |   SAME   |
|   F64   |      I32      |      2^20      |  10.198 us |       0.73% |  10.147 us |       1.05% | -0.052 us |  -0.51% |   SAME   |
|   F64   |      I32      |      2^24      |  64.556 us |       1.58% |  64.604 us |       1.54% |  0.048 us |   0.07% |   SAME   |
|   F64   |      I32      |      2^28      | 904.739 us |       0.18% | 904.923 us |       0.21% |  0.184 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^16      |   6.115 us |       1.03% |   6.066 us |       1.68% | -0.049 us |  -0.80% |   SAME   |
|   F64   |      I64      |      2^20      |  10.198 us |       0.70% |  10.148 us |       1.02% | -0.051 us |  -0.50% |   SAME   |
|   F64   |      I64      |      2^24      |  64.087 us |       1.48% |  64.090 us |       1.49% |  0.003 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^28      | 904.093 us |       0.18% | 903.996 us |       0.20% | -0.096 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^32      |  14.423 ms |       0.03% |  14.423 ms |       0.03% | -0.248 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   6.124 us |       3.59% |   6.090 us |       3.78% | -0.034 us |  -0.55% |   SAME   |
|  I128   |      I32      |      2^20      |  14.295 us |       0.52% |  14.247 us |       0.72% | -0.048 us |  -0.34% |   SAME   |
|  I128   |      I32      |      2^24      | 121.006 us |       0.56% | 121.049 us |       0.62% |  0.042 us |   0.03% |   SAME   |
|  I128   |      I32      |      2^28      |   1.807 ms |       0.11% |   1.807 ms |       0.11% | -0.021 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   6.088 us |       1.38% |   6.075 us |       2.63% | -0.013 us |  -0.21% |   SAME   |
|  I128   |      I64      |      2^20      |  14.291 us |       0.55% |  14.238 us |       0.75% | -0.052 us |  -0.37% |   SAME   |
|  I128   |      I64      |      2^24      | 121.033 us |       0.58% | 120.967 us |       0.54% | -0.066 us |  -0.05% |   SAME   |
|  I128   |      I64      |      2^28      |   1.807 ms |       0.11% |   1.807 ms |       0.11% | -0.172 us |  -0.01% |   SAME   |

# triad

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   6.098 us |       1.36% |   6.095 us |       1.62% | -0.003 us |  -0.05% |   SAME   |
|   I8    |      I32      |      2^20      |   6.079 us |       1.18% |   6.047 us |       2.31% | -0.032 us |  -0.53% |   SAME   |
|   I8    |      I32      |      2^24      |  16.308 us |       1.25% |  16.311 us |       1.21% |  0.002 us |   0.01% |   SAME   |
|   I8    |      I32      |      2^28      | 159.978 us |       0.44% | 159.947 us |       0.43% | -0.031 us |  -0.02% |   SAME   |
|   I8    |      I64      |      2^16      |   6.091 us |       1.40% |   6.067 us |       1.65% | -0.024 us |  -0.39% |   SAME   |
|   I8    |      I64      |      2^20      |   6.095 us |       1.18% |   6.047 us |       1.87% | -0.048 us |  -0.78% |   SAME   |
|   I8    |      I64      |      2^24      |  16.307 us |       1.36% |  16.321 us |       2.05% |  0.014 us |   0.08% |   SAME   |
|   I8    |      I64      |      2^28      | 163.179 us |       0.57% | 163.201 us |       0.56% |  0.022 us |   0.01% |   SAME   |
|   I8    |      I64      |      2^32      |   2.498 ms |       0.03% |   2.498 ms |       0.03% | -0.196 us |  -0.01% |   SAME   |
|   I16   |      I32      |      2^16      |   6.076 us |       3.85% |   6.015 us |       4.93% | -0.061 us |  -1.00% |   SAME   |
|   I16   |      I32      |      2^20      |   7.023 us |      13.49% |   7.113 us |      13.12% |  0.090 us |   1.28% |   SAME   |
|   I16   |      I32      |      2^24      |  22.486 us |       0.32% |  22.438 us |       0.44% | -0.048 us |  -0.21% |   SAME   |
|   I16   |      I32      |      2^28      | 243.679 us |       0.03% | 243.617 us |       0.04% | -0.062 us |  -0.03% |   FAST   |
|   I16   |      I64      |      2^16      |   6.097 us |       1.29% |   6.042 us |       1.83% | -0.055 us |  -0.90% |   SAME   |
|   I16   |      I64      |      2^20      |   6.591 us |      12.13% |   6.712 us |      12.33% |  0.121 us |   1.83% |   SAME   |
|   I16   |      I64      |      2^24      |  22.486 us |       0.33% |  22.443 us |       0.72% | -0.043 us |  -0.19% |   SAME   |
|   I16   |      I64      |      2^28      | 245.579 us |       0.21% | 245.591 us |       0.18% |  0.013 us |   0.01% |   SAME   |
|   I16   |      I64      |      2^32      |   3.792 ms |       0.02% |   3.792 ms |       0.02% | -0.011 us |  -0.00% |   SAME   |
|   F32   |      I32      |      2^16      |   6.081 us |       2.30% |   6.052 us |       2.92% | -0.029 us |  -0.48% |   SAME   |
|   F32   |      I32      |      2^20      |   8.158 us |       0.78% |   8.102 us |       1.25% | -0.056 us |  -0.69% |   SAME   |
|   F32   |      I32      |      2^24      |  36.826 us |       0.19% |  36.774 us |       0.28% | -0.052 us |  -0.14% |   SAME   |
|   F32   |      I32      |      2^28      | 452.730 us |       0.12% | 452.768 us |       0.14% |  0.038 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   6.073 us |       2.44% |   6.034 us |       3.17% | -0.039 us |  -0.65% |   SAME   |
|   F32   |      I64      |      2^20      |   8.139 us |       1.01% |   8.092 us |       1.28% | -0.047 us |  -0.57% |   SAME   |
|   F32   |      I64      |      2^24      |  36.818 us |       0.21% |  36.763 us |       0.29% | -0.056 us |  -0.15% |   SAME   |
|   F32   |      I64      |      2^28      | 453.560 us |       0.22% | 453.594 us |       0.22% |  0.034 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^32      |   7.169 ms |       0.56% |   7.168 ms |       0.56% | -1.498 us |  -0.02% |   SAME   |
|   F64   |      I32      |      2^16      |   6.111 us |       1.00% |   6.068 us |       1.59% | -0.043 us |  -0.70% |   SAME   |
|   F64   |      I32      |      2^20      |  10.182 us |       0.70% |  10.129 us |       0.94% | -0.053 us |  -0.52% |   SAME   |
|   F64   |      I32      |      2^24      |  64.203 us |       1.55% |  64.301 us |       1.58% |  0.099 us |   0.15% |   SAME   |
|   F64   |      I32      |      2^28      | 903.049 us |       0.29% | 903.056 us |       0.29% |  0.007 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   6.099 us |       1.06% |   6.052 us |       1.49% | -0.048 us |  -0.79% |   SAME   |
|   F64   |      I64      |      2^20      |  10.202 us |       0.70% |  10.134 us |       1.08% | -0.068 us |  -0.66% |   SAME   |
|   F64   |      I64      |      2^24      |  64.054 us |       1.45% |  63.957 us |       1.42% | -0.097 us |  -0.15% |   SAME   |
|   F64   |      I64      |      2^28      | 902.421 us |       0.30% | 902.103 us |       0.31% | -0.318 us |  -0.04% |   SAME   |
|   F64   |      I64      |      2^32      |  14.418 ms |       0.03% |  14.419 ms |       0.03% |  0.385 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   6.140 us |       4.35% |   6.088 us |       3.98% | -0.052 us |  -0.84% |   SAME   |
|  I128   |      I32      |      2^20      |  14.291 us |       0.55% |  14.237 us |       0.74% | -0.054 us |  -0.38% |   SAME   |
|  I128   |      I32      |      2^24      | 119.940 us |       0.83% | 119.984 us |       0.79% |  0.044 us |   0.04% |   SAME   |
|  I128   |      I32      |      2^28      |   1.808 ms |       0.16% |   1.808 ms |       0.16% | -0.266 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^16      |   6.116 us |       1.62% |   6.067 us |       1.62% | -0.049 us |  -0.80% |   SAME   |
|  I128   |      I64      |      2^20      |  14.292 us |       0.51% |  14.240 us |       0.71% | -0.052 us |  -0.36% |   SAME   |
|  I128   |      I64      |      2^24      | 120.344 us |       0.68% | 120.328 us |       0.71% | -0.015 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^28      |   1.807 ms |       0.16% |   1.807 ms |       0.16% | -0.040 us |  -0.00% |   SAME   |

# nstream

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |      I32      |      2^16      |   6.110 us |       1.14% |   6.096 us |       1.53% | -0.015 us |  -0.24% |   SAME   |
|   I8    |      I32      |      2^20      |   6.115 us |       3.37% |   6.085 us |       4.03% | -0.031 us |  -0.50% |   SAME   |
|   I8    |      I32      |      2^24      |  20.404 us |       0.75% |  20.377 us |       0.93% | -0.027 us |  -0.13% |   SAME   |
|   I8    |      I32      |      2^28      | 221.035 us |       0.22% | 220.995 us |       0.20% | -0.039 us |  -0.02% |   SAME   |
|   I8    |      I64      |      2^16      |   6.090 us |       1.37% |   6.044 us |       1.74% | -0.046 us |  -0.75% |   SAME   |
|   I8    |      I64      |      2^20      |   6.130 us |       4.36% |   6.115 us |       6.09% | -0.015 us |  -0.25% |   SAME   |
|   I8    |      I64      |      2^24      |  20.386 us |       0.71% |  20.345 us |       0.98% | -0.041 us |  -0.20% |   SAME   |
|   I8    |      I64      |      2^28      | 224.206 us |       0.45% | 224.272 us |       0.45% |  0.065 us |   0.03% |   SAME   |
|   I8    |      I64      |      2^32      |   3.470 ms |       0.03% |   3.470 ms |       0.03% |  0.054 us |   0.00% |   SAME   |
|   I16   |      I32      |      2^16      |   6.109 us |       1.03% |   6.059 us |       1.57% | -0.050 us |  -0.81% |   SAME   |
|   I16   |      I32      |      2^20      |   7.947 us |       6.92% |   7.945 us |       6.42% | -0.003 us |  -0.03% |   SAME   |
|   I16   |      I32      |      2^24      |  27.246 us |       3.47% |  27.502 us |       3.63% |  0.256 us |   0.94% |   SAME   |
|   I16   |      I32      |      2^28      | 323.509 us |       0.25% | 323.533 us |       0.25% |  0.024 us |   0.01% |   SAME   |
|   I16   |      I64      |      2^16      |   6.099 us |       1.31% |   6.041 us |       1.67% | -0.057 us |  -0.94% |   SAME   |
|   I16   |      I64      |      2^20      |   8.092 us |       2.99% |   8.093 us |       2.66% |  0.001 us |   0.01% |   SAME   |
|   I16   |      I64      |      2^24      |  27.815 us |       3.59% |  27.928 us |       3.36% |  0.113 us |   0.41% |   SAME   |
|   I16   |      I64      |      2^28      | 329.066 us |       0.29% | 329.021 us |       0.29% | -0.045 us |  -0.01% |   SAME   |
|   I16   |      I64      |      2^32      |   5.171 ms |       0.03% |   5.171 ms |       0.03% |  0.071 us |   0.00% |   SAME   |
|   F32   |      I32      |      2^16      |   6.087 us |       2.14% |   6.101 us |       2.12% |  0.015 us |   0.24% |   SAME   |
|   F32   |      I32      |      2^20      |   8.169 us |       2.60% |   8.149 us |       3.60% | -0.020 us |  -0.25% |   SAME   |
|   F32   |      I32      |      2^24      |  47.064 us |       0.15% |  47.008 us |       0.32% | -0.055 us |  -0.12% |   SAME   |
|   F32   |      I32      |      2^28      | 601.480 us |       0.16% | 601.540 us |       0.15% |  0.060 us |   0.01% |   SAME   |
|   F32   |      I64      |      2^16      |   6.049 us |       2.80% |   6.039 us |       3.06% | -0.010 us |  -0.17% |   SAME   |
|   F32   |      I64      |      2^20      |   8.155 us |       2.51% |   8.097 us |       2.18% | -0.057 us |  -0.70% |   SAME   |
|   F32   |      I64      |      2^24      |  47.049 us |       0.18% |  46.996 us |       0.24% | -0.053 us |  -0.11% |   SAME   |
|   F32   |      I64      |      2^28      | 602.068 us |       0.01% | 602.036 us |       0.02% | -0.033 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^32      |   9.471 ms |       0.01% |   9.471 ms |       0.01% |  0.007 us |   0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   6.110 us |       1.04% |   6.094 us |       1.45% | -0.016 us |  -0.26% |   SAME   |
|   F64   |      I32      |      2^20      |  11.624 us |       7.91% |  11.720 us |       7.08% |  0.096 us |   0.83% |   SAME   |
|   F64   |      I32      |      2^24      |  83.288 us |       1.15% |  83.313 us |       1.13% |  0.025 us |   0.03% |   SAME   |
|   F64   |      I32      |      2^28      |   1.185 ms |       0.08% |   1.185 ms |       0.08% | -0.080 us |  -0.01% |   SAME   |
|   F64   |      I64      |      2^16      |   6.106 us |       1.23% |   6.069 us |       1.60% | -0.037 us |  -0.60% |   SAME   |
|   F64   |      I64      |      2^20      |  11.860 us |       6.55% |  11.876 us |       5.98% |  0.016 us |   0.13% |   SAME   |
|   F64   |      I64      |      2^24      |  83.520 us |       1.00% |  83.614 us |       0.86% |  0.094 us |   0.11% |   SAME   |
|   F64   |      I64      |      2^28      |   1.185 ms |       0.08% |   1.185 ms |       0.08% |  0.119 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^32      |  18.775 ms |       0.01% |  18.775 ms |       0.01% | -0.019 us |  -0.00% |   SAME   |
|  I128   |      I32      |      2^16      |   6.285 us |       8.89% |   6.252 us |       8.80% | -0.033 us |  -0.52% |   SAME   |
|  I128   |      I32      |      2^20      |  16.343 us |       0.46% |  16.310 us |       1.32% | -0.033 us |  -0.20% |   SAME   |
|  I128   |      I32      |      2^24      | 156.726 us |       0.63% | 156.791 us |       0.62% |  0.066 us |   0.04% |   SAME   |
|  I128   |      I32      |      2^28      |   2.357 ms |       0.04% |   2.357 ms |       0.04% | -0.022 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   6.126 us |       3.54% |   6.072 us |       3.33% | -0.054 us |  -0.88% |   SAME   |
|  I128   |      I64      |      2^20      |  16.364 us |       1.35% |  16.327 us |       1.68% | -0.037 us |  -0.23% |   SAME   |
|  I128   |      I64      |      2^24      | 156.877 us |       0.60% | 156.785 us |       0.61% | -0.092 us |  -0.06% |   SAME   |
|  I128   |      I64      |      2^28      |   2.357 ms |       0.04% |   2.357 ms |       0.04% |  0.069 us |   0.00% |   SAME   |
```