### PR TITLE
Improve `auto(expr)` support

### DIFF
--- a/cudax/include/cuda/experimental/__execution/let_value.cuh
+++ b/cudax/include/cuda/experimental/__execution/let_value.cuh
@@ -57,7 +57,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t
   static ::cuda::std::__undefined<_LetTag> __set_tag;
 
   template <class _LetTag>
-  using __set_tag_for_t = decltype(_LIBCUDACXX_AUTO_CAST(__set_tag<_LetTag>));
+  using __set_tag_for_t = decltype(_CCCL_AUTO_CAST(__set_tag<_LetTag>));
 
   //! @brief Computes the type of a variant of tuples to hold the results of the
   //! predecessor sender.
@@ -341,7 +341,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __let_t
 
     template <class... _Ts>
     using __call _CCCL_NODEBUG_ALIAS = ::cuda::std::bool_constant<
-      (noexcept(_LIBCUDACXX_AUTO_CAST(declval<_Ts>())) && ...)
+      (noexcept(_CCCL_AUTO_CAST(declval<_Ts>())) && ...)
       && noexcept(execution::connect(declval<_Fn>()(declval<decay_t<_Ts>&>()...), __receiver_archetype<__env2_t>()))>;
   };
 

--- a/libcudacxx/include/cuda/std/__cccl/prologue.h
+++ b/libcudacxx/include/cuda/std/__cccl/prologue.h
@@ -345,4 +345,9 @@ _CCCL_DIAG_SUPPRESS_NVCC(3206) // "if consteval" and "if not consteval" are mean
 _CCCL_DIAG_SUPPRESS_NVCC(3060) // call to __builtin_is_constant_evaluated appearing in a non-constexpr function always
                                // produces "false"
 
+// suppress warnings about auto(expr)
+_CCCL_DIAG_SUPPRESS_NVHPC(auto_cast_is_cpp23)
+
+_CCCL_DIAG_SUPPRESS_NVCC(3347)
+
 // NO include guards here (this file is included multiple times)

--- a/libcudacxx/include/cuda/std/__ranges/access.h
+++ b/libcudacxx/include/cuda/std/__ranges/access.h
@@ -49,21 +49,20 @@ void begin(const _Tp&) = delete;
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
 concept __member_begin = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
-  { _LIBCUDACXX_AUTO_CAST(__t.begin()) } -> input_or_output_iterator;
+  { _CCCL_AUTO_CAST(__t.begin()) } -> input_or_output_iterator;
 };
 
 template <class _Tp>
 concept __unqualified_begin =
   !__member_begin<_Tp> && __can_borrow<_Tp> && __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) {
-    { _LIBCUDACXX_AUTO_CAST(begin(__t)) } -> input_or_output_iterator;
+    { _CCCL_AUTO_CAST(begin(__t)) } -> input_or_output_iterator;
   };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
-_CCCL_CONCEPT_FRAGMENT(
-  __member_begin_,
-  requires(_Tp&& __t)(requires(__can_borrow<_Tp>),
-                      requires(__workaround_52970<_Tp>),
-                      requires(input_or_output_iterator<decltype(_LIBCUDACXX_AUTO_CAST(__t.begin()))>)));
+_CCCL_CONCEPT_FRAGMENT(__member_begin_,
+                       requires(_Tp&& __t)(requires(__can_borrow<_Tp>),
+                                           requires(__workaround_52970<_Tp>),
+                                           requires(input_or_output_iterator<decltype(_CCCL_AUTO_CAST(__t.begin()))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __member_begin = _CCCL_FRAGMENT(__member_begin_, _Tp);
@@ -74,7 +73,7 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(_Tp&& __t)(requires(!__member_begin<_Tp>),
                       requires(__can_borrow<_Tp>),
                       requires(__class_or_enum<remove_cvref_t<_Tp>>),
-                      requires(input_or_output_iterator<decltype(_LIBCUDACXX_AUTO_CAST(begin(__t)))>)));
+                      requires(input_or_output_iterator<decltype(_CCCL_AUTO_CAST(begin(__t)))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __unqualified_begin = _CCCL_FRAGMENT(__unqualified_begin_, _Tp);
@@ -104,19 +103,17 @@ struct __fn
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__member_begin<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(__t.begin())))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_CCCL_AUTO_CAST(__t.begin())))
   {
-    return _LIBCUDACXX_AUTO_CAST(__t.begin());
+    return _CCCL_AUTO_CAST(__t.begin());
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__unqualified_begin<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(begin(__t))))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_CCCL_AUTO_CAST(begin(__t))))
   {
-    return _LIBCUDACXX_AUTO_CAST(begin(__t));
+    return _CCCL_AUTO_CAST(begin(__t));
   }
 
   _CCCL_TEMPLATE(class _Tp)
@@ -158,14 +155,14 @@ void end(const _Tp&) = delete;
 template <class _Tp>
 concept __member_end = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
   typename iterator_t<_Tp>;
-  { _LIBCUDACXX_AUTO_CAST(__t.end()) } -> sentinel_for<iterator_t<_Tp>>;
+  { _CCCL_AUTO_CAST(__t.end()) } -> sentinel_for<iterator_t<_Tp>>;
 };
 
 template <class _Tp>
 concept __unqualified_end =
   !__member_end<_Tp> && __can_borrow<_Tp> && __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) {
     typename iterator_t<_Tp>;
-    { _LIBCUDACXX_AUTO_CAST(end(__t)) } -> sentinel_for<iterator_t<_Tp>>;
+    { _CCCL_AUTO_CAST(end(__t)) } -> sentinel_for<iterator_t<_Tp>>;
   };
 #else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
 template <class _Tp>
@@ -174,7 +171,7 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(_Tp&& __t)(requires(__can_borrow<_Tp>),
                       requires(__workaround_52970<_Tp>),
                       typename(iterator_t<_Tp>),
-                      requires(sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(__t.end())), iterator_t<_Tp>>)));
+                      requires(sentinel_for<decltype(_CCCL_AUTO_CAST(__t.end())), iterator_t<_Tp>>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __member_end = _CCCL_FRAGMENT(__member_end_, _Tp);
@@ -186,7 +183,7 @@ _CCCL_CONCEPT_FRAGMENT(
                       requires(__can_borrow<_Tp>),
                       requires(__class_or_enum<remove_cvref_t<_Tp>>),
                       typename(iterator_t<_Tp>),
-                      requires(sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(end(__t))), iterator_t<_Tp>>)));
+                      requires(sentinel_for<decltype(_CCCL_AUTO_CAST(end(__t))), iterator_t<_Tp>>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __unqualified_end = _CCCL_FRAGMENT(__unqualified_end_, _Tp);
@@ -205,18 +202,17 @@ struct __fn
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__member_end<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(__t.end())))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_CCCL_AUTO_CAST(__t.end())))
   {
-    return _LIBCUDACXX_AUTO_CAST(__t.end());
+    return _CCCL_AUTO_CAST(__t.end());
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__unqualified_end<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(end(__t))))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_CCCL_AUTO_CAST(end(__t))))
   {
-    return _LIBCUDACXX_AUTO_CAST(end(__t));
+    return _CCCL_AUTO_CAST(end(__t));
   }
 
   _CCCL_TEMPLATE(class _Tp)

--- a/libcudacxx/include/cuda/std/__ranges/all.h
+++ b/libcudacxx/include/cuda/std/__ranges/all.h
@@ -53,10 +53,10 @@ struct __fn : __range_adaptor_closure<__fn>
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(::cuda::std::ranges::view<decay_t<_Tp>>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(::cuda::std::forward<_Tp>(__t))))
-      -> decltype(_LIBCUDACXX_AUTO_CAST(::cuda::std::forward<_Tp>(__t)))
+    noexcept(noexcept(_CCCL_AUTO_CAST(::cuda::std::forward<_Tp>(__t))))
+      -> decltype(_CCCL_AUTO_CAST(::cuda::std::forward<_Tp>(__t)))
   {
-    return _LIBCUDACXX_AUTO_CAST(::cuda::std::forward<_Tp>(__t));
+    return _CCCL_AUTO_CAST(::cuda::std::forward<_Tp>(__t));
   }
 
   _CCCL_TEMPLATE(class _Tp)

--- a/libcudacxx/include/cuda/std/__ranges/data.h
+++ b/libcudacxx/include/cuda/std/__ranges/data.h
@@ -46,7 +46,7 @@ _CCCL_CONCEPT __ptr_to_object = is_pointer_v<_Tp> && is_object_v<remove_pointer_
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
 concept __member_data = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
-  { _LIBCUDACXX_AUTO_CAST(__t.data()) } -> __ptr_to_object;
+  { _CCCL_AUTO_CAST(__t.data()) } -> __ptr_to_object;
 };
 
 template <class _Tp>
@@ -58,7 +58,7 @@ template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__member_data_,
                        requires(_Tp&& __t)(requires(__can_borrow<_Tp>),
                                            requires(__workaround_52970<_Tp>),
-                                           requires(__ptr_to_object<decltype(_LIBCUDACXX_AUTO_CAST(__t.data()))>)));
+                                           requires(__ptr_to_object<decltype(_CCCL_AUTO_CAST(__t.data()))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __member_data = _CCCL_FRAGMENT(__member_data_, _Tp);

--- a/libcudacxx/include/cuda/std/__ranges/drop_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/drop_view.h
@@ -283,9 +283,9 @@ struct __fn
   _CCCL_TEMPLATE(class _Range, class _Np, class _RawRange = remove_cvref_t<_Range>)
   _CCCL_REQUIRES(__use_empty<_Range, _Np>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __range, _Np&&) const
-    noexcept(noexcept(/**/ _LIBCUDACXX_AUTO_CAST(::cuda::std::forward<_Range>(__range)))) -> _RawRange
+    noexcept(noexcept(/**/ _CCCL_AUTO_CAST(::cuda::std::forward<_Range>(__range)))) -> _RawRange
   {
-    return /*-----------*/ _LIBCUDACXX_AUTO_CAST(::cuda::std::forward<_Range>(__range));
+    return /*-----------*/ _CCCL_AUTO_CAST(::cuda::std::forward<_Range>(__range));
   }
 
   // [range.drop.overview]: the `span | basic_string_view | iota_view | subrange (StoreSize == false)` case.
@@ -353,9 +353,9 @@ struct __fn
   _CCCL_REQUIRES(convertible_to<_Np, range_difference_t<_Range>> _CCCL_AND
                    __is_repeat_specialization<_RawRange> _CCCL_AND(!sized_range<_RawRange>))
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __range, _Np&&) const
-    noexcept(noexcept(/**/ _LIBCUDACXX_AUTO_CAST(::cuda::std::forward<_Range>(__range)))) -> _RawRange
+    noexcept(noexcept(/**/ _CCCL_AUTO_CAST(::cuda::std::forward<_Range>(__range)))) -> _RawRange
   {
-    return /*-----------*/ _LIBCUDACXX_AUTO_CAST(::cuda::std::forward<_Range>(__range));
+    return /*-----------*/ _CCCL_AUTO_CAST(::cuda::std::forward<_Range>(__range));
   }
 
   // [range.drop.overview]: the "otherwise" case.

--- a/libcudacxx/include/cuda/std/__ranges/rbegin.h
+++ b/libcudacxx/include/cuda/std/__ranges/rbegin.h
@@ -46,13 +46,13 @@ void rbegin(const _Tp&) = delete;
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
 concept __member_rbegin = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
-  { _LIBCUDACXX_AUTO_CAST(__t.rbegin()) } -> input_or_output_iterator;
+  { _CCCL_AUTO_CAST(__t.rbegin()) } -> input_or_output_iterator;
 };
 
 template <class _Tp>
 concept __unqualified_rbegin =
   !__member_rbegin<_Tp> && __can_borrow<_Tp> && __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) {
-    { _LIBCUDACXX_AUTO_CAST(rbegin(__t)) } -> input_or_output_iterator;
+    { _CCCL_AUTO_CAST(rbegin(__t)) } -> input_or_output_iterator;
   };
 
 template <class _Tp>
@@ -67,7 +67,7 @@ _CCCL_CONCEPT_FRAGMENT(
   __member_rbegin_,
   requires(_Tp&& __t)(requires(__can_borrow<_Tp>),
                       requires(__workaround_52970<_Tp>),
-                      requires(input_or_output_iterator<decltype(_LIBCUDACXX_AUTO_CAST(__t.rbegin()))>)));
+                      requires(input_or_output_iterator<decltype(_CCCL_AUTO_CAST(__t.rbegin()))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __member_rbegin = _CCCL_FRAGMENT(__member_rbegin_, _Tp);
@@ -78,7 +78,7 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(_Tp&& __t)(requires(!__member_rbegin<_Tp>),
                       requires(__can_borrow<_Tp>),
                       requires(__class_or_enum<remove_cvref_t<_Tp>>),
-                      requires(input_or_output_iterator<decltype(_LIBCUDACXX_AUTO_CAST(rbegin(__t)))>)));
+                      requires(input_or_output_iterator<decltype(_CCCL_AUTO_CAST(rbegin(__t)))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __unqualified_rbegin = _CCCL_FRAGMENT(__unqualified_rbegin_, _Tp);
@@ -103,19 +103,17 @@ struct __fn
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__member_rbegin<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(__t.rbegin())))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_CCCL_AUTO_CAST(__t.rbegin())))
   {
-    return _LIBCUDACXX_AUTO_CAST(__t.rbegin());
+    return _CCCL_AUTO_CAST(__t.rbegin());
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__unqualified_rbegin<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(rbegin(__t))))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_CCCL_AUTO_CAST(rbegin(__t))))
   {
-    return _LIBCUDACXX_AUTO_CAST(rbegin(__t));
+    return _CCCL_AUTO_CAST(rbegin(__t));
   }
 
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__ranges/rend.h
+++ b/libcudacxx/include/cuda/std/__ranges/rend.h
@@ -48,14 +48,14 @@ void rend(const _Tp&) = delete;
 template <class _Tp>
 concept __member_rend = __can_borrow<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
   ::cuda::std::ranges::__rbegin_cpo{}(__t);
-  { _LIBCUDACXX_AUTO_CAST(__t.rend()) } -> sentinel_for<decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>;
+  { _CCCL_AUTO_CAST(__t.rend()) } -> sentinel_for<decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>;
 };
 
 template <class _Tp>
 concept __unqualified_rend =
   !__member_rend<_Tp> && __can_borrow<_Tp> && __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) {
     ::cuda::std::ranges::__rbegin_cpo{}(__t);
-    { _LIBCUDACXX_AUTO_CAST(rend(__t)) } -> sentinel_for<decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>;
+    { _CCCL_AUTO_CAST(rend(__t)) } -> sentinel_for<decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>;
   };
 
 template <class _Tp>
@@ -71,8 +71,7 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(__can_borrow<_Tp>),
     requires(__workaround_52970<_Tp>),
     typename(decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))),
-    requires(
-      sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(__t.rend())), decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>)));
+    requires(sentinel_for<decltype(_CCCL_AUTO_CAST(__t.rend())), decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __member_rend = _CCCL_FRAGMENT(__member_rend_, _Tp);
@@ -85,8 +84,7 @@ _CCCL_CONCEPT_FRAGMENT(
     requires(__can_borrow<_Tp>),
     requires(__class_or_enum<remove_cvref_t<_Tp>>),
     typename(decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))),
-    requires(
-      sentinel_for<decltype(_LIBCUDACXX_AUTO_CAST(rend(__t))), decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>)));
+    requires(sentinel_for<decltype(_CCCL_AUTO_CAST(rend(__t))), decltype(::cuda::std::ranges::__rbegin_cpo{}(__t))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __unqualified_rend = _CCCL_FRAGMENT(__unqualified_rend_, _Tp);
@@ -112,19 +110,17 @@ public:
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__member_rend<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(__t.rend())))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_CCCL_AUTO_CAST(__t.rend())))
   {
-    return _LIBCUDACXX_AUTO_CAST(__t.rend());
+    return _CCCL_AUTO_CAST(__t.rend());
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__unqualified_rend<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(rend(__t))))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_CCCL_AUTO_CAST(rend(__t))))
   {
-    return _LIBCUDACXX_AUTO_CAST(rend(__t));
+    return _CCCL_AUTO_CAST(rend(__t));
   }
 
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/std/__ranges/size.h
+++ b/libcudacxx/include/cuda/std/__ranges/size.h
@@ -55,13 +55,13 @@ _CCCL_CONCEPT __size_enabled = !disable_sized_range<remove_cvref_t<_Tp>>;
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>
 concept __member_size = __size_enabled<_Tp> && __workaround_52970<_Tp> && requires(_Tp&& __t) {
-  { _LIBCUDACXX_AUTO_CAST(__t.size()) } -> __integer_like;
+  { _CCCL_AUTO_CAST(__t.size()) } -> __integer_like;
 };
 
 template <class _Tp>
 concept __unqualified_size =
   __size_enabled<_Tp> && !__member_size<_Tp> && __class_or_enum<remove_cvref_t<_Tp>> && requires(_Tp&& __t) {
-    { _LIBCUDACXX_AUTO_CAST(size(__t)) } -> __integer_like;
+    { _CCCL_AUTO_CAST(size(__t)) } -> __integer_like;
   };
 
 template <class _Tp>
@@ -77,7 +77,7 @@ template <class _Tp>
 _CCCL_CONCEPT_FRAGMENT(__member_size_,
                        requires(_Tp&& __t)(requires(__size_enabled<_Tp>),
                                            requires(__workaround_52970<_Tp>),
-                                           requires(__integer_like<decltype(_LIBCUDACXX_AUTO_CAST(__t.size()))>)));
+                                           requires(__integer_like<decltype(_CCCL_AUTO_CAST(__t.size()))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __member_size = _CCCL_FRAGMENT(__member_size_, _Tp);
@@ -88,7 +88,7 @@ _CCCL_CONCEPT_FRAGMENT(
   requires(_Tp&& __t)(requires(__size_enabled<_Tp>),
                       requires(!__member_size<_Tp>),
                       requires(__class_or_enum<remove_cvref_t<_Tp>>),
-                      requires(__integer_like<decltype(_LIBCUDACXX_AUTO_CAST(size(__t)))>)));
+                      requires(__integer_like<decltype(_CCCL_AUTO_CAST(size(__t)))>)));
 
 template <class _Tp>
 _CCCL_CONCEPT __unqualified_size = _CCCL_FRAGMENT(__unqualified_size_, _Tp);
@@ -128,20 +128,18 @@ struct __fn
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__member_size<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(__t.size())))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_CCCL_AUTO_CAST(__t.size())))
   {
-    return _LIBCUDACXX_AUTO_CAST(__t.size());
+    return _CCCL_AUTO_CAST(__t.size());
   }
 
   // `[range.prim.size]`: `auto(size(t))` is a valid expression.
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__unqualified_size<_Tp>)
-  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(size(__t))))
+  [[nodiscard]] _CCCL_API constexpr auto operator()(_Tp&& __t) const noexcept(noexcept(_CCCL_AUTO_CAST(size(__t))))
   {
-    return _LIBCUDACXX_AUTO_CAST(size(__t));
+    return _CCCL_AUTO_CAST(size(__t));
   }
 
   // [range.prim.size]: the `to-unsigned-like` case.

--- a/libcudacxx/include/cuda/std/__ranges/take_view.h
+++ b/libcudacxx/include/cuda/std/__ranges/take_view.h
@@ -370,9 +370,9 @@ struct __fn
   _CCCL_TEMPLATE(class _Range, class _Np, class _RawRange = remove_cvref_t<_Range>)
   _CCCL_REQUIRES(__use_empty<_Range, _Np>)
   [[nodiscard]] _CCCL_API constexpr auto operator()(_Range&& __range, _Np&&) const
-    noexcept(noexcept(_LIBCUDACXX_AUTO_CAST(::cuda::std::forward<_Range>(__range)))) -> _RawRange
+    noexcept(noexcept(_CCCL_AUTO_CAST(::cuda::std::forward<_Range>(__range)))) -> _RawRange
   {
-    return _LIBCUDACXX_AUTO_CAST(::cuda::std::forward<_Range>(__range));
+    return _CCCL_AUTO_CAST(::cuda::std::forward<_Range>(__range));
   }
 
   // [range.take.overview]: the `span | basic_string_view | subrange` case.

--- a/libcudacxx/include/cuda/std/__utility/auto_cast.h
+++ b/libcudacxx/include/cuda/std/__utility/auto_cast.h
@@ -1,10 +1,9 @@
-// -*- C++ -*-
 //===----------------------------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -23,12 +22,24 @@
 
 #include <cuda/std/__type_traits/decay.h>
 
-#if _CCCL_STD_VER >= 2023 && __cpp_auto_cast >= 202110L && !_CCCL_CUDA_COMPILER(NVCC)
-#  define _LIBCUDACXX_AUTO_CAST(expr) auto(expr)
+#if _CCCL_COMPILER(GCC, >=, 12) || (_CCCL_COMPILER(NVHPC) && _CCCL_HOST_STD_LIB(LIBSTDCXX, >=, 12))
+#  define _CCCL_HAS_AUTO_CAST_BEFORE_CXX23() 1
+#else // ^^^ has auto(expr) before c++23 ^^^ / vvv no auto(expr) before c++23 vvv
+#  define _CCCL_HAS_AUTO_CAST_BEFORE_CXX23() 0
+#endif // ^^^ no auto(expr) before c++23 ^^^
+
+// nvcc < 13 does not support auto(expr), nvhpc fails to use auto(expr) in noexcept(noexcept(...)) (nvbug 5742468)
+#if _CCCL_CUDA_COMPILER(NVCC, <, 13) || _CCCL_COMPILER(NVHPC)
+#  undef _CCCL_HAS_AUTO_CAST_BEFORE_CXX23
+#  define _CCCL_HAS_AUTO_CAST_BEFORE_CXX23() 0
+#endif // _CCCL_CUDA_COMPILER(NVCC, <, 13)
+
+#if (_CCCL_STD_VER >= 2023 && __cpp_auto_cast >= 202110L) || _CCCL_HAS_AUTO_CAST_BEFORE_CXX23()
+#  define _CCCL_AUTO_CAST(_EXPR) auto(_EXPR)
 #elif _CCCL_STD_VER < 2020 && _CCCL_COMPILER(MSVC)
-#  define _LIBCUDACXX_AUTO_CAST(expr) (::cuda::std::decay_t<decltype((expr))>) (expr)
+#  define _CCCL_AUTO_CAST(_EXPR) (::cuda::std::decay_t<decltype((_EXPR))>) (_EXPR)
 #else
-#  define _LIBCUDACXX_AUTO_CAST(expr) static_cast<::cuda::std::decay_t<decltype((expr))>>(expr)
+#  define _CCCL_AUTO_CAST(_EXPR) static_cast<::cuda::std::decay_t<decltype((_EXPR))>>(_EXPR)
 #endif
 
 #endif // _CUDA_STD___UTILITY_AUTO_CAST_H


### PR DESCRIPTION
gcc and nvhpc support `auto(expr)` even before c++23 as an extension, nvcc supports this since 13.0.

This renames `_LIBCUDACXX_AUTO_CAST` to `_CCCL_AUTO_CAST` and allows more efficient implementation via `auto(expr)` even in earlier c++ modes.