### PR TITLE
Add `_CCCL_DEDUCTION_GUIDE_EXSPACE`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -32,6 +32,7 @@ AttributeMacros: [
                   '_CCCL_FORCEINLINE',
                   '_CCCL_HIDE_FROM_ABI',
                   '_CCCL_HOST_DEVICE',
+                  '_CCCL_DEDUCTION_GUIDE_ATTRIBUTES',
                   '_CCCL_HOST',
                   '_CCCL_KERNEL_ATTRIBUTES',
                   '_CCCL_NO_UNIQUE_ADDRESS',

--- a/cub/cub/detail/segmented_scan_helpers.cuh
+++ b/cub/cub/detail/segmented_scan_helpers.cuh
@@ -32,7 +32,7 @@ struct augmented_value_t
 };
 
 template <typename ValueT, typename FlagT = bool>
-_CCCL_HOST_DEVICE augmented_value_t(ValueT, FlagT) -> augmented_value_t<ValueT, FlagT>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES augmented_value_t(ValueT, FlagT) -> augmented_value_t<ValueT, FlagT>;
 
 template <typename ComputeT, int MaxSegmentsPerWorker>
 using agent_segmented_scan_compute_t =
@@ -406,7 +406,8 @@ private:
 };
 
 template <typename IterT, typename OffsetT, typename SearcherT, typename BeginOffsetIterT, typename ReadTransformT>
-_CCCL_HOST_DEVICE multi_segmented_input_iterator(IterT, OffsetT, SearcherT, BeginOffsetIterT, ReadTransformT)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+multi_segmented_input_iterator(IterT, OffsetT, SearcherT, BeginOffsetIterT, ReadTransformT)
   -> multi_segmented_input_iterator<IterT,
                                     ::cuda::std::remove_cv_t<OffsetT>,
                                     SearcherT,
@@ -475,7 +476,8 @@ private:
 };
 
 template <typename IterT, typename OffsetT, typename SearcherT, typename BeginOffsetIterT, typename WriteTransformT>
-_CCCL_HOST_DEVICE multi_segmented_output_iterator(IterT, OffsetT, SearcherT, BeginOffsetIterT, WriteTransformT)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+multi_segmented_output_iterator(IterT, OffsetT, SearcherT, BeginOffsetIterT, WriteTransformT)
   -> multi_segmented_output_iterator<IterT,
                                      ::cuda::std::remove_cv_t<OffsetT>,
                                      SearcherT,

--- a/cudax/include/cuda/experimental/__execution/any_allocator.cuh
+++ b/cudax/include/cuda/experimental/__execution/any_allocator.cuh
@@ -135,9 +135,9 @@ private:
 };
 
 template <class _Allocator>
-_CCCL_HOST_DEVICE any_allocator(_Allocator) -> any_allocator<typename _Allocator::value_type>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES any_allocator(_Allocator) -> any_allocator<typename _Allocator::value_type>;
 
-_CCCL_HOST_DEVICE any_allocator(::cuda::std::allocator<void>) -> any_allocator<::cuda::std::byte>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES any_allocator(::cuda::std::allocator<void>) -> any_allocator<::cuda::std::byte>;
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_signatures.cuh
@@ -473,7 +473,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT completion_signatures
   }
 };
 
-_CCCL_HOST_DEVICE completion_signatures() -> completion_signatures<>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES completion_signatures() -> completion_signatures<>;
 
 // work-around for https://gcc.gnu.org/bugzilla/show_bug.cgi?id=95629
 #if _CCCL_COMPILER(GCC, ==, 11)

--- a/cudax/include/cuda/experimental/__execution/domain.cuh
+++ b/cudax/include/cuda/experimental/__execution/domain.cuh
@@ -212,7 +212,7 @@ struct __hide_scheduler : __hide_query<_Env, get_scheduler_t, get_domain_t>
 };
 
 template <class _Env>
-_CCCL_HOST_DEVICE __hide_scheduler(_Env&&) -> __hide_scheduler<_Env>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __hide_scheduler(_Env&&) -> __hide_scheduler<_Env>;
 
 template <class _Sch, class... _Env>
 using __scheduler_domain_t _CCCL_NODEBUG_ALIAS = __call_result_t<get_completion_domain_t<set_value_t>, _Sch, _Env...>;

--- a/cudax/include/cuda/experimental/__execution/env.cuh
+++ b/cudax/include/cuda/experimental/__execution/env.cuh
@@ -187,7 +187,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sch_env_t
 };
 
 template <class _Sch>
-_CCCL_HOST_DEVICE __sch_env_t(_Sch) -> __sch_env_t<_Sch>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __sch_env_t(_Sch) -> __sch_env_t<_Sch>;
 
 struct __mk_sch_env_t
 {
@@ -225,7 +225,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __sch_attrs_t
 };
 
 template <class _Sch>
-_CCCL_HOST_DEVICE __sch_attrs_t(_Sch) -> __sch_attrs_t<_Sch>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __sch_attrs_t(_Sch) -> __sch_attrs_t<_Sch>;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // __inln_attrs

--- a/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
+++ b/cudax/include/cuda/experimental/__execution/rcvr_with_env.cuh
@@ -95,7 +95,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __rcvr_with_env_t : _Rcvr
 };
 
 template <class _Rcvr, class _Env>
-_CCCL_HOST_DEVICE __rcvr_with_env_t(_Rcvr, _Env) -> __rcvr_with_env_t<_Rcvr, _Env>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __rcvr_with_env_t(_Rcvr, _Env) -> __rcvr_with_env_t<_Rcvr, _Env>;
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/sndr_ref.cuh
+++ b/cudax/include/cuda/experimental/__execution/sndr_ref.cuh
@@ -60,7 +60,7 @@ private:
 };
 
 template <class _Sndr>
-_CCCL_HOST_DEVICE __sndr_ref(_Sndr&& __sndr) -> __sndr_ref<_Sndr>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __sndr_ref(_Sndr&& __sndr) -> __sndr_ref<_Sndr>;
 } // namespace cuda::experimental::execution
 
 #include <cuda/experimental/__execution/epilogue.cuh>

--- a/cudax/include/cuda/experimental/__execution/utility.cuh
+++ b/cudax/include/cuda/experimental/__execution/utility.cuh
@@ -250,7 +250,7 @@ public:
 };
 
 template <class... _Fns>
-_CCCL_HOST_DEVICE __first_callable(_Fns...) -> __first_callable<_Fns...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __first_callable(_Fns...) -> __first_callable<_Fns...>;
 
 //////////////////////////////////////////////////////////////////////////////////////////
 // __call_or
@@ -322,7 +322,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __always
 };
 
 template <class _Ty>
-_CCCL_HOST_DEVICE __always(_Ty) -> __always<_Ty>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __always(_Ty) -> __always<_Ty>;
 
 // @brief A type that turns a nullary callable into an object that is
 // implicitly convertible to the result type of the callable.
@@ -341,7 +341,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __emplace_from
 };
 
 template <class _Fn>
-_CCCL_HOST_DEVICE __emplace_from(_Fn) -> __emplace_from<_Fn>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __emplace_from(_Fn) -> __emplace_from<_Fn>;
 
 template <class _Ty, class... _Us>
 using __unless_one_of_t = ::cuda::std::enable_if_t<__none_of<_Ty, _Us...>, _Ty>;

--- a/cudax/include/cuda/experimental/__group/this_group.cuh
+++ b/cudax/include/cuda/experimental/__group/this_group.cuh
@@ -225,14 +225,14 @@ public:
 #  endif // _CCCL_CUDA_COMPILATION()
 };
 
-_CCCL_HOST_DEVICE this_thread() -> this_thread<__implicit_hierarchy_t>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_thread() -> this_thread<__implicit_hierarchy_t>;
 
 _CCCL_TEMPLATE(class _Hierarchy)
 _CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
-_CCCL_HOST_DEVICE this_thread(const _Hierarchy&) -> this_thread<__hierarchy_type_of<_Hierarchy>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_thread(const _Hierarchy&) -> this_thread<__hierarchy_type_of<_Hierarchy>>;
 
 #  if _CCCL_HAS_COOPERATIVE_GROUPS()
-_CCCL_HOST_DEVICE this_thread(const ::cooperative_groups::thread_block_tile<1, void>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_thread(const ::cooperative_groups::thread_block_tile<1, void>&)
   -> this_thread<__implicit_hierarchy_t>;
 #  endif // _CCCL_HAS_COOPERATIVE_GROUPS()
 
@@ -283,15 +283,15 @@ public:
 #  endif // _CCCL_CUDA_COMPILATION()
 };
 
-_CCCL_HOST_DEVICE this_warp() -> this_warp<__implicit_hierarchy_t>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_warp() -> this_warp<__implicit_hierarchy_t>;
 
 _CCCL_TEMPLATE(class _Hierarchy)
 _CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
-_CCCL_HOST_DEVICE this_warp(const _Hierarchy&) -> this_warp<__hierarchy_type_of<_Hierarchy>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_warp(const _Hierarchy&) -> this_warp<__hierarchy_type_of<_Hierarchy>>;
 
 #  if _CCCL_HAS_COOPERATIVE_GROUPS()
 template <class _Parent>
-_CCCL_HOST_DEVICE this_warp(const ::cooperative_groups::thread_block_tile<32, _Parent>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_warp(const ::cooperative_groups::thread_block_tile<32, _Parent>&)
   -> this_warp<__implicit_hierarchy_t>;
 #  endif // _CCCL_HAS_COOPERATIVE_GROUPS()
 
@@ -341,14 +341,15 @@ public:
 #  endif // _CCCL_CUDA_COMPILATION()
 };
 
-_CCCL_HOST_DEVICE this_block() -> this_block<__implicit_hierarchy_t>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_block() -> this_block<__implicit_hierarchy_t>;
 
 _CCCL_TEMPLATE(class _Hierarchy)
 _CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
-_CCCL_HOST_DEVICE this_block(const _Hierarchy&) -> this_block<__hierarchy_type_of<_Hierarchy>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_block(const _Hierarchy&) -> this_block<__hierarchy_type_of<_Hierarchy>>;
 
 #  if _CCCL_HAS_COOPERATIVE_GROUPS()
-_CCCL_HOST_DEVICE this_block(const ::cooperative_groups::thread_block&) -> this_block<__implicit_hierarchy_t>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_block(const ::cooperative_groups::thread_block&)
+  -> this_block<__implicit_hierarchy_t>;
 #  endif // _CCCL_HAS_COOPERATIVE_GROUPS()
 
 template <class _Hierarchy>
@@ -411,14 +412,15 @@ public:
 #  endif // _CCCL_CUDA_COMPILATION()
 };
 
-_CCCL_HOST_DEVICE this_cluster() -> this_cluster<__implicit_hierarchy_t>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_cluster() -> this_cluster<__implicit_hierarchy_t>;
 
 _CCCL_TEMPLATE(class _Hierarchy)
 _CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
-_CCCL_HOST_DEVICE this_cluster(const _Hierarchy&) -> this_cluster<__hierarchy_type_of<_Hierarchy>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_cluster(const _Hierarchy&) -> this_cluster<__hierarchy_type_of<_Hierarchy>>;
 
 #  if _CCCL_HAS_COOPERATIVE_GROUPS() && defined(_CG_HAS_CLUSTER_GROUP)
-_CCCL_HOST_DEVICE this_cluster(const ::cooperative_groups::cluster_group&) -> this_cluster<__implicit_hierarchy_t>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_cluster(const ::cooperative_groups::cluster_group&)
+  -> this_cluster<__implicit_hierarchy_t>;
 #  endif // _CCCL_HAS_COOPERATIVE_GROUPS() && defined(_CG_HAS_CLUSTER_GROUP)
 
 // Synchronizing whole grid requires driver support and the kernel must be launched using the cooperative launch API.
@@ -533,14 +535,15 @@ public:
 #  endif // _CCCL_CUDA_COMPILATION()
 };
 
-_CCCL_HOST_DEVICE this_grid() -> this_grid<__implicit_hierarchy_t>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_grid() -> this_grid<__implicit_hierarchy_t>;
 
 _CCCL_TEMPLATE(class _Hierarchy)
 _CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
-_CCCL_HOST_DEVICE this_grid(const _Hierarchy&) -> this_grid<__hierarchy_type_of<_Hierarchy>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_grid(const _Hierarchy&) -> this_grid<__hierarchy_type_of<_Hierarchy>>;
 
 #  if _CCCL_HAS_COOPERATIVE_GROUPS()
-_CCCL_HOST_DEVICE this_grid(const ::cooperative_groups::grid_group&) -> this_grid<__implicit_hierarchy_t>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES this_grid(const ::cooperative_groups::grid_group&)
+  -> this_grid<__implicit_hierarchy_t>;
 #  endif // _CCCL_HAS_COOPERATIVE_GROUPS()
 
 _CCCL_TEMPLATE(class _Level, class... _Args)

--- a/cudax/include/cuda/experimental/__utility/scope_exit.cuh
+++ b/cudax/include/cuda/experimental/__utility/scope_exit.cuh
@@ -94,7 +94,7 @@ private:
 };
 
 template <class _Fn>
-_CCCL_HOST_DEVICE scope_exit(_Fn) -> scope_exit<_Fn>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES scope_exit(_Fn) -> scope_exit<_Fn>;
 } // namespace cuda::experimental
 
 #endif // _CUDAX__EXPERIMENTAL_UTILITY_SCOPE_EXIT

--- a/cudax/test/execution/common/checked_receiver.cuh
+++ b/cudax/test/execution/common/checked_receiver.cuh
@@ -92,7 +92,7 @@ struct checked_value_receiver
 };
 
 template <class... Values>
-_CCCL_HOST_DEVICE checked_value_receiver(Values...) -> checked_value_receiver<Values...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES checked_value_receiver(Values...) -> checked_value_receiver<Values...>;
 
 template <class Error = cudax::execution::exception_ptr>
 struct checked_error_receiver
@@ -163,7 +163,7 @@ struct checked_error_receiver
 };
 
 template <class Error>
-_CCCL_HOST_DEVICE checked_error_receiver(Error) -> checked_error_receiver<Error>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES checked_error_receiver(Error) -> checked_error_receiver<Error>;
 
 struct checked_stopped_receiver
 {
@@ -215,5 +215,5 @@ struct proxy_value_receiver
 };
 
 template <class Ty>
-_CCCL_HOST_DEVICE proxy_value_receiver(Ty&) -> proxy_value_receiver<Ty>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES proxy_value_receiver(Ty&) -> proxy_value_receiver<Ty>;
 } // namespace

--- a/libcudacxx/include/cuda/__complex/complex.h
+++ b/libcudacxx/include/cuda/__complex/complex.h
@@ -222,13 +222,13 @@ public:
 //! @brief Deduction guide for construction from complex types.
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES(__is_any_complex_v<_Tp>)
-_CCCL_HOST_DEVICE complex(const _Tp&) -> complex<typename _Tp::value_type>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES complex(const _Tp&) -> complex<typename _Tp::value_type>;
 
 #if _CCCL_STD_VER >= 2020
 //! @brief Deduction guide for construction from a tuple-like object.
 _CCCL_TEMPLATE(class _Tp)
 _CCCL_REQUIRES((!__is_any_complex_v<_Tp>) _CCCL_AND __is_complex_compatible_tuple_like<_Tp>)
-_CCCL_HOST_DEVICE complex(const _Tp&) -> complex<__complex_tuple_like_value_type_t<_Tp>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES complex(const _Tp&) -> complex<__complex_tuple_like_value_type_t<_Tp>>;
 #endif // _CCCL_STD_VER >= 2020
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__hierarchy/hierarchy_dimensions.h
+++ b/libcudacxx/include/cuda/__hierarchy/hierarchy_dimensions.h
@@ -431,7 +431,7 @@ public:
 
 _CCCL_TEMPLATE(class... _LevelDescs)
 _CCCL_REQUIRES(::cuda::std::__fold_and_v<__is_hierarchy_level_desc_v<_LevelDescs>...>)
-_CCCL_HOST_DEVICE hierarchy(const _LevelDescs&...)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES hierarchy(const _LevelDescs&...)
   -> hierarchy<__detail::__default_unit_below<
                  ::cuda::std::__type_index_c<sizeof...(_LevelDescs) - 1, __level_type_of<_LevelDescs>...>>,
                _LevelDescs...>;
@@ -439,11 +439,12 @@ _CCCL_HOST_DEVICE hierarchy(const _LevelDescs&...)
 _CCCL_TEMPLATE(class _BottomUnit, class... _LevelDescs)
 _CCCL_REQUIRES(
   __is_hierarchy_level_v<_BottomUnit> _CCCL_AND ::cuda::std::__fold_and_v<__is_hierarchy_level_desc_v<_LevelDescs>...>)
-_CCCL_HOST_DEVICE hierarchy(const _BottomUnit&, const _LevelDescs&...) -> hierarchy<_BottomUnit, _LevelDescs...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES hierarchy(const _BottomUnit&, const _LevelDescs&...)
+  -> hierarchy<_BottomUnit, _LevelDescs...>;
 
 _CCCL_TEMPLATE(class... _LevelDescs)
 _CCCL_REQUIRES(::cuda::std::__fold_and_v<__is_hierarchy_level_desc_v<_LevelDescs>...>)
-_CCCL_HOST_DEVICE hierarchy(const ::cuda::std::tuple<_LevelDescs...>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES hierarchy(const ::cuda::std::tuple<_LevelDescs...>&)
   -> hierarchy<__detail::__default_unit_below<
                  ::cuda::std::__type_index_c<sizeof...(_LevelDescs) - 1, __level_type_of<_LevelDescs>...>>,
                _LevelDescs...>;
@@ -451,7 +452,7 @@ _CCCL_HOST_DEVICE hierarchy(const ::cuda::std::tuple<_LevelDescs...>&)
 _CCCL_TEMPLATE(class _BottomUnit, class... _LevelDescs)
 _CCCL_REQUIRES(
   __is_hierarchy_level_v<_BottomUnit> _CCCL_AND ::cuda::std::__fold_and_v<__is_hierarchy_level_desc_v<_LevelDescs>...>)
-_CCCL_HOST_DEVICE hierarchy(const _BottomUnit&, const ::cuda::std::tuple<_LevelDescs...>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES hierarchy(const _BottomUnit&, const ::cuda::std::tuple<_LevelDescs...>&)
   -> hierarchy<_BottomUnit, _LevelDescs...>;
 
 #  if !_CCCL_COMPILER(NVRTC)

--- a/libcudacxx/include/cuda/__iterator/constant_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/constant_iterator.h
@@ -310,11 +310,11 @@ public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class _Tp>
-_CCCL_HOST_DEVICE constant_iterator(_Tp) -> constant_iterator<_Tp, ::cuda::std::ptrdiff_t>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES constant_iterator(_Tp) -> constant_iterator<_Tp, ::cuda::std::ptrdiff_t>;
 
 _CCCL_TEMPLATE(class _Tp, typename _Index)
 _CCCL_REQUIRES(::cuda::std::__integer_like<_Index>)
-_CCCL_HOST_DEVICE constant_iterator(_Tp, _Index) -> constant_iterator<_Tp, _Index>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES constant_iterator(_Tp, _Index) -> constant_iterator<_Tp, _Index>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
 //! @brief Creates a @c constant_iterator from a value and an index

--- a/libcudacxx/include/cuda/__iterator/permutation_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/permutation_iterator.h
@@ -435,7 +435,7 @@ public:
 _CCCL_TEMPLATE(class _Iter, class _Index)
 _CCCL_REQUIRES(
   ::cuda::std::__has_random_access_traversal<_Iter> _CCCL_AND ::cuda::std::__has_random_access_traversal<_Index>)
-_CCCL_HOST_DEVICE permutation_iterator(_Iter, _Index) -> permutation_iterator<_Iter, _Index>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES permutation_iterator(_Iter, _Index) -> permutation_iterator<_Iter, _Index>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
 //! @brief Creates an @c permutation_iterator from a base iterator and an iterator to an integral index

--- a/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/shuffle_iterator.h
@@ -309,11 +309,12 @@ public:
 
 _CCCL_TEMPLATE(class _Bijection)
 _CCCL_REQUIRES(__is_bijection<_Bijection>)
-_CCCL_HOST_DEVICE shuffle_iterator(_Bijection) -> shuffle_iterator<typename _Bijection::index_type, _Bijection>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES shuffle_iterator(_Bijection)
+  -> shuffle_iterator<typename _Bijection::index_type, _Bijection>;
 
 _CCCL_TEMPLATE(class _Bijection, typename _Integral)
 _CCCL_REQUIRES(__is_bijection<_Bijection> _CCCL_AND ::cuda::std::is_integral_v<_Integral>)
-_CCCL_HOST_DEVICE shuffle_iterator(_Bijection, _Integral)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES shuffle_iterator(_Bijection, _Integral)
   -> shuffle_iterator<typename _Bijection::index_type, _Bijection>;
 
 //! @brief make_shuffle_iterator creates a @c shuffle_iterator from an integer and a bijection function

--- a/libcudacxx/include/cuda/__iterator/strided_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/strided_iterator.h
@@ -389,7 +389,7 @@ public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class _Iter, typename _Stride>
-_CCCL_HOST_DEVICE strided_iterator(_Iter, _Stride) -> strided_iterator<_Iter, _Stride>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES strided_iterator(_Iter, _Stride) -> strided_iterator<_Iter, _Stride>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
 //! @brief Creates a @c strided_iterator from a random access iterator

--- a/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/tabulate_output_iterator.h
@@ -342,11 +342,11 @@ public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class _Fn>
-_CCCL_HOST_DEVICE tabulate_output_iterator(_Fn) -> tabulate_output_iterator<_Fn, ::cuda::std::ptrdiff_t>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES tabulate_output_iterator(_Fn) -> tabulate_output_iterator<_Fn, ::cuda::std::ptrdiff_t>;
 
 _CCCL_TEMPLATE(class _Fn, class _Index)
 _CCCL_REQUIRES(::cuda::std::__integer_like<_Index>)
-_CCCL_HOST_DEVICE tabulate_output_iterator(_Fn, _Index) -> tabulate_output_iterator<_Fn, _Index>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES tabulate_output_iterator(_Fn, _Index) -> tabulate_output_iterator<_Fn, _Index>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
 //! @brief Creates a @c tabulate_output_iterator from an output function and an optional index.

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -517,10 +517,10 @@ public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class... _Iterators>
-_CCCL_HOST_DEVICE zip_iterator(::cuda::std::tuple<_Iterators...>) -> zip_iterator<_Iterators...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES zip_iterator(::cuda::std::tuple<_Iterators...>) -> zip_iterator<_Iterators...>;
 
 template <class... _Iterators>
-_CCCL_HOST_DEVICE zip_iterator(_Iterators...) -> zip_iterator<_Iterators...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES zip_iterator(_Iterators...) -> zip_iterator<_Iterators...>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
 //! @brief Creates a @c zip_iterator from a tuple of iterators.

--- a/libcudacxx/include/cuda/__iterator/zip_transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_transform_iterator.h
@@ -550,11 +550,12 @@ public:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class _Fn, class... _Iterators>
-_CCCL_HOST_DEVICE zip_transform_iterator(_Fn, ::cuda::std::tuple<_Iterators...>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES zip_transform_iterator(_Fn, ::cuda::std::tuple<_Iterators...>)
   -> zip_transform_iterator<_Fn, _Iterators...>;
 
 template <class _Fn, class... _Iterators>
-_CCCL_HOST_DEVICE zip_transform_iterator(_Fn, _Iterators...) -> zip_transform_iterator<_Fn, _Iterators...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES zip_transform_iterator(_Fn, _Iterators...)
+  -> zip_transform_iterator<_Fn, _Iterators...>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
 //! @brief Creates a @c zip_transform_iterator from a tuple of iterators.

--- a/libcudacxx/include/cuda/__mdspan/host_device_mdspan.h
+++ b/libcudacxx/include/cuda/__mdspan/host_device_mdspan.h
@@ -58,41 +58,43 @@ public:
 _CCCL_TEMPLATE(class _ElementType, class... _OtherIndexTypes)
 _CCCL_REQUIRES((sizeof...(_OtherIndexTypes) > 0)
                  _CCCL_AND(::cuda::std::is_convertible_v<_OtherIndexTypes, size_t>&&...))
-_CCCL_HOST_DEVICE explicit host_mdspan(_ElementType*, _OtherIndexTypes...)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES explicit host_mdspan(_ElementType*, _OtherIndexTypes...)
   -> host_mdspan<_ElementType, ::cuda::std::extents<size_t, ::cuda::std::__maybe_static_ext<_OtherIndexTypes>...>>;
 
 _CCCL_TEMPLATE(class _Pointer)
 _CCCL_REQUIRES(::cuda::std::is_pointer_v<::cuda::std::remove_reference_t<_Pointer>>)
-_CCCL_HOST_DEVICE host_mdspan(_Pointer&&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES host_mdspan(_Pointer&&)
   -> host_mdspan<::cuda::std::remove_pointer_t<::cuda::std::remove_reference_t<_Pointer>>, ::cuda::std::extents<size_t>>;
 
 _CCCL_TEMPLATE(class _CArray)
 _CCCL_REQUIRES(::cuda::std::is_array_v<_CArray> _CCCL_AND(::cuda::std::rank_v<_CArray> == 1))
-_CCCL_HOST_DEVICE host_mdspan(_CArray&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES host_mdspan(_CArray&)
   -> host_mdspan<::cuda::std::remove_all_extents_t<_CArray>,
                  ::cuda::std::extents<size_t, ::cuda::std::extent_v<_CArray, 0>>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Size>
-_CCCL_HOST_DEVICE host_mdspan(_ElementType*, const ::cuda::std::array<_OtherIndexType, _Size>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES host_mdspan(_ElementType*, const ::cuda::std::array<_OtherIndexType, _Size>&)
   -> host_mdspan<_ElementType, ::cuda::std::dextents<size_t, _Size>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Size>
-_CCCL_HOST_DEVICE host_mdspan(_ElementType*, ::cuda::std::span<_OtherIndexType, _Size>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES host_mdspan(_ElementType*, ::cuda::std::span<_OtherIndexType, _Size>)
   -> host_mdspan<_ElementType, ::cuda::std::dextents<size_t, _Size>>;
 
 // This one is necessary because all the constructors take `data_handle_type`s, not
 // `_ElementType*`s, and `data_handle_type` is taken from `accessor_type::data_handle_type`, which
 // seems to throw off automatic deduction guides.
 template <class _ElementType, class _OtherIndexType, size_t... _ExtentsPack>
-_CCCL_HOST_DEVICE host_mdspan(_ElementType*, const ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+host_mdspan(_ElementType*, const ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>&)
   -> host_mdspan<_ElementType, ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>>;
 
 template <class _ElementType, class _MappingType>
-_CCCL_HOST_DEVICE host_mdspan(_ElementType*, const _MappingType&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES host_mdspan(_ElementType*, const _MappingType&)
   -> host_mdspan<_ElementType, typename _MappingType::extents_type, typename _MappingType::layout_type>;
 
 template <class _MappingType, class _AccessorType>
-_CCCL_HOST_DEVICE host_mdspan(const typename _AccessorType::data_handle_type, const _MappingType&, const _AccessorType&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+host_mdspan(const typename _AccessorType::data_handle_type, const _MappingType&, const _AccessorType&)
   -> host_mdspan<typename _AccessorType::element_type,
                  typename _MappingType::extents_type,
                  typename _MappingType::layout_type,
@@ -118,42 +120,43 @@ public:
 _CCCL_TEMPLATE(class _ElementType, class... _OtherIndexTypes)
 _CCCL_REQUIRES((sizeof...(_OtherIndexTypes) > 0)
                  _CCCL_AND(::cuda::std::is_convertible_v<_OtherIndexTypes, size_t>&&... && true))
-_CCCL_HOST_DEVICE explicit device_mdspan(_ElementType*, _OtherIndexTypes...)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES explicit device_mdspan(_ElementType*, _OtherIndexTypes...)
   -> device_mdspan<_ElementType, ::cuda::std::extents<size_t, ::cuda::std::__maybe_static_ext<_OtherIndexTypes>...>>;
 
 _CCCL_TEMPLATE(class _Pointer)
 _CCCL_REQUIRES(::cuda::std::is_pointer_v<::cuda::std::remove_reference_t<_Pointer>>)
-_CCCL_HOST_DEVICE device_mdspan(_Pointer&&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES device_mdspan(_Pointer&&)
   -> device_mdspan<::cuda::std::remove_pointer_t<::cuda::std::remove_reference_t<_Pointer>>,
                    ::cuda::std::extents<size_t>>;
 
 _CCCL_TEMPLATE(class _CArray)
 _CCCL_REQUIRES(::cuda::std::is_array_v<_CArray> _CCCL_AND(::cuda::std::rank_v<_CArray> == 1))
-_CCCL_HOST_DEVICE device_mdspan(_CArray&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES device_mdspan(_CArray&)
   -> device_mdspan<::cuda::std::remove_all_extents_t<_CArray>,
                    ::cuda::std::extents<size_t, ::cuda::std::extent_v<_CArray, 0>>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Size>
-_CCCL_HOST_DEVICE device_mdspan(_ElementType*, const ::cuda::std::array<_OtherIndexType, _Size>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES device_mdspan(_ElementType*, const ::cuda::std::array<_OtherIndexType, _Size>&)
   -> device_mdspan<_ElementType, ::cuda::std::dextents<size_t, _Size>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Size>
-_CCCL_HOST_DEVICE device_mdspan(_ElementType*, ::cuda::std::span<_OtherIndexType, _Size>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES device_mdspan(_ElementType*, ::cuda::std::span<_OtherIndexType, _Size>)
   -> device_mdspan<_ElementType, ::cuda::std::dextents<size_t, _Size>>;
 
 // This one is necessary because all the constructors take `data_handle_type`s, not
 // `_ElementType*`s, and `data_handle_type` is taken from `accessor_type::data_handle_type`, which
 // seems to throw off automatic deduction guides.
 template <class _ElementType, class _OtherIndexType, size_t... _ExtentsPack>
-_CCCL_HOST_DEVICE device_mdspan(_ElementType*, const ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+device_mdspan(_ElementType*, const ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>&)
   -> device_mdspan<_ElementType, ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>>;
 
 template <class _ElementType, class _MappingType>
-_CCCL_HOST_DEVICE device_mdspan(_ElementType*, const _MappingType&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES device_mdspan(_ElementType*, const _MappingType&)
   -> device_mdspan<_ElementType, typename _MappingType::extents_type, typename _MappingType::layout_type>;
 
 template <class _MappingType, class _AccessorType>
-_CCCL_HOST_DEVICE
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
 device_mdspan(const typename _AccessorType::data_handle_type, const _MappingType&, const _AccessorType&)
   -> device_mdspan<typename _AccessorType::element_type,
                    typename _MappingType::extents_type,
@@ -180,42 +183,43 @@ public:
 _CCCL_TEMPLATE(class _ElementType, class... _OtherIndexTypes)
 _CCCL_REQUIRES((sizeof...(_OtherIndexTypes) > 0)
                  _CCCL_AND(::cuda::std::is_convertible_v<_OtherIndexTypes, size_t>&&... && true))
-_CCCL_HOST_DEVICE explicit managed_mdspan(_ElementType*, _OtherIndexTypes...)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES explicit managed_mdspan(_ElementType*, _OtherIndexTypes...)
   -> managed_mdspan<_ElementType, ::cuda::std::extents<size_t, ::cuda::std::__maybe_static_ext<_OtherIndexTypes>...>>;
 
 _CCCL_TEMPLATE(class _Pointer)
 _CCCL_REQUIRES(::cuda::std::is_pointer_v<::cuda::std::remove_reference_t<_Pointer>>)
-_CCCL_HOST_DEVICE managed_mdspan(_Pointer&&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES managed_mdspan(_Pointer&&)
   -> managed_mdspan<::cuda::std::remove_pointer_t<::cuda::std::remove_reference_t<_Pointer>>,
                     ::cuda::std::extents<size_t>>;
 
 _CCCL_TEMPLATE(class _CArray)
 _CCCL_REQUIRES(::cuda::std::is_array_v<_CArray> _CCCL_AND(::cuda::std::rank_v<_CArray> == 1))
-_CCCL_HOST_DEVICE managed_mdspan(_CArray&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES managed_mdspan(_CArray&)
   -> managed_mdspan<::cuda::std::remove_all_extents_t<_CArray>,
                     ::cuda::std::extents<size_t, ::cuda::std::extent_v<_CArray, 0>>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Size>
-_CCCL_HOST_DEVICE managed_mdspan(_ElementType*, const ::cuda::std::array<_OtherIndexType, _Size>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES managed_mdspan(_ElementType*, const ::cuda::std::array<_OtherIndexType, _Size>&)
   -> managed_mdspan<_ElementType, ::cuda::std::dextents<size_t, _Size>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Size>
-_CCCL_HOST_DEVICE managed_mdspan(_ElementType*, ::cuda::std::span<_OtherIndexType, _Size>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES managed_mdspan(_ElementType*, ::cuda::std::span<_OtherIndexType, _Size>)
   -> managed_mdspan<_ElementType, ::cuda::std::dextents<size_t, _Size>>;
 
 // This one is necessary because all the constructors take `data_handle_type`s, not
 // `_ElementType*`s, and `data_handle_type` is taken from `accessor_type::data_handle_type`, which
 // seems to throw off automatic deduction guides.
 template <class _ElementType, class _OtherIndexType, size_t... _ExtentsPack>
-_CCCL_HOST_DEVICE managed_mdspan(_ElementType*, const ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+managed_mdspan(_ElementType*, const ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>&)
   -> managed_mdspan<_ElementType, ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>>;
 
 template <class _ElementType, class _MappingType>
-_CCCL_HOST_DEVICE managed_mdspan(_ElementType*, const _MappingType&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES managed_mdspan(_ElementType*, const _MappingType&)
   -> managed_mdspan<_ElementType, typename _MappingType::extents_type, typename _MappingType::layout_type>;
 
 template <class _MappingType, class _AccessorType>
-_CCCL_HOST_DEVICE
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
 managed_mdspan(const typename _AccessorType::data_handle_type, const _MappingType&, const _AccessorType&)
   -> managed_mdspan<typename _AccessorType::element_type,
                     typename _MappingType::extents_type,

--- a/libcudacxx/include/cuda/__mdspan/restrict_mdspan.h
+++ b/libcudacxx/include/cuda/__mdspan/restrict_mdspan.h
@@ -59,42 +59,43 @@ public:
 _CCCL_TEMPLATE(class _ElementType, class... _OtherIndexTypes)
 _CCCL_REQUIRES((sizeof...(_OtherIndexTypes) > 0)
                  _CCCL_AND(::cuda::std::is_convertible_v<_OtherIndexTypes, size_t>&&... && true))
-_CCCL_HOST_DEVICE explicit restrict_mdspan(_ElementType*, _OtherIndexTypes...)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES explicit restrict_mdspan(_ElementType*, _OtherIndexTypes...)
   -> restrict_mdspan<_ElementType, ::cuda::std::extents<size_t, ::cuda::std::__maybe_static_ext<_OtherIndexTypes>...>>;
 
 _CCCL_TEMPLATE(class _Pointer)
 _CCCL_REQUIRES(::cuda::std::is_pointer_v<::cuda::std::remove_reference_t<_Pointer>>)
-_CCCL_HOST_DEVICE restrict_mdspan(_Pointer&&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES restrict_mdspan(_Pointer&&)
   -> restrict_mdspan<::cuda::std::remove_pointer_t<::cuda::std::remove_reference_t<_Pointer>>,
                      ::cuda::std::extents<size_t>>;
 
 _CCCL_TEMPLATE(class _CArray)
 _CCCL_REQUIRES(::cuda::std::is_array_v<_CArray> _CCCL_AND(::cuda::std::rank_v<_CArray> == 1))
-_CCCL_HOST_DEVICE restrict_mdspan(_CArray&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES restrict_mdspan(_CArray&)
   -> restrict_mdspan<::cuda::std::remove_all_extents_t<_CArray>,
                      ::cuda::std::extents<size_t, ::cuda::std::extent_v<_CArray, 0>>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Size>
-_CCCL_HOST_DEVICE restrict_mdspan(_ElementType*, const ::cuda::std::array<_OtherIndexType, _Size>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES restrict_mdspan(_ElementType*, const ::cuda::std::array<_OtherIndexType, _Size>&)
   -> restrict_mdspan<_ElementType, ::cuda::std::dextents<size_t, _Size>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Size>
-_CCCL_HOST_DEVICE restrict_mdspan(_ElementType*, ::cuda::std::span<_OtherIndexType, _Size>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES restrict_mdspan(_ElementType*, ::cuda::std::span<_OtherIndexType, _Size>)
   -> restrict_mdspan<_ElementType, ::cuda::std::dextents<size_t, _Size>>;
 
 // This one is necessary because all the constructors take `data_handle_type`s, not
 // `_ElementType*`s, and `data_handle_type` is taken from `accessor_type::data_handle_type`, which
 // seems to throw off automatic deduction guides.
 template <class _ElementType, class _OtherIndexType, size_t... _ExtentsPack>
-_CCCL_HOST_DEVICE restrict_mdspan(_ElementType*, const ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+restrict_mdspan(_ElementType*, const ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>&)
   -> restrict_mdspan<_ElementType, ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>>;
 
 template <class _ElementType, class _MappingType>
-_CCCL_HOST_DEVICE restrict_mdspan(_ElementType*, const _MappingType&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES restrict_mdspan(_ElementType*, const _MappingType&)
   -> restrict_mdspan<_ElementType, typename _MappingType::extents_type, typename _MappingType::layout_type>;
 
 template <class _MappingType, class _AccessorType>
-_CCCL_HOST_DEVICE
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
 restrict_mdspan(const typename _AccessorType::data_handle_type, const _MappingType&, const _AccessorType&)
   -> restrict_mdspan<typename _AccessorType::element_type,
                      typename _MappingType::extents_type,

--- a/libcudacxx/include/cuda/__mdspan/shared_memory_mdspan.h
+++ b/libcudacxx/include/cuda/__mdspan/shared_memory_mdspan.h
@@ -69,43 +69,45 @@ public:
 _CCCL_TEMPLATE(typename _ElementType, typename... _OtherIndexTypes)
 _CCCL_REQUIRES((sizeof...(_OtherIndexTypes) > 0)
                  _CCCL_AND(::cuda::std::is_convertible_v<_OtherIndexTypes, ::cuda::std::size_t>&&... && true))
-_CCCL_HOST_DEVICE explicit shared_memory_mdspan(_ElementType*, _OtherIndexTypes...) -> shared_memory_mdspan<
-  _ElementType,
-  ::cuda::std::extents<::cuda::std::size_t, ::cuda::std::__maybe_static_ext<_OtherIndexTypes>...>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES explicit shared_memory_mdspan(_ElementType*, _OtherIndexTypes...)
+  -> shared_memory_mdspan<
+    _ElementType,
+    ::cuda::std::extents<::cuda::std::size_t, ::cuda::std::__maybe_static_ext<_OtherIndexTypes>...>>;
 
 _CCCL_TEMPLATE(typename _Pointer)
 _CCCL_REQUIRES(::cuda::std::is_pointer_v<::cuda::std::remove_reference_t<_Pointer>>)
-_CCCL_HOST_DEVICE shared_memory_mdspan(_Pointer&&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES shared_memory_mdspan(_Pointer&&)
   -> shared_memory_mdspan<::cuda::std::remove_pointer_t<::cuda::std::remove_reference_t<_Pointer>>,
                           ::cuda::std::extents<::cuda::std::size_t>>;
 
 _CCCL_TEMPLATE(typename _CArray)
 _CCCL_REQUIRES(::cuda::std::is_array_v<_CArray> _CCCL_AND(::cuda::std::rank_v<_CArray> == 1))
-_CCCL_HOST_DEVICE shared_memory_mdspan(_CArray&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES shared_memory_mdspan(_CArray&)
   -> shared_memory_mdspan<::cuda::std::remove_all_extents_t<_CArray>,
                           ::cuda::std::extents<::cuda::std::size_t, ::cuda::std::extent_v<_CArray, 0>>>;
 
 template <typename _ElementType, typename _OtherIndexType, ::cuda::std::size_t _Size>
-_CCCL_HOST_DEVICE shared_memory_mdspan(_ElementType*, const ::cuda::std::array<_OtherIndexType, _Size>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES shared_memory_mdspan(_ElementType*, const ::cuda::std::array<_OtherIndexType, _Size>&)
   -> shared_memory_mdspan<_ElementType, ::cuda::std::dextents<::cuda::std::size_t, _Size>>;
 
 template <typename _ElementType, typename _OtherIndexType, ::cuda::std::size_t _Size>
-_CCCL_HOST_DEVICE shared_memory_mdspan(_ElementType*, ::cuda::std::span<_OtherIndexType, _Size>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES shared_memory_mdspan(_ElementType*, ::cuda::std::span<_OtherIndexType, _Size>)
   -> shared_memory_mdspan<_ElementType, ::cuda::std::dextents<::cuda::std::size_t, _Size>>;
 
 // This one is necessary because all the constructors take `data_handle_type`s, not
 // `_ElementType*`s, and `data_handle_type` is taken from `accessor_type::data_handle_type`, which
 // seems to throw off automatic deduction guides.
 template <typename _ElementType, typename _OtherIndexType, ::cuda::std::size_t... _ExtentsPack>
-_CCCL_HOST_DEVICE shared_memory_mdspan(_ElementType*, const ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+shared_memory_mdspan(_ElementType*, const ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>&)
   -> shared_memory_mdspan<_ElementType, ::cuda::std::extents<_OtherIndexType, _ExtentsPack...>>;
 
 template <typename _ElementType, typename _MappingType>
-_CCCL_HOST_DEVICE shared_memory_mdspan(_ElementType*, const _MappingType&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES shared_memory_mdspan(_ElementType*, const _MappingType&)
   -> shared_memory_mdspan<_ElementType, typename _MappingType::extents_type, typename _MappingType::layout_type>;
 
 template <typename _MappingType, typename _AccessorType>
-_CCCL_HOST_DEVICE
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
 shared_memory_mdspan(const typename _AccessorType::data_handle_type, const _MappingType&, const _AccessorType&)
   -> shared_memory_mdspan<typename _AccessorType::element_type,
                           typename _MappingType::extents_type,

--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_ptr.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_ptr.h
@@ -289,12 +289,12 @@ private:
 
 _CCCL_TEMPLATE(template <class...> class _Interface, class _Super)
 _CCCL_REQUIRES(__is_interface<_Interface<_Super>>)
-_CCCL_HOST_DEVICE __basic_any(_Interface<_Super>*) //
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __basic_any(_Interface<_Super>*) //
   -> __basic_any<__normalized_interface_of<__basic_any<_Super>*>>;
 
 _CCCL_TEMPLATE(template <class...> class _Interface, class _Super)
 _CCCL_REQUIRES(__is_interface<_Interface<_Super>>)
-_CCCL_HOST_DEVICE __basic_any(_Interface<_Super> const*) //
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __basic_any(_Interface<_Super> const*) //
   -> __basic_any<__normalized_interface_of<__basic_any<_Super> const*>>;
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -40,6 +40,13 @@
 #  define _CCCL_TILE
 #endif // ^^^ !_CCCL_TILE_COMPILATION() ^^^
 
+// clang-cuda before version 22 requires __host__ __device__ annotations on deduction guides
+#if _CCCL_CUDA_COMPILER(CLANG, <, 22)
+#  define _CCCL_DEDUCTION_GUIDE_ATTRIBUTES _CCCL_HOST_DEVICE
+#else // ^^^ _CCCL_CUDA_COMPILER(CLANG, <, 22) ^^^ / vvv !_CCCL_CUDA_COMPILER(CLANG, <, 22) vvv
+#  define _CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+#endif // ^^ !_CCCL_CUDA_COMPILER(CLANG, <, 22) ^^^
+
 // Global variables of non builtin types are only device accessible if they are marked as `__device__`
 #if _CCCL_DEVICE_COMPILATION() && !_CCCL_CUDA_COMPILER(NVHPC)
 #  define _CCCL_GLOBAL_VARIABLE _CCCL_DEVICE

--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -233,7 +233,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_DECLSPEC_EMPTY_BASES prop : _Query
 #endif // !_CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS()
 
 template <class _Query, class _Value>
-_CCCL_HOST_DEVICE prop(_Query, _Value) -> prop<_Query, _Value>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES prop(_Query, _Value) -> prop<_Query, _Value>;
 
 //! @brief A variadic template structure representing an environment.
 //!
@@ -306,7 +306,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT env
 };
 
 template <class... _Envs>
-_CCCL_HOST_DEVICE env(_Envs...) -> env<__unwrap_reference_t<_Envs>...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES env(_Envs...) -> env<__unwrap_reference_t<_Envs>...>;
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 

--- a/libcudacxx/include/cuda/std/__format/format_args.h
+++ b/libcudacxx/include/cuda/std/__format/format_args.h
@@ -99,7 +99,8 @@ private:
 };
 
 template <class _Context, class... _Args>
-_CCCL_HOST_DEVICE basic_format_args(__format_arg_store<_Context, _Args...>) -> basic_format_args<_Context>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES basic_format_args(__format_arg_store<_Context, _Args...>)
+  -> basic_format_args<_Context>;
 
 template <class _Context = format_context, class... _Args>
 [[nodiscard]] _CCCL_API __format_arg_store<_Context, _Args...> make_format_args(_Args&... __args)

--- a/libcudacxx/include/cuda/std/__format/format_spec_parser.h
+++ b/libcudacxx/include/cuda/std/__format/format_spec_parser.h
@@ -1230,7 +1230,7 @@ struct __fmt_column_width_result
 };
 
 template <class _It>
-_CCCL_HOST_DEVICE __fmt_column_width_result(size_t, _It) -> __fmt_column_width_result<_It>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __fmt_column_width_result(size_t, _It) -> __fmt_column_width_result<_It>;
 
 //! Since a column width can be two it's possible that the requested column
 //! width can't be achieved. Depending on the intended usage the policy can be

--- a/libcudacxx/include/cuda/std/__format/parse_arg_id.h
+++ b/libcudacxx/include/cuda/std/__format/parse_arg_id.h
@@ -37,7 +37,7 @@ struct __fmt_parse_number_result
 };
 
 template <class _It>
-_CCCL_HOST_DEVICE __fmt_parse_number_result(_It, uint32_t) -> __fmt_parse_number_result<_It>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __fmt_parse_number_result(_It, uint32_t) -> __fmt_parse_number_result<_It>;
 
 //! The maximum value of a numeric argument.
 //!

--- a/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__functional/reference_wrapper.h
@@ -76,7 +76,7 @@ public:
 };
 
 template <class _Tp>
-_CCCL_HOST_DEVICE reference_wrapper(_Tp&) -> reference_wrapper<_Tp>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES reference_wrapper(_Tp&) -> reference_wrapper<_Tp>;
 
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr reference_wrapper<_Tp> ref(_Tp& __t) noexcept

--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -637,7 +637,8 @@ struct __to_dynamic_extent
 
 // Deduction guide for extents
 template <class... _IndexTypes>
-_CCCL_HOST_DEVICE extents(_IndexTypes...) -> extents<size_t, __to_dynamic_extent::template value<_IndexTypes>...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES extents(_IndexTypes...)
+  -> extents<size_t, __to_dynamic_extent::template value<_IndexTypes>...>;
 
 namespace __mdspan_detail
 {

--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -544,37 +544,41 @@ public:
 
 _CCCL_TEMPLATE(class _ElementType, class... _OtherIndexTypes)
 _CCCL_REQUIRES((sizeof...(_OtherIndexTypes) > 0) _CCCL_AND(is_convertible_v<_OtherIndexTypes, size_t>&&... && true))
-_CCCL_HOST_DEVICE explicit mdspan(_ElementType*, _OtherIndexTypes...)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES explicit mdspan(_ElementType*, _OtherIndexTypes...)
   -> mdspan<_ElementType, extents<size_t, __maybe_static_ext<_OtherIndexTypes>...>>;
 
 _CCCL_TEMPLATE(class _Pointer)
 _CCCL_REQUIRES(is_pointer_v<remove_reference_t<_Pointer>>)
-_CCCL_HOST_DEVICE mdspan(_Pointer&&) -> mdspan<remove_pointer_t<remove_reference_t<_Pointer>>, extents<size_t>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES mdspan(_Pointer&&)
+  -> mdspan<remove_pointer_t<remove_reference_t<_Pointer>>, extents<size_t>>;
 
 _CCCL_TEMPLATE(class _CArray)
 _CCCL_REQUIRES(is_array_v<_CArray> _CCCL_AND(rank_v<_CArray> == 1))
-_CCCL_HOST_DEVICE mdspan(_CArray&) -> mdspan<remove_all_extents_t<_CArray>, extents<size_t, extent_v<_CArray, 0>>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES mdspan(_CArray&)
+  -> mdspan<remove_all_extents_t<_CArray>, extents<size_t, extent_v<_CArray, 0>>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Size>
-_CCCL_HOST_DEVICE mdspan(_ElementType*, const array<_OtherIndexType, _Size>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES mdspan(_ElementType*, const array<_OtherIndexType, _Size>&)
   -> mdspan<_ElementType, dextents<size_t, _Size>>;
 
 template <class _ElementType, class _OtherIndexType, size_t _Size>
-_CCCL_HOST_DEVICE mdspan(_ElementType*, span<_OtherIndexType, _Size>) -> mdspan<_ElementType, dextents<size_t, _Size>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES mdspan(_ElementType*, span<_OtherIndexType, _Size>)
+  -> mdspan<_ElementType, dextents<size_t, _Size>>;
 
 // This one is necessary because all the constructors take `data_handle_type`s, not
 // `_ElementType*`s, and `data_handle_type` is taken from `accessor_type::data_handle_type`, which
 // seems to throw off automatic deduction guides.
 template <class _ElementType, class _OtherIndexType, size_t... _ExtentsPack>
-_CCCL_HOST_DEVICE mdspan(_ElementType*, const extents<_OtherIndexType, _ExtentsPack...>&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES mdspan(_ElementType*, const extents<_OtherIndexType, _ExtentsPack...>&)
   -> mdspan<_ElementType, extents<_OtherIndexType, _ExtentsPack...>>;
 
 template <class _ElementType, class _MappingType>
-_CCCL_HOST_DEVICE mdspan(_ElementType*, const _MappingType&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES mdspan(_ElementType*, const _MappingType&)
   -> mdspan<_ElementType, typename _MappingType::extents_type, typename _MappingType::layout_type>;
 
 template <class _MappingType, class _AccessorType>
-_CCCL_HOST_DEVICE mdspan(const typename _AccessorType::data_handle_type, const _MappingType&, const _AccessorType&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES
+mdspan(const typename _AccessorType::data_handle_type, const _MappingType&, const _AccessorType&)
   -> mdspan<typename _AccessorType::element_type,
             typename _MappingType::extents_type,
             typename _MappingType::layout_type,

--- a/libcudacxx/include/cuda/std/__mdspan/submdspan_helper.h
+++ b/libcudacxx/include/cuda/std/__mdspan/submdspan_helper.h
@@ -70,7 +70,7 @@ struct strided_slice
 };
 
 template <class _OffsetType, class _ExtentType, class _StrideType>
-_CCCL_HOST_DEVICE strided_slice(_OffsetType, _ExtentType, _StrideType)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES strided_slice(_OffsetType, _ExtentType, _StrideType)
   -> strided_slice<_OffsetType, _ExtentType, _StrideType>;
 
 template <typename>

--- a/libcudacxx/include/cuda/std/__optional/optional.h
+++ b/libcudacxx/include/cuda/std/__optional/optional.h
@@ -544,7 +544,7 @@ public:
 };
 
 template <class _Tp>
-_CCCL_HOST_DEVICE optional(_Tp) -> optional<_Tp>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES optional(_Tp) -> optional<_Tp>;
 
 // Comparisons between optionals
 _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__ranges/common_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/common_view.h
@@ -155,7 +155,7 @@ public:
 };
 
 template <class _Range>
-_CCCL_HOST_DEVICE common_view(_Range&&) -> common_view<::cuda::std::ranges::views::all_t<_Range>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES common_view(_Range&&) -> common_view<::cuda::std::ranges::views::all_t<_Range>>;
 
 template <class _View>
 inline constexpr bool enable_borrowed_range<common_view<_View>> = enable_borrowed_range<_View>;

--- a/libcudacxx/include/cuda/std/__ranges/drop_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_view.h
@@ -179,7 +179,7 @@ public:
 };
 
 template <class _Range>
-_CCCL_HOST_DEVICE drop_view(_Range&&, range_difference_t<_Range>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES drop_view(_Range&&, range_difference_t<_Range>)
   -> drop_view<::cuda::std::ranges::views::all_t<_Range>>;
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_while_view.h
@@ -136,7 +136,8 @@ template <class _View, class _Pred>
 inline constexpr bool enable_borrowed_range<drop_while_view<_View, _Pred>> = enable_borrowed_range<_View>;
 
 template <class _Range, class _Pred>
-_CCCL_HOST_DEVICE drop_while_view(_Range&&, _Pred) -> drop_while_view<::cuda::std::ranges::views::all_t<_Range>, _Pred>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES drop_while_view(_Range&&, _Pred)
+  -> drop_while_view<::cuda::std::ranges::views::all_t<_Range>, _Pred>;
 
 _CCCL_END_NAMESPACE_CUDA_STD_VIEWS
 

--- a/libcudacxx/include/cuda/std/__ranges/filter_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/filter_view.h
@@ -353,7 +353,7 @@ public:
 };
 
 template <class _Range, class _Pred>
-_CCCL_HOST_DEVICE filter_view(_Range&&, _Pred) -> filter_view<ranges::views::all_t<_Range>, _Pred>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES filter_view(_Range&&, _Pred) -> filter_view<ranges::views::all_t<_Range>, _Pred>;
 
 _LIBCUDACXX_END_HIDDEN_FRIEND_NAMESPACE(filter_view)
 

--- a/libcudacxx/include/cuda/std/__ranges/iota_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/iota_view.h
@@ -220,7 +220,7 @@ public:
 _CCCL_TEMPLATE(class _Start, class _BoundSentinel)
 _CCCL_REQUIRES((!__integer_like<_Start> || !__integer_like<_BoundSentinel>
                 || (__signed_integer_like<_Start> == __signed_integer_like<_BoundSentinel>) ))
-_CCCL_HOST_DEVICE iota_view(_Start, _BoundSentinel) -> iota_view<_Start, _BoundSentinel>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES iota_view(_Start, _BoundSentinel) -> iota_view<_Start, _BoundSentinel>;
 
 template <class _Start, class _BoundSentinel>
 inline constexpr bool enable_borrowed_range<iota_view<_Start, _BoundSentinel>> = true;

--- a/libcudacxx/include/cuda/std/__ranges/ref_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/ref_view.h
@@ -109,7 +109,7 @@ public:
 };
 
 template <class _Range>
-_CCCL_HOST_DEVICE ref_view(_Range&) -> ref_view<_Range>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES ref_view(_Range&) -> ref_view<_Range>;
 
 template <class _Tp>
 inline constexpr bool enable_borrowed_range<ref_view<_Tp>> = true;

--- a/libcudacxx/include/cuda/std/__ranges/repeat_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/repeat_view.h
@@ -301,7 +301,7 @@ private:
 };
 
 template <class _Tp, class _Bound>
-_CCCL_HOST_DEVICE repeat_view(_Tp, _Bound) -> repeat_view<_Tp, _Bound>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES repeat_view(_Tp, _Bound) -> repeat_view<_Tp, _Bound>;
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/reverse_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/reverse_view.h
@@ -153,7 +153,7 @@ public:
 };
 
 template <class _Range>
-_CCCL_HOST_DEVICE reverse_view(_Range&&) -> reverse_view<::cuda::std::ranges::views::all_t<_Range>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES reverse_view(_Range&&) -> reverse_view<::cuda::std::ranges::views::all_t<_Range>>;
 
 template <class _Tp>
 inline constexpr bool enable_borrowed_range<reverse_view<_Tp>> = enable_borrowed_range<_Tp>;

--- a/libcudacxx/include/cuda/std/__ranges/single_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/single_view.h
@@ -121,7 +121,7 @@ public:
 };
 
 template <class _Tp>
-_CCCL_HOST_DEVICE single_view(_Tp) -> single_view<_Tp>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES single_view(_Tp) -> single_view<_Tp>;
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/subrange.h
+++ b/libcudacxx/include/cuda/std/__ranges/subrange.h
@@ -387,16 +387,16 @@ public:
 
 _CCCL_TEMPLATE(class _Iter, class _Sent)
 _CCCL_REQUIRES(input_or_output_iterator<_Iter> _CCCL_AND sentinel_for<_Sent, _Iter>)
-_CCCL_HOST_DEVICE subrange(_Iter, _Sent) -> subrange<_Iter, _Sent>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES subrange(_Iter, _Sent) -> subrange<_Iter, _Sent>;
 
 _CCCL_TEMPLATE(class _Iter, class _Sent)
 _CCCL_REQUIRES(input_or_output_iterator<_Iter> _CCCL_AND sentinel_for<_Sent, _Iter>)
-_CCCL_HOST_DEVICE subrange(_Iter, _Sent, make_unsigned_t<iter_difference_t<_Iter>>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES subrange(_Iter, _Sent, make_unsigned_t<iter_difference_t<_Iter>>)
   -> subrange<_Iter, _Sent, subrange_kind::sized>;
 
 _CCCL_TEMPLATE(class _Range)
 _CCCL_REQUIRES(borrowed_range<_Range>)
-_CCCL_HOST_DEVICE subrange(_Range&&)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES subrange(_Range&&)
   -> subrange<iterator_t<_Range>,
               sentinel_t<_Range>,
               (sized_range<_Range> || sized_sentinel_for<sentinel_t<_Range>, iterator_t<_Range>>)
@@ -405,7 +405,7 @@ _CCCL_HOST_DEVICE subrange(_Range&&)
 
 _CCCL_TEMPLATE(class _Range)
 _CCCL_REQUIRES(borrowed_range<_Range>)
-_CCCL_HOST_DEVICE subrange(_Range&&, make_unsigned_t<range_difference_t<_Range>>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES subrange(_Range&&, make_unsigned_t<range_difference_t<_Range>>)
   -> subrange<iterator_t<_Range>, sentinel_t<_Range>, subrange_kind::sized>;
 
 // Not _CCCL_TEMPLATE because we need to forward declare them

--- a/libcudacxx/include/cuda/std/__ranges/take_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_view.h
@@ -277,7 +277,7 @@ public:
 };
 
 template <class _Range>
-_CCCL_HOST_DEVICE take_view(_Range&&, range_difference_t<_Range>)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES take_view(_Range&&, range_difference_t<_Range>)
   -> take_view<::cuda::std::ranges::views::all_t<_Range>>;
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__ranges/take_while_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_while_view.h
@@ -215,7 +215,8 @@ public:
 };
 
 template <class _Range, class _Pred>
-_CCCL_HOST_DEVICE take_while_view(_Range&&, _Pred) -> take_while_view<::cuda::std::ranges::views::all_t<_Range>, _Pred>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES take_while_view(_Range&&, _Pred)
+  -> take_while_view<::cuda::std::ranges::views::all_t<_Range>, _Pred>;
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__ranges/transform_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/transform_view.h
@@ -479,7 +479,8 @@ public:
 };
 
 template <class _Range, class _Fn>
-_CCCL_HOST_DEVICE transform_view(_Range&&, _Fn) -> transform_view<::cuda::std::ranges::views::all_t<_Range>, _Fn>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES transform_view(_Range&&, _Fn)
+  -> transform_view<::cuda::std::ranges::views::all_t<_Range>, _Fn>;
 
 _CCCL_END_NAMESPACE_CUDA_STD_RANGES
 

--- a/libcudacxx/include/cuda/std/__simd/basic_vec.h
+++ b/libcudacxx/include/cuda/std/__simd/basic_vec.h
@@ -540,7 +540,7 @@ public:
 _CCCL_TEMPLATE(typename _Range, typename... _Ts)
 _CCCL_REQUIRES(
   ranges::contiguous_range<_Range> _CCCL_AND ranges::sized_range<_Range> _CCCL_AND __has_static_size<_Range>)
-_CCCL_HOST_DEVICE basic_vec(_Range&&, _Ts...)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES basic_vec(_Range&&, _Ts...)
   -> basic_vec<ranges::range_value_t<_Range>,
                __deduce_abi_t<ranges::range_value_t<_Range>, __static_range_size_v<_Range>>>;
 
@@ -552,7 +552,7 @@ _CCCL_HOST_DEVICE basic_vec(_Range&&, _Ts...)
 // The deduced type is equivalent to decltype(+k), i.e. basic_vec<__integer_from<Bytes>, Abi>
 _CCCL_TEMPLATE(size_t _Bytes, typename _Abi)
 _CCCL_REQUIRES(__has_unary_plus<basic_mask<_Bytes, _Abi>>)
-_CCCL_HOST_DEVICE basic_vec(basic_mask<_Bytes, _Abi>) -> basic_vec<__integer_from<_Bytes>, _Abi>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES basic_vec(basic_mask<_Bytes, _Abi>) -> basic_vec<__integer_from<_Bytes>, _Abi>;
 
 _CCCL_END_NAMESPACE_CUDA_STD_SIMD
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple.h
@@ -436,15 +436,15 @@ public:
 };
 
 template <class... _Tp>
-_CCCL_HOST_DEVICE tuple(_Tp...) -> tuple<_Tp...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES tuple(_Tp...) -> tuple<_Tp...>;
 template <class _Tp1, class _Tp2>
-_CCCL_HOST_DEVICE tuple(pair<_Tp1, _Tp2>) -> tuple<_Tp1, _Tp2>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES tuple(pair<_Tp1, _Tp2>) -> tuple<_Tp1, _Tp2>;
 template <class _Alloc, class... _Tp>
-_CCCL_HOST_DEVICE tuple(allocator_arg_t, _Alloc, _Tp...) -> tuple<_Tp...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES tuple(allocator_arg_t, _Alloc, _Tp...) -> tuple<_Tp...>;
 template <class _Alloc, class _Tp1, class _Tp2>
-_CCCL_HOST_DEVICE tuple(allocator_arg_t, _Alloc, pair<_Tp1, _Tp2>) -> tuple<_Tp1, _Tp2>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES tuple(allocator_arg_t, _Alloc, pair<_Tp1, _Tp2>) -> tuple<_Tp1, _Tp2>;
 template <class _Alloc, class... _Tp>
-_CCCL_HOST_DEVICE tuple(allocator_arg_t, _Alloc, tuple<_Tp...>) -> tuple<_Tp...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES tuple(allocator_arg_t, _Alloc, tuple<_Tp...>) -> tuple<_Tp...>;
 
 template <class _T1, class _T2, bool _IsRef>
 template <class... _Args1, class... _Args2, size_t... _I1, size_t... _I2>

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -526,7 +526,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 };
 
 template <class _T1, class _T2>
-_CCCL_HOST_DEVICE pair(_T1, _T2) -> pair<_T1, _T2>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES pair(_T1, _T2) -> pair<_T1, _T2>;
 
 // [pairs.spec], specialized algorithms
 

--- a/libcudacxx/include/cuda/std/__utility/pod_tuple.h
+++ b/libcudacxx/include/cuda/std/__utility/pod_tuple.h
@@ -229,7 +229,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __tuple<_Tp0, _Tp1, _Tp2, _Tp3, _Tp4, _Tp5,
 };
 
 template <class... _Ts>
-_CCCL_HOST_DEVICE __tuple(_Ts...) -> __tuple<_Ts...>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __tuple(_Ts...) -> __tuple<_Ts...>;
 
 //
 // __apply(fn, tuple, extra...)
@@ -388,7 +388,7 @@ struct __pair
 };
 
 template <class _First, class _Second>
-_CCCL_HOST_DEVICE __pair(_First, _Second) -> __pair<_First, _Second>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES __pair(_First, _Second) -> __pair<_First, _Second>;
 
 //
 // __tuple_size_v

--- a/libcudacxx/include/cuda/std/array
+++ b/libcudacxx/include/cuda/std/array
@@ -397,7 +397,7 @@ _CCCL_DIAG_POP
 
 _CCCL_TEMPLATE(class _Tp, class... _Args)
 _CCCL_REQUIRES((is_same_v<_Tp, _Args> && ...))
-_CCCL_HOST_DEVICE array(_Tp, _Args...) -> array<_Tp, 1 + sizeof...(_Args)>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES array(_Tp, _Args...) -> array<_Tp, 1 + sizeof...(_Args)>;
 
 template <class _Tp, size_t _Size>
 [[nodiscard]] _CCCL_API constexpr bool operator==(const array<_Tp, _Size>& __x, const array<_Tp, _Size>& __y)

--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -572,22 +572,23 @@ _CCCL_API inline auto as_writable_bytes(span<_Tp, _Extent> __s) noexcept
 
 //  Deduction guides
 template <class _Tp, size_t _Sz>
-_CCCL_HOST_DEVICE span(_Tp (&)[_Sz]) -> span<_Tp, _Sz>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES span(_Tp (&)[_Sz]) -> span<_Tp, _Sz>;
 
 template <class _Tp, size_t _Sz>
-_CCCL_HOST_DEVICE span(array<_Tp, _Sz>&) -> span<_Tp, _Sz>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES span(array<_Tp, _Sz>&) -> span<_Tp, _Sz>;
 
 template <class _Tp, size_t _Sz>
-_CCCL_HOST_DEVICE span(const array<_Tp, _Sz>&) -> span<const _Tp, _Sz>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES span(const array<_Tp, _Sz>&) -> span<const _Tp, _Sz>;
 
 _CCCL_TEMPLATE(class _It, class _EndOrSize)
 _CCCL_REQUIRES(contiguous_iterator<_It>)
-_CCCL_HOST_DEVICE span(_It, _EndOrSize)
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES span(_It, _EndOrSize)
   -> span<remove_reference_t<iter_reference_t<_It>>, __maybe_static_ext<_EndOrSize>>;
 
 _CCCL_TEMPLATE(class _Range)
 _CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range>)
-_CCCL_HOST_DEVICE span(_Range&&) -> span<remove_reference_t<::cuda::std::ranges::range_reference_t<_Range>>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES span(_Range&&)
+  -> span<remove_reference_t<::cuda::std::ranges::range_reference_t<_Range>>>;
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/string_view
+++ b/libcudacxx/include/cuda/std/string_view
@@ -814,11 +814,12 @@ _CCCL_CTAD_SUPPORTED_FOR_TYPE(basic_string_view);
 
 _CCCL_TEMPLATE(class _It, class _End)
 _CCCL_REQUIRES(contiguous_iterator<_It> _CCCL_AND sized_sentinel_for<_End, _It>)
-_CCCL_HOST_DEVICE basic_string_view(_It, _End) -> basic_string_view<iter_value_t<_It>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES basic_string_view(_It, _End) -> basic_string_view<iter_value_t<_It>>;
 
 _CCCL_TEMPLATE(class _Range)
 _CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range>)
-_CCCL_HOST_DEVICE basic_string_view(_Range&&) -> basic_string_view<::cuda::std::ranges::range_value_t<_Range>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES basic_string_view(_Range&&)
+  -> basic_string_view<::cuda::std::ranges::range_value_t<_Range>>;
 
 #if _CCCL_HOSTED()
 template <class _CharT, class _Alloc>

--- a/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr.createpolicy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/annotated_ptr/annotated_ptr.createpolicy.pass.cpp
@@ -89,7 +89,7 @@ __global__ void test_range_kernel(void* ptr, uint64_t property, uint32_t primary
   {
     printf("  primary_size = %u, total_size = %u\n", primary_size, total_size);
     printf("  primary = %u, secondary = %u\n", (int) to_enum<Primary>(), (int) to_enum<Secondary>());
-    printf("  0x%llX vs 0x%llX\n", policy, static_cast<uint64_t>(property));
+    printf("  0x%llX vs 0x%llX\n", static_cast<unsigned long long>(policy), static_cast<unsigned long long>(property));
   }
   assert(static_cast<uint64_t>(property) == policy);
 }

--- a/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/range.iter.ops/types.h
+++ b/libcudacxx/test/libcudacxx/std/iterators/iterator.primitives/range.iter.ops/types.h
@@ -113,6 +113,6 @@ private:
 };
 
 template <class It>
-TEST_FUNC assignable_sentinel(const It&) -> assignable_sentinel<It>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES assignable_sentinel(const It&) -> assignable_sentinel<It>;
 
 #endif // TEST_STD_ITERATORS_ITERATOR_PRIMITIVES_RANGE_ITER_OPS_TYPES_H

--- a/libcudacxx/test/libcudacxx/std/ranges/range.factories/range.iota.view/types.h
+++ b/libcudacxx/test/libcudacxx/std/ranges/range.factories/range.iota.view/types.h
@@ -188,7 +188,7 @@ struct IntComparableWith
   }
 };
 template <class T>
-TEST_FUNC IntComparableWith(T) -> IntComparableWith<T>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES IntComparableWith(T) -> IntComparableWith<T>;
 
 template <class T>
 struct IntSentinelWith
@@ -262,7 +262,7 @@ struct IntSentinelWith
   }
 };
 template <class T>
-TEST_FUNC IntSentinelWith(T) -> IntSentinelWith<T>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES IntSentinelWith(T) -> IntSentinelWith<T>;
 
 struct NotIncrementable
 {

--- a/thrust/thrust/iterator/constant_iterator.h
+++ b/thrust/thrust/iterator/constant_iterator.h
@@ -178,7 +178,7 @@ private: // Core iterator interface
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class ValueT>
-_CCCL_HOST_DEVICE constant_iterator(ValueT) -> constant_iterator<ValueT>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES constant_iterator(ValueT) -> constant_iterator<ValueT>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
 //! This version of \p make_constant_iterator creates a \p constant_iterator from values given for both value and index.

--- a/thrust/thrust/iterator/offset_iterator.h
+++ b/thrust/thrust/iterator/offset_iterator.h
@@ -185,7 +185,7 @@ private:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <typename Iterator>
-_CCCL_HOST_DEVICE offset_iterator(Iterator) -> offset_iterator<Iterator>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES offset_iterator(Iterator) -> offset_iterator<Iterator>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
 //! \} // end fancyiterators

--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -300,7 +300,7 @@ private:
 
 #ifndef _CCCL_DOXYGEN_INVOKED
 template <class... Iterators>
-_CCCL_HOST_DEVICE zip_iterator(Iterators...) -> zip_iterator<::cuda::std::tuple<Iterators...>>;
+_CCCL_DEDUCTION_GUIDE_ATTRIBUTES zip_iterator(Iterators...) -> zip_iterator<::cuda::std::tuple<Iterators...>>;
 #endif // _CCCL_DOXYGEN_INVOKED
 
 //! \p make_zip_iterator creates a \p zip_iterator from a \p tuple of iterators.


### PR DESCRIPTION
clang-cuda has always forced us to add `__host__ __device__` annotations to deduction guides. However, since clang-22, this is no longer the case + clang emits ton of warnings about this behaviour being deprecated.

This PR introduces `_CCCL_DEDUCTION_GUIDE_EXSPACE` macro that expands to `_host__ __device__` for clang < 22, otherwise is empty.