### PR TITLE
do not introduce a pack in a structured binding with nvcc

### DIFF
--- a/cudax/include/cuda/experimental/__execution/visit.cuh
+++ b/cudax/include/cuda/experimental/__execution/visit.cuh
@@ -40,8 +40,13 @@
 #  define _CCCL_BUILTIN_STRUCTURED_BINDING_SIZE(...) __builtin_structured_binding_size(__VA_ARGS__)
 #endif // _CCCL_HAS_BUILTIN(__builtin_structured_binding_size)
 
+#if __cpp_structured_bindings >= 202411L
+#  define _CCCL_STRUCTURED_BINDING_CAN_INTRODUCE_A_PACK
+#endif // __cpp_structured_bindings >= 202411L
+
 #if _CCCL_CUDA_COMPILER(NVCC)
 #  undef _CCCL_BUILTIN_STRUCTURED_BINDING_SIZE
+#  undef _CCCL_STRUCTURED_BINDING_CAN_INTRODUCE_A_PACK
 #endif // _CCCL_CUDA_COMPILER(NVCC)
 
 namespace cuda::experimental::execution
@@ -117,7 +122,7 @@ inline constexpr int structured_binding_size<_Sndr const&> = structured_binding_
 
 // If structured bindings can be used to introduce a pack, then `visit` has a very simple
 // implementation.
-#if __cpp_structured_bindings >= 202411L
+#if defined(_CCCL_STRUCTURED_BINDING_CAN_INTRODUCE_A_PACK)
 
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wc++2c-extensions")


### PR DESCRIPTION
## Description

`cudax/__execution/visit.cuh` is using [P1061](https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p1061r10.html), "Structured Bindings can introduce a Pack", whenever the feature is available.

however, it fails to account for the fact that P1061 is _not_ available when your CUDA compiler is nvcc.

this pr disables the use of packs in structured bindings when the compiler is nvcc.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
