### PR TITLE
[Backport 3.2] Disable test that is failing in multiple configurations (#6745)

### DIFF
--- a/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/memory/smartptr/unique.ptr/unique.ptr.dltr/unique.ptr.dltr.dflt1/default.pass.cpp
@@ -9,6 +9,9 @@
 //===----------------------------------------------------------------------===//
 // <memory>
 
+// UNSUPPORTED: true
+// The test is dependent on compiler combination, it may pass or it might not
+
 // default_delete
 
 // Test that default_delete<T[]> has a working default constructor


### PR DESCRIPTION
We do not officially expose this though a public header, and user defined operator new is super sketchy on device, so just disable this.

Addresses nvbug5393380
