### PR TITLE
[libcu++] Fix memory pool and buffer test issues on Windows

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/device_memory_resource.cu
@@ -178,7 +178,8 @@ C2H_CCCLRT_TEST("device_memory_resource construction", "[memory_resource]")
     CHECK(ensure_export_handle(get, ::cudaMemHandleTypeNone));
   }
 
-  // Allocation handles are only supported after 11.2
+  // Allocation handles are only supported after 11.2 and not on Windows
+#if !_CCCL_OS(WINDOWS)
   SECTION("Construct with allocation handle")
   {
     cuda::memory_pool_properties props = {
@@ -200,6 +201,7 @@ C2H_CCCLRT_TEST("device_memory_resource construction", "[memory_resource]")
     // Ensure that we disable export
     CHECK(ensure_export_handle(get, props.allocation_handle_type));
   }
+#endif // !_CCCL_OS(WINDOWS)
 }
 
 static void ensure_device_ptr(void* ptr)

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/managed_memory_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/managed_memory_resource.cu
@@ -17,7 +17,7 @@
 #include <testing.cuh>
 #include <utility.cuh>
 
-#if _CCCL_CTK_AT_LEAST(13, 0)
+#if _CCCL_CTK_AT_LEAST(13, 0) && !_CCCL_OS(WINDOWS)
 #  define TEST_TYPES cuda::mr::legacy_managed_memory_resource, cuda::managed_memory_pool_ref
 #else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
 #  define TEST_TYPES cuda::mr::legacy_managed_memory_resource

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/resources/memory_pools.cu
@@ -19,7 +19,7 @@
 
 #include <testing.cuh>
 
-#if _CCCL_CTK_AT_LEAST(13, 0)
+#if _CCCL_CTK_AT_LEAST(13, 0) && !_CCCL_OS(WINDOWS)
 #  define TEST_TYPES cuda::managed_memory_pool, cuda::device_memory_pool, cuda::pinned_memory_pool
 #elif _CCCL_CTK_AT_LEAST(12, 6)
 #  define TEST_TYPES cuda::device_memory_pool, cuda::pinned_memory_pool
@@ -611,6 +611,7 @@ C2H_CCCLRT_TEST("pinned_memory_pool::enable_access", "[memory_resource]")
 }
 #endif // _CCCL_CTK_AT_LEAST(12, 6)
 
+#if !_CCCL_OS(WINDOWS)
 C2H_CCCLRT_TEST("device_memory_pool with allocation handle", "[memory_resource]")
 {
   cuda::memory_pool_properties props              = {20, 42, ::cudaMemHandleTypePosixFileDescriptor};
@@ -635,7 +636,7 @@ C2H_CCCLRT_TEST("device_memory_pool with allocation handle", "[memory_resource]"
   CHECK(ensure_export_handle(get, static_cast<cudaMemAllocationHandleType>(props.allocation_handle_type)));
 }
 
-#if _CCCL_CTK_AT_LEAST(12, 6)
+#  if _CCCL_CTK_AT_LEAST(12, 6)
 C2H_CCCLRT_TEST("pinned_memory_pool with allocation handle", "[memory_resource]")
 {
   cuda::memory_pool_properties props              = {20, 42, ::cudaMemHandleTypePosixFileDescriptor};
@@ -653,6 +654,7 @@ C2H_CCCLRT_TEST("pinned_memory_pool with allocation handle", "[memory_resource]"
   // Ensure that we disable export
   CHECK(ensure_export_handle(get, static_cast<cudaMemAllocationHandleType>(props.allocation_handle_type)));
 }
-#endif // _CCCL_CTK_AT_LEAST(12, 6)
+#  endif // _CCCL_CTK_AT_LEAST(12, 6)
 
 // managed memory pool does not support allocation handles yet.
+#endif // !_CCCL_OS(WINDOWS)

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_resource.cu
@@ -133,7 +133,7 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
   SECTION("basic sanity test about shared resource handling")
   {
     Counts expected{};
-    this->align(alignof(int) * 4);
+    this->align(alignof(cuda::std::max_align_t));
     {
       this->bytes(42 * sizeof(int));
       cuda::stream stream{cuda::device_ref{0}};


### PR DESCRIPTION
There are some test failures on Windows in memory pool and buffer testing.
The memory pool failures are only cases where we test unsupported managed memory pools or export handles. This PR removes those test from Windows configs.

There was some problem with hard-coded alignment, that seems to be different on Windows.

There were also device side memory access issues in buffer testing. It seems to come with thrust calls in our tests. I looks like a thrust issue, because when its replaced with a simple kernel it works correctly. For now this PR just makes that switch to a check kernel, we can investigate to confirm what the problem is in a separate issue