### PR TITLE
Expand warning suppression for braces around subobject

### DIFF
--- a/libcudacxx/include/cuda/__memory/is_pointer_accessible.h
+++ b/libcudacxx/include/cuda/__memory/is_pointer_accessible.h
@@ -28,6 +28,10 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
+// clang complains about missing braces in CUmemLocation constructor but GCC complains if we add them
+
 _CCCL_BEGIN_NAMESPACE_CUDA
 
 #if _CCCL_HAS_CTK() && !_CCCL_COMPILER(NVRTC)
@@ -140,10 +144,6 @@ _CCCL_HOST_API inline bool __is_host_accessible_nothrow(const void* __p) noexcep
 {
   return ::cuda::__is_host_accessible(__p, ::cuda::std::true_type{});
 }
-
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
-// clang complains about missing braces in CUmemLocation constructor but GCC complains if we add them
 
 /**
  * @brief Checks if a pointer is a device pointer.
@@ -265,13 +265,13 @@ _CCCL_HOST_API inline bool __is_device_accessible_nothrow(const void* __p, devic
   return ::cuda::__is_device_accessible(__p, __device, ::cuda::std::true_type{});
 }
 
-_CCCL_DIAG_POP
-
 #  undef _CCCL_THROW_OR_RETURN
 
 #endif // _CCCL_HAS_CTK() && !_CCCL_COMPILER(NVRTC)
 
 _CCCL_END_NAMESPACE_CUDA
+
+_CCCL_DIAG_POP
 
 #include <cuda/std/__cccl/epilogue.h>
 


### PR DESCRIPTION
We need to disable a warning about missing braces around a subobject, because clang warns without them but GCC warns if we add them.

Unfortunately I was too conservative in my warning suppression placement and we added annother occurence outside of the push pop
