### PR TITLE
Macros for symbol ABI revisions

### DIFF
--- a/libcudacxx/include/cuda/std/__internal/revision.h
+++ b/libcudacxx/include/cuda/std/__internal/revision.h
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___INTERNAL_REVISION_H
+#define _CUDA_STD___INTERNAL_REVISION_H
+
+#include <cuda/__cccl_config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// This module allows us to create revisioned symbols in the current ABI namespace. To create a revisioned symbol, the
+// symbol must be forward declared as:
+//
+// _CCCL_DECLARE_ABI_REV(template (class T) class my_class, N);
+//
+// first, where N is the revision number. Then when the symbol is being defined, wrap the synbol name by _CCCL_REV macro
+// as:
+//
+// template <class T>
+// class _CCCL_REV(my_class) { ... };
+//
+// _CCCL_REV automatically selects the right revision namespace to define the symbol in. _CCCL_DECLARE_ABI_REV imports
+// the symbol to the current namespace, too.
+
+#define _CCCL_REV_NS(_NAME) __##_NAME##_rev_ns
+#define _CCCL_REV(_NAME)    _CCCL_REV_NS(_NAME)::_NAME
+
+#define _CCCL_DECLARE_ABI_REV_UNPACK_class         class
+#define _CCCL_DECLARE_ABI_REV_UNPACK_struct        struct
+#define _CCCL_DECLARE_ABI_REV_UNPACK_template(...) template <__VA_ARGS__>
+
+#define _CCCL_DECLARE_ABI_REV_EXTRACT_NAME_class
+#define _CCCL_DECLARE_ABI_REV_EXTRACT_NAME_struct
+#define _CCCL_DECLARE_ABI_REV_EXTRACT_NAME_template(...) _CCCL_DECLARE_ABI_REV_EXTRACT_NAME_,
+
+#define _CCCL_DECLARE_ABI_REV_MAKE_NS_IMPL4(_X)      _CCCL_REV_NS(_X)
+#define _CCCL_DECLARE_ABI_REV_MAKE_NS_IMPL3(_X)      _CCCL_DECLARE_ABI_REV_MAKE_NS_IMPL4(_X)
+#define _CCCL_DECLARE_ABI_REV_MAKE_NS_IMPL2(_X, ...) _CCCL_DECLARE_ABI_REV_MAKE_NS_IMPL3(_X##__VA_ARGS__)
+#define _CCCL_DECLARE_ABI_REV_MAKE_NS_IMPL1(_X)      _CCCL_DECLARE_ABI_REV_MAKE_NS_IMPL2(_X)
+#define _CCCL_DECLARE_ABI_REV_MAKE_NS(_X)            _CCCL_DECLARE_ABI_REV_MAKE_NS_IMPL1(_CCCL_DECLARE_ABI_REV_EXTRACT_NAME_##_X)
+
+#define _CCCL_DECLARE_ABI_REV(_TYPE, _REV) \
+  inline namespace __r##_REV               \
+  {                                        \
+    _CCCL_DECLARE_ABI_REV_UNPACK_##_TYPE;  \
+  }                                        \
+  namespace _CCCL_DECLARE_ABI_REV_MAKE_NS(_TYPE) = __r##_REV;
+
+#endif // _CUDA_STD___INTERNAL_REVISION_H

--- a/libcudacxx/include/cuda/std/detail/__config
+++ b/libcudacxx/include/cuda/std/detail/__config
@@ -16,6 +16,7 @@
 #include <cuda/std/__internal/features.h>
 #include <cuda/std/__internal/namespaces.h>
 #include <cuda/std/__internal/pstl_config.h>
+#include <cuda/std/__internal/revision.h>
 #include <cuda/std/__internal/thread_api.h>
 #include <cuda/std/__internal/version.h>
 

--- a/libcudacxx/test/libcudacxx/libcxx/macros/revision.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/macros/revision.compile.pass.cpp
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/type_traits>
+
+// The public namespace.
+namespace ns
+{
+// The inline ABI namespace.
+inline namespace v1
+{
+// Forward declarations.
+struct unrev_struct;
+_CCCL_DECLARE_ABI_REV(struct my_struct, 2);
+_CCCL_DECLARE_ABI_REV(class my_class, 1);
+_CCCL_DECLARE_ABI_REV(template(class T) class my_template_class, 3);
+
+// Definitions.
+struct unrev_struct
+{
+  int value;
+};
+
+struct _CCCL_REV(my_struct)
+{
+  int value;
+  __host__ __device__ int method();
+};
+
+__host__ __device__ int my_struct::method()
+{
+  return value;
+}
+
+class _CCCL_REV(my_class)
+{
+public:
+  __host__ __device__ int my_struct_interact(const my_struct& v)
+  {
+    return v.value;
+  }
+};
+
+template <class T>
+class _CCCL_REV(my_template_class)
+{};
+
+template <>
+class _CCCL_REV(my_template_class)<my_struct> : public my_struct
+{};
+
+template <class T>
+__host__ __device__ auto adl_fn(const T& v)
+{
+  return v.value;
+}
+} // namespace v1
+} // namespace ns
+
+__host__ __device__ void test()
+{
+  // 1. Test that the symbols are in the expected namespace.
+  static_assert(cuda::std::is_same_v<ns::my_class, ns::v1::__r1::my_class>);
+  static_assert(cuda::std::is_same_v<ns::v1::__r1::my_class, ns::v1::__my_class_rev_ns::my_class>);
+
+  static_assert(cuda::std::is_same_v<ns::my_struct, ns::v1::__r2::my_struct>);
+  static_assert(cuda::std::is_same_v<ns::v1::__r2::my_struct, ns::v1::__my_struct_rev_ns::my_struct>);
+
+  static_assert(cuda::std::is_same_v<ns::my_template_class<int>, ns::v1::__r3::my_template_class<int>>);
+  static_assert(cuda::std::is_same_v<ns::v1::__r3::my_template_class<int>,
+                                     ns::v1::__my_template_class_rev_ns::my_template_class<int>>);
+
+  // 2. Test construction.
+  [[maybe_unused]] ns::unrev_struct us{};
+  [[maybe_unused]] ns::my_class c{};
+  [[maybe_unused]] ns::my_struct s{};
+  [[maybe_unused]] ns::my_template_class<int> tci{};
+  [[maybe_unused]] ns::my_template_class<ns::my_struct> tcs{};
+
+  // 3. Test ADL.
+  [[maybe_unused]] const auto result1 = adl_fn(us);
+  [[maybe_unused]] const auto result2 = adl_fn(s);
+  [[maybe_unused]] const auto result3 = adl_fn(tcs);
+
+  // 4. Test interaction.
+  [[maybe_unused]] const auto result4 = c.my_struct_interact(s);
+  [[maybe_unused]] const auto result5 = c.my_struct_interact(tcs);
+}
+
+int main(int, char**)
+{
+  return 0;
+}


### PR DESCRIPTION
See discussion on slack.

This solution has one problem:
```cpp
namespace ns::inline v1 {

// We declare revision 1 for my_struct
_CCCL_DECLARE_ABI_REV(struct my_struct, 1);

// But forget to use _CCCL_REV(my_struct) in the definition.
struct my_struct { ...};

// That causes will cause the ns::v1::my_struct to be defined which overrides
// the ns::v1::__rev1::my_struct which is potentially dangerous. I haven't found
// a good way to prevent that unfortunately.

} // namespace ns::inline v1
```