### PR TITLE
Add accessor methods to shared_resource<T>

### DIFF
--- a/libcudacxx/include/cuda/__memory_resource/shared_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/shared_resource.h
@@ -136,6 +136,48 @@ struct shared_resource : ::cuda::mr::__copy_default_queries<_Resource>
     __left.swap(__right);
   }
 
+  //! @brief Returns a reference to the stored resource.
+  //! @return A reference to the stored resource.
+  [[nodiscard]] _Resource& get() noexcept
+  {
+    return __control_block->__resource;
+  }
+
+  //! @brief Returns a const reference to the stored resource.
+  //! @return A const reference to the stored resource.
+  [[nodiscard]] const _Resource& get() const noexcept
+  {
+    return __control_block->__resource;
+  }
+
+  //! @brief Returns a pointer to the stored resource.
+  //! @return A pointer to the stored resource.
+  [[nodiscard]] _Resource* operator->() noexcept
+  {
+    return &__control_block->__resource;
+  }
+
+  //! @brief Returns a const pointer to the stored resource.
+  //! @return A const pointer to the stored resource.
+  [[nodiscard]] const _Resource* operator->() const noexcept
+  {
+    return &__control_block->__resource;
+  }
+
+  //! @brief Returns a reference to the stored resource.
+  //! @return A reference to the stored resource.
+  [[nodiscard]] _Resource& operator*() noexcept
+  {
+    return __control_block->__resource;
+  }
+
+  //! @brief Returns a const reference to the stored resource.
+  //! @return A const reference to the stored resource.
+  [[nodiscard]] const _Resource& operator*() const noexcept
+  {
+    return __control_block->__resource;
+  }
+
   //! @brief Allocate memory of size at least \p __bytes using the stored resource.
   //! @param __bytes The size in bytes of the allocation.
   //! @param __alignment The requested alignment of the allocation.

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_resource.cu
@@ -78,6 +78,42 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
   // Reset the counters:
   this->counts = Counts();
 
+  SECTION("get, operator->, and operator*")
+  {
+    Counts expected{};
+    CHECK(this->counts == expected);
+    {
+      cuda::mr::shared_resource mr{cuda::std::in_place_type<TestResource>, 42, this};
+      ++expected.object_count;
+      CHECK(this->counts == expected);
+
+      // Test get()
+      TestResource& ref = mr.get();
+      CHECK(ref.data == 42);
+
+      // Test operator->
+      CHECK(mr->data == 42);
+
+      // Test operator*
+      TestResource& deref = *mr;
+      CHECK(deref.data == 42);
+
+      // Test const versions
+      const auto& cmr          = mr;
+      const TestResource& cref = cmr.get();
+      CHECK(cref.data == 42);
+      CHECK(cmr->data == 42);
+      const TestResource& cderef = *cmr;
+      CHECK(cderef.data == 42);
+    }
+
+    --expected.object_count;
+    CHECK(this->counts == expected);
+  }
+
+  // Reset the counters:
+  this->counts = Counts();
+
   SECTION("allocate_sync and deallocate_sync")
   {
     Counts expected{};


### PR DESCRIPTION
## Summary

- Add `get()`, `operator->()`, and `operator*()` to `shared_resource<T>` to allow access to the underlying resource
- Add tests for the new accessor methods

Resolves #7313