### PR TITLE
Test passing a custom policy to DispatchHistogram

### DIFF
--- a/cub/test/catch2_test_device_histogram_custom_policy_hub.cu
+++ b/cub/test/catch2_test_device_histogram_custom_policy_hub.cu
@@ -10,7 +10,6 @@
 #include <cuda/std/array>
 #include <cuda/std/type_traits>
 
-
 #include <c2h/catch2_test_helper.h>
 
 using namespace cub;


### PR DESCRIPTION
Generated using Cursor+gpt-5.2-codex, prompt:
```
Look at commit 186c97c adding a custom policy hub test for DispatchRadixSort.
Implement a similar test for DispatchHistogram, run the tests, and fix any errors.
```
Reviewed and applied a few fixed.

This is not a great test for `DispatchHistogram`, but it's main use case is to ensure that the rewrite to the new tuning API does not break users who supply a custom policy hub, which is rare and never intended, but Hyrum's law. We will throw this test and all dispatchers away with CCCL 4.0, so I think a quick AI generated test is fine.