### PR TITLE
[BUG] use references for mdspan internal methods

### DIFF
--- a/libcudacxx/include/cuda/std/__mdspan/mdspan.h
+++ b/libcudacxx/include/cuda/std/__mdspan/mdspan.h
@@ -448,24 +448,24 @@ public:
   [[nodiscard]]
   _CCCL_API constexpr bool is_unique() const noexcept(noexcept(::cuda::std::declval<const mapping_type&>().is_unique()))
   {
-    auto __tmp = mapping(); // workaround for clang with nodiscard
+    const auto& __tmp = mapping(); // workaround for clang with nodiscard
     return __tmp.is_unique();
   }
   [[nodiscard]] _CCCL_API constexpr bool is_exhaustive() const
     noexcept(noexcept(::cuda::std::declval<const mapping_type&>().is_exhaustive()))
   {
-    auto __tmp = mapping(); // workaround for clang with nodiscard
+    const auto& __tmp = mapping(); // workaround for clang with nodiscard
     return __tmp.is_exhaustive();
   }
   [[nodiscard]] _CCCL_API constexpr bool is_strided() const
     noexcept(noexcept(::cuda::std::declval<const mapping_type&>().is_strided()))
   {
-    auto __tmp = mapping(); // workaround for clang with nodiscard
+    const auto& __tmp = mapping(); // workaround for clang with nodiscard
     return __tmp.is_strided();
   }
   [[nodiscard]] _CCCL_API constexpr index_type stride(rank_type __r) const
   {
-    auto __tmp = mapping(); // workaround for clang with nodiscard
+    const auto& __tmp = mapping(); // workaround for clang with nodiscard
     return __tmp.stride(__r);
   }
 };


### PR DESCRIPTION
Fixes #7057

## Description

Refactor mdspan methods to use const references for temporary mapping objects to fix https://github.com/NVIDIA/cccl/issues/7057
