### PR TITLE
Don't run CPU-only import test if the wheel artifact doesn't exist

### DIFF
--- a/.github/workflows/ci-workflow-pull-request.yml
+++ b/.github/workflows/ci-workflow-pull-request.yml
@@ -315,23 +315,39 @@ jobs:
       contents: read
     steps:
       - name: Download wheel artifact
+        id: download
         uses: actions/download-artifact@v4
+        continue-on-error: true
         with:
           name: wheel-cccl-linux-amd64-py3.13
           path: artifact
 
+      - name: Check if wheel exists
+        id: check-wheel
+        run: |
+          if [[ "${{ steps.download.outcome }}" != "success" ]]; then
+            echo "No wheel artifact found (Python jobs likely didn't run). Skipping test."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Wheel artifact found."
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Set up Python
+        if: steps.check-wheel.outputs.skip != 'true'
         uses: actions/setup-python@v5
         with:
           python-version: '3.13'
 
       - name: Install wheel
+        if: steps.check-wheel.outputs.skip != 'true'
         run: |
           echo "Artifact contents:"
           find artifact -name "*.whl" -type f
           pip install $(find artifact -name "*.whl" -type f | head -1)[cu13]
 
       - name: Test CPU-only import
+        if: steps.check-wheel.outputs.skip != 'true'
         run: |
           python -c "
           import cuda.compute


### PR DESCRIPTION
## Description

Unblocks CI on PRs that don't touch Python.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
