### PR TITLE
use cooperative_groups in `execution::bulk` to synchronize across thread blocks

### DIFF
--- a/cudax/include/cuda/experimental/__execution/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/bulk.cuh
@@ -73,7 +73,8 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __attrs_t
   {
     constexpr int __block_threads = 256;
     const int __grid_blocks       = ::cuda::ceil_div(static_cast<int>(__shape), __block_threads);
-    return make_config(block_dims<__block_threads>(), grid_dims(__grid_blocks));
+    auto __dims                   = ::cuda::make_hierarchy(block_dims<__block_threads>(), grid_dims(__grid_blocks));
+    return make_config(__dims, cooperative_launch());
   }
 
   using __launch_config_t = decltype(__get_launch_config(_Shape()));

--- a/cudax/include/cuda/experimental/__execution/stream/bulk.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/bulk.cuh
@@ -29,7 +29,9 @@
 #include <cuda/experimental/__execution/cpos.cuh>
 #include <cuda/experimental/__execution/policy.cuh>
 #include <cuda/experimental/__execution/stream/domain.cuh>
+#include <cuda/experimental/launch.cuh>
 
+#include <cooperative_groups.h>
 #include <cuda_runtime_api.h>
 
 #include <cuda/experimental/__execution/prologue.cuh>
@@ -66,7 +68,7 @@ struct __bulk_chunked_t : execution::__bulk_t<__bulk_chunked_t>
         }
       }
 
-      __syncthreads();
+      ::cooperative_groups::this_grid().sync();
 
       // Only call the downstream receiver once, after all threads have processed their
       // elements.
@@ -130,7 +132,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __bulk_unchunked_t : execution::__bulk_t<__
         this->__state_->__fn_(_Shape(__tid), __values...);
       }
 
-      __syncthreads();
+      ::cooperative_groups::this_grid().sync();
 
       // Only call the downstream receiver once, after all threads have processed their
       // elements.


### PR DESCRIPTION

## Description

the `execution::bulk` customization for the stream scheduler was only synchronizing the current thread block. the `bulk` launch may have launched multiple thread blocks, and we need to synchronize across all of them.

this PR uses `cooperative_groups` to synchronize the current grid and changes the `bulk` kernel launch config to specify a cooperative launch.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
