### PR TITLE
Use ublkcp/memcpy_async in transform when dtype size is not a power of two

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -360,8 +360,7 @@ struct policy_hub<RequiresStableAddress,
     (::cuda::is_power_of_two(sizeof(it_value_t<RandomAccessIteratorsIn>)) && ...)
     && ::cuda::is_power_of_two(size_of<it_value_t<RandomAccessIteratorOut>>);
 
-  static constexpr bool fallback_to_prefetch =
-    RequiresStableAddress || !can_memcpy_contiguous_inputs || !all_value_types_have_power_of_two_size || !DenseOutput;
+  static constexpr bool fallback_to_prefetch = RequiresStableAddress || !can_memcpy_contiguous_inputs || !DenseOutput;
 
   // TODO(bgruber): consider a separate kernel for just filling
 
@@ -371,8 +370,9 @@ struct policy_hub<RequiresStableAddress,
     using prefetch_policy        = prefetch_policy_t<256>;
     using vectorized_policy      = vectorized_policy_t<
            tuning_vec<500, size_of<it_value_t<RandomAccessIteratorOut>>, sizeof(it_value_t<RandomAccessIteratorsIn>)...>>;
-    using async_policy              = async_copy_policy_t<256, 16>; // dummy policy, never used
-    static constexpr auto algorithm = fallback_to_prefetch ? Algorithm::prefetch : Algorithm::vectorized;
+    using async_policy = async_copy_policy_t<256, 16>; // dummy policy, never used
+    static constexpr auto algorithm =
+      (fallback_to_prefetch || !all_value_types_have_power_of_two_size) ? Algorithm::prefetch : Algorithm::vectorized;
   };
 
   struct policy800 : ChainedPolicy<800, policy800, policy300>
@@ -403,7 +403,7 @@ struct policy_hub<RequiresStableAddress,
     static constexpr auto algorithm =
       fallback_to_prefetch ? Algorithm::prefetch
       : fallback_to_vectorized
-        ? Algorithm::vectorized
+        ? (all_value_types_have_power_of_two_size ? Algorithm::vectorized : Algorithm::prefetch)
         : Algorithm::memcpy_async;
   };
 
@@ -455,7 +455,7 @@ struct policy_hub<RequiresStableAddress,
     static constexpr auto algorithm =
       fallback_to_prefetch ? Algorithm::prefetch
       : fallback_to_vectorized
-        ? Algorithm::vectorized
+        ? (all_value_types_have_power_of_two_size ? Algorithm::vectorized : Algorithm::prefetch)
         : Algorithm::ublkcp;
   };
 


### PR DESCRIPTION
## Description

This affects the `grayscale` benchmark. `fill`, `babelstream`, and other benchmarks are unaffected and have no SASS differences since dtype is a power of size two.

Performance differences on different GPUs. Minor regressions on A100 but improved performance otherwise

```
['before.json', 'after.json']
# grayscale

## [0] NVIDIA A100-SXM4-80GB

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   F32   |      I32      |      2^16      |   8.783 us |       8.56% |   9.092 us |       8.63% |  0.309 us |   3.52% |   SAME   |
|   F32   |      I32      |      2^20      |  18.851 us |       3.65% |  18.528 us |       3.75% | -0.323 us |  -1.72% |   SAME   |
|   F32   |      I32      |      2^24      | 173.113 us |       1.13% | 173.462 us |       1.12% |  0.349 us |   0.20% |   SAME   |
|   F32   |      I32      |      2^28      |   2.567 ms |       0.75% |   2.575 ms |       0.76% |  8.032 us |   0.31% |   SAME   |
|   F32   |      I64      |      2^16      |   8.391 us |       8.25% |   9.082 us |       8.63% |  0.691 us |   8.23% |   SAME   |
|   F32   |      I64      |      2^20      |  19.164 us |       3.86% |  18.821 us |       3.84% | -0.343 us |  -1.79% |   SAME   |
|   F32   |      I64      |      2^24      | 173.634 us |       1.11% | 174.060 us |       1.24% |  0.426 us |   0.25% |   SAME   |
|   F32   |      I64      |      2^28      |   2.573 ms |       0.77% |   2.588 ms |       0.74% | 14.898 us |   0.58% |   SAME   |
|   F64   |      I32      |      2^16      |   9.333 us |       7.54% |  10.130 us |       7.97% |  0.798 us |   8.55% |   SLOW   |
|   F64   |      I32      |      2^20      |  29.762 us |       3.31% |  29.563 us |       2.97% | -0.199 us |  -0.67% |   SAME   |
|   F64   |      I32      |      2^24      | 321.348 us |       0.34% | 322.425 us |       0.34% |  1.077 us |   0.34% |   SAME   |
|   F64   |      I32      |      2^28      |   4.814 ms |       0.55% |   4.839 ms |       0.52% | 24.525 us |   0.51% |   SAME   |
|   F64   |      I64      |      2^16      |   9.280 us |       8.67% |  10.074 us |       7.66% |  0.794 us |   8.56% |   SLOW   |
|   F64   |      I64      |      2^20      |  28.396 us |       2.79% |  28.227 us |       2.66% | -0.168 us |  -0.59% |   SAME   |
|   F64   |      I64      |      2^24      | 314.739 us |       0.31% | 316.549 us |       0.32% |  1.810 us |   0.58% |   SLOW   |
|   F64   |      I64      |      2^28      |   4.816 ms |       0.56% |   4.848 ms |       0.52% | 32.003 us |   0.66% |   SLOW   |

['before.json', 'after.json']
# grayscale

## [0] NVIDIA L4

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   F32   |      I32      |      2^16      |   6.460 us |       7.90% |   6.534 us |       7.87% |    0.074 us |   1.15% |   SAME   |
|   F32   |      I32      |      2^20      |  87.168 us |       1.85% |  82.463 us |       2.42% |   -4.705 us |  -5.40% |   FAST   |
|   F32   |      I32      |      2^24      |   1.174 ms |       0.27% |   1.137 ms |       0.95% |  -36.822 us |  -3.14% |   FAST   |
|   F32   |      I32      |      2^28      |  16.945 ms |       0.44% |  16.726 ms |       0.69% | -218.533 us |  -1.29% |   FAST   |
|   F32   |      I64      |      2^16      |   7.995 us |      15.98% |   8.104 us |      15.68% |    0.109 us |   1.36% |   SAME   |
|   F32   |      I64      |      2^20      |  87.206 us |       1.80% |  82.487 us |       2.44% |   -4.719 us |  -5.41% |   FAST   |
|   F32   |      I64      |      2^24      |   1.173 ms |       0.29% |   1.128 ms |       0.73% |  -45.885 us |  -3.91% |   FAST   |
|   F32   |      I64      |      2^28      |  16.946 ms |       0.52% |  16.723 ms |       0.69% | -222.630 us |  -1.31% |   FAST   |
|   F64   |      I32      |      2^16      |  14.954 us |       6.63% |  13.766 us |       4.65% |   -1.187 us |  -7.94% |   FAST   |
|   F64   |      I32      |      2^20      | 162.436 us |       1.22% | 152.963 us |       1.19% |   -9.473 us |  -5.83% |   FAST   |
|   F64   |      I32      |      2^24      |   2.232 ms |       0.17% |   2.230 ms |       0.39% |   -2.176 us |  -0.10% |   SAME   |
|   F64   |      I32      |      2^28      |  33.919 ms |       0.02% |  33.631 ms |       0.03% | -288.715 us |  -0.85% |   FAST   |
|   F64   |      I64      |      2^16      |  13.480 us |      16.46% |  12.416 us |      11.08% |   -1.064 us |  -7.89% |   SAME   |
|   F64   |      I64      |      2^20      | 162.647 us |       1.15% | 149.616 us |       1.10% |  -13.031 us |  -8.01% |   FAST   |
|   F64   |      I64      |      2^24      |   2.232 ms |       0.17% |   2.229 ms |       0.38% |   -3.736 us |  -0.17% |   FAST   |
|   F64   |      I64      |      2^28      |  33.921 ms |       0.02% |  33.625 ms |       0.03% | -295.361 us |  -0.87% |   FAST   |

['before.json', 'after.json']
# grayscale

## [0] NVIDIA H100 80GB HBM3

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   F32   |      I32      |      2^16      |   4.325 us |       2.88% |   4.432 us |       2.65% |  0.107 us |   2.47% |   SAME   |
|   F32   |      I32      |      2^20      |  10.736 us |       2.25% |  10.770 us |       2.47% |  0.034 us |   0.31% |   SAME   |
|   F32   |      I32      |      2^24      |  93.084 us |       0.54% |  93.429 us |       0.50% |  0.346 us |   0.37% |   SAME   |
|   F32   |      I32      |      2^28      |   1.374 ms |       0.05% |   1.373 ms |       0.06% | -0.651 us |  -0.05% |   SAME   |
|   F32   |      I64      |      2^16      |   4.754 us |       5.44% |   4.821 us |       5.20% |  0.066 us |   1.39% |   SAME   |
|   F32   |      I64      |      2^20      |  10.926 us |       2.19% |  10.856 us |       2.18% | -0.071 us |  -0.65% |   SAME   |
|   F32   |      I64      |      2^24      |  93.272 us |       0.54% |  93.423 us |       0.51% |  0.151 us |   0.16% |   SAME   |
|   F32   |      I64      |      2^28      |   1.374 ms |       0.05% |   1.373 ms |       0.06% | -0.642 us |  -0.05% |   SAME   |
|   F64   |      I32      |      2^16      |   5.453 us |       4.70% |   5.483 us |       4.47% |  0.030 us |   0.55% |   SAME   |
|   F64   |      I32      |      2^20      |  17.071 us |       1.94% |  16.982 us |       1.85% | -0.089 us |  -0.52% |   SAME   |
|   F64   |      I32      |      2^24      | 179.757 us |       0.32% | 179.463 us |       0.37% | -0.295 us |  -0.16% |   SAME   |
|   F64   |      I32      |      2^28      |   2.741 ms |       0.05% |   2.737 ms |       0.03% | -4.080 us |  -0.15% |   FAST   |
|   F64   |      I64      |      2^16      |   5.532 us |       4.87% |   5.498 us |       4.66% | -0.035 us |  -0.63% |   SAME   |
|   F64   |      I64      |      2^20      |  17.171 us |       1.98% |  17.080 us |       1.98% | -0.091 us |  -0.53% |   SAME   |
|   F64   |      I64      |      2^24      | 179.869 us |       0.31% | 179.582 us |       0.38% | -0.286 us |  -0.16% |   SAME   |
|   F64   |      I64      |      2^28      |   2.741 ms |       0.05% |   2.737 ms |       0.03% | -3.994 us |  -0.15% |   FAST   |

['before.json', 'after.json']
# grayscale

## [0] NVIDIA H200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   F32   |      I32      |      2^16      |   4.130 us |       3.27% |   4.256 us |       2.51% |    0.126 us |   3.05% |   SLOW   |
|   F32   |      I32      |      2^20      |   8.988 us |       2.63% |   8.947 us |       2.78% |   -0.041 us |  -0.46% |   SAME   |
|   F32   |      I32      |      2^24      |  70.379 us |       1.00% |  68.819 us |       1.05% |   -1.560 us |  -2.22% |   FAST   |
|   F32   |      I32      |      2^28      |   1.040 ms |       0.13% | 982.469 us |       0.09% |  -57.142 us |  -5.50% |   FAST   |
|   F32   |      I64      |      2^16      |   4.456 us |       4.55% |   4.572 us |       5.74% |    0.116 us |   2.61% |   SAME   |
|   F32   |      I64      |      2^20      |   9.197 us |       2.69% |   9.009 us |       2.90% |   -0.189 us |  -2.05% |   SAME   |
|   F32   |      I64      |      2^24      |  70.767 us |       1.03% |  68.819 us |       1.03% |   -1.947 us |  -2.75% |   FAST   |
|   F32   |      I64      |      2^28      |   1.040 ms |       0.12% | 983.135 us |       0.09% |  -56.611 us |  -5.44% |   FAST   |
|   F32   |      I64      |      2^32      |  16.561 ms |       0.28% |  15.640 ms |       0.08% | -921.701 us |  -5.57% |   FAST   |
|   F64   |      I32      |      2^16      |   4.984 us |       5.70% |   5.045 us |       5.11% |    0.061 us |   1.23% |   SAME   |
|   F64   |      I32      |      2^20      |  13.741 us |       2.29% |  13.502 us |       2.45% |   -0.239 us |  -1.74% |   SAME   |
|   F64   |      I32      |      2^24      | 134.700 us |       0.71% | 129.137 us |       0.81% |   -5.562 us |  -4.13% |   FAST   |
|   F64   |      I32      |      2^28      |   2.070 ms |       0.10% |   1.954 ms |       0.32% | -115.547 us |  -5.58% |   FAST   |
|   F64   |      I64      |      2^16      |   5.062 us |       6.36% |   5.065 us |       5.36% |    0.003 us |   0.05% |   SAME   |
|   F64   |      I64      |      2^20      |  13.885 us |       2.39% |  13.599 us |       2.43% |   -0.286 us |  -2.06% |   SAME   |
|   F64   |      I64      |      2^24      | 134.669 us |       0.73% | 129.204 us |       0.82% |   -5.466 us |  -4.06% |   FAST   |
|   F64   |      I64      |      2^28      |   2.069 ms |       0.10% |   1.956 ms |       0.25% | -113.102 us |  -5.47% |   FAST   |

# Summary

```

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
