### PR TITLE
Increase ulimit in RAPIDS devcontainer

### DIFF
--- a/ci/rapids/cuda13.0-conda/devcontainer.json
+++ b/ci/rapids/cuda13.0-conda/devcontainer.json
@@ -4,7 +4,9 @@
     "--init",
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-25.12-cuda13.0-conda"
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-25.12-cuda13.0-conda",
+    "--ulimit",
+    "nofile=500000"
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {


### PR DESCRIPTION
Adds `--ulimit nofile=500000` to the RAPIDS devcontainer docker run arguments.

Suggested by @trxcllnt as a workaround for a [failure in CCCL+RAPIDS CI](https://github.com/NVIDIA/cccl/actions/runs/20329428892/job/58403167622#step:6:3262).

```
[146/1627] Custom command to JIT-compile files.
ninja: fatal: pipe: Too many open files
```