### PR TITLE
Fix clang warning about missing braces again

### DIFF
--- a/libcudacxx/include/cuda/__device/device_ref.h
+++ b/libcudacxx/include/cuda/__device/device_ref.h
@@ -33,6 +33,10 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
+// clang complains about missing braces in CUmemLocation constructor but GCC complains if we add them
+
 ::cuda::std::size_t __physical_devices_count();
 
 //! @brief A non-owning representation of a CUDA device
@@ -158,6 +162,8 @@ public:
                                                                                   // <cuda/__device/physical_device.h>
                                                                                   // to avoid circular dependency
 };
+
+_CCCL_DIAG_POP
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
+++ b/libcudacxx/include/cuda/__memory_pool/memory_pool_base.h
@@ -38,6 +38,10 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
+// clang complains about missing braces in CUmemLocation constructor but GCC complains if we add them
+
 enum class __pool_attr_settable : bool
 {
 };
@@ -635,6 +639,8 @@ public:
 };
 
 _CCCL_END_NAMESPACE_CUDA
+
+_CCCL_DIAG_POP
 
 #  include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__memory_pool/pinned_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/pinned_memory_pool.h
@@ -38,6 +38,10 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 
 #  if _CCCL_CTK_AT_LEAST(12, 6)
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
+// clang complains about missing braces in CUmemLocation constructor but GCC complains if we add them
+
 static ::cudaMemPool_t __get_default_host_pinned_pool();
 
 //! @rst
@@ -205,6 +209,8 @@ static_assert(::cuda::mr::resource_with<pinned_memory_pool, ::cuda::mr::host_acc
 #    endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
   return __default_pool;
 }
+
+_CCCL_DIAG_POP
 
 #  endif // _CCCL_CTK_AT_LEAST(12, 6)
 

--- a/libcudacxx/include/cuda/__runtime/types.h
+++ b/libcudacxx/include/cuda/__runtime/types.h
@@ -27,10 +27,16 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
+// clang complains about missing braces in CUmemLocation constructor but GCC complains if we add them
+
 using memory_location = ::cudaMemLocation;
 #  if _CCCL_CTK_AT_LEAST(12, 2)
 inline constexpr memory_location host_memory_location = {::cudaMemLocationTypeHost, 0};
 #  endif // _CCCL_CTK_AT_LEAST(12, 2)
+
+_CCCL_DIAG_POP
 
 _CCCL_END_NAMESPACE_CUDA
 


### PR DESCRIPTION
Its annoying but nothing we can do against it

Fixes nvbug5683879 