### PR TITLE
[branch 3.2.x] Revert "Change the MSVC preprocessor check to an error. (#6827)"

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/preprocessor.h
+++ b/libcudacxx/include/cuda/std/__cccl/preprocessor.h
@@ -11,16 +11,14 @@
 #ifndef __CCCL_PREPROCESSOR_H
 #define __CCCL_PREPROCESSOR_H
 
-// Error when MSVC is used with the traditional preprocessor.
-// We can't use `#pragma message` here because MSVC will encounter
-// errors and exit before it processes pragma message directives.
+// warn when MSVC is used with the traditional preprocessor
 #if defined(_MSC_VER) && !defined(__clang__)
 #  if (!defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL == 1) \
     && !defined(CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING)
-#    error \
-MSVC/cl.exe with traditional preprocessor is used. This may lead to unexpected compilation errors. Please \
-switch to the standard conforming preprocessor by passing `/Zc:preprocessor` to cl.exe. You can define \
-CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING to suppress this warning.
+#    pragma message(                                                                                               \
+      "MSVC/cl.exe with traditional preprocessor is used. This may lead to unexpected compilation errors. Please " \
+      "switch to the standard conforming preprocessor by passing `/Zc:preprocessor` to cl.exe. You can define "    \
+      "CCCL_IGNORE_MSVC_TRADITIONAL_PREPROCESSOR_WARNING to suppress this warning.")
 #  endif // !defined(_MSVC_TRADITIONAL) || _MSVC_TRADITIONAL == 1
 #endif // defined(_MSC_VER) && !defined(__clang__)
 


### PR DESCRIPTION
This reverts commit f3335eb78ba0968e729957367fa8c4064bd251d9.

## Description

Reverts the preprocessor error due to failures with other infrastructure.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
