### PR TITLE
Align local vector storage arrays in vec transform

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -251,7 +251,9 @@ _CCCL_DEVICE void transform_kernel_vectorized(
 
   // if we can vectorize, we convert f's return type to the output type right away, so we can reinterpret later
   using THRUST_NS_QUALIFIER::cuda_cub::core::detail::uninitialized_array;
-  uninitialized_array<::cuda::std::conditional_t<can_vectorize_store, output_t, result_t>, items_per_thread> output;
+  using output_array_t                  = ::cuda::std::conditional_t<can_vectorize_store, output_t, result_t>;
+  constexpr auto output_array_alignment = can_vectorize_store ? sizeof(output_t) * vec_size : alignof(result_t);
+  uninitialized_array<output_array_t, items_per_thread, output_array_alignment> output;
 
   auto provide_array = [&](auto... inputs) {
     // load inputs
@@ -298,7 +300,9 @@ _CCCL_DEVICE void transform_kernel_vectorized(
       output[i] = f(inputs[i]...);
     }
   };
-  provide_array(uninitialized_array<it_value_t<RandomAccessIteratorsIn>, items_per_thread>{}...);
+  provide_array(uninitialized_array<it_value_t<RandomAccessIteratorsIn>,
+                                    items_per_thread,
+                                    sizeof(it_value_t<RandomAccessIteratorsIn>) * vec_size>{}...);
 
   // write output
   if constexpr (can_vectorize_store)

--- a/thrust/thrust/system/cuda/detail/core/util.h
+++ b/thrust/thrust/system/cuda/detail/core/util.h
@@ -510,12 +510,12 @@ struct uninitialized
 // uninitialized_array
 // --------------
 // allocates uninitialized data on stack
-template <class T, size_t N>
+template <class T, size_t N, size_t Alignment = alignof(T)>
 struct uninitialized_array
 {
   using value_type = T;
   static constexpr ::cuda::std::integral_constant<size_t, N> size{};
-  alignas(T) char data_[N * sizeof(T)];
+  alignas(Alignment) char data_[N * sizeof(T)];
 
   _CCCL_HOST_DEVICE T* data()
   {


### PR DESCRIPTION
We previously only aligned to `alignof(T)` and not `alignof(T) * vec_size`. This wasn't noticed since the compiler just keeps the data in registers anyway. However, in a debug build, the arrays are spilled to local memory so the alignment matters.

Small SASS changes for `cub.test.device.transform.lid_0` on sm86 and sm120 but only a few immediates: 
```
<         /*00b0*/                   IMAD.MOV.U32 R8, RZ, RZ, 0x3e2 ;                           /* 0x000003e2ff087424 */
---
>         /*00b0*/                   IMAD.MOV.U32 R8, RZ, RZ, 0x3e6 ;                           /* 0x000003e6ff087424 */
29401c29401
<         /*0220*/                   IMAD.MOV.U32 R8, RZ, RZ, 0x230 ;                           /* 0x00000230ff087424 */
---
>         /*0220*/                   IMAD.MOV.U32 R8, RZ, RZ, 0x234 ;                           /* 0x00000234ff087424 */
29477c29477
<         /*0480*/                   IMAD.MOV.U32 R8, RZ, RZ, 0x213 ;                           /* 0x00000213ff087424 */
---
>         /*0480*/                   IMAD.MOV.U32 R8, RZ, RZ, 0x217 ;                           /* 0x00000217ff087424 */
```
I am not worried, given we also need the fix for correctness.

Fixes: #7160