### PR TITLE
cuda.compute: Fix deferred annotations handling in signature_from_annotations

### DIFF
--- a/python/cuda_cccl/tests/compute/test_deferred_annotations.py
+++ b/python/cuda_cccl/tests/compute/test_deferred_annotations.py
@@ -17,3 +17,22 @@ def test_deferred_annotations():
     class MyStruct:
         x: np.int32
         y: np.int32
+
+
+def test_transform_iterator_future_annotations():
+    def add_one(x: "np.int32") -> "np.int32":
+        return x + np.int32(1)
+
+    import cupy as cp
+
+    from cuda.compute import OpKind, TransformIterator, reduce_into
+
+    d_in = cp.arange(8, dtype=np.int32)
+    d_out = cp.empty(1, dtype=np.int32)
+    h_init = np.array([0], dtype=np.int32)
+
+    transform_it = TransformIterator(d_in, add_one)
+    reduce_into(transform_it, d_out, OpKind.PLUS, d_in.size, h_init)
+
+    expected = int(cp.sum(d_in + 1).get())
+    assert int(d_out.get()[0]) == expected


### PR DESCRIPTION
## Description

I missed this other occurrence of how we handle annotations when working on https://github.com/NVIDIA/cccl/pull/7121.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
