### PR TITLE
fix off-by-one error in the implementation of `cuda::std::__tuple`

### DIFF
--- a/libcudacxx/include/cuda/std/__utility/pod_tuple.h
+++ b/libcudacxx/include/cuda/std/__utility/pod_tuple.h
@@ -245,11 +245,7 @@ __apply(_Fn&& __fn, _Tuple&& __tupl, _Us&&... __us) noexcept(__detail::__nothrow
 {
   constexpr size_t __size = remove_reference_t<_Tuple>::__size;
 
-  if constexpr (__size >= 8)
-  {
-    return __tupl.__apply(static_cast<_Fn&&>(__fn), static_cast<_Tuple&&>(__tupl), static_cast<_Us&&>(__us)...);
-  }
-  else if constexpr (__size == 0)
+  if constexpr (__size == 0)
   {
     return static_cast<_Fn&&>(__fn)(static_cast<_Us&&>(__us)...);
   }
@@ -277,9 +273,17 @@ __apply(_Fn&& __fn, _Tuple&& __tupl, _Us&&... __us) noexcept(__detail::__nothrow
   {
     return static_cast<_Fn&&>(__fn)(static_cast<_Us&&>(__us)... _CCCL_PP_REPEAT(6, _CCCL_TUPLE_GET));
   }
-  else // if constexpr (__size == 7)
+  else if constexpr (__size == 7)
   {
     return static_cast<_Fn&&>(__fn)(static_cast<_Us&&>(__us)... _CCCL_PP_REPEAT(7, _CCCL_TUPLE_GET));
+  }
+  else if constexpr (__size == 8)
+  {
+    return static_cast<_Fn&&>(__fn)(static_cast<_Us&&>(__us)... _CCCL_PP_REPEAT(8, _CCCL_TUPLE_GET));
+  }
+  else
+  {
+    return __tupl.__apply(static_cast<_Fn&&>(__fn), static_cast<_Tuple&&>(__tupl), static_cast<_Us&&>(__us)...);
   }
 }
 
@@ -325,11 +329,7 @@ _CCCL_TRIVIAL_API constexpr auto __get(_Tuple&& __tupl) noexcept -> auto&&
   constexpr auto __size = remove_reference_t<_Tuple>::__size;
   static_assert(_Index < __size, "Index out of bounds in __get");
 
-  if constexpr (__size >= 8)
-  {
-    return __detail::__get<_Index>(static_cast<_Tuple&&>(__tupl));
-  }
-  else if constexpr (_Index == 0)
+  if constexpr (_Index == 0)
   {
     return static_cast<_Tuple&&>(__tupl).__val0;
   }
@@ -357,9 +357,17 @@ _CCCL_TRIVIAL_API constexpr auto __get(_Tuple&& __tupl) noexcept -> auto&&
   {
     return static_cast<_Tuple&&>(__tupl).__val6;
   }
-  else // if constexpr (_Index == 7)
+  else if constexpr (_Index == 7)
   {
     return static_cast<_Tuple&&>(__tupl).__val7;
+  }
+  else if constexpr (_Index == 8)
+  {
+    return static_cast<_Tuple&&>(__tupl).__val8;
+  }
+  else
+  {
+    return __detail::__get<_Index>(static_cast<_Tuple&&>(__tupl));
   }
 }
 


### PR DESCRIPTION
## Description

`cuda::std::__tuple` is a lightweight replacement for `cuda::std::tuple`. it can have up to 8 elements in a flat struct. (with more than 8, `__tuple` uses base classes like `cuda::std::tuple`.)

`cuda::std::__apply` and `cuda::std::__get` are helpers that do what `std::apply` and `std::get` do. they explicitly handle tuples up to _7_ elements, and then uses a fallback implementation.

but because of an off-by-one error, a tuple with _exactly_ 8 elements causes both `cuda::std::__apply` and `cuda::std::__get` to choke.

this pr fixes the problem.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
