### PR TITLE
Drop leftover code after tuning API migration

### DIFF
--- a/c/parallel/src/transform.cu
+++ b/c/parallel/src/transform.cu
@@ -10,7 +10,6 @@
 
 #include <cub/detail/choose_offset.cuh>
 #include <cub/detail/launcher/cuda_driver.cuh>
-#include <cub/detail/ptx-json-parser.cuh>
 #include <cub/device/dispatch/dispatch_transform.cuh>
 #include <cub/device/dispatch/tuning/tuning_transform.cuh>
 #include <cub/util_arch.cuh>
@@ -524,9 +523,6 @@ static_assert(device_transform_policy()(::cuda::arch_id{{CUB_PTX_ARCH / 10}}) ==
 
   cuLibraryLoadData(&build_ptr->library, result.data.get(), nullptr, nullptr, 0, nullptr, nullptr, 0);
   check(cuLibraryGetKernel(&build_ptr->transform_kernel, build_ptr->library, kernel_lowered_name.c_str()));
-
-  nlohmann::json runtime_policy =
-    cub::detail::ptx_json::parse("device_transform_policy", {result.data.get(), result.size});
 
   build_ptr->loaded_bytes_per_iteration = static_cast<int>((input1_it.value_type.size + input2_it.value_type.size));
   build_ptr->cc                         = cc_major * 10 + cc_minor;


### PR DESCRIPTION
PR #6914 seems to have missed a few pieces to remove