### PR TITLE
Remove `[[nodiscard]]` from barrier's `.arrive(...)` method

### DIFF
--- a/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
@@ -55,7 +55,7 @@
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
-_CCCL_DEVICE inline ::cuda::std::uint64_t* barrier_native_handle(barrier<thread_scope_block>& __b);
+[[nodiscard]] _CCCL_DEVICE ::cuda::std::uint64_t* barrier_native_handle(barrier<thread_scope_block>& __b);
 _CCCL_END_NAMESPACE_CUDA_DEVICE
 
 _CCCL_BEGIN_NAMESPACE_CUDA
@@ -112,7 +112,7 @@ public:
                     "barrier must not be in cluster shared memory");))
   }
 
-  _CCCL_API friend inline void init(barrier* __b,
+  _CCCL_API inline friend void init(barrier* __b,
                                     ::cuda::std::ptrdiff_t __expected,
                                     ::cuda::std::__empty_completion = ::cuda::std::__empty_completion())
   {

--- a/libcudacxx/include/cuda/std/__barrier/barrier.h
+++ b/libcudacxx/include/cuda/std/__barrier/barrier.h
@@ -107,7 +107,7 @@ public:
   _CCCL_API void arrive_and_drop()
   {
     __expected.fetch_sub(1, memory_order_relaxed);
-    (void) arrive();
+    arrive();
   }
 
   [[nodiscard]] _CCCL_API static constexpr ptrdiff_t max() noexcept
@@ -175,7 +175,7 @@ public:
   __barrier_base(__barrier_base const&)            = delete;
   __barrier_base& operator=(__barrier_base const&) = delete;
 
-  [[nodiscard]] _CCCL_API arrival_token arrive(ptrdiff_t __update = 1)
+  /*discard*/ _CCCL_API arrival_token arrive(ptrdiff_t __update = 1)
   {
     auto const __inc = __arrived_unit * __update;
     auto const __old = __phase_arrived_expected.fetch_add(__inc, memory_order_acq_rel);
@@ -202,7 +202,7 @@ public:
   _CCCL_API void arrive_and_drop()
   {
     __phase_arrived_expected.fetch_add(__expected_unit, memory_order_relaxed);
-    (void) arrive();
+    arrive();
   }
 
   [[nodiscard]] _CCCL_API static constexpr ptrdiff_t max() noexcept


### PR DESCRIPTION
Closes #6943, removes superfluous `inline`s, adds missing `[[nodiscard]]` to `.try_wait_meow()` methods and fixes `__try_wait_parity` UB.