### PR TITLE
Add Android-specific assert handling in `__cccl/assert.h`

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/assert.h
+++ b/libcudacxx/include/cuda/std/__cccl/assert.h
@@ -90,6 +90,10 @@ void __assert_fail(const char* __assertion, const char* __file, unsigned int __l
 #    define _CCCL_ASSERT_IMPL_HOST(expression, message)      \
       _CCCL_BUILTIN_EXPECT(static_cast<bool>(expression), 1) \
       ? (void) 0 : __assert_rtn(__func__, __FILE__, __LINE__, __message__)
+#  elif _CCCL_OS(ANDROID)
+#    define _CCCL_ASSERT_IMPL_HOST(expression, message)      \
+      _CCCL_BUILTIN_EXPECT(static_cast<bool>(expression), 1) \
+      ? (void) 0 : __assert2(__FILE__, __LINE__, __func__, message)
 #  else // ^^^ _CCCL_OS(APPLE) ^^^ / vvv !_CCCL_OS(APPLE) ^^^
 #    define _CCCL_ASSERT_IMPL_HOST(expression, message)      \
       _CCCL_BUILTIN_EXPECT(static_cast<bool>(expression), 1) \
@@ -110,6 +114,10 @@ void __assert_fail(const char* __assertion, const char* __file, unsigned int __l
 #    define _CCCL_ASSERT_IMPL_DEVICE(expression, message)    \
       _CCCL_BUILTIN_EXPECT(static_cast<bool>(expression), 1) \
       ? (void) 0 : _wassert(_CRT_WIDE(#message), __FILEW__, __LINE__)
+#  elif _CCCL_OS(ANDROID)
+#    define _CCCL_ASSERT_IMPL_DEVICE(expression, message)    \
+      _CCCL_BUILTIN_EXPECT(static_cast<bool>(expression), 1) \
+      ? (void) 0 : __assert2(__FILE__, __LINE__, __func__, message)
 #  else // ^^^ _CCCL_COMPILER(MSVC) ^^^ / vvv !_CCCL_COMPILER(MSVC) vvv
 #    define _CCCL_ASSERT_IMPL_DEVICE(expression, message)    \
       _CCCL_BUILTIN_EXPECT(static_cast<bool>(expression), 1) \


### PR DESCRIPTION
## Description

Replaced `__assert_fail` with `__assert2` for Android Bionic libc implementation https://android.googlesource.com/platform/bionic/+/main/libc/include/assert.h

Updated `_CCCL_ASSERT_IMPL_HOST` and `_CCCL_ASSERT_IMPL_DEVICE` macros for Android to utilize `__assert2` for assertion failures.


