### PR TITLE
libcu++: silence msvc+nvcc12.9 warning plaguing c.parallel.

### DIFF
--- a/libcudacxx/include/cuda/std/__complex/roots.h
+++ b/libcudacxx/include/cuda/std/__complex/roots.h
@@ -78,10 +78,10 @@ template <class _Tp>
 
   // NVCC 12.9 seems to be eliminating some parentheses which makes MSVC unhappy.
   _CCCL_DIAG_PUSH
-#if _CCCL_CUDACC_BELOW(13, 0)
+#if _CCCL_CUDA_COMPILER(NVCC, <, 13, 0)
   _CCCL_DIAG_SUPPRESS_MSVC(4554) // warning C4554: '<<': check operator precedence for possible error; use parentheses
                                  // to clarify precedence
-#endif
+#endif // _CCCL_CUDA_COMPILER(NVCC, <, 13, 0)
 
   // Get some bounds where __re +- |__x| won't overflow.
   // Doesn't need to be too exact, enough to cover extremal cases.


### PR DESCRIPTION
## Description

Seems like there's shenanigans in nvcc 12.9's output w.r.t. parentheses, and that makes msvc unhappy: https://github.com/NVIDIA/cccl/actions/runs/20770250706/job/59644951459?pr=7007#step:4:1321. Silence that warning.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
