### PR TITLE
Skip checking build prereqs if installing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if (NOT CCCL_TOPLEVEL_PROJECT)
   include(cmake/CCCLAddSubdir.cmake)
 endif()
 
-if (CCCL_TOPLEVEL_PROJECT)
+if (CCCL_TOPLEVEL_PROJECT AND NOT CCCL_SKIP_BUILD_CHECKS)
   # We require a higher cmake version for dev builds
   cmake_minimum_required(VERSION 3.21)
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -23,6 +23,7 @@
         "CCCL_ENABLE_EXAMPLES": false,
         "CCCL_ENABLE_C_PARALLEL": false,
         "CCCL_ENABLE_C_EXPERIMENTAL_STF": false,
+        "CCCL_SKIP_BUILD_CHECKS": false,
         "libcudacxx_ENABLE_INSTALL_RULES": true,
         "CUB_ENABLE_INSTALL_RULES": true,
         "Thrust_ENABLE_INSTALL_RULES": true,
@@ -34,18 +35,19 @@
       "displayName": "Installation / Packaging (only stable libraries)",
       "inherits": "base",
       "cacheVariables": {
-        "cudax_ENABLE_INSTALL_RULES": false
+        "cudax_ENABLE_INSTALL_RULES": false,
+        "CCCL_SKIP_BUILD_CHECKS": true
       }
     },
     {
       "name": "install-unstable",
       "displayName": "Installation / Packaging (includes experimental libraries)",
-      "inherits": "base"
+      "inherits": "install"
     },
     {
       "name": "install-unstable-only",
       "displayName": "Installation / Packaging (*only* experimental libraries)",
-      "inherits": "base",
+      "inherits": "install",
       "cacheVariables": {
         "libcudacxx_ENABLE_INSTALL_RULES": false,
         "CUB_ENABLE_INSTALL_RULES": false,


### PR DESCRIPTION
## Description

Fixes release action which fails to build on stock GitHub Ubuntu runner.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
