### PR TITLE
tidy up the primitive variant type used by cudax::execution

### DIFF
--- a/cudax/include/cuda/experimental/__execution/continues_on.cuh
+++ b/cudax/include/cuda/experimental/__execution/continues_on.cuh
@@ -113,7 +113,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT continues_on_t
 
     _CCCL_API constexpr void set_value() noexcept
     {
-      __state_->__result_.__visit(__send_result_visitor{}, __state_->__result_, __state_->__rcvr_);
+      __visit(__send_result_visitor{}, __state_->__result_, __state_->__rcvr_);
     }
 
     template <class _Error>

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -123,7 +123,7 @@ _CCCL_VISIBILITY_HIDDEN __launch_bounds__(_BlockThreads) __global__
   void __completion_kernel(__state_base_t<_Rcvr, _Variant>* __state)
 {
   _CCCL_ASSERT(__state->__results_.__index() != __npos, "__completion_kernel called with empty results");
-  _Variant::__visit(__visit_results{}, __state->__results_, __state->__rcvr_);
+  __visit(__visit_results{}, __state->__results_, __state->__rcvr_);
 }
 
 // This is the environment of the inner receiver that is used to connect the child sender.
@@ -229,7 +229,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT __opstate_t
   template <class _Rcvr2>
   _CCCL_API auto __set_results(_Rcvr2& __rcvr) noexcept
   {
-    __results_t::__visit(__visit_results{}, __get_state().__state_.__results_, __rcvr);
+    __visit(__visit_results{}, __get_state().__state_.__results_, __rcvr);
   }
 
 private:
@@ -322,7 +322,9 @@ private:
   // in dyncamically-allocated managed memory.
   [[nodiscard]] _CCCL_API constexpr auto __get_state() noexcept -> __state_t&
   {
-    return __state_.__index() == 0 ? __state_.template __get<0>() : __state_.template __get<1>()->__value;
+    return __state_.__index() == 0
+           ? execution::__variant_get<0>(__state_)
+           : execution::__variant_get<1>(__state_)->__value;
   }
 
   stream_ref __stream_;

--- a/cudax/include/cuda/experimental/__execution/stream/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/sync_wait.cuh
@@ -49,8 +49,8 @@ struct __sync_wait_t : private sync_wait_t
     auto __new_sndr = stream_domain{}.transform_sender(set_value, static_cast<_Sndr&&>(__sndr), __env);
 
     NV_IF_TARGET(NV_IS_HOST,
-                 (return __host_apply(::cuda::std::move(__new_sndr), static_cast<_Env&&>(__env));),
-                 (return __device_apply(::cuda::std::move(__new_sndr), static_cast<_Env&&>(__env));))
+                 (return __host_apply(_CCCL_MOVE(__new_sndr), static_cast<_Env&&>(__env));),
+                 (return __device_apply(_CCCL_MOVE(__new_sndr), static_cast<_Env&&>(__env));))
     _CCCL_UNREACHABLE();
   }
 
@@ -112,10 +112,10 @@ private:
 
     if (__state.__errors_.__index() != __npos)
     {
-      __state.__errors_.__visit(sync_wait_t::__throw_error_fn{}, ::cuda::std::move(__state.__errors_));
+      __visit(sync_wait_t::__throw_error_fn{}, _CCCL_MOVE(__state.__errors_));
     }
 
-    return ::cuda::std::move(__box->__value.__result_);
+    return _CCCL_MOVE(__box->__value.__result_);
   }
 };
 } // namespace __stream

--- a/cudax/include/cuda/experimental/__execution/sync_wait.cuh
+++ b/cudax/include/cuda/experimental/__execution/sync_wait.cuh
@@ -260,7 +260,7 @@ public:
 
     if (__state.__errors_.__index() != __npos)
     {
-      __errors_t::__visit(__throw_error_fn{}, static_cast<__errors_t&&>(__state.__errors_));
+      __visit(__throw_error_fn{}, static_cast<__errors_t&&>(__state.__errors_));
     }
 
     return __result; // uses NRVO to return the result

--- a/cudax/include/cuda/experimental/__execution/task_scheduler.cuh
+++ b/cudax/include/cuda/experimental/__execution/task_scheduler.cuh
@@ -406,7 +406,7 @@ public:
   _CCCL_API void set_value() noexcept final override
   {
     // Send the stored values to the downstream receiver.
-    _Values::__visit(
+    __visit(
       [this](auto& __tupl) {
         constexpr bool __valid_args = __not_same_as<decltype(__tupl), ::cuda::std::monostate&>;
         // runtime assert that we never take this path without valid args from the predecessor:
@@ -426,8 +426,7 @@ public:
     _CCCL_TRY
     {
       constexpr bool __parallelize = _Policy() == par || _Policy() == par_unseq;
-      _Values::__visit(__detail::__get_execute_bulk_fn<__parallelize>(_BulkTag(), __fn_, __shape_, __begin, __end),
-                       __values_);
+      __visit(__detail::__get_execute_bulk_fn<__parallelize>(_BulkTag(), __fn_, __shape_, __begin, __end), __values_);
     }
     _CCCL_CATCH_ALL
     {

--- a/cudax/include/cuda/experimental/__execution/variant.cuh
+++ b/cudax/include/cuda/experimental/__execution/variant.cuh
@@ -23,12 +23,16 @@
 
 #include <cuda/std/__cccl/assert.h>
 #include <cuda/std/__concepts/constructible.h>
-#include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__memory/construct_at.h>
 #include <cuda/std/__new/device_new.h>
 #include <cuda/std/__new/launder.h>
+#include <cuda/std/__type_traits/copy_cvref.h>
 #include <cuda/std/__type_traits/decay.h>
-#include <cuda/std/__type_traits/type_set.h>
+#include <cuda/std/__type_traits/remove_reference.h>
+#include <cuda/std/__type_traits/type_list.h>
+#include <cuda/std/__utility/declval.h>
+#include <cuda/std/__utility/exchange.h>
 #include <cuda/std/__utility/integer_sequence.h>
 #include <cuda/std/__utility/monostate.h>
 
@@ -52,93 +56,133 @@ namespace cuda::experimental::execution
 
 using __monostate = ::cuda::std::monostate;
 
-template <class _Idx, class... _Ts>
-class __variant_impl;
-
-template <>
-class __variant_impl<::cuda::std::index_sequence<>>
+template <size_t _Idx, bool _Check = true, class _CvVariant>
+[[nodiscard]]
+_CCCL_TRIVIAL_API constexpr auto&& __variant_get(_CvVariant&& __var) noexcept
 {
-public:
-  template <class _Fn, class... _Us>
-  _CCCL_API static void __visit(_Fn&&, _Us&&...) noexcept
+  using __variant_t = ::cuda::std::remove_reference_t<_CvVariant>;
+  using __element_t = typename __variant_t::template __at<_Idx>;
+  using __result_t  = ::cuda::std::__copy_cvref_t<_CvVariant, __element_t>;
+  if constexpr (_Check)
   {
-    _CCCL_ASSERT(false, "cannot visit a stateless variant");
+    _CCCL_ASSERT(__var.__index() == _Idx, "variant index mismatch");
+  }
+  return static_cast<__result_t&&>(*static_cast<__element_t*>(__var.__ptr()));
+}
+
+struct __visit_t
+{
+  _CCCL_EXEC_CHECK_DISABLE
+  template <size_t... _Idx, class _Fn, class _CvVariant, class... _As>
+  _CCCL_API static void
+  __visit(::cuda::std::index_sequence<_Idx...>*,
+          const size_t __index,
+          _Fn&& __fn,
+          _CvVariant&& __var,
+          _As&&... __as) //
+    noexcept(noexcept((
+      (_Idx == __index ? declval<_Fn>()(declval<_As>()..., execution::__variant_get<_Idx, false>(declval<_CvVariant>()))
+                       : void()),
+      ...)))
+  {
+    _CCCL_ASSERT(__index != __npos, "cannot visit a stateless variant");
+    // Use a fold expression to avoid the need for a loop.
+    ((_Idx == __index
+        ? static_cast<_Fn&&>(
+            __fn)(static_cast<_As&&>(__as)..., execution::__variant_get<_Idx, false>(static_cast<_CvVariant&&>(__var)))
+        : void()),
+     ...);
   }
 
-  [[nodiscard]] _CCCL_API static constexpr size_t __index() noexcept
+  template <class _Fn, class _CvVariant, class... _As>
+  _CCCL_TRIVIAL_API void operator()(_Fn&& __fn, _CvVariant&& __var, _As&&... __as) const noexcept(
+    noexcept(__visit_t::__visit(__var.__indices(), size_t(), declval<_Fn>(), declval<_CvVariant>(), declval<_As>()...)))
   {
-    return __npos;
+    __visit_t::__visit(
+      __var.__indices(),
+      __var.__index(),
+      static_cast<_Fn&&>(__fn),
+      static_cast<_CvVariant&&>(__var),
+      static_cast<_As&&>(__as)...);
   }
 };
 
-template <size_t... _Idx, class... _Ts>
-class __variant_impl<::cuda::std::index_sequence<_Idx...>, _Ts...>
-{
-  static constexpr size_t __max_size = __maximum({sizeof(_Ts)...});
-  static_assert(__max_size != 0);
-  size_t __index_{__npos};
-  alignas(_Ts...) unsigned char __storage_[__max_size];
+_CCCL_GLOBAL_CONSTANT __visit_t __visit{};
 
+namespace __detail
+{
+struct __destroy_fn
+{
+  template <class _Ty>
+  _CCCL_API void operator()(_Ty& __ty) const noexcept
+  {
+    ::cuda::std::__destroy_at(::cuda::std::addressof(__ty));
+  }
+};
+
+struct __move_to_fn
+{
+  template <class _Ty>
+  _CCCL_API void operator()(_Ty&& __from) const noexcept
+  {
+    ::cuda::std::__construct_at(static_cast<decay_t<_Ty>*>(__to), static_cast<_Ty&&>(__from));
+  }
+
+  void* __to;
+};
+} // namespace __detail
+
+template <class... _Ts>
+class __variant
+{
+public:
   template <size_t _Ny>
   using __at _CCCL_NODEBUG_ALIAS = ::cuda::std::__type_index_c<_Ny, _Ts...>;
 
-  _CCCL_API void __destroy() noexcept
-  {
-    if (__index_ != __npos)
-    {
-      // make this local in case destroying the sub-object destroys *this
-      const auto index = execution::__exchange(__index_, __npos);
-      ((_Idx == index ? ::cuda::std::destroy_at(static_cast<__at<_Idx>*>(__ptr())) : void(0)), ...);
-    }
-  }
-
-public:
-  _CCCL_API __variant_impl() noexcept {}
+  _CCCL_API __variant() noexcept {}
 
   _CCCL_TEMPLATE(class...)
   _CCCL_REQUIRES((::cuda::std::move_constructible<_Ts> && ...))
-  __variant_impl(__variant_impl&& __other) noexcept
+  __variant(__variant&& __other) noexcept
   {
     if (__other.__index_ != __npos)
     {
-      ((_Idx == __other.__index_
-          ? static_cast<void>(__emplace<__at<_Idx>>(static_cast<__variant_impl&&>(__other).template __get<_Idx>()))
-          : void(0)),
-       ...);
+      __visit_t::__visit(
+        __indices(), __other.__index(), __detail::__move_to_fn{__ptr()}, static_cast<__variant&&>(__other));
       __index_ = __other.__index_;
-      __other.__destroy();
+      __other.__reset();
     }
   }
 
-  _CCCL_API ~__variant_impl()
+  _CCCL_API ~__variant()
   {
-    __destroy();
+    __reset();
   }
 
-  [[nodiscard]] _CCCL_API void* __ptr() noexcept
+  [[nodiscard]] _CCCL_TRIVIAL_API void* __ptr() noexcept
   {
     return __storage_;
   }
 
-  [[nodiscard]] _CCCL_API size_t __index() const noexcept
+  [[nodiscard]] _CCCL_TRIVIAL_API size_t __index() const noexcept
   {
     return __index_;
   }
 
-  template <class _Ty>
+  template <int = 0, class _Ty>
   _CCCL_API auto __emplace(_Ty&& __value) noexcept(__nothrow_decay_copyable<_Ty>) -> decay_t<_Ty>&
   {
-    return __emplace<decay_t<_Ty>, _Ty>(static_cast<_Ty&&>(__value));
+    return __emplace<decay_t<_Ty>>(static_cast<_Ty&&>(__value));
   }
 
   _CCCL_EXEC_CHECK_DISABLE
   template <class _Ty, class... _As>
   _CCCL_API auto __emplace(_As&&... __as) noexcept(__nothrow_constructible<_Ty, _As...>) -> _Ty&
   {
-    constexpr size_t __new_index = execution::__index_of<_Ty, _Ts...>();
+    constexpr size_t __new_index = __index_of<_Ty, _Ts...>();
     static_assert(__new_index != __npos, "Type not in variant");
 
-    __destroy();
+    __reset();
     _Ty* __value = ::new (__ptr()) _Ty{static_cast<_As&&>(__as)...};
     __index_     = __new_index;
     return *::cuda::std::launder(__value);
@@ -150,7 +194,7 @@ public:
   {
     static_assert(_Ny < sizeof...(_Ts), "variant index is too large");
 
-    __destroy();
+    __reset();
     __at<_Ny>* __value = ::new (__ptr()) __at<_Ny>{static_cast<_As&&>(__as)...};
     __index_           = _Ny;
     return *::cuda::std::launder(__value);
@@ -162,54 +206,61 @@ public:
     noexcept(__nothrow_callable<_Fn, _As...>) -> __call_result_t<_Fn, _As...>&
   {
     using __result_t _CCCL_NODEBUG_ALIAS = __call_result_t<_Fn, _As...>;
-    constexpr size_t __new_index         = execution::__index_of<__result_t, _Ts...>();
+    constexpr size_t __new_index         = __index_of<__result_t, _Ts...>();
     static_assert(__new_index != __npos, "_Type not in variant");
 
-    __destroy();
+    __reset();
     __result_t* __value = ::new (__ptr()) __result_t(static_cast<_Fn&&>(__fn)(static_cast<_As&&>(__as)...));
     __index_            = __new_index;
     return *::cuda::std::launder(__value);
   }
 
-  _CCCL_EXEC_CHECK_DISABLE
-  template <class _Fn, class _Self, class... _As>
-  _CCCL_API static void __visit(_Fn&& __fn, _Self&& __self, _As&&... __as) //
-    noexcept((__nothrow_callable<_Fn, _As..., ::cuda::std::__copy_cvref_t<_Self, _Ts>> && ...))
+  _CCCL_API void __reset() noexcept
   {
-    // make this local in case destroying the sub-object destroys *this
-    const auto index = __self.__index_;
-    _CCCL_ASSERT(index != __npos, "cannot visit a stateless variant");
-    ((_Idx == index
-        ? static_cast<_Fn&&>(__fn)(static_cast<_As&&>(__as)..., static_cast<_Self&&>(__self).template __get<_Idx>())
-        : void()),
-     ...);
+    if (__index_ != __npos)
+    {
+      // We must set the index to __npos *before* destroying the value on the off chance that
+      // destroying the active value might cause the destruction of *this. But then, we must
+      // tell the __visit function what the old index was so it can destroy the correct type.
+      const auto __index = ::cuda::std::exchange(__index_, __npos);
+      __visit_t::__visit(__indices(), __index, __detail::__destroy_fn{}, *this);
+    }
   }
 
-  template <size_t _Ny>
-  [[nodiscard]] _CCCL_API auto __get() && noexcept -> __at<_Ny>&&
+private:
+  friend struct __visit_t;
+
+  template <size_t, bool _Check, class _CvVariant>
+  friend _CCCL_API constexpr auto&& __variant_get(_CvVariant&& __var) noexcept;
+
+  _CCCL_TRIVIAL_API static constexpr auto __indices() noexcept -> ::cuda::std::make_index_sequence<sizeof...(_Ts)>*
   {
-    _CCCL_ASSERT(_Ny == __index_, "");
-    return static_cast<__at<_Ny>&&>(*static_cast<__at<_Ny>*>(__ptr()));
+    return nullptr;
   }
 
-  template <size_t _Ny>
-  [[nodiscard]] _CCCL_API auto __get() & noexcept -> __at<_Ny>&
-  {
-    _CCCL_ASSERT(_Ny == __index_, "");
-    return *static_cast<__at<_Ny>*>(__ptr());
-  }
-
-  template <size_t _Ny>
-  [[nodiscard]] _CCCL_API auto __get() const& noexcept -> const __at<_Ny>&
-  {
-    _CCCL_ASSERT(_Ny == __index_, "");
-    return *static_cast<const __at<_Ny>*>(__ptr());
-  }
+  size_t __index_{__npos};
+  alignas(_Ts...) unsigned char __storage_[__maximum({sizeof(_Ts)...})];
 };
 
-template <class... _Ts>
-struct __variant : __variant_impl<::cuda::std::index_sequence_for<_Ts...>, _Ts...>
-{};
+template <>
+class __variant<>
+{
+public:
+  _CCCL_HIDE_FROM_ABI __variant() noexcept = default;
+
+  [[nodiscard]] _CCCL_TRIVIAL_API static constexpr size_t __index() noexcept
+  {
+    return __npos;
+  }
+
+private:
+  friend struct __visit_t;
+
+  _CCCL_TRIVIAL_API static constexpr auto __indices() noexcept -> ::cuda::std::index_sequence<>*
+  {
+    return nullptr;
+  }
+};
 
 template <class... _Ts>
 using __nullable_variant _CCCL_NODEBUG_ALIAS = __variant<__monostate, _Ts...>;

--- a/cudax/include/cuda/experimental/__execution/when_all.cuh
+++ b/cudax/include/cuda/experimental/__execution/when_all.cuh
@@ -272,7 +272,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT when_all_t
           break;
         case __error:
           // One or more child operations completed with an error:
-          __errors_.__visit(execution::set_error, static_cast<__errors_t&&>(__errors_), static_cast<_Rcvr&&>(__rcvr_));
+          __visit(execution::set_error, static_cast<__errors_t&&>(__errors_), static_cast<_Rcvr&&>(__rcvr_));
           break;
         case __stopped:
           execution::set_stopped(static_cast<_Rcvr&&>(__rcvr_));


### PR DESCRIPTION
## Description

this PR collects some drive-by clean-ups of `cudax::execution::__variant` that i made while working on other things.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
