### PR TITLE
Avoid benign overflow in `__calloc_device`

### DIFF
--- a/libcudacxx/include/cuda/std/__cstdlib/malloc.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/malloc.h
@@ -42,12 +42,12 @@ using ::malloc;
 [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE void* __calloc_device(size_t __n, size_t __size) noexcept
 {
   void* __ptr{};
-
-  const size_t __nbytes = __n * __size;
-
+  // check for overflow through a hypothetical larger integer
+  // TODO (miscco): use `mul_overflow` once implemented
   if (::cuda::mul_hi(__n, __size) == 0)
   {
-    __ptr = ::cuda::std::malloc(__nbytes);
+    const size_t __nbytes = __n * __size;
+    __ptr                 = ::cuda::std::malloc(__nbytes);
     if (__ptr != nullptr)
     {
       ::cuda::std::memset(__ptr, 0, __nbytes);


### PR DESCRIPTION
In `__calloc_device` we calculate the number of bytes to allocate through a  straight multiplication of `__n * __size`

This can potentially overflow, which is fine because we catch that in the following line. However, this may trip tooling that searches for such potential vulnerabilities.

To be clear in the intend of the code move the calculation of `__nbytes` after the overflow check

To be clear, there was no vulnerability in the code but it was less clear what it does

Fixes nvbug5705993
