### PR TITLE
[libcu++] Rename device_transform back to launch_transform

### DIFF
--- a/cudax/examples/vector.cuh
+++ b/cudax/examples/vector.cuh
@@ -118,20 +118,20 @@ private:
   };
 
   [[nodiscard]] friend __action<__detail::__param_kind::_inout>
-  transform_device_argument(::cuda::stream_ref __str, vector& __v) noexcept
+  transform_launch_argument(::cuda::stream_ref __str, vector& __v) noexcept
   {
     return __action<__detail::__param_kind::_inout>{__str, __v};
   }
 
   [[nodiscard]] friend __action<__detail::__param_kind::_in>
-  transform_device_argument(::cuda::stream_ref __str, const vector& __v) noexcept
+  transform_launch_argument(::cuda::stream_ref __str, const vector& __v) noexcept
   {
     return __action<__detail::__param_kind::_in>{__str, __v};
   }
 
   template <__detail::__param_kind _Kind>
   [[nodiscard]] friend __action<_Kind>
-  transform_device_argument(::cuda::stream_ref __str, __detail::__box<vector, _Kind> __b) noexcept
+  transform_launch_argument(::cuda::stream_ref __str, __detail::__box<vector, _Kind> __b) noexcept
   {
     return __action<_Kind>{__str, __b.__val};
   }

--- a/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
+++ b/cudax/include/cuda/experimental/__container/uninitialized_buffer.cuh
@@ -103,7 +103,7 @@ private:
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   template <class _Tp2 = _Tp>
   [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto
-  transform_device_argument(::cuda::stream_ref, uninitialized_buffer& __self) noexcept
+  transform_launch_argument(::cuda::stream_ref, uninitialized_buffer& __self) noexcept
     _CCCL_TRAILING_REQUIRES(::cuda::std::span<_Tp>)(
       ::cuda::std::same_as<_Tp, _Tp2>&& ::cuda::std::__is_included_in_v<::cuda::mr::device_accessible, _Properties...>)
   {
@@ -114,7 +114,7 @@ private:
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   template <class _Tp2 = _Tp>
   [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto
-  transform_device_argument(::cuda::stream_ref, const uninitialized_buffer& __self) noexcept
+  transform_launch_argument(::cuda::stream_ref, const uninitialized_buffer& __self) noexcept
     _CCCL_TRAILING_REQUIRES(::cuda::std::span<const _Tp>)(
       ::cuda::std::same_as<_Tp, _Tp2>&& ::cuda::std::__is_included_in_v<::cuda::mr::device_accessible, _Properties...>)
   {

--- a/cudax/include/cuda/experimental/__launch/launch.cuh
+++ b/cudax/include/cuda/experimental/__launch/launch.cuh
@@ -24,7 +24,7 @@
 #include <cuda/__driver/driver_api.h>
 #include <cuda/__launch/configuration.h>
 #include <cuda/__launch/launch.h>
-#include <cuda/__stream/device_transform.h>
+#include <cuda/__stream/launch_transform.h>
 #include <cuda/__stream/stream_ref.h>
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/__type_traits/is_function.h>
@@ -209,7 +209,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
       ::cuda::__get_cufunction_of(__launcher),
       __combined,
       __kernel,
-      device_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_Args>(__args))...);
+      launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_Args>(__args))...);
   }
   else
   {
@@ -221,7 +221,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
       __combined,
       ::cuda::__get_cufunction_of(__launcher),
       __kernel,
-      device_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_Args>(__args))...);
+      launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_Args>(__args))...);
   }
 }
 
@@ -278,7 +278,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
     __conf,
     ::cuda::__get_cufunction_of(__kernel),
     __conf,
-    device_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
+    launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
 }
 
 //! @brief Launch a kernel with specified configuration and arguments
@@ -334,7 +334,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
     __conf,
     ::cuda::__get_cufunction_of(__kernel),
     __conf,
-    device_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
+    launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
 }
 
 //! @brief Launch a kernel function with specified configuration and arguments
@@ -388,7 +388,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
     ::cuda::__forward_or_cast_to_stream_ref<_Submitter>(::cuda::std::forward<_Submitter>(__submitter)), //
     __conf,
     ::cuda::__get_cufunction_of(__kernel),
-    device_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
+    launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
 }
 
 //! @brief Launch a kernel with specified configuration and arguments
@@ -442,7 +442,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
     ::cuda::__forward_or_cast_to_stream_ref<_Submitter>(::cuda::std::forward<_Submitter>(__submitter)), //
     __conf,
     ::cuda::__get_cufunction_of(__kernel),
-    device_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
+    launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
 }
 
 //

--- a/cudax/include/cuda/experimental/launch.cuh
+++ b/cudax/include/cuda/experimental/launch.cuh
@@ -12,7 +12,7 @@
 #define __CUDAX_LAUNCH___
 
 #include <cuda/__launch/configuration.h>
-#include <cuda/__stream/device_transform.h>
+#include <cuda/__stream/launch_transform.h>
 
 #include <cuda/experimental/__launch/launch.cuh>
 #include <cuda/experimental/__launch/param_kind.cuh>

--- a/cudax/test/algorithm/common.cuh
+++ b/cudax/test/algorithm/common.cuh
@@ -118,7 +118,7 @@ struct weird_buffer
     }
   };
 
-  [[nodiscard]] friend transform_result transform_device_argument(cuda::stream_ref, const weird_buffer& self) noexcept
+  [[nodiscard]] friend transform_result transform_launch_argument(cuda::stream_ref, const weird_buffer& self) noexcept
   {
     return {self.data, self.size};
   }

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -128,7 +128,7 @@ struct launch_transform_to_int_convertible
       // CUDAX_CHECK_FALSE(kernel_run_proof);
     }
 
-    // Immovable to ensure that device_transform doesn't copy the returned
+    // Immovable to ensure that launch_transform doesn't copy the returned
     // object
     int_convertible(int_convertible&&) noexcept = delete;
 
@@ -148,7 +148,7 @@ struct launch_transform_to_int_convertible
   };
 
   [[nodiscard]] friend int_convertible
-  transform_device_argument(::cuda::stream_ref stream, launch_transform_to_int_convertible self) noexcept
+  transform_launch_argument(::cuda::stream_ref stream, launch_transform_to_int_convertible self) noexcept
   {
     return int_convertible(stream.get(), self.value_);
   }

--- a/examples/cudax/vector_add/vector.cuh
+++ b/examples/cudax/vector_add/vector.cuh
@@ -118,20 +118,20 @@ private:
   };
 
   [[nodiscard]] friend __action<__detail::__param_kind::_inout>
-  transform_device_argument(::cuda::stream_ref __str, vector& __v) noexcept
+  transform_launch_argument(::cuda::stream_ref __str, vector& __v) noexcept
   {
     return __action<__detail::__param_kind::_inout>{__str, __v};
   }
 
   [[nodiscard]] friend __action<__detail::__param_kind::_in>
-  transform_device_argument(::cuda::stream_ref __str, const vector& __v) noexcept
+  transform_launch_argument(::cuda::stream_ref __str, const vector& __v) noexcept
   {
     return __action<__detail::__param_kind::_in>{__str, __v};
   }
 
   template <__detail::__param_kind _Kind>
   [[nodiscard]] friend __action<_Kind>
-  transform_device_argument(::cuda::stream_ref __str, __detail::__box<vector, _Kind> __b) noexcept
+  transform_launch_argument(::cuda::stream_ref __str, __detail::__box<vector, _Kind> __b) noexcept
   {
     return __action<_Kind>{__str, __b.__val};
   }

--- a/libcudacxx/include/cuda/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/__algorithm/copy.h
@@ -24,7 +24,7 @@
 #if _CCCL_HAS_CTK() && !_CCCL_COMPILER(NVRTC)
 
 #  include <cuda/__algorithm/common.h>
-#  include <cuda/__stream/device_transform.h>
+#  include <cuda/__stream/launch_transform.h>
 #  include <cuda/__stream/stream_ref.h>
 #  include <cuda/std/__concepts/concept_macros.h>
 #  include <cuda/std/mdspan>
@@ -156,8 +156,8 @@ _CCCL_HOST_API void copy_bytes(stream_ref __stream, _SrcTy&& __src, _DstTy&& __d
 {
   ::cuda::__detail::__copy_bytes_impl(
     __stream,
-    ::cuda::std::span(device_transform(__stream, ::cuda::std::forward<_SrcTy>(__src))),
-    ::cuda::std::span(device_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))),
+    ::cuda::std::span(launch_transform(__stream, ::cuda::std::forward<_SrcTy>(__src))),
+    ::cuda::std::span(launch_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))),
     __config);
 }
 
@@ -185,8 +185,8 @@ _CCCL_HOST_API void copy_bytes(stream_ref __stream, _SrcTy&& __src, _DstTy&& __d
 {
   ::cuda::__detail::__copy_bytes_impl(
     __stream,
-    ::cuda::__as_mdspan(device_transform(__stream, ::cuda::std::forward<_SrcTy>(__src))),
-    ::cuda::__as_mdspan(device_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))),
+    ::cuda::__as_mdspan(launch_transform(__stream, ::cuda::std::forward<_SrcTy>(__src))),
+    ::cuda::__as_mdspan(launch_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))),
     __config);
 }
 

--- a/libcudacxx/include/cuda/__algorithm/fill.h
+++ b/libcudacxx/include/cuda/__algorithm/fill.h
@@ -24,7 +24,7 @@
 #if _CCCL_HAS_CTK() && !_CCCL_COMPILER(NVRTC)
 
 #  include <cuda/__algorithm/common.h>
-#  include <cuda/__stream/device_transform.h>
+#  include <cuda/__stream/launch_transform.h>
 #  include <cuda/__stream/stream_ref.h>
 #  include <cuda/std/__concepts/concept_macros.h>
 
@@ -63,7 +63,7 @@ _CCCL_HOST_API void __fill_bytes_impl(stream_ref __stream,
 
 //! @brief Launches an operation to bytewise fill the memory into the provided stream.
 //!
-//! The destination needs to be or device_transform to a `contiguous_range` and convert to `cuda::std::span`.
+//! The destination needs to be or launch_transform to a `contiguous_range` and convert to `cuda::std::span`.
 //! The element type of the destination is required to be trivially copyable.
 //!
 //! The destination cannot reside in pagable host memory.
@@ -76,12 +76,12 @@ _CCCL_REQUIRES(__spannable<transformed_device_argument_t<_DstTy>>)
 _CCCL_HOST_API void fill_bytes(stream_ref __stream, _DstTy&& __dst, ::cuda::std::uint8_t __value)
 {
   ::cuda::__detail::__fill_bytes_impl(
-    __stream, ::cuda::std::span(device_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))), __value);
+    __stream, ::cuda::std::span(launch_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))), __value);
 }
 
 //! @brief Launches an operation to bytewise fill the memory into the provided stream.
 //!
-//! Destination needs to be or device_transform to an instance of `cuda::std::mdspan`.
+//! Destination needs to be or launch_transform to an instance of `cuda::std::mdspan`.
 //! It can also convert to `cuda::std::mdspan`, but the type needs to
 //! contain `mdspan` template arguments as member aliases named `value_type`,
 //! `extents_type`, `layout_type` and `accessor_type`. The resulting mdspan is required to
@@ -98,7 +98,7 @@ _CCCL_REQUIRES(__mdspannable<transformed_device_argument_t<_DstTy>>)
 _CCCL_HOST_API void fill_bytes(stream_ref __stream, _DstTy&& __dst, ::cuda::std::uint8_t __value)
 {
   ::cuda::__detail::__fill_bytes_impl(
-    __stream, __as_mdspan(device_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))), __value);
+    __stream, __as_mdspan(launch_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))), __value);
 }
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -571,10 +571,9 @@ public:
   //! cuda::launch.
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   template <class _DeviceAccessible = ::cuda::mr::device_accessible>
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto transform_device_argument(::cuda::stream_ref, buffer& __self) noexcept
+  [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto transform_launch_argument(::cuda::stream_ref, buffer& __self) noexcept
     _CCCL_TRAILING_REQUIRES(::cuda::std::span<_Tp>)(::cuda::std::__is_included_in_v<_DeviceAccessible, _Properties...>)
   {
-    // TODO add auto synchronization
     return {__self.__unwrapped_begin(), __self.size()};
   }
 
@@ -583,10 +582,9 @@ public:
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   template <class _DeviceAccessible = ::cuda::mr::device_accessible>
   [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto
-  transform_device_argument(::cuda::stream_ref, const buffer& __self) noexcept _CCCL_TRAILING_REQUIRES(
+  transform_launch_argument(::cuda::stream_ref, const buffer& __self) noexcept _CCCL_TRAILING_REQUIRES(
     ::cuda::std::span<const _Tp>)(::cuda::std::__is_included_in_v<_DeviceAccessible, _Properties...>)
   {
-    // TODO add auto synchronization
     return {__self.__unwrapped_begin(), __self.size()};
   }
 

--- a/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
+++ b/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
@@ -119,11 +119,10 @@ private:
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   template <class _Tp2 = _Tp>
   [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto
-  transform_device_argument(::cuda::stream_ref, __uninitialized_async_buffer& __self) noexcept
+  transform_launch_argument(::cuda::stream_ref, __uninitialized_async_buffer& __self) noexcept
     _CCCL_TRAILING_REQUIRES(::cuda::std::span<_Tp>)(
       ::cuda::std::same_as<_Tp, _Tp2>&& ::cuda::std::__is_included_in_v<::cuda::mr::device_accessible, _Properties...>)
   {
-    // TODO add auto synchronization
     return {__self.__get_data(), __self.size()};
   }
 
@@ -132,11 +131,10 @@ private:
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   template <class _Tp2 = _Tp>
   [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto
-  transform_device_argument(::cuda::stream_ref, const __uninitialized_async_buffer& __self) noexcept
+  transform_launch_argument(::cuda::stream_ref, const __uninitialized_async_buffer& __self) noexcept
     _CCCL_TRAILING_REQUIRES(::cuda::std::span<const _Tp>)(
       ::cuda::std::same_as<_Tp, _Tp2>&& ::cuda::std::__is_included_in_v<::cuda::mr::device_accessible, _Properties...>)
   {
-    // TODO add auto synchronization
     return {__self.__get_data(), __self.size()};
   }
 

--- a/libcudacxx/include/cuda/__launch/launch.h
+++ b/libcudacxx/include/cuda/__launch/launch.h
@@ -27,7 +27,7 @@
 #  include <cuda/__launch/configuration.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/__runtime/ensure_current_context.h>
-#  include <cuda/__stream/device_transform.h>
+#  include <cuda/__stream/launch_transform.h>
 #  include <cuda/__stream/stream_ref.h>
 #  include <cuda/std/__exception/cuda_error.h>
 #  include <cuda/std/__type_traits/is_function.h>
@@ -196,7 +196,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
       ::cuda::__get_cufunction_of(__launcher),
       __combined,
       __kernel,
-      device_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_Args>(__args))...);
+      launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_Args>(__args))...);
   }
   else
   {
@@ -208,7 +208,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
       __combined,
       ::cuda::__get_cufunction_of(__launcher),
       __kernel,
-      device_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_Args>(__args))...);
+      launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_Args>(__args))...);
   }
 }
 
@@ -268,7 +268,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
     __conf,
     ::cuda::__get_cufunction_of(__kernel),
     __conf,
-    device_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
+    launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
 }
 
 //! @brief Launch a kernel function with specified configuration and arguments
@@ -322,7 +322,7 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
     cuda::__forward_or_cast_to_stream_ref<_Submitter>(::cuda::std::forward<_Submitter>(__submitter)), //
     __conf,
     ::cuda::__get_cufunction_of(__kernel),
-    device_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
+    launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
 }
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/launch_smoke.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/launch/launch_smoke.cu
@@ -122,7 +122,7 @@ struct launch_transform_to_int_convertible
       // CUDAX_CHECK_FALSE(kernel_run_proof);
     }
 
-    // Immovable to ensure that device_transform doesn't copy the returned
+    // Immovable to ensure that launch_transform doesn't copy the returned
     // object
     int_convertible(int_convertible&&) noexcept = delete;
 
@@ -142,7 +142,7 @@ struct launch_transform_to_int_convertible
   };
 
   [[nodiscard]] friend int_convertible
-  transform_device_argument(::cuda::stream_ref stream, launch_transform_to_int_convertible self) noexcept
+  transform_launch_argument(::cuda::stream_ref stream, launch_transform_to_int_convertible self) noexcept
   {
     return int_convertible(stream.get(), self.value_);
   }

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/transform.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/transform.cu
@@ -27,7 +27,7 @@
 #include "helper.h"
 #include "types.h"
 
-C2H_TEST("DeviceTransform::Transform cuda::device_buffer", "[device][device_transform]")
+C2H_TEST("DeviceTransform::Transform cuda::device_buffer", "[device][launch_transform]")
 {
   using type          = int;
   const int num_items = 1 << 24;


### PR DESCRIPTION
We renamed `launch_transform` to `device_transform`, because it's applicable in more places, for example `copy_bytes`. But the new name clashes with the CUB algorithm, this PR restores the old name back