### PR TITLE
[libcu++] Fix driver api test after curand changes

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/driver_api.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/utility/driver_api.c2h.cu
@@ -60,6 +60,12 @@ C2H_TEST("Call each driver api", "[utility]")
   CCCLRT_REQUIRE(driver::__primaryCtxReleaseNoThrow(0) == cudaSuccess);
   CCCLRT_REQUIRE(driver::__primaryCtxReleaseNoThrow(0) == cudaSuccess);
 
+  // Try a third release in case curand retained the primary ctx as well
+  if (driver::__isPrimaryCtxActive(0))
+  {
+    CCCLRT_REQUIRE(driver::__primaryCtxReleaseNoThrow(0) == cudaSuccess);
+  }
+
   CCCLRT_REQUIRE(!driver::__isPrimaryCtxActive(0));
 
   // Confirm cudart can recover


### PR DESCRIPTION
It seems that https://github.com/NVIDIA/cccl/pull/7067 caused all c2h tests to initialize curand which retains the primary context and it ended up breaking the driver API test, which expected the primary context to be inactive after two release calls.
This PR adds an optional third release to account for curand