### PR TITLE
Disable _CCCL_NO_UNIQUE_ADDRESS for CTK 12.9

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -157,7 +157,7 @@
 
 // _CCCL_NO_UNIQUE_ADDRESS
 
-#if _CCCL_COMPILER(MSVC) || _CCCL_HAS_CPP_ATTRIBUTE(no_unique_address) < 201803L || _CCCL_CTK_EQUAL(12, 9)
+#if _CCCL_COMPILER(MSVC) || _CCCL_HAS_CPP_ATTRIBUTE(no_unique_address) < 201803L || _CCCL_CUDA_COMPILER(NVCC, <, 13)
 // MSVC implementation has lead to multiple issues with silent runtime corruption when passing data into kernels
 // CTK 12.9 seg faults when using [[no_unique_address]] with instantiations of empty base classes
 #  define _CCCL_HAS_ATTRIBUTE_NO_UNIQUE_ADDRESS() 0

--- a/libcudacxx/include/cuda/std/__cccl/cuda_toolkit.h
+++ b/libcudacxx/include/cuda/std/__cccl/cuda_toolkit.h
@@ -52,6 +52,5 @@
 #define _CCCL_CTK_MAKE_VERSION(_MAJOR, _MINOR) ((_MAJOR) * 1000 + (_MINOR) * 10)
 #define _CCCL_CTK_BELOW(...)                   _CCCL_VERSION_COMPARE(_CCCL_CTK_, _CCCL_CTK, <, __VA_ARGS__)
 #define _CCCL_CTK_AT_LEAST(...)                _CCCL_VERSION_COMPARE(_CCCL_CTK_, _CCCL_CTK, >=, __VA_ARGS__)
-#define _CCCL_CTK_EQUAL(...)                   _CCCL_VERSION_COMPARE(_CCCL_CTK_, _CCCL_CTK, ==, __VA_ARGS__)
 
 #endif // __CCCL_CUDA_TOOLKIT_H


### PR DESCRIPTION
## Description

closes #7111 

`::cuda::std::__tuple` fails to compile with empty classes when `_CCCL_NO_UNIQUE_ADDRESS` is defined on CTK 12.9 with both GCC and Clang with both C++17,20. 

We might have to disable `_CCCL_NO_UNIQUE_ADDRESS` macro for CTK 12.9, inorder to make stateless env work properly. 


