### PR TITLE
Add support for `__tuple_like` for `::std::{array, pair, tuple}`

### DIFF
--- a/libcudacxx/include/cuda/std/__complex/tuple.h
+++ b/libcudacxx/include/cuda/std/__complex/tuple.h
@@ -33,11 +33,11 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>
-struct tuple_size<complex<_Tp>> : ::cuda::std::integral_constant<size_t, 2>
+struct tuple_size<complex<_Tp>> : integral_constant<size_t, 2>
 {};
 
 template <size_t _Index, class _Tp>
-  struct tuple_element<_Index, complex<_Tp>> : ::cuda::std::enable_if < _Index<2, _Tp>
+struct tuple_element<_Index, complex<_Tp>> : enable_if<(_Index < 2), _Tp>
 {};
 
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__fwd/array.h
+++ b/libcudacxx/include/cuda/std/__fwd/array.h
@@ -24,6 +24,24 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+// std:: forward declarations
+
+#if _CCCL_HAS_HOST_STD_LIB()
+_CCCL_BEGIN_NAMESPACE_STD
+
+#  if _CCCL_HOST_STD_LIB(STL)
+template <class _Tp, size_t _Size>
+class array;
+#  else // ^^^ _CCCL_HOST_STD_LIB(STL) ^^^ / vvv !_CCCL_HOST_STD_LIB(STL) vvv
+template <class _Tp, size_t _Size>
+struct array;
+#  endif // !_CCCL_HOST_STD_LIB(STL)
+
+_CCCL_END_NAMESPACE_STD
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+// ::cuda::std:: forward declaration
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp, size_t _Size>

--- a/libcudacxx/include/cuda/std/__fwd/tuple.h
+++ b/libcudacxx/include/cuda/std/__fwd/tuple.h
@@ -22,6 +22,15 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if _CCCL_HAS_HOST_STD_LIB()
+_CCCL_BEGIN_NAMESPACE_STD
+
+template <class...>
+class tuple;
+
+_CCCL_END_NAMESPACE_STD
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class...>

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_element.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_element.h
@@ -20,12 +20,17 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/array.h>
+#include <cuda/std/__fwd/complex.h>
+#include <cuda/std/__fwd/pair.h>
 #include <cuda/std/__fwd/tuple.h>
 #include <cuda/std/__tuple_dir/tuple_indices.h>
 #include <cuda/std/__tuple_dir/tuple_types.h>
 #include <cuda/std/__type_traits/add_const.h>
 #include <cuda/std/__type_traits/add_cv.h>
 #include <cuda/std/__type_traits/add_volatile.h>
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/type_list.h>
 #include <cuda/std/cstddef>
 
@@ -60,7 +65,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, const volatile _Tp>
 template <size_t _Ip, class... _Types>
 struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, __tuple_types<_Types...>>
 {
-  static_assert(_Ip < sizeof...(_Types), "tuple_element index out of range");
+  static_assert(_Ip < sizeof...(_Types), "cuda::std::tuple_element index out of range");
   using type _CCCL_NODEBUG_ALIAS = __type_index_c<_Ip, _Types...>;
 };
 
@@ -69,6 +74,27 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, tuple<_Tp...>>
 {
   using type _CCCL_NODEBUG_ALIAS = tuple_element_t<_Ip, __tuple_types<_Tp...>>;
 };
+
+#if _CCCL_HAS_HOST_STD_LIB()
+template <size_t _Ip, class _Tp, size_t _Np>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, ::std::array<_Tp, _Np>> : enable_if<(_Ip < _Np), _Tp>
+{};
+
+template <size_t _Ip, class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, ::std::complex<_Tp>> : enable_if<(_Ip < 2), _Tp>
+{};
+
+template <size_t _Ip, class _T1, class _T2>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT
+tuple_element<_Ip, ::std::pair<_T1, _T2>> : enable_if<(_Ip < 2), conditional_t<_Ip == 0, _T1, _T2>>
+{};
+
+template <size_t _Ip, class... _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_element<_Ip, ::std::tuple<_Tp...>>
+{
+  using type _CCCL_NODEBUG_ALIAS = tuple_element_t<_Ip, __tuple_types<_Tp...>>;
+};
+#endif // _CCCL_HAS_HOST_STD_LIB()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_like.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_like.h
@@ -50,11 +50,26 @@ inline constexpr bool __tuple_like_impl<const volatile _Tp> = __tuple_like_impl<
 template <class... _Tp>
 inline constexpr bool __tuple_like_impl<tuple<_Tp...>> = true;
 
+#if _CCCL_HAS_HOST_STD_LIB()
+template <class... _Tp>
+inline constexpr bool __tuple_like_impl<::std::tuple<_Tp...>> = true;
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
 template <class _T1, class _T2>
 inline constexpr bool __tuple_like_impl<pair<_T1, _T2>> = true;
 
+#if _CCCL_HAS_HOST_STD_LIB()
+template <class _T1, class _T2>
+inline constexpr bool __tuple_like_impl<::std::pair<_T1, _T2>> = true;
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
 template <class _Tp, size_t _Size>
 inline constexpr bool __tuple_like_impl<array<_Tp, _Size>> = true;
+
+#if _CCCL_HAS_HOST_STD_LIB()
+template <class _Tp, size_t _Size>
+inline constexpr bool __tuple_like_impl<::std::array<_Tp, _Size>> = true;
+#endif // _CCCL_HAS_HOST_STD_LIB()
 
 template <class _Tp>
 inline constexpr bool __tuple_like_impl<complex<_Tp>> = true;

--- a/libcudacxx/include/cuda/std/__tuple_dir/tuple_size.h
+++ b/libcudacxx/include/cuda/std/__tuple_dir/tuple_size.h
@@ -20,6 +20,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__fwd/array.h>
+#include <cuda/std/__fwd/complex.h>
+#include <cuda/std/__fwd/pair.h>
 #include <cuda/std/__fwd/tuple.h>
 #include <cuda/std/__tuple_dir/tuple_types.h>
 #include <cuda/std/__type_traits/enable_if.h>
@@ -71,6 +74,25 @@ tuple_size<__tuple_types<_Tp...>> : public integral_constant<size_t, sizeof...(_
 
 template <class _Tp>
 inline constexpr size_t tuple_size_v = tuple_size<_Tp>::value;
+
+#if _CCCL_HAS_HOST_STD_LIB()
+template <class _Tp, size_t _Np>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_size<::std::array<_Tp, _Np>> : public integral_constant<size_t, _Np>
+{};
+
+template <class _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_size<::std::complex<_Tp>> : integral_constant<size_t, 2>
+{};
+
+template <class _T1, class _T2>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_size<::std::pair<_T1, _T2>> : public integral_constant<size_t, 2>
+{};
+
+template <class... _Tp>
+struct _CCCL_TYPE_VISIBILITY_DEFAULT tuple_size<::std::tuple<_Tp...>> : public integral_constant<size_t, sizeof...(_Tp)>
+{};
+
+#endif // _CCCL_HAS_HOST_STD_LIB()
 
 _CCCL_END_NAMESPACE_CUDA_STD
 

--- a/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/from_tuple_like.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/complex/complex.number/complex.members/constructors/from_tuple_like.pass.cpp
@@ -183,22 +183,6 @@ TEST_FUNC constexpr bool test()
 
 #if !_CCCL_COMPILER(NVRTC)
 
-template <class... Args>
-struct cuda::std::tuple_size<std::tuple<Args...>> : cuda::std::integral_constant<cuda::std::size_t, sizeof...(Args)>
-{};
-
-template <std::size_t I, class... Args>
-struct cuda::std::tuple_element<I, std::tuple<Args...>> : std::tuple_element<I, cuda::std::tuple<Args...>>
-{};
-
-template <class A, class B>
-struct cuda::std::tuple_size<std::pair<A, B>> : cuda::std::integral_constant<cuda::std::size_t, 2>
-{};
-
-template <cuda::std::size_t I, class A, class B>
-struct cuda::std::tuple_element<I, std::pair<A, B>> : cuda::std::conditional<I == 0, A, B>
-{};
-
 template <class T>
 void test_constructor_from_host_tuple_like()
 {

--- a/libcudacxx/test/libcudacxx/cuda/utilities/tuple/std_types_tuple_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/tuple/std_types_tuple_element.pass.cpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+
+#include <array>
+#include <complex>
+#include <tuple>
+#include <utility>
+
+#include "test_macros.h"
+
+template <class STD_TYPE, size_t Index, typename Expected>
+__host__ __device__ constexpr void test()
+{
+  static_assert(cuda::std::is_same_v<cuda::std::tuple_element_t<Index, STD_TYPE>, Expected>);
+  static_assert(cuda::std::is_same_v<cuda::std::tuple_element_t<Index, const STD_TYPE>, const Expected>);
+  static_assert(cuda::std::is_same_v<cuda::std::tuple_element_t<Index, volatile STD_TYPE>, volatile Expected>);
+  static_assert(
+    cuda::std::is_same_v<cuda::std::tuple_element_t<Index, const volatile STD_TYPE>, const volatile Expected>);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // complex has both elements as the template argument
+  test<::std::complex<float>, 0, float>();
+  test<::std::complex<float>, 1, float>();
+  test<::std::complex<double>, 0, double>();
+  test<::std::complex<double>, 1, double>();
+#if _CCCL_HAS_NVFP16()
+  test<::std::complex<__half>, 0, __half>();
+  test<::std::complex<__half>, 1, __half>();
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+  test<::std::complex<__nv_bfloat16>, 0, __nv_bfloat16>();
+  test<::std::complex<__nv_bfloat16>, 1, __nv_bfloat16>();
+#endif // _CCCL_HAS_NVBF16()
+
+  test<::std::pair<int, float>, 0, int>();
+  test<::std::pair<int, float>, 1, float>();
+
+  // tuple has the size of the number of template arguments
+  test<::std::tuple<int>, 0, int>();
+  test<::std::tuple<int, float>, 0, int>();
+  test<::std::tuple<int, float>, 1, float>();
+  test<::std::tuple<int, float, short>, 0, int>();
+  test<::std::tuple<int, float, short>, 1, float>();
+  test<::std::tuple<int, float, short>, 2, short>();
+
+  // array has always the same element
+  test<::std::array<int, 4>, 0, int>();
+  test<::std::array<int, 4>, 1, int>();
+  test<::std::array<int, 4>, 2, int>();
+  test<::std::array<int, 4>, 3, int>();
+
+  return true;
+}
+
+int main(int arg, char** argv)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/utilities/tuple/std_types_tuple_size.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/utilities/tuple/std_types_tuple_size.pass.cpp
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/std/cassert>
+#include <cuda/std/tuple>
+
+#include <array>
+#include <complex>
+#include <tuple>
+#include <utility>
+
+#include "test_macros.h"
+
+template <class STD_TYPE, size_t Size>
+__host__ __device__ constexpr void test()
+{
+  static_assert(cuda::std::tuple_size<STD_TYPE>::value == Size);
+  static_assert(cuda::std::tuple_size<const STD_TYPE>::value == Size);
+  static_assert(cuda::std::tuple_size<volatile STD_TYPE>::value == Size);
+  static_assert(cuda::std::tuple_size<const volatile STD_TYPE>::value == Size);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  // complex has a size of 2
+  test<::std::complex<float>, 2>();
+  test<::std::complex<double>, 2>();
+#if _CCCL_HAS_NVFP16()
+  test<::std::complex<__half>, 2>();
+#endif // _CCCL_HAS_NVFP16()
+#if _CCCL_HAS_NVBF16()
+  test<::std::complex<__nv_bfloat16>, 2>();
+#endif // _CCCL_HAS_NVBF16()
+
+  // pair always has a size of 2
+  test<::std::pair<int, float>, 2>();
+
+  // tuple has the size of the number of template arguments
+  test<::std::tuple<int>, 1>();
+  test<::std::tuple<int, int>, 2>();
+  test<::std::tuple<int, int, int>, 3>();
+
+  // array has the size of the number of elements
+  test<::std::array<int, 4>, 4>();
+  test<::std::array<int, 1337>, 1337>();
+
+  return true;
+}
+
+int main(int arg, char** argv)
+{
+  test();
+  static_assert(test());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/pair_like.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/pair_like.pass.cpp
@@ -1,0 +1,265 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <mdspan>
+
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/complex>
+#include <cuda/std/mdspan>
+#include <cuda/std/tuple>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include "helper.h"
+#include "test_macros.h"
+
+#if !TEST_COMPILER(NVRTC)
+#  include <array>
+#  include <tuple>
+#  include <utility>
+#endif // !TEST_COMPILER(NVRTC)
+
+template <class Tuple>
+__host__ __device__ constexpr void test()
+{
+  constexpr char data[] = {'H', 'O', 'P', 'P', 'E', 'R'};
+
+  { // 1d mdspan
+    // ['H', 'O', 'P', 'P', 'E', 'R']
+    cuda::std::dims<1> extent{6};
+    cuda::std::layout_left::mapping<cuda::std::dims<1>> mapping{extent};
+    cuda::std::mdspan md{data, mapping};
+    static_assert(md.rank() == 1);
+    static_assert(md.rank_dynamic() == 1);
+    assert(equal_to(md, "HOPPER"));
+
+    using mdspan_t = decltype(md);
+    static_assert(cuda::std::is_same_v<typename mdspan_t::layout_type, cuda::std::layout_left>);
+
+    { // Slice of elements from start 0:4
+      // ['H', 'O', 'P', 'P', 'E', 'R']
+      // [ x    x    x    x           ]
+      const auto slice      = Tuple{0, 4};
+      cuda::std::mdspan sub = cuda::std::submdspan(md, slice);
+
+      static_assert(sub.rank() == 1);
+      static_assert(sub.rank_dynamic() == 1);
+
+      using submdspan_t = decltype(sub);
+      static_assert(cuda::std::is_same_v<typename submdspan_t::layout_type, cuda::std::layout_left>);
+
+      assert(sub.stride(0) == 1);
+      assert(sub.extent(0) == 4);
+      assert(sub.size() == 4);
+      assert(equal_to(sub, "HOPP"));
+    }
+
+    { // Slice of elements in the middle 2:5
+      // ['H', 'O', 'P', 'P', 'E', 'R']
+      // [           x    x    x      ]
+      const auto slice      = Tuple{2, 5};
+      cuda::std::mdspan sub = cuda::std::submdspan(md, slice);
+
+      static_assert(sub.rank() == 1);
+      static_assert(sub.rank_dynamic() == 1);
+
+      using submdspan_t = decltype(sub);
+      static_assert(cuda::std::is_same_v<typename submdspan_t::layout_type, cuda::std::layout_left>);
+
+      assert(sub.stride(0) == 1);
+      assert(sub.extent(0) == 3);
+      assert(sub.size() == 3);
+      assert(equal_to(sub, "PPE"));
+    }
+
+    { // Slice of elements in the end 3:6
+      // ['H', 'O', 'P', 'P', 'E', 'R']
+      // [                x    x    x ]
+      const auto slice      = Tuple{3, 6};
+      cuda::std::mdspan sub = cuda::std::submdspan(md, slice);
+
+      static_assert(sub.rank() == 1);
+      static_assert(sub.rank_dynamic() == 1);
+
+      using submdspan_t = decltype(sub);
+      static_assert(cuda::std::is_same_v<typename submdspan_t::layout_type, cuda::std::layout_left>);
+
+      assert(sub.stride(0) == 1);
+      assert(sub.extent(0) == 3);
+      assert(sub.size() == 3);
+      assert(equal_to(sub, "PER"));
+    }
+  }
+
+  { // 2d mdspan
+    // ['H', 'P', 'E']
+    // ['O', 'P', 'R']
+    cuda::std::dims<2> extent{2, 3};
+    cuda::std::layout_left::mapping<cuda::std::dims<2>> mapping{extent};
+    cuda::std::mdspan md{data, mapping};
+    static_assert(md.rank() == 2);
+    static_assert(md.rank_dynamic() == 2);
+
+    assert(md.stride(0) == 1);
+    assert(md.stride(1) == md.extent(0));
+    assert(md.extent(0) == 2);
+    assert(md.extent(1) == 3);
+    assert(md.size() == 6);
+    assert(equal_to(md, {"HPE", "OPR"}));
+
+    { // full extent, then slice of elements from start 0:2
+      // ['H', 'P', 'E'] [ x ] [ x    x      ]
+      // ['O', 'P', 'R'] [ x ] [ x    x      ]
+      const auto slice2     = Tuple{0, 2};
+      cuda::std::mdspan sub = cuda::std::submdspan(md, cuda::std::full_extent, slice2);
+
+      static_assert(sub.rank() == 2);
+      static_assert(sub.rank_dynamic() == 2);
+
+      using submdspan_t = decltype(sub);
+      static_assert(cuda::std::is_same_v<typename submdspan_t::layout_type, cuda::std::layout_left>);
+
+      assert(sub.stride(0) == md.stride(0));
+      assert(sub.stride(1) == md.stride(1));
+      assert(sub.extent(0) == md.extent(0));
+      assert(sub.extent(1) == 2);
+      assert(sub.size() == 4);
+      assert(equal_to(sub, {"HP", "OP"}));
+    }
+
+    { // Slice of elements from start 0:1, then full extent
+      // ['H', 'P', 'E'] [ x ] [ x    x    x ]
+      // ['O', 'P', 'R'] [   ] [             ]
+      const auto slice1     = Tuple{0, 1};
+      cuda::std::mdspan sub = cuda::std::submdspan(md, slice1, cuda::std::full_extent);
+
+      static_assert(sub.rank() == 2);
+      static_assert(sub.rank_dynamic() == 2);
+
+      using submdspan_t = decltype(sub);
+      static_assert(cuda::std::is_same_v<typename submdspan_t::layout_type, cuda::std::layout_stride>);
+
+      assert(sub.stride(0) == md.stride(0));
+      assert(sub.stride(1) == md.stride(1));
+      assert(sub.extent(0) == 1);
+      assert(sub.extent(1) == md.extent(1));
+      assert(sub.size() == 3);
+      assert(equal_to(sub, {"HPE", ""}));
+    }
+
+    { // Slice of elements from middle 1:2, then strided_slice without offset, full size and stride 1
+      // ['H', 'P', 'E'] [   ] [             ]
+      // ['O', 'P', 'R'] [ x ] [ x    x    x ]
+      const auto slice1 = Tuple{1, 2};
+      const cuda::std::strided_slice slice2{0, md.extent(1), 1};
+      cuda::std::mdspan sub = cuda::std::submdspan(md, slice1, slice2);
+
+      static_assert(sub.rank() == 2);
+      static_assert(sub.rank_dynamic() == 2);
+
+      using submdspan_t = decltype(sub);
+      static_assert(cuda::std::is_same_v<typename submdspan_t::layout_type, cuda::std::layout_stride>);
+
+      assert(sub.stride(0) == md.stride(0));
+      assert(sub.stride(1) == md.stride(1));
+      assert(sub.extent(0) == 1);
+      assert(sub.extent(1) == md.extent(1));
+      assert(sub.size() == 3);
+      assert(equal_to(sub, {"OPR", ""}));
+    }
+
+    { // Slice of elements from middle 1:2, then strided_slice with offset, full size and stride 1
+      // ['H', 'P', 'E'] [   ] [             ]
+      // ['O', 'P', 'R'] [ x ] [      x    x ]
+      const auto slice1 = Tuple{1, 2};
+      const cuda::std::strided_slice slice2{1, md.extent(1) - 1, 1};
+      cuda::std::mdspan sub = cuda::std::submdspan(md, slice1, slice2);
+
+      static_assert(sub.rank() == 2);
+      static_assert(sub.rank_dynamic() == 2);
+
+      using submdspan_t = decltype(sub);
+      static_assert(cuda::std::is_same_v<typename submdspan_t::layout_type, cuda::std::layout_stride>);
+
+      assert(sub.stride(0) == md.stride(0));
+      assert(sub.stride(1) == md.stride(1));
+      assert(sub.extent(0) == 1);
+      assert(sub.extent(1) == md.extent(1) - 1);
+      assert(sub.size() == 2);
+      assert(equal_to(sub, {"PR", ""}));
+    }
+
+    { // Slice of elements from middle 1:2, then strided_slice without offset, full size and stride 2
+      // ['H', 'P', 'E'] [   ] [             ]
+      // ['O', 'P', 'R'] [ x ] [ x         x ]
+      const auto slice1 = Tuple{1, 2};
+      const cuda::std::strided_slice slice2{0, md.extent(1), 2};
+      cuda::std::mdspan sub = cuda::std::submdspan(md, slice1, slice2);
+
+      static_assert(sub.rank() == 2);
+      static_assert(sub.rank_dynamic() == 2);
+
+      using submdspan_t = decltype(sub);
+      static_assert(cuda::std::is_same_v<typename submdspan_t::layout_type, cuda::std::layout_stride>);
+
+      assert(sub.stride(0) == md.stride(0));
+      assert(sub.stride(1) == 2 * md.stride(1));
+      assert(sub.extent(0) == 1);
+      assert(sub.extent(1) == md.extent(1) - 1);
+      assert(sub.size() == 2);
+      assert(equal_to(sub, {"OR", ""}));
+    }
+
+    { // Slice of elements from middle 1:2, then index
+      // ['H', 'P', 'E'] [   ] [             ]
+      // ['O', 'P', 'R'] [ x ] [           x ]
+      const auto slice1     = Tuple{1, 2};
+      cuda::std::mdspan sub = cuda::std::submdspan(md, slice1, 2);
+
+      static_assert(sub.rank() == 1);
+      static_assert(sub.rank_dynamic() == 1);
+
+      using submdspan_t = decltype(sub);
+      static_assert(cuda::std::is_same_v<typename submdspan_t::layout_type, cuda::std::layout_stride>);
+
+      assert(sub.stride(0) == md.stride(0));
+      assert(sub.extent(0) == 1);
+      assert(sub.size() == 1);
+      assert(equal_to(sub, "R"));
+    }
+  }
+}
+
+__host__ __device__ constexpr bool test()
+{
+  test<cuda::std::array<int, 2>>();
+  test<cuda::std::pair<int, int>>();
+  test<cuda::std::tuple<int, int>>();
+  test<cuda::std::complex<int>>();
+
+#if !TEST_COMPILER(NVRTC)
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 test<std::array<int, 2>>();
+                 test<std::pair<int, int>>();
+                 test<std::tuple<int, int>>();
+               }))
+#endif // !TEST_COMPILER(NVRTC)
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if !_CCCL_COMPILER(GCC, <, 11) // gcc-10 complains about __submdspan_offset not being constexpr...
+  static_assert(test());
+#endif // !_CCCL_COMPILER(GCC, <, 11)
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/pair_like.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/submdspan/pair_like.pass.cpp
@@ -114,6 +114,7 @@ __host__ __device__ constexpr void test()
     assert(md.size() == 6);
     assert(equal_to(md, {"HPE", "OPR"}));
 
+#if !TEST_COMPILER(MSVC) // error C3546: '...': there are no parameter packs available to expand
     { // full extent, then slice of elements from start 0:2
       // ['H', 'P', 'E'] [ x ] [ x    x      ]
       // ['O', 'P', 'R'] [ x ] [ x    x      ]
@@ -133,6 +134,7 @@ __host__ __device__ constexpr void test()
       assert(sub.size() == 4);
       assert(equal_to(sub, {"HP", "OP"}));
     }
+#endif // !TEST_COMPILER(MSVC)
 
     { // Slice of elements from start 0:1, then full extent
       // ['H', 'P', 'E'] [ x ] [ x    x    x ]


### PR DESCRIPTION
This allows us to use standard library types with submdspan

Fixes [BUG]: CUDA 13.1 cuda::std::mdspan does not implement P3663 Fixes #7110
