### PR TITLE
Introduce OpAdapter abstraction for unified operator handling

### DIFF
--- a/python/cuda_cccl/cuda/compute/_cccl_interop.py
+++ b/python/cuda_cccl/cuda/compute/_cccl_interop.py
@@ -419,29 +419,7 @@ def _create_output_dereference_wrapper(deref_fn, state_ptr_type, value_type):
     return wrapper_func, void_sig
 
 
-def to_cccl_op(op: Callable | OpKind, sig: Signature | None) -> Op:
-    """Return an `Op` object corresponding to the given callable or well-known operation.
-
-    For well-known operations (Ops), returns an Op with the appropriate
-    kind and empty ltoir/state.
-
-    For callables, wraps the callable in a device function that takes void* arguments
-    and a void* return value. This is the only way to match the corresponding "extern"
-    declaration of the device function in the C code, which knows nothing about the types
-    of the arguments and return value. The two functions must have the same signature in
-    order to link correctly without violating ODR.
-    """
-    # Check if op is a well-known operation
-    if isinstance(op, OpKind):
-        return Op(
-            operator_type=op,
-            name="",
-            ltoir=b"",
-            state_alignment=1,
-            state=b"",
-        )
-
-    # op is a callable:
+def to_stateless_cccl_op(op, sig: "Signature") -> Op:
     wrapped_op, wrapper_sig = _create_void_ptr_wrapper(op, sig)
 
     ltoir, _ = cuda.compile(wrapped_op, sig=wrapper_sig, output="ltoir")

--- a/python/cuda_cccl/cuda/compute/algorithms/_scan.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_scan.py
@@ -3,14 +3,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Callable, Union, cast
+from typing import Callable, cast
 
 import numba
 import numpy as np
 
 from .. import _bindings
 from .. import _cccl_interop as cccl
-from .._caching import CachableFunction, cache_with_key
+from .._caching import cache_with_key
 from .._cccl_interop import (
     call_build,
     get_value_type,
@@ -21,7 +21,7 @@ from .._utils import protocols
 from .._utils.protocols import get_data_pointer, validate_and_get_stream
 from .._utils.temp_storage_buffer import TempStorageBuffer
 from ..iterators._iterators import IteratorBase
-from ..op import OpKind
+from ..op import OpAdapter, OpKind, make_op_adapter
 from ..typing import DeviceArrayLike, GpuStruct
 
 
@@ -43,7 +43,8 @@ class _Scan:
         "d_in_cccl",
         "d_out_cccl",
         "init_value_cccl",
-        "op_wrapper",
+        "op",
+        "op_cccl",
         "device_scan_fn",
         "init_kind",
     ]
@@ -53,12 +54,13 @@ class _Scan:
         self,
         d_in: DeviceArrayLike | IteratorBase,
         d_out: DeviceArrayLike | IteratorBase,
-        op: Callable | OpKind,
+        op: OpAdapter,
         init_value: np.ndarray | DeviceArrayLike | GpuStruct | None,
         force_inclusive: bool,
     ):
         self.d_in_cccl = cccl.to_cccl_input_iter(d_in)
         self.d_out_cccl = cccl.to_cccl_output_iter(d_out)
+        self.op = op
 
         self.init_kind = get_init_kind(init_value)
 
@@ -85,17 +87,14 @@ class _Scan:
                 value_type = get_value_type(init_value_typed)
                 init_value_type_info = self.init_value_cccl.type
 
-        # For well-known operations, we don't need a signature
-        if isinstance(op, OpKind):
-            self.op_wrapper = cccl.to_cccl_op(op, None)
-        else:
-            self.op_wrapper = cccl.to_cccl_op(op, value_type(value_type, value_type))
+        # Compile the op with value types
+        self.op_cccl = self.op.compile((value_type, value_type), value_type)
 
         self.build_result = call_build(
             _bindings.DeviceScanBuildResult,
             self.d_in_cccl,
             self.d_out_cccl,
-            self.op_wrapper,
+            self.op_cccl,
             init_value_type_info,
             force_inclusive,
             self.init_kind,
@@ -159,17 +158,17 @@ class _Scan:
             self.d_in_cccl,
             self.d_out_cccl,
             num_items,
-            self.op_wrapper,
+            self.op_cccl,
             self.init_value_cccl,
             stream_handle,
         )
         return temp_storage_bytes
 
 
-def make_cache_key(
+def _make_cache_key(
     d_in: DeviceArrayLike | IteratorBase,
     d_out: DeviceArrayLike | IteratorBase,
-    op: Callable | OpKind,
+    op: OpAdapter,
     init_value: np.ndarray | DeviceArrayLike | GpuStruct | None,
 ):
     d_in_key = (
@@ -178,13 +177,6 @@ def make_cache_key(
     d_out_key = (
         d_out.kind if isinstance(d_out, IteratorBase) else protocols.get_dtype(d_out)
     )
-
-    # Handle well-known operations differently
-    op_key: Union[tuple[str, int], CachableFunction]
-    if isinstance(op, OpKind):
-        op_key = (op.name, op.value)
-    else:
-        op_key = CachableFunction(op)
 
     init_kind_key = get_init_kind(init_value)
     match init_kind_key:
@@ -196,12 +188,33 @@ def make_cache_key(
             init_value = cast(np.ndarray | GpuStruct, init_value)
             init_value_key = init_value.dtype
 
-    return (d_in_key, d_out_key, op_key, init_value_key, init_kind_key)
+    return (d_in_key, d_out_key, op.get_cache_key(), init_value_key, init_kind_key)
+
+
+@cache_with_key(_make_cache_key)
+def _make_exclusive_scan_cached(
+    d_in: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike | IteratorBase,
+    op: OpAdapter,
+    init_value: np.ndarray | DeviceArrayLike | GpuStruct | None,
+):
+    """Internal cached factory for exclusive _Scan."""
+    return _Scan(d_in, d_out, op, init_value, False)
+
+
+@cache_with_key(_make_cache_key)
+def _make_inclusive_scan_cached(
+    d_in: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike | IteratorBase,
+    op: OpAdapter,
+    init_value: np.ndarray | DeviceArrayLike | GpuStruct | None,
+):
+    """Internal cached factory for inclusive _Scan."""
+    return _Scan(d_in, d_out, op, init_value, True)
 
 
 # TODO Figure out `sum` without operator and initial value
 # TODO Accept stream
-@cache_with_key(make_cache_key)
 def make_exclusive_scan(
     d_in: DeviceArrayLike | IteratorBase,
     d_out: DeviceArrayLike | IteratorBase,
@@ -227,7 +240,8 @@ def make_exclusive_scan(
     Returns:
         A callable object that can be used to perform the scan
     """
-    return _Scan(d_in, d_out, op, init_value, False)
+    op_adapter = make_op_adapter(op)
+    return _make_exclusive_scan_cached(d_in, d_out, op_adapter, init_value)
 
 
 def exclusive_scan(
@@ -267,7 +281,6 @@ def exclusive_scan(
 
 # TODO Figure out `sum` without operator and initial value
 # TODO Accept stream
-@cache_with_key(make_cache_key)
 def make_inclusive_scan(
     d_in: DeviceArrayLike | IteratorBase,
     d_out: DeviceArrayLike | IteratorBase,
@@ -293,7 +306,8 @@ def make_inclusive_scan(
     Returns:
         A callable object that can be used to perform the scan
     """
-    return _Scan(d_in, d_out, op, init_value, True)
+    op_adapter = make_op_adapter(op)
+    return _make_inclusive_scan_cached(d_in, d_out, op_adapter, init_value)
 
 
 def inclusive_scan(

--- a/python/cuda_cccl/cuda/compute/algorithms/_segmented_reduce.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_segmented_reduce.py
@@ -1,10 +1,10 @@
-from typing import Callable, Union
+from typing import Callable
 
 import numpy as np
 
 from .. import _bindings
 from .. import _cccl_interop as cccl
-from .._caching import CachableFunction, cache_with_key
+from .._caching import cache_with_key
 from .._cccl_interop import (
     call_build,
     get_value_type,
@@ -18,7 +18,7 @@ from .._utils.protocols import (
 )
 from .._utils.temp_storage_buffer import TempStorageBuffer
 from ..iterators._iterators import IteratorBase
-from ..op import OpKind
+from ..op import OpAdapter, OpKind, make_op_adapter
 from ..typing import DeviceArrayLike, GpuStruct
 
 
@@ -30,7 +30,8 @@ class _SegmentedReduce:
         "start_offsets_in_cccl",
         "end_offsets_in_cccl",
         "h_init_cccl",
-        "op_wrapper",
+        "op",
+        "op_cccl",
     ]
 
     def __init__(
@@ -39,13 +40,15 @@ class _SegmentedReduce:
         d_out: DeviceArrayLike | IteratorBase,
         start_offsets_in: DeviceArrayLike | IteratorBase,
         end_offsets_in: DeviceArrayLike | IteratorBase,
-        op: Callable | OpKind,
+        op: OpAdapter,
         h_init: np.ndarray | GpuStruct,
     ):
         self.d_in_cccl = cccl.to_cccl_input_iter(d_in)
         self.d_out_cccl = cccl.to_cccl_output_iter(d_out)
         self.start_offsets_in_cccl = cccl.to_cccl_input_iter(start_offsets_in)
         self.end_offsets_in_cccl = cccl.to_cccl_input_iter(end_offsets_in)
+        self.op = op
+
         # set host advance functions
         cccl.cccl_iterator_set_host_advance(self.d_out_cccl, d_out)
         cccl.cccl_iterator_set_host_advance(
@@ -67,20 +70,18 @@ class _SegmentedReduce:
             )
 
         self.h_init_cccl = cccl.to_cccl_value(h_init)
-        value_type = get_value_type(h_init)
 
-        # For well-known operations, we don't need a signature
-        if isinstance(op, OpKind):
-            self.op_wrapper = cccl.to_cccl_op(op, None)
-        else:
-            self.op_wrapper = cccl.to_cccl_op(op, value_type(value_type, value_type))
+        # Compile the op with value types
+        value_type = get_value_type(h_init)
+        self.op_cccl = self.op.compile((value_type, value_type), value_type)
+
         self.build_result = call_build(
             _bindings.DeviceSegmentedReduceBuildResult,
             self.d_in_cccl,
             self.d_out_cccl,
             self.start_offsets_in_cccl,
             self.end_offsets_in_cccl,
-            self.op_wrapper,
+            self.op_cccl,
             self.h_init_cccl,
         )
 
@@ -118,7 +119,7 @@ class _SegmentedReduce:
             num_segments,
             self.start_offsets_in_cccl,
             self.end_offsets_in_cccl,
-            self.op_wrapper,
+            self.op_cccl,
             self.h_init_cccl,
             stream_handle,
         )
@@ -133,13 +134,13 @@ def _to_key(d_in: DeviceArrayLike | IteratorBase):
     return d_in_key
 
 
-def make_cache_key(
+def _make_cache_key(
     d_in: DeviceArrayLike | IteratorBase,
     d_out: DeviceArrayLike | IteratorBase,
     start_offsets_in: DeviceArrayLike | IteratorBase,
     end_offsets_in: DeviceArrayLike | IteratorBase,
-    op: Callable | OpKind,
-    h_init: np.ndarray,
+    op: OpAdapter,
+    h_init: np.ndarray | GpuStruct,
 ):
     d_in_key = _to_key(d_in)
     d_out_key = (
@@ -147,33 +148,37 @@ def make_cache_key(
     )
     start_offsets_in_key = _to_key(start_offsets_in)
     end_offsets_in_key = _to_key(end_offsets_in)
-
-    # Handle well-known operations differently
-    op_key: Union[tuple[str, int], CachableFunction]
-    if isinstance(op, OpKind):
-        op_key = (op.name, op.value)
-    else:
-        op_key = CachableFunction(op)
-
     h_init_key = h_init.dtype
     return (
         d_in_key,
         d_out_key,
         start_offsets_in_key,
         end_offsets_in_key,
-        op_key,
+        op.get_cache_key(),
         h_init_key,
     )
 
 
-@cache_with_key(make_cache_key)
+@cache_with_key(_make_cache_key)
+def _make_segmented_reduce_cached(
+    d_in: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike | IteratorBase,
+    start_offsets_in: DeviceArrayLike | IteratorBase,
+    end_offsets_in: DeviceArrayLike | IteratorBase,
+    op: OpAdapter,
+    h_init: np.ndarray | GpuStruct,
+):
+    """Internal cached factory for _SegmentedReduce."""
+    return _SegmentedReduce(d_in, d_out, start_offsets_in, end_offsets_in, op, h_init)
+
+
 def make_segmented_reduce(
     d_in: DeviceArrayLike | IteratorBase,
     d_out: DeviceArrayLike | IteratorBase,
     start_offsets_in: DeviceArrayLike | IteratorBase,
     end_offsets_in: DeviceArrayLike | IteratorBase,
     op: Callable | OpKind,
-    h_init: np.ndarray,
+    h_init: np.ndarray | GpuStruct,
 ):
     """Computes a device-wide segmented reduction using the specified binary ``op`` and initial value ``init``.
 
@@ -196,7 +201,10 @@ def make_segmented_reduce(
     Returns:
         A callable object that can be used to perform the reduction
     """
-    return _SegmentedReduce(d_in, d_out, start_offsets_in, end_offsets_in, op, h_init)
+    op_adapter = make_op_adapter(op)
+    return _make_segmented_reduce_cached(
+        d_in, d_out, start_offsets_in, end_offsets_in, op_adapter, h_init
+    )
 
 
 def segmented_reduce(

--- a/python/cuda_cccl/cuda/compute/algorithms/_select.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_select.py
@@ -5,19 +5,21 @@
 
 from typing import Callable
 
-from .._caching import CachableFunction, cache_with_key
+from .._caching import cache_with_key
 from .._utils import protocols
+from .._utils.temp_storage_buffer import TempStorageBuffer
 from ..iterators._factories import DiscardIterator
 from ..iterators._iterators import IteratorBase
+from ..op import OpAdapter, make_op_adapter
 from ..typing import DeviceArrayLike
 from ._three_way_partition import make_three_way_partition
 
 
-def make_cache_key(
+def _make_cache_key(
     d_in: DeviceArrayLike | IteratorBase,
     d_out: DeviceArrayLike | IteratorBase,
     d_num_selected_out: DeviceArrayLike,
-    cond: Callable,
+    cond: OpAdapter,
 ):
     d_in_key = (
         d_in.kind if isinstance(d_in, IteratorBase) else protocols.get_dtype(d_in)
@@ -26,8 +28,8 @@ def make_cache_key(
         d_out.kind if isinstance(d_out, IteratorBase) else protocols.get_dtype(d_out)
     )
     d_num_selected_out_key = protocols.get_dtype(d_num_selected_out)
-    cond_key = CachableFunction(cond)
-    return (d_in_key, d_out_key, d_num_selected_out_key, cond_key)
+
+    return (d_in_key, d_out_key, d_num_selected_out_key, cond.get_cache_key())
 
 
 class _Select:
@@ -38,7 +40,7 @@ class _Select:
         d_in: DeviceArrayLike | IteratorBase,
         d_out: DeviceArrayLike | IteratorBase,
         d_num_selected_out: DeviceArrayLike,
-        cond: Callable,
+        cond: Callable | OpAdapter,  # Raw callable or Operator
     ):
         # Create discard iterators for unused outputs, using d_out as reference
         # to match the input/output type
@@ -81,7 +83,20 @@ class _Select:
         )
 
 
-@cache_with_key(make_cache_key)
+@cache_with_key(_make_cache_key)
+def _make_select_cached(
+    d_in: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike | IteratorBase,
+    d_num_selected_out: DeviceArrayLike,
+    cond: OpAdapter,
+):
+    """Internal cached factory for _Select."""
+    # Note: _Select internally calls make_three_way_partition which will
+    # normalize the cond. But we've already normalized it, so the Op
+    # will be passed through make_op unchanged.
+    return _Select(d_in, d_out, d_num_selected_out, cond)
+
+
 def make_select(
     d_in: DeviceArrayLike | IteratorBase,
     d_out: DeviceArrayLike | IteratorBase,
@@ -112,7 +127,8 @@ def make_select(
     Returns:
         A callable object that performs the selection operation.
     """
-    return _Select(d_in, d_out, d_num_selected_out, cond)
+    cond_adapter = make_op_adapter(cond)
+    return _make_select_cached(d_in, d_out, d_num_selected_out, cond_adapter)
 
 
 def select(
@@ -131,6 +147,9 @@ def select(
     compacted form. The number of selected elements is written to ``d_num_selected_out[0]``.
 
     This function automatically handles temporary storage allocation and execution.
+
+    The ``cond`` function can reference device arrays as globals or closures - they will
+    be automatically captured as state arrays, enabling stateful operations like counting.
 
     Example:
         Below, ``select`` is used to select even numbers from an input array:
@@ -152,12 +171,12 @@ def select(
             The count is stored in ``d_num_selected_out[0]``.
         cond: Callable representing the selection condition (predicate). Should return a
             boolean-like value (typically uint8) where non-zero means the item passes the selection.
+            Can reference device arrays as globals/closures - they will be automatically captured.
         num_items: Number of items in the input sequence.
         stream: CUDA stream to use for the operation (optional).
     """
-    from .._utils.temp_storage_buffer import TempStorageBuffer
-
     selector = make_select(d_in, d_out, d_num_selected_out, cond)
+
     tmp_storage_bytes = selector(
         None,
         d_in,

--- a/python/cuda_cccl/cuda/compute/algorithms/_sort/_merge_sort.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_sort/_merge_sort.py
@@ -3,13 +3,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Callable, Union
+from typing import Callable
 
 import numba
 
 from ... import _bindings
 from ... import _cccl_interop as cccl
-from ..._caching import CachableFunction, cache_with_key
+from ..._caching import cache_with_key
 from ..._cccl_interop import call_build, set_cccl_iterator_state
 from ..._utils import protocols
 from ..._utils.protocols import (
@@ -18,16 +18,16 @@ from ..._utils.protocols import (
 )
 from ..._utils.temp_storage_buffer import TempStorageBuffer
 from ...iterators._iterators import IteratorBase
-from ...op import OpKind
+from ...op import OpAdapter, OpKind, make_op_adapter
 from ...typing import DeviceArrayLike
 
 
-def make_cache_key(
+def _make_cache_key(
     d_in_keys: DeviceArrayLike | IteratorBase,
     d_in_items: DeviceArrayLike | IteratorBase | None,
     d_out_keys: DeviceArrayLike,
     d_out_items: DeviceArrayLike | None,
-    op: Callable | OpKind,
+    op: OpAdapter,
 ):
     d_in_keys_key = (
         d_in_keys.kind
@@ -52,14 +52,13 @@ def make_cache_key(
             else protocols.get_dtype(d_out_items)
         )
 
-    # Handle well-known operations differently
-    op_key: Union[tuple[str, int], CachableFunction]
-    if isinstance(op, OpKind):
-        op_key = (op.name, op.value)
-    else:
-        op_key = CachableFunction(op)
-
-    return (d_in_keys_key, d_in_items_key, d_out_keys_key, d_out_items_key, op_key)
+    return (
+        d_in_keys_key,
+        d_in_items_key,
+        d_out_keys_key,
+        d_out_items_key,
+        op.get_cache_key(),
+    )
 
 
 class _MergeSort:
@@ -68,7 +67,8 @@ class _MergeSort:
         "d_in_items_cccl",
         "d_out_keys_cccl",
         "d_out_items_cccl",
-        "op_wrapper",
+        "op_adapter",
+        "op_cccl",
         "build_result",
     ]
 
@@ -78,7 +78,7 @@ class _MergeSort:
         d_in_items: DeviceArrayLike | IteratorBase | None,
         d_out_keys: DeviceArrayLike,
         d_out_items: DeviceArrayLike | None,
-        op: Callable | OpKind,
+        op: OpAdapter,
     ):
         present_in_values = d_in_items is not None
         present_out_values = d_out_items is not None
@@ -88,15 +88,11 @@ class _MergeSort:
         self.d_in_items_cccl = cccl.to_cccl_input_iter(d_in_items)
         self.d_out_keys_cccl = cccl.to_cccl_output_iter(d_out_keys)
         self.d_out_items_cccl = cccl.to_cccl_output_iter(d_out_items)
+        self.op_adapter = op
 
+        # Compile the op - merge_sort expects int8 return (comparison)
         value_type = cccl.get_value_type(d_in_keys)
-
-        # For well-known operations, we don't need a signature
-        if isinstance(op, OpKind):
-            self.op_wrapper = cccl.to_cccl_op(op, None)
-        else:
-            sig = numba.types.int8(value_type, value_type)
-            self.op_wrapper = cccl.to_cccl_op(op, sig)
+        self.op_cccl = op.compile((value_type, value_type), numba.types.int8)
 
         self.build_result = call_build(
             _bindings.DeviceMergeSortBuildResult,
@@ -104,7 +100,7 @@ class _MergeSort:
             self.d_in_items_cccl,
             self.d_out_keys_cccl,
             self.d_out_items_cccl,
-            self.op_wrapper,
+            self.op_cccl,
         )
 
     def __call__(
@@ -146,14 +142,25 @@ class _MergeSort:
             self.d_out_keys_cccl,
             self.d_out_items_cccl,
             num_items,
-            self.op_wrapper,
+            self.op_cccl,
             stream_handle,
         )
 
         return temp_storage_bytes
 
 
-@cache_with_key(make_cache_key)
+@cache_with_key(_make_cache_key)
+def _make_merge_sort_cached(
+    d_in_keys: DeviceArrayLike | IteratorBase,
+    d_in_items: DeviceArrayLike | IteratorBase | None,
+    d_out_keys: DeviceArrayLike,
+    d_out_items: DeviceArrayLike | None,
+    op: OpAdapter,
+):
+    """Internal cached factory for _MergeSort."""
+    return _MergeSort(d_in_keys, d_in_items, d_out_keys, d_out_items, op)
+
+
 def make_merge_sort(
     d_in_keys: DeviceArrayLike | IteratorBase,
     d_in_items: DeviceArrayLike | IteratorBase | None,
@@ -181,7 +188,10 @@ def make_merge_sort(
     Returns:
         A callable object that can be used to perform the merge sort
     """
-    return _MergeSort(d_in_keys, d_in_items, d_out_keys, d_out_items, op)
+    op_adapter = make_op_adapter(op)
+    return _make_merge_sort_cached(
+        d_in_keys, d_in_items, d_out_keys, d_out_items, op_adapter
+    )
 
 
 def merge_sort(

--- a/python/cuda_cccl/cuda/compute/algorithms/_three_way_partition.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_three_way_partition.py
@@ -9,22 +9,23 @@ import numba
 
 from .. import _bindings
 from .. import _cccl_interop as cccl
-from .._caching import CachableFunction, cache_with_key
+from .._caching import cache_with_key
 from .._cccl_interop import call_build, set_cccl_iterator_state
 from .._utils import protocols
 from .._utils.temp_storage_buffer import TempStorageBuffer
 from ..iterators._iterators import IteratorBase
+from ..op import OpAdapter, make_op_adapter
 from ..typing import DeviceArrayLike
 
 
-def make_cache_key(
+def _make_cache_key(
     d_in: DeviceArrayLike | IteratorBase,
     d_first_part_out: DeviceArrayLike | IteratorBase,
     d_second_part_out: DeviceArrayLike | IteratorBase,
     d_unselected_out: DeviceArrayLike | IteratorBase,
     d_num_selected_out: DeviceArrayLike | IteratorBase,
-    select_first_part_op: Callable,
-    select_second_part_op: Callable,
+    select_first_part_op: OpAdapter,
+    select_second_part_op: OpAdapter,
 ):
     d_in_key = (
         d_in.kind if isinstance(d_in, IteratorBase) else protocols.get_dtype(d_in)
@@ -49,16 +50,15 @@ def make_cache_key(
         if isinstance(d_num_selected_out, IteratorBase)
         else protocols.get_dtype(d_num_selected_out)
     )
-    select_first_part_op_key = CachableFunction(select_first_part_op)
-    select_second_part_op_key = CachableFunction(select_second_part_op)
+
     return (
         d_in_key,
         d_first_part_out_key,
         d_second_part_out_key,
         d_unselected_out_key,
         d_num_selected_out_key,
-        select_first_part_op_key,
-        select_second_part_op_key,
+        select_first_part_op.get_cache_key(),
+        select_second_part_op.get_cache_key(),
     )
 
 
@@ -70,8 +70,10 @@ class _ThreeWayPartition:
         "d_second_part_out_cccl",
         "d_unselected_out_cccl",
         "d_num_selected_out_cccl",
-        "select_first_part_op_wrapper",
-        "select_second_part_op_wrapper",
+        "select_first_part_op",
+        "select_second_part_op",
+        "select_first_part_op_cccl",
+        "select_second_part_op_cccl",
     ]
 
     def __init__(
@@ -81,8 +83,8 @@ class _ThreeWayPartition:
         d_second_part_out: DeviceArrayLike | IteratorBase,
         d_unselected_out: DeviceArrayLike | IteratorBase,
         d_num_selected_out: DeviceArrayLike | IteratorBase,
-        select_first_part_op: Callable,
-        select_second_part_op: Callable,
+        select_first_part_op: OpAdapter,
+        select_second_part_op: OpAdapter,
     ):
         self.d_in_cccl = cccl.to_cccl_input_iter(d_in)
         self.d_first_part_out_cccl = cccl.to_cccl_output_iter(d_first_part_out)
@@ -90,12 +92,17 @@ class _ThreeWayPartition:
         self.d_unselected_out_cccl = cccl.to_cccl_output_iter(d_unselected_out)
         self.d_num_selected_out_cccl = cccl.to_cccl_output_iter(d_num_selected_out)
 
-        value_type = cccl.get_value_type(d_in)
-        sig = numba.types.uint8(value_type)
+        self.select_first_part_op = select_first_part_op
+        self.select_second_part_op = select_second_part_op
 
-        # There are no well-known operations that can be used with three_way_partition
-        self.select_first_part_op_wrapper = cccl.to_cccl_op(select_first_part_op, sig)
-        self.select_second_part_op_wrapper = cccl.to_cccl_op(select_second_part_op, sig)
+        # Compile ops - partition predicates return uint8 (boolean)
+        value_type = cccl.get_value_type(d_in)
+        self.select_first_part_op_cccl = self.select_first_part_op.compile(
+            (value_type,), numba.types.uint8
+        )
+        self.select_second_part_op_cccl = self.select_second_part_op.compile(
+            (value_type,), numba.types.uint8
+        )
 
         self.build_result = call_build(
             _bindings.DeviceThreeWayPartitionBuildResult,
@@ -104,8 +111,8 @@ class _ThreeWayPartition:
             self.d_second_part_out_cccl,
             self.d_unselected_out_cccl,
             self.d_num_selected_out_cccl,
-            self.select_first_part_op_wrapper,
-            self.select_second_part_op_wrapper,
+            self.select_first_part_op_cccl,
+            self.select_second_part_op_cccl,
         )
 
     def __call__(
@@ -124,6 +131,7 @@ class _ThreeWayPartition:
         set_cccl_iterator_state(self.d_second_part_out_cccl, d_second_part_out)
         set_cccl_iterator_state(self.d_unselected_out_cccl, d_unselected_out)
         set_cccl_iterator_state(self.d_num_selected_out_cccl, d_num_selected_out)
+
         stream_handle = protocols.validate_and_get_stream(stream)
 
         if temp_storage is None:
@@ -141,23 +149,44 @@ class _ThreeWayPartition:
             self.d_second_part_out_cccl,
             self.d_unselected_out_cccl,
             self.d_num_selected_out_cccl,
-            self.select_first_part_op_wrapper,
-            self.select_second_part_op_wrapper,
+            self.select_first_part_op_cccl,
+            self.select_second_part_op_cccl,
             num_items,
             stream_handle,
         )
         return temp_storage_bytes
 
 
-@cache_with_key(make_cache_key)
+@cache_with_key(_make_cache_key)
+def _make_three_way_partition_cached(
+    d_in: DeviceArrayLike | IteratorBase,
+    d_first_part_out: DeviceArrayLike | IteratorBase,
+    d_second_part_out: DeviceArrayLike | IteratorBase,
+    d_unselected_out: DeviceArrayLike | IteratorBase,
+    d_num_selected_out: DeviceArrayLike | IteratorBase,
+    select_first_part_op: OpAdapter,
+    select_second_part_op: OpAdapter,
+):
+    """Internal cached factory for _ThreeWayPartition."""
+    return _ThreeWayPartition(
+        d_in,
+        d_first_part_out,
+        d_second_part_out,
+        d_unselected_out,
+        d_num_selected_out,
+        select_first_part_op,
+        select_second_part_op,
+    )
+
+
 def make_three_way_partition(
     d_in: DeviceArrayLike | IteratorBase,
     d_first_part_out: DeviceArrayLike | IteratorBase,
     d_second_part_out: DeviceArrayLike | IteratorBase,
     d_unselected_out: DeviceArrayLike | IteratorBase,
     d_num_selected_out: DeviceArrayLike | IteratorBase,
-    select_first_part_op: Callable,
-    select_second_part_op: Callable,
+    select_first_part_op: Callable | OpAdapter,
+    select_second_part_op: Callable | OpAdapter,
 ):
     """
     Computes a device-wide three-way partition using the specified unary ``select_first_part_op`` and ``select_second_part_op`` operators.
@@ -175,20 +204,25 @@ def make_three_way_partition(
         d_second_part_out: Device array or iterator to store the second part of the output
         d_unselected_out: Device array or iterator to store the unselected items
         d_num_selected_out: Device array to store the number of items selected. The total number of items selected by ``select_first_part_op`` and ``select_second_part_op`` is stored in ``d_num_selected_out[0]`` and ``d_num_selected_out[1]``, respectively.
-        select_first_part_op: Callable representing the unary operator to select the first part
-        select_second_part_op: Callable representing the unary operator to select the second part
+        select_first_part_op: Callable representing the unary operator to select the first part.
+            Can reference device arrays as globals/closures - they will be automatically captured.
+        select_second_part_op: Callable representing the unary operator to select the second part.
+            Can reference device arrays as globals/closures - they will be automatically captured.
 
     Returns:
         A callable object that can be used to perform the three-way partition
     """
-    return _ThreeWayPartition(
+    first_op_adapter = make_op_adapter(select_first_part_op)
+    second_op_adapter = make_op_adapter(select_second_part_op)
+
+    return _make_three_way_partition_cached(
         d_in,
         d_first_part_out,
         d_second_part_out,
         d_unselected_out,
         d_num_selected_out,
-        select_first_part_op,
-        select_second_part_op,
+        first_op_adapter,
+        second_op_adapter,
     )
 
 

--- a/python/cuda_cccl/cuda/compute/algorithms/_transform.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_transform.py
@@ -3,55 +3,41 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Callable, Union
+from typing import Callable
 
 from .. import _bindings
 from .. import _cccl_interop as cccl
-from .._caching import CachableFunction, cache_with_key
+from .._caching import cache_with_key
 from .._cccl_interop import set_cccl_iterator_state
 from .._utils import protocols
 from ..iterators._iterators import IteratorBase
-from ..numba_utils import get_inferred_return_type, signature_from_annotations
-from ..op import OpKind
+from ..op import OpAdapter, OpKind, make_op_adapter
 from ..typing import DeviceArrayLike
 
 
 class _UnaryTransform:
-    __slots__ = [
-        "d_in_cccl",
-        "d_out_cccl",
-        "op_wrapper",
-        "build_result",
-    ]
+    __slots__ = ["d_in_cccl", "d_out_cccl", "op", "op_cccl", "build_result"]
 
     def __init__(
         self,
         d_in: DeviceArrayLike | IteratorBase,
         d_out: DeviceArrayLike | IteratorBase,
-        op: Callable | OpKind,
+        op: OpAdapter,
     ):
         self.d_in_cccl = cccl.to_cccl_input_iter(d_in)
         self.d_out_cccl = cccl.to_cccl_output_iter(d_out)
+        self.op = op
 
-        # For well-known operations, we don't need a signature
-        if isinstance(op, OpKind):
-            self.op_wrapper = cccl.to_cccl_op(op, None)
-        else:
-            try:
-                sig = signature_from_annotations(op)
-            except ValueError:
-                in_value_type = cccl.get_value_type(d_in)
-                out_value_type = cccl.get_value_type(d_out)
-                if not out_value_type.is_internal:
-                    out_value_type = get_inferred_return_type(op, (in_value_type,))
-                sig = out_value_type(in_value_type)
+        # Compile the op with input/output types
+        in_type = cccl.get_value_type(d_in)
+        out_type = cccl.get_value_type(d_out)
+        self.op_cccl = self.op.compile((in_type,), out_type)
 
-            self.op_wrapper = cccl.to_cccl_op(op, sig=sig)
         self.build_result = cccl.call_build(
             _bindings.DeviceUnaryTransform,
             self.d_in_cccl,
             self.d_out_cccl,
-            self.op_wrapper,
+            self.op_cccl,
         )
 
     def __call__(
@@ -63,12 +49,13 @@ class _UnaryTransform:
     ):
         set_cccl_iterator_state(self.d_in_cccl, d_in)
         set_cccl_iterator_state(self.d_out_cccl, d_out)
+
         stream_handle = protocols.validate_and_get_stream(stream)
         self.build_result.compute(
             self.d_in_cccl,
             self.d_out_cccl,
             num_items,
-            self.op_wrapper,
+            self.op_cccl,
             stream_handle,
         )
         return None
@@ -79,7 +66,8 @@ class _BinaryTransform:
         "d_in1_cccl",
         "d_in2_cccl",
         "d_out_cccl",
-        "op_wrapper",
+        "op",
+        "op_cccl",
         "build_result",
     ]
 
@@ -88,34 +76,25 @@ class _BinaryTransform:
         d_in1: DeviceArrayLike | IteratorBase,
         d_in2: DeviceArrayLike | IteratorBase,
         d_out: DeviceArrayLike | IteratorBase,
-        op: Callable | OpKind,
+        op: OpAdapter,
     ):
         self.d_in1_cccl = cccl.to_cccl_input_iter(d_in1)
         self.d_in2_cccl = cccl.to_cccl_input_iter(d_in2)
         self.d_out_cccl = cccl.to_cccl_output_iter(d_out)
-        in1_value_type = cccl.get_value_type(d_in1)
-        in2_value_type = cccl.get_value_type(d_in2)
-        out_value_type = cccl.get_value_type(d_out)
+        self.op = op
 
-        # For well-known operations, we don't need a signature
-        if isinstance(op, OpKind):
-            self.op_wrapper = cccl.to_cccl_op(op, None)
-        else:
-            try:
-                sig = signature_from_annotations(op)
-            except ValueError:
-                if not out_value_type.is_internal:
-                    out_value_type = get_inferred_return_type(
-                        op, (in1_value_type, in2_value_type)
-                    )
-                sig = out_value_type(in1_value_type, in2_value_type)
-            self.op_wrapper = cccl.to_cccl_op(op, sig=sig)
+        # Compile the op with input/output types
+        in1_type = cccl.get_value_type(d_in1)
+        in2_type = cccl.get_value_type(d_in2)
+        out_type = cccl.get_value_type(d_out)
+        self.op_cccl = self.op.compile((in1_type, in2_type), out_type)
+
         self.build_result = cccl.call_build(
             _bindings.DeviceBinaryTransform,
             self.d_in1_cccl,
             self.d_in2_cccl,
             self.d_out_cccl,
-            self.op_wrapper,
+            self.op_cccl,
         )
 
     def __call__(
@@ -129,22 +108,23 @@ class _BinaryTransform:
         set_cccl_iterator_state(self.d_in1_cccl, d_in1)
         set_cccl_iterator_state(self.d_in2_cccl, d_in2)
         set_cccl_iterator_state(self.d_out_cccl, d_out)
+
         stream_handle = protocols.validate_and_get_stream(stream)
         self.build_result.compute(
             self.d_in1_cccl,
             self.d_in2_cccl,
             self.d_out_cccl,
             num_items,
-            self.op_wrapper,
+            self.op_cccl,
             stream_handle,
         )
         return None
 
 
-def make_unary_transform_cache_key(
+def _make_unary_transform_cache_key(
     d_in: DeviceArrayLike | IteratorBase,
     d_out: DeviceArrayLike | IteratorBase,
-    op: Callable | OpKind,
+    op: OpAdapter,
 ):
     d_in_key = (
         d_in.kind if isinstance(d_in, IteratorBase) else protocols.get_dtype(d_in)
@@ -152,22 +132,14 @@ def make_unary_transform_cache_key(
     d_out_key = (
         d_out.kind if isinstance(d_out, IteratorBase) else protocols.get_dtype(d_out)
     )
-
-    # Handle well-known operations differently
-    op_key: Union[tuple[str, int], CachableFunction]
-    if isinstance(op, OpKind):
-        op_key = (op.name, op.value)
-    else:
-        op_key = CachableFunction(op)
-
-    return (d_in_key, d_out_key, op_key)
+    return (d_in_key, d_out_key, op.get_cache_key())
 
 
-def make_binary_transform_cache_key(
+def _make_binary_transform_cache_key(
     d_in1: DeviceArrayLike | IteratorBase,
     d_in2: DeviceArrayLike | IteratorBase,
     d_out: DeviceArrayLike | IteratorBase,
-    op: Callable | OpKind,
+    op: OpAdapter,
 ):
     d_in1_key = (
         d_in1.kind if isinstance(d_in1, IteratorBase) else protocols.get_dtype(d_in1)
@@ -178,18 +150,30 @@ def make_binary_transform_cache_key(
     d_out_key = (
         d_out.kind if isinstance(d_out, IteratorBase) else protocols.get_dtype(d_out)
     )
-
-    # Handle well-known operations differently
-    op_key: Union[tuple[str, int], CachableFunction]
-    if isinstance(op, OpKind):
-        op_key = (op.name, op.value)
-    else:
-        op_key = CachableFunction(op)
-
-    return (d_in1_key, d_in2_key, d_out_key, op_key)
+    return (d_in1_key, d_in2_key, d_out_key, op.get_cache_key())
 
 
-@cache_with_key(make_unary_transform_cache_key)
+@cache_with_key(_make_unary_transform_cache_key)
+def _make_unary_transform_cached(
+    d_in: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike | IteratorBase,
+    op: OpAdapter,
+):
+    """Internal cached factory for _UnaryTransform."""
+    return _UnaryTransform(d_in, d_out, op)
+
+
+@cache_with_key(_make_binary_transform_cache_key)
+def _make_binary_transform_cached(
+    d_in1: DeviceArrayLike | IteratorBase,
+    d_in2: DeviceArrayLike | IteratorBase,
+    d_out: DeviceArrayLike | IteratorBase,
+    op: OpAdapter,
+):
+    """Internal cached factory for _BinaryTransform."""
+    return _BinaryTransform(d_in1, d_in2, d_out, op)
+
+
 def make_unary_transform(
     d_in: DeviceArrayLike | IteratorBase,
     d_out: DeviceArrayLike | IteratorBase,
@@ -216,10 +200,10 @@ def make_unary_transform(
     Returns:
         A callable object that performs the transformation.
     """
-    return _UnaryTransform(d_in, d_out, op)
+    op_adapter = make_op_adapter(op)
+    return _make_unary_transform_cached(d_in, d_out, op_adapter)
 
 
-@cache_with_key(make_binary_transform_cache_key)
 def make_binary_transform(
     d_in1: DeviceArrayLike | IteratorBase,
     d_in2: DeviceArrayLike | IteratorBase,
@@ -248,7 +232,8 @@ def make_binary_transform(
     Returns:
         A callable object that performs the transformation.
     """
-    return _BinaryTransform(d_in1, d_in2, d_out, op)
+    op_adapter = make_op_adapter(op)
+    return _make_binary_transform_cached(d_in1, d_in2, d_out, op_adapter)
 
 
 def unary_transform(
@@ -262,6 +247,9 @@ def unary_transform(
     Performs device-wide unary transform.
 
     This function automatically handles temporary storage allocation and execution.
+
+    The ``op`` function can reference device arrays as globals or closures - they will
+    be automatically captured as state arrays, enabling stateful operations like counting.
 
     Example:
         Below, ``unary_transform`` is used to apply a transformation to each element of the input.
@@ -282,6 +270,7 @@ def unary_transform(
         d_in: Device array or iterator containing the input sequence of data items.
         d_out: Device array or iterator to store the result of the transformation.
         op: Callable or OpKind representing the unary operation to apply to each element of the input.
+            Can reference device arrays as globals/closures - they will be automatically captured.
         num_items: Number of items to transform.
         stream: CUDA stream to use for the operation.
     """
@@ -322,6 +311,7 @@ def binary_transform(
         d_in2: Device array or iterator containing the second input sequence of data items.
         d_out: Device array or iterator to store the result of the transformation.
         op: Callable or OpKind representing the binary operation to apply to each pair of items from the input sequences.
+            Can reference device arrays as globals/closures - they will be automatically captured.
         num_items: Number of items to transform.
         stream: CUDA stream to use for the operation.
     """

--- a/python/cuda_cccl/cuda/compute/algorithms/_unique_by_key.py
+++ b/python/cuda_cccl/cuda/compute/algorithms/_unique_by_key.py
@@ -3,13 +3,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from typing import Callable, Union
+from typing import Callable
 
 import numba
 
 from .. import _bindings
 from .. import _cccl_interop as cccl
-from .._caching import CachableFunction, cache_with_key
+from .._caching import cache_with_key
 from .._cccl_interop import call_build, set_cccl_iterator_state
 from .._utils import protocols
 from .._utils.protocols import (
@@ -18,17 +18,17 @@ from .._utils.protocols import (
 )
 from .._utils.temp_storage_buffer import TempStorageBuffer
 from ..iterators._iterators import IteratorBase
-from ..op import OpKind
+from ..op import OpAdapter, OpKind, make_op_adapter
 from ..typing import DeviceArrayLike
 
 
-def make_cache_key(
+def _make_cache_key(
     d_in_keys: DeviceArrayLike | IteratorBase,
     d_in_items: DeviceArrayLike | IteratorBase,
     d_out_keys: DeviceArrayLike | IteratorBase,
     d_out_items: DeviceArrayLike | IteratorBase,
     d_out_num_selected: DeviceArrayLike,
-    op: Callable | OpKind,
+    op: OpAdapter,
 ):
     d_in_keys_key = (
         d_in_keys.kind
@@ -52,20 +52,13 @@ def make_cache_key(
     )
     d_out_num_selected_key = protocols.get_dtype(d_out_num_selected)
 
-    # Handle well-known operations differently
-    op_key: Union[tuple[str, int], CachableFunction]
-    if isinstance(op, OpKind):
-        op_key = (op.name, op.value)
-    else:
-        op_key = CachableFunction(op)
-
     return (
         d_in_keys_key,
         d_in_items_key,
         d_out_keys_key,
         d_out_items_key,
         d_out_num_selected_key,
-        op_key,
+        op.get_cache_key(),
     )
 
 
@@ -77,7 +70,8 @@ class _UniqueByKey:
         "d_out_keys_cccl",
         "d_out_items_cccl",
         "d_out_num_selected_cccl",
-        "op_wrapper",
+        "op",
+        "op_cccl",
     ]
 
     def __init__(
@@ -87,23 +81,18 @@ class _UniqueByKey:
         d_out_keys: DeviceArrayLike | IteratorBase,
         d_out_items: DeviceArrayLike | IteratorBase,
         d_out_num_selected: DeviceArrayLike,
-        op: Callable | OpKind,
+        op: OpAdapter,
     ):
         self.d_in_keys_cccl = cccl.to_cccl_input_iter(d_in_keys)
         self.d_in_items_cccl = cccl.to_cccl_input_iter(d_in_items)
         self.d_out_keys_cccl = cccl.to_cccl_output_iter(d_out_keys)
         self.d_out_items_cccl = cccl.to_cccl_output_iter(d_out_items)
         self.d_out_num_selected_cccl = cccl.to_cccl_output_iter(d_out_num_selected)
+        self.op = op
 
+        # Compile the op - unique_by_key expects bool return (comparison)
         value_type = cccl.get_value_type(d_in_keys)
-
-        # For well-known operations, we don't need a signature
-        if isinstance(op, OpKind):
-            self.op_wrapper = cccl.to_cccl_op(op, None)
-        else:
-            self.op_wrapper = cccl.to_cccl_op(
-                op, numba.types.uint8(value_type, value_type)
-            )
+        self.op_cccl = self.op.compile((value_type, value_type), numba.types.uint8)
 
         self.build_result = call_build(
             _bindings.DeviceUniqueByKeyBuildResult,
@@ -112,7 +101,7 @@ class _UniqueByKey:
             self.d_out_keys_cccl,
             self.d_out_items_cccl,
             self.d_out_num_selected_cccl,
-            self.op_wrapper,
+            self.op_cccl,
         )
 
     def __call__(
@@ -150,14 +139,28 @@ class _UniqueByKey:
             self.d_out_keys_cccl,
             self.d_out_items_cccl,
             self.d_out_num_selected_cccl,
-            self.op_wrapper,
+            self.op_cccl,
             num_items,
             stream_handle,
         )
         return temp_storage_bytes
 
 
-@cache_with_key(make_cache_key)
+@cache_with_key(_make_cache_key)
+def _make_unique_by_key_cached(
+    d_in_keys: DeviceArrayLike | IteratorBase,
+    d_in_items: DeviceArrayLike | IteratorBase,
+    d_out_keys: DeviceArrayLike | IteratorBase,
+    d_out_items: DeviceArrayLike | IteratorBase,
+    d_out_num_selected: DeviceArrayLike,
+    op: OpAdapter,
+):
+    """Internal cached factory for _UniqueByKey."""
+    return _UniqueByKey(
+        d_in_keys, d_in_items, d_out_keys, d_out_items, d_out_num_selected, op
+    )
+
+
 def make_unique_by_key(
     d_in_keys: DeviceArrayLike | IteratorBase,
     d_in_items: DeviceArrayLike | IteratorBase,
@@ -187,9 +190,14 @@ def make_unique_by_key(
     Returns:
         A callable object that can be used to perform unique by key
     """
-
-    return _UniqueByKey(
-        d_in_keys, d_in_items, d_out_keys, d_out_items, d_out_num_selected, op
+    op_adapter = make_op_adapter(op)
+    return _make_unique_by_key_cached(
+        d_in_keys,
+        d_in_items,
+        d_out_keys,
+        d_out_items,
+        d_out_num_selected,
+        op_adapter,
     )
 
 

--- a/python/cuda_cccl/cuda/compute/op.py
+++ b/python/cuda_cccl/cuda/compute/op.py
@@ -1,3 +1,140 @@
-from ._bindings import OpKind
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. ALL RIGHTS RESERVED.
+#
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-__all__ = ["OpKind"]
+from typing import Callable, Hashable
+
+from ._bindings import Op, OpKind
+from ._caching import CachableFunction
+
+
+def _is_well_known_op(op: OpKind) -> bool:
+    return isinstance(op, OpKind) and op not in (OpKind.STATELESS, OpKind.STATEFUL)
+
+
+class _OpAdapter:
+    """
+    Provides a unified interface for operators, whether they are:
+    - Well-known operations (OpKind.PLUS, OpKind.MAXIMUM, etc.)
+    - Stateless user-provided callables
+    """
+
+    def get_cache_key(self) -> Hashable:
+        """Return a hashable cache key for this operator."""
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def compile(self, input_types, output_type=None) -> Op:
+        """
+        Compile this operator to an Op for CCCL interop.
+
+        Args:
+            input_types: Tuple of numba types for input arguments
+            output_type: Optional numba type for return value (inferred if None)
+
+        Returns:
+            Compiled Op object for C++ interop
+        """
+        raise NotImplementedError("Subclasses must implement this method")
+
+    @property
+    def func(self) -> Callable | None:
+        """The underlying callable, if any."""
+        return None
+
+
+class _WellKnownOp(_OpAdapter):
+    """Internal wrapper for well-known OpKind values."""
+
+    __slots__ = ["_kind"]
+
+    def __init__(self, kind: OpKind):
+        if not _is_well_known_op(kind):
+            raise ValueError(
+                f"OpKind.{kind.name} is not a well-known operation. "
+                "Use OpKind.PLUS, OpKind.MAXIMUM, etc."
+            )
+        self._kind = kind
+
+    def get_cache_key(self) -> Hashable:
+        return (self.__class__.__name__, self._kind.name, self._kind.value)
+
+    def compile(self, input_types, output_type=None) -> Op:
+        return Op(
+            operator_type=self._kind,
+            name="",
+            ltoir=b"",
+            state_alignment=1,
+            state=b"",
+        )
+
+    @property
+    def kind(self) -> OpKind:
+        """The underlying OpKind."""
+        return self._kind
+
+
+class _StatelessOp(_OpAdapter):
+    """Internal wrapper for stateless callables."""
+
+    __slots__ = ["_func", "_cachable"]
+
+    def __init__(self, func: Callable):
+        self._func = func
+        self._cachable = CachableFunction(func)
+
+    def get_cache_key(self) -> Hashable:
+        return (self.__class__.__name__, self._cachable)
+
+    def compile(self, input_types, output_type=None) -> Op:
+        from . import _cccl_interop as cccl
+        from .numba_utils import get_inferred_return_type, signature_from_annotations
+
+        # Try to get signature from annotations first
+        try:
+            sig = signature_from_annotations(self._func)
+        except ValueError:
+            # Infer signature from input/output types
+            if output_type is None or (
+                hasattr(output_type, "is_internal") and not output_type.is_internal
+            ):
+                output_type = get_inferred_return_type(self._func, input_types)
+            sig = output_type(*input_types)
+
+        return cccl.to_stateless_cccl_op(self._func, sig)
+
+    @property
+    def func(self) -> Callable:
+        """Access the wrapped callable."""
+        return self._func
+
+
+# Public aliases
+OpAdapter = _OpAdapter
+
+
+def make_op_adapter(op) -> OpAdapter:
+    """
+    Create an Op from a callable or well-known OpKind.
+
+    Args:
+        op: Callable or OpKind
+
+    Returns:
+        A value with appropriate subtype of _BaseOp
+    """
+    # Already an _OpAdapter instance:
+    if isinstance(op, _OpAdapter):
+        return op
+
+    # Well-known operation
+    if isinstance(op, OpKind):
+        return _WellKnownOp(op)
+
+    return _StatelessOp(op)
+
+
+__all__ = [
+    "OpAdapter",
+    "OpKind",
+    "make_op_adapter",
+]


### PR DESCRIPTION
This refactors the operator handling in `cuda.compute` to use a unified OpAdapter interface that provides:

- `_WellKnownOp`: wrapper for built-in OpKind values (PLUS, MAXIMUM, etc.)
- `_StatelessOp`: wrapper for user-provided callables

The `OpAdapter` provides:
- `get_cache_key()`: consistent caching across all operator types
- `compile()`: compilation to CCCL Op for interop

All algorithms now use make_op_adapter() to normalize operators and store both the adapter and compiled op, enabling future extensibility (supporting stateful ops using this unified interface).

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
