### PR TITLE
Guard against user defined `major` and `minor` macros

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/epilogue.h
+++ b/libcudacxx/include/cuda/std/__cccl/epilogue.h
@@ -352,4 +352,20 @@ _CCCL_DIAG_POP
 #  undef _CCCL_POP_MACRO_clang
 #endif
 
+// major and minor are defined in sys/sysmacros.h in libc
+#if defined(major)
+#  error \
+    "cccl internal error: macro `major` was redefined between <cuda/std/__cccl/prologue.h> and <cuda/std/__cccl/epilogue.h>"
+#elif defined(_CCCL_POP_MACRO_major)
+#  pragma pop_macro("major")
+#  undef _CCCL_POP_MACRO_major
+#endif
+
+#if defined(minor)
+#  error \
+    "cccl internal error: macro `minor` was redefined between <cuda/std/__cccl/prologue.h> and <cuda/std/__cccl/epilogue.h>"
+#elif defined(_CCCL_POP_MACRO_minor)
+#  pragma pop_macro("minor")
+#  undef _CCCL_POP_MACRO_minor
+#endif
 // NO include guards here (this file is included multiple times)

--- a/libcudacxx/include/cuda/std/__cccl/prologue.h
+++ b/libcudacxx/include/cuda/std/__cccl/prologue.h
@@ -270,6 +270,19 @@
 #  define _CCCL_POP_MACRO_clang
 #endif // defined(clang)
 
+// major and minor are defined in sys/sysmacros.h in libc
+#if defined(major)
+#  pragma push_macro("major")
+#  undef clang
+#  define _CCCL_POP_MACRO_major
+#endif // defined(major)
+
+#if defined(minor)
+#  pragma push_macro("minor")
+#  undef clang
+#  define _CCCL_POP_MACRO_minor
+#endif // defined(minor)
+
 _CCCL_DIAG_PUSH
 _CCCL_NV_DIAG_PUSH()
 


### PR DESCRIPTION
We need to avoid using those identifiers as they are frequently used by users

Addresses nvbug5781562
