### PR TITLE
cuda.coop: Use `cuda.core.experimental.Linker` instead of internal numba-cuda `_Linker`

### DIFF
--- a/python/cuda_cccl/cuda/coop/_types.py
+++ b/python/cuda_cccl/cuda/coop/_types.py
@@ -14,8 +14,8 @@ from numba import cuda, types
 from numba.core import cgutils
 from numba.core.extending import intrinsic, overload
 from numba.core.typing import signature
-from numba.cuda import LTOIR
-from numba.cuda.cudadrv import driver as cuda_driver
+
+from cuda.core.experimental import Linker, LinkerOptions, ObjectCode
 
 from . import _nvrtc as nvrtc
 from ._common import find_unsigned
@@ -765,16 +765,15 @@ class Algorithm:
 
         # Convert the LTO into PTX in order to extract the size and alignment
         # variables.
-        obj = LTOIR(name=self.c_name, data=blob)
-        linker = cuda_driver._Linker.new(
-            cc=device.compute_capability,
-            additional_flags=["-ptx"],
-            lto=obj,
+        ltoir_obj = ObjectCode.from_ltoir(blob, name=self.c_name)
+        linker_options = LinkerOptions(
+            arch=f"sm_{cc}",
+            link_time_optimization=True,
+            ptx=True,
         )
-        ltoir_bytes = obj.data
-        linker.add_ltoir(ltoir_bytes)
-        ptx = linker.get_linked_ptx()
-        ptx = ptx.decode("utf-8")
+        linker = Linker(ltoir_obj, options=linker_options)
+        linked_ptx = linker.link("ptx")
+        ptx = linked_ptx.code.decode("utf-8")
         self._temp_storage_bytes = find_unsigned("temp_storage_bytes", ptx)
         self._temp_storage_alignment = find_unsigned("temp_storage_alignment", ptx)
 


### PR DESCRIPTION
Currently, we're using an internal `_Linker` type from `numba-cuda` to link LTOIRs in `cuda.coop`. Sooner or later this was going to bite us, and now it has; CI is currently failing after the new `numba-cuda` release:

https://github.com/NVIDIA/cccl/actions/runs/20309802881/job/58413381534?pr=6999

This PR migrates to using [`cuda.core.experimental.Linker`](https://nvidia.github.io/cuda-python/cuda-core/latest/generated/cuda.core.Linker.html), which is the right tool for the job.