### PR TITLE
Error out when nvrtcc cannot parse `cuda_thread_count`

### DIFF
--- a/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc_common.h
+++ b/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc_common.h
@@ -95,6 +95,9 @@ static int parse_int_assignment(const std::string& input, std::string var, int d
     return std::stoi(match[1].str(), nullptr);
   }
 
+  fprintf(stderr, "ERROR: Could not find an integer literal for '%s' on line '%s':\r\n", var.c_str(), line.c_str());
+  exit(1);
+
   return def;
 }
 


### PR DESCRIPTION
`ncrtcc` is the compiler driver for nvrtc behind libcu++'s lit tests. Since it does not run the host part of the unit test to set `cuda_thread_count`, it regex-matches the initializer of the variable from the JIT-compiled source code. This fails when `cuda_thread_count` is not followed by an integer literal on the same source line. This cost me two days on #6608 to figure out why some unit tests got stuck via nvrtc, but ran fine with nvcc. 

This PR lets `nvrtcc` report an error if it finds the `cuda_thread_count` (or `cuda_block_shmem_size`) but fails to read the integer constant afterwards.