### PR TITLE
Avoid compiler issue with MSVC _CCCL_UNREACHABLE

### DIFF
--- a/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
+++ b/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
@@ -29,6 +29,7 @@
 #  include <cuda/std/__algorithm/min.h>
 #  include <cuda/std/__cstddef/types.h>
 #  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__utility/unreachable.h>
 #  include <cuda/std/array>
 #  include <cuda/std/cstdint>
 #  include <cuda/std/span>
@@ -96,7 +97,7 @@ enum class tma_swizzle
     case tma_oob_fill::nan:
       return ::CU_TENSOR_MAP_FLOAT_OOB_FILL_NAN_REQUEST_ZERO_FMA;
     default:
-      _CCCL_UNREACHABLE();
+      ::cuda::std::unreachable();
   }
 }
 
@@ -114,7 +115,7 @@ __to_cutensor_map(tma_l2_fetch_size __l2_fetch_size) noexcept
     case tma_l2_fetch_size::bytes256:
       return ::CU_TENSOR_MAP_L2_PROMOTION_L2_256B;
     default:
-      _CCCL_UNREACHABLE();
+      ::cuda::std::unreachable();
   }
 }
 
@@ -130,7 +131,7 @@ __to_cutensor_map(tma_interleave_layout __interleave_layout) noexcept
     case tma_interleave_layout::bytes32:
       return ::CU_TENSOR_MAP_INTERLEAVE_32B;
     default:
-      _CCCL_UNREACHABLE();
+      ::cuda::std::unreachable();
   }
 }
 
@@ -155,7 +156,7 @@ __to_cutensor_map(tma_interleave_layout __interleave_layout) noexcept
       return ::CU_TENSOR_MAP_SWIZZLE_128B_ATOM_64B;
 #  endif // _CCCL_CTK_AT_LEAST(12, 8)
     default:
-      _CCCL_UNREACHABLE();
+      ::cuda::std::unreachable();
   }
 }
 

--- a/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
+++ b/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
@@ -408,11 +408,11 @@ __get_tensor_sizes(const ::DLTensor& __tensor, int __rank, ::CUtensorMapDataType
 {
   using ::cuda::std::int64_t;
   __tma_strides_array_t __output_strides{1}; // inner stride is implicit = 1
-  const auto __input_strides                = __tensor.strides;
-  const auto __input_sizes                  = __tensor.shape;
-  const auto __alignment                    = (__interleave_layout == tma_interleave_layout::bytes32) ? 32 : 16;
-  constexpr auto __max_allowed_stride_bytes = int64_t{1} << 40; // 2^40
-  int64_t __cumulative_size                 = 1;
+  const auto __input_strides                 = __tensor.strides;
+  const auto __input_sizes                   = __tensor.shape;
+  const auto __alignment                     = (__interleave_layout == tma_interleave_layout::bytes32) ? 32 : 16;
+  constexpr auto __max_allowed_stride_bytes  = int64_t{1} << 40; // 2^40
+  [[maybe_unused]] int64_t __cumulative_size = 1;
   if (__input_strides == nullptr)
   {
 #  if DLPACK_MAJOR_VERSION > 1 || (DLPACK_MAJOR_VERSION == 1 && DLPACK_MINOR_VERSION >= 2)

--- a/libcudacxx/test/libcudacxx/cuda/tma/make_tma_descriptor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/tma/make_tma_descriptor.pass.cpp
@@ -228,7 +228,7 @@ bool test_enums()
         cuda::tma_swizzle swizzle,
         cuda::tma_l2_fetch_size l2_fetch_size,
         cuda::tma_oob_fill oobfill) {
-      tensor.dtype.bits    = bits;
+      tensor.dtype.bits    = static_cast<uint8_t>(bits);
       box_sizes_storage[0] = /*min_align=*/16 * /*bits=*/8 / tensor.dtype.bits;
       box_sizes_storage[1] = /*min_align=*/16 * /*bits=*/8 / tensor.dtype.bits;
       box_sizes_storage[2] = /*min_align=*/16 * /*bits=*/8 / tensor.dtype.bits;
@@ -280,7 +280,7 @@ bool test_enums()
                   kDLFloat8_e5m2fnuz,
                   kDLFloat8_e8m0fnu})
             {
-              tensor.dtype.code  = code;
+              tensor.dtype.code  = static_cast<uint8_t>(code);
               constexpr int bits = 8;
               exec_make_tma_descriptor(bits, no_interleave, swizzle, l2_fetch_size, oobfill);
             }


### PR DESCRIPTION
For whatever reason the compiler cannot deal with `_CCCL_UNREACHABLE()` but `::cuda::std::unreachable` seems fine, so we are going for that.

:shrug:

Fixes nvbug5778303