### PR TITLE
Implement comparison operators for `thrust::reference` and `thrust::pointer`

### DIFF
--- a/thrust/testing/device_reference.cu
+++ b/thrust/testing/device_reference.cu
@@ -248,3 +248,310 @@ void TestDeviceReferenceSwap()
   ASSERT_EQUAL(13, ref2);
 }
 DECLARE_UNITTEST(TestDeviceReferenceSwap);
+
+void TestDeviceReferenceCompare()
+{
+  using T1 = int;
+
+  thrust::device_vector<T1> v1 = {42, 1337};
+
+  { // test same element type
+    using device_ref = thrust::device_reference<T1>;
+
+    device_ref ref1 = v1.front();
+    device_ref ref2 = v1.back();
+
+    // Equality
+    ASSERT_EQUAL(true, (ref1 == ref1));
+    ASSERT_EQUAL(false, (ref1 != ref1));
+
+    ASSERT_EQUAL(false, (ref1 == ref2));
+    ASSERT_EQUAL(true, (ref1 != ref2));
+
+    // Relations
+    ASSERT_EQUAL(true, (ref1 < ref2));
+    ASSERT_EQUAL(true, (ref1 <= ref2));
+    ASSERT_EQUAL(true, (ref2 > ref1));
+    ASSERT_EQUAL(true, (ref2 >= ref1));
+
+    ASSERT_EQUAL(false, (ref2 < ref1));
+    ASSERT_EQUAL(false, (ref2 <= ref1));
+    ASSERT_EQUAL(false, (ref1 > ref2));
+    ASSERT_EQUAL(false, (ref1 >= ref2));
+  }
+
+  using T2                     = float;
+  thrust::device_vector<T2> v2 = {42.0f, 1337.0f};
+  { // test different element type
+    using device_ref = thrust::device_reference<T1>;
+    using other_ref  = thrust::device_reference<T2>;
+
+    device_ref ref1 = v1.front();
+    other_ref ref2  = v2.back();
+
+    // Equality
+    ASSERT_EQUAL(true, (ref1 == ref1));
+    ASSERT_EQUAL(false, (ref1 != ref1));
+
+    ASSERT_EQUAL(false, (ref1 == ref2));
+    ASSERT_EQUAL(true, (ref1 != ref2));
+
+    // Relations
+    ASSERT_EQUAL(true, (ref1 < ref2));
+    ASSERT_EQUAL(true, (ref1 <= ref2));
+    ASSERT_EQUAL(true, (ref2 > ref1));
+    ASSERT_EQUAL(true, (ref2 >= ref1));
+
+    ASSERT_EQUAL(false, (ref2 < ref1));
+    ASSERT_EQUAL(false, (ref2 <= ref1));
+    ASSERT_EQUAL(false, (ref1 > ref2));
+    ASSERT_EQUAL(false, (ref1 >= ref2));
+  }
+
+  { // test different reference types
+    using device_ref    = thrust::device_reference<T1>;
+    using other_ref     = thrust::tagged_reference<T1, thrust::device_system_tag>;
+    using other_pointer = typename other_ref::pointer;
+    static_assert(!::cuda::std::is_same_v<device_ref, other_ref>);
+
+    device_ref ref1 = v1.front();
+    other_ref ref2{other_pointer{thrust::raw_pointer_cast(v1.data() + 1)}};
+
+    // Equality
+    ASSERT_EQUAL(true, (ref1 == ref1));
+    ASSERT_EQUAL(false, (ref1 != ref1));
+
+    ASSERT_EQUAL(false, (ref1 == ref2));
+    ASSERT_EQUAL(true, (ref1 != ref2));
+
+    // Relations
+    ASSERT_EQUAL(true, (ref1 < ref2));
+    ASSERT_EQUAL(true, (ref1 <= ref2));
+    ASSERT_EQUAL(true, (ref2 > ref1));
+    ASSERT_EQUAL(true, (ref2 >= ref1));
+
+    ASSERT_EQUAL(false, (ref2 < ref1));
+    ASSERT_EQUAL(false, (ref2 <= ref1));
+    ASSERT_EQUAL(false, (ref1 > ref2));
+    ASSERT_EQUAL(false, (ref1 >= ref2));
+  }
+
+  { // test different reference types with different element types
+    using device_ref    = thrust::device_reference<T1>;
+    using other_ref     = thrust::tagged_reference<T2, thrust::device_system_tag>;
+    using other_pointer = typename other_ref::pointer;
+    static_assert(!::cuda::std::is_same_v<device_ref, other_ref>);
+
+    device_ref ref1 = v1.front();
+    other_ref ref2{other_pointer{thrust::raw_pointer_cast(v2.data() + 1)}};
+
+    // Equality
+    ASSERT_EQUAL(true, (ref1 == ref1));
+    ASSERT_EQUAL(false, (ref1 != ref1));
+
+    ASSERT_EQUAL(false, (ref1 == ref2));
+    ASSERT_EQUAL(true, (ref1 != ref2));
+
+    // Relations
+    ASSERT_EQUAL(true, (ref1 < ref2));
+    ASSERT_EQUAL(true, (ref1 <= ref2));
+    ASSERT_EQUAL(true, (ref2 > ref1));
+    ASSERT_EQUAL(true, (ref2 >= ref1));
+
+    ASSERT_EQUAL(false, (ref2 < ref1));
+    ASSERT_EQUAL(false, (ref2 <= ref1));
+    ASSERT_EQUAL(false, (ref1 > ref2));
+    ASSERT_EQUAL(false, (ref1 >= ref2));
+  }
+
+  // For the non-cuda backends host_system_tag and device_system_tag are comparable
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+  { // ensure that references with different tags are not comparable
+    using device_ref = thrust::device_reference<T1>;
+    using other_ref  = thrust::tagged_reference<T1, thrust::host_system_tag>;
+    static_assert(!::cuda::std::is_same_v<device_ref, other_ref>);
+
+    static_assert(
+      !thrust::detail::is_pointer_system_convertible_v<typename device_ref::pointer, typename other_ref::pointer>);
+    static_assert(!::cuda::std::__is_cpp17_equality_comparable_v<device_ref, other_ref>);
+    static_assert(!::cuda::std::__is_cpp17_less_than_comparable_v<device_ref, other_ref>);
+  }
+
+  { // ensure that references with different tags and types are not comparable
+    using device_ref = thrust::device_reference<T1>;
+    using other_ref  = thrust::tagged_reference<T2, thrust::host_system_tag>;
+    static_assert(!::cuda::std::is_same_v<device_ref, other_ref>);
+
+    static_assert(
+      !thrust::detail::is_pointer_system_convertible_v<typename device_ref::pointer, typename other_ref::pointer>);
+    static_assert(!::cuda::std::__is_cpp17_equality_comparable_v<device_ref, other_ref>);
+    static_assert(!::cuda::std::__is_cpp17_less_than_comparable_v<device_ref, other_ref>);
+  }
+#endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+
+  { // ensure that references with incomparable element type are not comparable
+    using device_ref = thrust::device_reference<T1>;
+    using other_ref  = thrust::tagged_reference<cuda::std::pair<T1, T2>, thrust::device_system_tag>;
+    static_assert(!::cuda::std::is_same_v<device_ref, other_ref>);
+
+    static_assert(
+      thrust::detail::is_pointer_system_convertible_v<typename device_ref::pointer, typename other_ref::pointer>);
+    static_assert(!::cuda::std::__is_cpp17_equality_comparable_v<T1, cuda::std::pair<T1, T2>>);
+    static_assert(!::cuda::std::__is_cpp17_equality_comparable_v<device_ref, other_ref>);
+    static_assert(!::cuda::std::__is_cpp17_less_than_comparable_v<device_ref, other_ref>);
+  }
+}
+DECLARE_UNITTEST(TestDeviceReferenceCompare);
+
+void TestTaggedReferenceCompare()
+{
+  using T1 = int;
+
+  thrust::device_vector<T1> v1 = {42, 1337};
+
+  { // test same element type
+    using tagged_ref = thrust::tagged_reference<T1, thrust::device_system_tag>;
+    using tagged_ptr = typename tagged_ref::pointer;
+
+    tagged_ref ref1{tagged_ptr{thrust::raw_pointer_cast(v1.data())}};
+    tagged_ref ref2{tagged_ptr{thrust::raw_pointer_cast(v1.data() + 1)}};
+
+    // Equality
+    ASSERT_EQUAL(true, (ref1 == ref1));
+    ASSERT_EQUAL(false, (ref1 != ref1));
+
+    ASSERT_EQUAL(false, (ref1 == ref2));
+    ASSERT_EQUAL(true, (ref1 != ref2));
+
+    // Relations
+    ASSERT_EQUAL(true, (ref1 < ref2));
+    ASSERT_EQUAL(true, (ref1 <= ref2));
+    ASSERT_EQUAL(true, (ref2 > ref1));
+    ASSERT_EQUAL(true, (ref2 >= ref1));
+
+    ASSERT_EQUAL(false, (ref2 < ref1));
+    ASSERT_EQUAL(false, (ref2 <= ref1));
+    ASSERT_EQUAL(false, (ref1 > ref2));
+    ASSERT_EQUAL(false, (ref1 >= ref2));
+  }
+
+  using T2                     = float;
+  thrust::device_vector<T2> v2 = {42.0f, 1337.0f};
+  { // test different element type
+    using tagged_ref = thrust::device_reference<T1>;
+    using other_ref  = thrust::device_reference<T2>;
+
+    tagged_ref ref1 = v1.front();
+    other_ref ref2  = v2.back();
+
+    // Equality
+    ASSERT_EQUAL(true, (ref1 == ref1));
+    ASSERT_EQUAL(false, (ref1 != ref1));
+
+    ASSERT_EQUAL(false, (ref1 == ref2));
+    ASSERT_EQUAL(true, (ref1 != ref2));
+
+    // Relations
+    ASSERT_EQUAL(true, (ref1 < ref2));
+    ASSERT_EQUAL(true, (ref1 <= ref2));
+    ASSERT_EQUAL(true, (ref2 > ref1));
+    ASSERT_EQUAL(true, (ref2 >= ref1));
+
+    ASSERT_EQUAL(false, (ref2 < ref1));
+    ASSERT_EQUAL(false, (ref2 <= ref1));
+    ASSERT_EQUAL(false, (ref1 > ref2));
+    ASSERT_EQUAL(false, (ref1 >= ref2));
+  }
+
+  { // test different reference types
+    using tagged_ref    = thrust::device_reference<T1>;
+    using other_ref     = thrust::tagged_reference<T1, thrust::device_system_tag>;
+    using other_pointer = typename other_ref::pointer;
+    static_assert(!::cuda::std::is_same_v<tagged_ref, other_ref>);
+
+    tagged_ref ref1 = v1.front();
+    other_ref ref2{other_pointer{thrust::raw_pointer_cast(v1.data() + 1)}};
+
+    // Equality
+    ASSERT_EQUAL(true, (ref1 == ref1));
+    ASSERT_EQUAL(false, (ref1 != ref1));
+
+    ASSERT_EQUAL(false, (ref1 == ref2));
+    ASSERT_EQUAL(true, (ref1 != ref2));
+
+    // Relations
+    ASSERT_EQUAL(true, (ref1 < ref2));
+    ASSERT_EQUAL(true, (ref1 <= ref2));
+    ASSERT_EQUAL(true, (ref2 > ref1));
+    ASSERT_EQUAL(true, (ref2 >= ref1));
+
+    ASSERT_EQUAL(false, (ref2 < ref1));
+    ASSERT_EQUAL(false, (ref2 <= ref1));
+    ASSERT_EQUAL(false, (ref1 > ref2));
+    ASSERT_EQUAL(false, (ref1 >= ref2));
+  }
+
+  { // test different reference types with different element types
+    using tagged_ref    = thrust::device_reference<T1>;
+    using other_ref     = thrust::tagged_reference<T2, thrust::device_system_tag>;
+    using other_pointer = typename other_ref::pointer;
+    static_assert(!::cuda::std::is_same_v<tagged_ref, other_ref>);
+
+    tagged_ref ref1 = v1.front();
+    other_ref ref2{other_pointer{thrust::raw_pointer_cast(v2.data() + 1)}};
+
+    // Equality
+    ASSERT_EQUAL(true, (ref1 == ref1));
+    ASSERT_EQUAL(false, (ref1 != ref1));
+
+    ASSERT_EQUAL(false, (ref1 == ref2));
+    ASSERT_EQUAL(true, (ref1 != ref2));
+
+    // Relations
+    ASSERT_EQUAL(true, (ref1 < ref2));
+    ASSERT_EQUAL(true, (ref1 <= ref2));
+    ASSERT_EQUAL(true, (ref2 > ref1));
+    ASSERT_EQUAL(true, (ref2 >= ref1));
+
+    ASSERT_EQUAL(false, (ref2 < ref1));
+    ASSERT_EQUAL(false, (ref2 <= ref1));
+    ASSERT_EQUAL(false, (ref1 > ref2));
+    ASSERT_EQUAL(false, (ref1 >= ref2));
+  }
+
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+  { // ensure that references with different tags are not comparable
+    using tagged_ref = thrust::device_reference<T1>;
+    using other_ref  = thrust::tagged_reference<T1, thrust::host_system_tag>;
+    static_assert(!::cuda::std::is_same_v<tagged_ref, other_ref>);
+
+    static_assert(
+      !thrust::detail::is_pointer_system_convertible_v<typename tagged_ref::pointer, typename other_ref::pointer>);
+    static_assert(!::cuda::std::__is_cpp17_equality_comparable_v<tagged_ref, other_ref>);
+    static_assert(!::cuda::std::__is_cpp17_less_than_comparable_v<tagged_ref, other_ref>);
+  }
+
+  { // ensure that references with different tags and types are not comparable
+    using tagged_ref = thrust::device_reference<T1>;
+    using other_ref  = thrust::tagged_reference<T2, thrust::host_system_tag>;
+    static_assert(!::cuda::std::is_same_v<tagged_ref, other_ref>);
+
+    static_assert(
+      !thrust::detail::is_pointer_system_convertible_v<typename tagged_ref::pointer, typename other_ref::pointer>);
+    static_assert(!::cuda::std::__is_cpp17_equality_comparable_v<tagged_ref, other_ref>);
+    static_assert(!::cuda::std::__is_cpp17_less_than_comparable_v<tagged_ref, other_ref>);
+  }
+#endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
+
+  { // ensure that references with incomparable element type are not comparable
+    using tagged_ref = thrust::device_reference<T1>;
+    using other_ref  = thrust::tagged_reference<cuda::std::pair<T1, T2>, thrust::device_system_tag>;
+    static_assert(!::cuda::std::is_same_v<tagged_ref, other_ref>);
+
+    static_assert(
+      thrust::detail::is_pointer_system_convertible_v<typename tagged_ref::pointer, typename other_ref::pointer>);
+    static_assert(!::cuda::std::__is_cpp17_equality_comparable_v<tagged_ref, other_ref>);
+    static_assert(!::cuda::std::__is_cpp17_less_than_comparable_v<tagged_ref, other_ref>);
+  }
+}
+DECLARE_UNITTEST(TestTaggedReferenceCompare);

--- a/thrust/thrust/detail/reference.h
+++ b/thrust/thrust/detail/reference.h
@@ -31,11 +31,13 @@
 #  pragma system_header
 #endif // no system header
 #include <thrust/detail/reference_forward_declaration.h>
+#include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/detail/generic/memory.h>
 #include <thrust/system/detail/generic/select_system.h>
 
 #include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_comparable.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/move.h>
@@ -319,6 +321,102 @@ public:
     *this = tmp;
     return derived();
   }
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<detail::ref_can_compare_equal<Pointer, OtherPointer>, bool>
+  operator==(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) noexcept(
+    ::cuda::std::__is_cpp17_nothrow_equality_comparable_v<value_type, ::cuda::std::remove_cvref_t<OtherElement>>)
+  { // MSVC cannot directly compare the references thinking its a recursive function call
+    const value_type& lhs_ref                                = *&lhs;
+    const ::cuda::std::remove_cvref_t<OtherElement>& rhs_ref = *&rhs;
+    return lhs_ref == rhs_ref;
+  }
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<!detail::ref_can_compare_equal<Pointer, OtherPointer>, bool>
+  operator==(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) = delete;
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<detail::ref_can_compare_equal<Pointer, OtherPointer>, bool>
+  operator!=(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) noexcept(
+    ::cuda::std::__is_cpp17_nothrow_equality_comparable_v<value_type, ::cuda::std::remove_cvref_t<OtherElement>>)
+  {
+    const value_type& lhs_ref                                = *&lhs;
+    const ::cuda::std::remove_cvref_t<OtherElement>& rhs_ref = *&rhs;
+    return !(lhs_ref == rhs_ref);
+  }
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<!detail::ref_can_compare_equal<Pointer, OtherPointer>, bool>
+  operator!=(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) = delete;
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<detail::ref_can_compare_less_than<Pointer, OtherPointer>, bool>
+  operator<(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) noexcept(
+    ::cuda::std::__is_cpp17_nothrow_less_than_comparable_v<value_type, ::cuda::std::remove_cvref_t<OtherElement>>)
+  { // MSVC cannot directly compare the references thinking its a recursive function call
+    const value_type& lhs_ref                                = *&lhs;
+    const ::cuda::std::remove_cvref_t<OtherElement>& rhs_ref = *&rhs;
+    return lhs_ref < rhs_ref;
+  }
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<!detail::ref_can_compare_less_than<Pointer, OtherPointer>, bool>
+  operator<(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) = delete;
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<detail::ref_can_compare_less_than<Pointer, OtherPointer>, bool>
+  operator>=(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) noexcept(
+    ::cuda::std::__is_cpp17_nothrow_less_than_comparable_v<value_type, ::cuda::std::remove_cvref_t<OtherElement>>)
+  { // MSVC cannot directly compare the references thinking its a recursive function call
+    const value_type& lhs_ref                                = *&lhs;
+    const ::cuda::std::remove_cvref_t<OtherElement>& rhs_ref = *&rhs;
+    return !(lhs_ref < rhs_ref);
+  }
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<!detail::ref_can_compare_less_than<Pointer, OtherPointer>, bool>
+  operator>=(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) = delete;
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<detail::ref_can_compare_less_than<Pointer, OtherPointer>, bool>
+  operator>(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) noexcept(
+    ::cuda::std::__is_cpp17_nothrow_less_than_comparable_v<value_type, ::cuda::std::remove_cvref_t<OtherElement>>)
+  { // MSVC cannot directly compare the references thinking its a recursive function call
+    const value_type& lhs_ref                                = *&lhs;
+    const ::cuda::std::remove_cvref_t<OtherElement>& rhs_ref = *&rhs;
+    return rhs_ref < lhs_ref;
+  }
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<!detail::ref_can_compare_less_than<Pointer, OtherPointer>, bool>
+  operator>(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) = delete;
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<detail::ref_can_compare_less_than<Pointer, OtherPointer>, bool>
+  operator<=(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) noexcept(
+    ::cuda::std::__is_cpp17_nothrow_less_than_comparable_v<value_type, ::cuda::std::remove_cvref_t<OtherElement>>)
+  { // MSVC cannot directly compare the references thinking its a recursive function call
+    const value_type& lhs_ref                                = *&lhs;
+    const ::cuda::std::remove_cvref_t<OtherElement>& rhs_ref = *&rhs;
+    return !(rhs_ref < lhs_ref);
+  }
+
+  template <typename OtherElement, typename OtherPointer, typename OtherDerived>
+  [[nodiscard]]
+  _CCCL_HOST_DEVICE friend ::cuda::std::enable_if_t<!detail::ref_can_compare_less_than<Pointer, OtherPointer>, bool>
+  operator<=(reference const& lhs, reference<OtherElement, OtherPointer, OtherDerived> const& rhs) = delete;
 
 private:
   pointer const ptr;

--- a/thrust/thrust/detail/type_traits/pointer_traits.h
+++ b/thrust/thrust/detail/type_traits/pointer_traits.h
@@ -34,6 +34,7 @@
 #include <cuda/std/__type_traits/add_lvalue_reference.h>
 #include <cuda/std/__type_traits/conjunction.h>
 #include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_comparable.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_void.h>
@@ -288,45 +289,60 @@ struct pointer_traits<const void*>
 };
 
 template <typename FromPtr, typename ToPtr>
-struct is_pointer_system_convertible : ::cuda::std::is_convertible<iterator_system_t<FromPtr>, iterator_system_t<ToPtr>>
-{};
+inline constexpr bool is_pointer_system_convertible_v =
+  ::cuda::std::is_convertible_v<iterator_system_t<FromPtr>, iterator_system_t<ToPtr>>;
 
 template <typename FromPtr, typename ToPtr>
-struct is_pointer_convertible
-    : ::cuda::std::_And<
-        ::cuda::std::is_convertible<typename pointer_element<FromPtr>::type*, typename pointer_element<ToPtr>::type*>,
-        is_pointer_system_convertible<FromPtr, ToPtr>>
-{};
+inline constexpr bool is_pointer_convertible_v =
+  ::cuda::std::is_convertible_v<typename pointer_element<FromPtr>::type*, typename pointer_element<ToPtr>::type*>
+  && is_pointer_system_convertible_v<FromPtr, ToPtr>;
 
 template <typename FromPtr, typename ToPtr>
-struct is_void_pointer_system_convertible
-    : ::cuda::std::_And<::cuda::std::is_same<typename pointer_element<FromPtr>::type, void>,
-                        is_pointer_system_convertible<FromPtr, ToPtr>>
-{};
+inline constexpr bool is_void_pointer_system_convertible_v =
+  ::cuda::std::is_void_v<typename pointer_element<FromPtr>::type> //
+  && is_pointer_system_convertible_v<FromPtr, ToPtr>;
 
 // avoid inspecting traits of the arguments if they aren't known to be pointers
-template <typename FromPtr, typename ToPtr>
-struct lazy_is_pointer_convertible
-    : thrust::detail::eval_if<is_thrust_pointer_v<FromPtr> && is_thrust_pointer_v<ToPtr>,
-                              is_pointer_convertible<FromPtr, ToPtr>,
-                              ::cuda::std::type_identity<thrust::detail::false_type>>
-{};
+template <typename FromPtr, typename ToPtr, bool = is_thrust_pointer_v<FromPtr> && is_thrust_pointer_v<ToPtr>>
+inline constexpr bool lazy_is_pointer_convertible_v = false;
 
 template <typename FromPtr, typename ToPtr>
-struct lazy_is_void_pointer_system_convertible
-    : thrust::detail::eval_if<is_thrust_pointer_v<FromPtr> && is_thrust_pointer_v<ToPtr>,
-                              is_void_pointer_system_convertible<FromPtr, ToPtr>,
-                              ::cuda::std::type_identity<thrust::detail::false_type>>
-{};
+inline constexpr bool lazy_is_pointer_convertible_v<FromPtr, ToPtr, true> = is_pointer_convertible_v<FromPtr, ToPtr>;
+
+template <typename FromPtr, typename ToPtr, bool = is_thrust_pointer_v<FromPtr> && is_thrust_pointer_v<ToPtr>>
+inline constexpr bool lazy_is_void_pointer_system_convertible_v = false;
+
+template <typename FromPtr, typename ToPtr>
+inline constexpr bool lazy_is_void_pointer_system_convertible_v<FromPtr, ToPtr, true> =
+  is_void_pointer_system_convertible_v<FromPtr, ToPtr>;
 
 template <typename FromPtr, typename ToPtr, typename T = void>
-struct enable_if_pointer_is_convertible
-    : ::cuda::std::enable_if<lazy_is_pointer_convertible<FromPtr, ToPtr>::type::value, T>
-{};
+using enable_if_pointer_is_convertible_t = ::cuda::std::enable_if_t<lazy_is_pointer_convertible_v<FromPtr, ToPtr>, T>;
 
 template <typename FromPtr, typename ToPtr, typename T = void>
-struct enable_if_void_pointer_is_system_convertible
-    : ::cuda::std::enable_if<lazy_is_void_pointer_system_convertible<FromPtr, ToPtr>::type::value, T>
-{};
+using enable_if_void_pointer_is_system_convertible_t =
+  ::cuda::std::enable_if_t<lazy_is_void_pointer_system_convertible_v<FromPtr, ToPtr>, T>;
+
+// tagged pointers can only compare if they have a matching system and comparable pointer type
+template <typename FromPtr, typename ToPtr>
+inline constexpr bool ptr_can_compare_equal =
+  is_pointer_system_convertible_v<FromPtr, ToPtr>
+  && ::cuda::std::__is_cpp17_equality_comparable_v<typename FromPtr::value_type*, typename ToPtr::value_type*>;
+
+template <typename FromPtr, typename ToPtr>
+inline constexpr bool ptr_can_compare_less_than =
+  is_pointer_system_convertible_v<FromPtr, ToPtr>
+  && ::cuda::std::__is_cpp17_less_than_comparable_v<typename FromPtr::value_type*, typename ToPtr::value_type*>;
+
+// tagged references can only compare if they have a matching system and comparable value type
+template <typename FromPtr, typename ToPtr>
+inline constexpr bool ref_can_compare_equal =
+  is_pointer_system_convertible_v<FromPtr, ToPtr>
+  && ::cuda::std::__is_cpp17_equality_comparable_v<typename FromPtr::value_type, typename ToPtr::value_type>;
+
+template <typename FromPtr, typename ToPtr>
+inline constexpr bool ref_can_compare_less_than =
+  is_pointer_system_convertible_v<FromPtr, ToPtr>
+  && ::cuda::std::__is_cpp17_less_than_comparable_v<typename FromPtr::value_type, typename ToPtr::value_type>;
 } // namespace detail
 THRUST_NAMESPACE_END


### PR DESCRIPTION
We want to be able to compare tagged pointer and references because they are effectively just pointer / references

The difficulty is that we need to make sure that we cannot compare them if the systems are incompatible

Fixes #7042
