### PR TITLE
Provide thrust::find_if benchmark

### DIFF
--- a/thrust/benchmarks/bench/find_if/basic.cu
+++ b/thrust/benchmarks/bench/find_if/basic.cu
@@ -21,7 +21,7 @@ void find_if(nvbench::state& state, nvbench::type_list<T>)
   thrust::fill(dinput.begin(), dinput.begin() + mismatch_point, T{0});
   thrust::fill(dinput.begin() + mismatch_point, dinput.end(), val);
 
-  state.add_global_memory_reads<T>(mismatch_point);
+  state.add_global_memory_reads<T>(mismatch_point + 1);
   state.add_global_memory_writes<size_t>(1);
 
   caching_allocator_t alloc;


### PR DESCRIPTION
Provides `thrust::find_if` benchmark that will be needed when new `cub::FindIf` is introduced and `thrust::find` ports to that.
