### PR TITLE
Avoid invalid compiler warning with VS2026

### DIFF
--- a/libcudacxx/test/support/type_algorithms.h
+++ b/libcudacxx/test/support/type_algorithms.h
@@ -53,11 +53,16 @@ template <class... Types>
 __host__ __device__ constexpr void swallow(Types...)
 {}
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_MSVC(4864) // nvbug5765092 latest toolchain complains about missing template
+
 template <class... Types, class Functor>
 __host__ __device__ constexpr void for_each(type_list<Types...>, Functor f)
 {
   swallow((f.template operator()<Types>(), 0)...);
 }
+
+_CCCL_DIAG_POP
 
 template <class T>
 struct type_identity


### PR DESCRIPTION
internally we are seeing invalid compiler warnings about a missing `template` keyword which is definitely there.

To unblock internal CI disable that warning until the actual compiler issue is found

Addresses nvbug5765092
