### PR TITLE
Implement internal `min`/`max`/`clamp` returning value

### DIFF
--- a/libcudacxx/codegen/generate_prologue_epilogue.py
+++ b/libcudacxx/codegen/generate_prologue_epilogue.py
@@ -81,7 +81,7 @@ PUSH_POP_MACROS = {
         "noinline_calls",
         "no_tls_guard",
     ],
-    "Windows nasty macros": ["min", "max", "interface"],
+    "Windows nasty macros": ["min", "__min", "max", "__max", "interface"],
     "sal.h on Windows": ["__valid", "__callback"],
     "other macros": ["clang"],
     "sys/sysmacros.h on linux": ["major", "minor", "makedev"],

--- a/libcudacxx/include/cuda/__annotated_ptr/access_property_encoding.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/access_property_encoding.h
@@ -76,7 +76,7 @@ enum class __l2_descriptor_mode_t : uint32_t
   auto __raw_ptr         = ::cuda::std::bit_cast<uintptr_t>(__ptr);
   auto __log2_total_size = ::cuda::ceil_ilog2(__total_bytes);
   // replace with ::cuda::std::add_sat when available PR #3449
-  auto __block_size_enum = static_cast<uint32_t>(::cuda::std::__vmax(__log2_total_size - 19, 0)); // min block size = 4K
+  auto __block_size_enum = static_cast<uint32_t>(::cuda::std::__max(__log2_total_size - 19, 0)); // min block size = 4K
   auto __log2_block_size = 12u + __block_size_enum;
   auto __block_size      = 1u << __log2_block_size;
   auto __block_start     = static_cast<uint32_t>(__raw_ptr >> __log2_block_size); // ptr / block_size
@@ -87,8 +87,8 @@ enum class __l2_descriptor_mode_t : uint32_t
   //       following code:
   // auto __block_count        = (__block_size_enum == 13)
   //                            ? ((__block_end - __block_start <= 127u) ? (__block_end - __block_start) : 1)
-  //                            : ::cuda::std::__vclamp(__block_end - __block_start, 1u, 127u);
-  auto __block_count        = ::cuda::std::__vclamp(__block_end - __block_start, 1u, 127u);
+  //                            : ::cuda::std::__clamp(__block_end - __block_start, 1u, 127u);
+  auto __block_count        = ::cuda::std::__clamp(__block_end - __block_start, 1u, 127u);
   auto __l2_cop_off         = ::cuda::std::to_underlying(__secondary);
   auto __l2_cop_on          = ::cuda::std::to_underlying(__primary);
   auto __l2_descriptor_mode = ::cuda::std::to_underlying(__l2_descriptor_mode_t::_Desc_Block_Type);

--- a/libcudacxx/include/cuda/__annotated_ptr/access_property_encoding.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/access_property_encoding.h
@@ -76,7 +76,7 @@ enum class __l2_descriptor_mode_t : uint32_t
   auto __raw_ptr         = ::cuda::std::bit_cast<uintptr_t>(__ptr);
   auto __log2_total_size = ::cuda::ceil_ilog2(__total_bytes);
   // replace with ::cuda::std::add_sat when available PR #3449
-  auto __block_size_enum = static_cast<uint32_t>(::cuda::std::max(__log2_total_size - 19, 0)); // min block size = 4K
+  auto __block_size_enum = static_cast<uint32_t>(::cuda::std::__vmax(__log2_total_size - 19, 0)); // min block size = 4K
   auto __log2_block_size = 12u + __block_size_enum;
   auto __block_size      = 1u << __log2_block_size;
   auto __block_start     = static_cast<uint32_t>(__raw_ptr >> __log2_block_size); // ptr / block_size
@@ -87,8 +87,8 @@ enum class __l2_descriptor_mode_t : uint32_t
   //       following code:
   // auto __block_count        = (__block_size_enum == 13)
   //                            ? ((__block_end - __block_start <= 127u) ? (__block_end - __block_start) : 1)
-  //                            : ::cuda::std::clamp(__block_end - __block_start, 1u, 127u);
-  auto __block_count        = ::cuda::std::clamp(__block_end - __block_start, 1u, 127u);
+  //                            : ::cuda::std::__vclamp(__block_end - __block_start, 1u, 127u);
+  auto __block_count        = ::cuda::std::__vclamp(__block_end - __block_start, 1u, 127u);
   auto __l2_cop_off         = ::cuda::std::to_underlying(__secondary);
   auto __l2_cop_on          = ::cuda::std::to_underlying(__primary);
   auto __l2_descriptor_mode = ::cuda::std::to_underlying(__l2_descriptor_mode_t::_Desc_Block_Type);

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -69,7 +69,7 @@ _CCCL_REQUIRES(::cuda::std::is_integral_v<_Tp> _CCCL_AND ::cuda::std::is_integra
     {
       // the ::min method is faster even if __b is a compile-time constant
       NV_IF_ELSE_TARGET(NV_IS_DEVICE,
-                        (return static_cast<_Common>(::cuda::std::min(__a1, 1 + ((__a1 - 1) / __b1)));),
+                        (return static_cast<_Common>(::cuda::std::__vmin(__a1, 1 + ((__a1 - 1) / __b1)));),
                         (const auto __res = __a1 / __b1; //
                          return static_cast<_Common>(__res + (__res * __b1 != __a1));))
     }

--- a/libcudacxx/include/cuda/__cmath/ceil_div.h
+++ b/libcudacxx/include/cuda/__cmath/ceil_div.h
@@ -69,7 +69,7 @@ _CCCL_REQUIRES(::cuda::std::is_integral_v<_Tp> _CCCL_AND ::cuda::std::is_integra
     {
       // the ::min method is faster even if __b is a compile-time constant
       NV_IF_ELSE_TARGET(NV_IS_DEVICE,
-                        (return static_cast<_Common>(::cuda::std::__vmin(__a1, 1 + ((__a1 - 1) / __b1)));),
+                        (return static_cast<_Common>(::cuda::std::__min(__a1, 1 + ((__a1 - 1) / __b1)));),
                         (const auto __res = __a1 / __b1; //
                          return static_cast<_Common>(__res + (__res * __b1 != __a1));))
     }

--- a/libcudacxx/include/cuda/__random/feistel_bijection.h
+++ b/libcudacxx/include/cuda/__random/feistel_bijection.h
@@ -53,8 +53,8 @@ public:
   {
     // Calculate number of bits needed to represent num_elements - 1
     // Prevent zero
-    const uint64_t __max_index  = ::cuda::std::max(static_cast<uint64_t>(1), __num_elements) - 1;
-    const uint64_t __total_bits = static_cast<uint64_t>(::cuda::std::max(8, ::cuda::std::bit_width(__max_index)));
+    const uint64_t __max_index  = ::cuda::std::__vmax(static_cast<uint64_t>(1), __num_elements) - 1;
+    const uint64_t __total_bits = static_cast<uint64_t>(::cuda::std::__vmax(8, ::cuda::std::bit_width(__max_index)));
 
     // Half bits rounded down
     __L_bits_ = __total_bits / 2;

--- a/libcudacxx/include/cuda/__random/feistel_bijection.h
+++ b/libcudacxx/include/cuda/__random/feistel_bijection.h
@@ -53,8 +53,8 @@ public:
   {
     // Calculate number of bits needed to represent num_elements - 1
     // Prevent zero
-    const uint64_t __max_index  = ::cuda::std::__vmax(static_cast<uint64_t>(1), __num_elements) - 1;
-    const uint64_t __total_bits = static_cast<uint64_t>(::cuda::std::__vmax(8, ::cuda::std::bit_width(__max_index)));
+    const uint64_t __max_index  = ::cuda::std::__max(static_cast<uint64_t>(1), __num_elements) - 1;
+    const uint64_t __total_bits = static_cast<uint64_t>(::cuda::std::__max(8, ::cuda::std::bit_width(__max_index)));
 
     // Half bits rounded down
     __L_bits_ = __total_bits / 2;

--- a/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
+++ b/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
@@ -479,7 +479,7 @@ _CCCL_HOST_API inline __tma_box_sizes_array_t __get_box_sizes(
   size_t __total_size = 1;
   for (int __i = 0; __i < __rank; ++__i)
   {
-    const auto __max_box_size = static_cast<int>(::cuda::std::__vmin(__tensor_sizes[__i], uint64_t{256}));
+    const auto __max_box_size = static_cast<int>(::cuda::std::__min(__tensor_sizes[__i], uint64_t{256}));
     const auto __box_size     = __box_sizes[__rank - 1 - __i];
     if (__box_size <= 0 || __box_size > __max_box_size)
     {
@@ -569,7 +569,7 @@ _CCCL_HOST_API inline __tma_elem_strides_array_t __get_elem_strides(
   const int __init_index = (__interleave_layout == tma_interleave_layout::none) ? 1 : 0;
   for (int __i = __init_index; __i < __rank; ++__i)
   {
-    const auto __max_elem_stride = static_cast<int>(::cuda::std::__vmin(__tensor_sizes[__i], uint64_t{8}));
+    const auto __max_elem_stride = static_cast<int>(::cuda::std::__min(__tensor_sizes[__i], uint64_t{8}));
     const auto __elem_stride     = __elem_strides[__rank - 1 - __i];
     if (__elem_stride <= 0 || __elem_stride > __max_elem_stride)
     {

--- a/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
+++ b/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
@@ -479,7 +479,7 @@ _CCCL_HOST_API inline __tma_box_sizes_array_t __get_box_sizes(
   size_t __total_size = 1;
   for (int __i = 0; __i < __rank; ++__i)
   {
-    const auto __max_box_size = static_cast<int>(::cuda::std::min(__tensor_sizes[__i], uint64_t{256}));
+    const auto __max_box_size = static_cast<int>(::cuda::std::__vmin(__tensor_sizes[__i], uint64_t{256}));
     const auto __box_size     = __box_sizes[__rank - 1 - __i];
     if (__box_size <= 0 || __box_size > __max_box_size)
     {
@@ -569,7 +569,7 @@ _CCCL_HOST_API inline __tma_elem_strides_array_t __get_elem_strides(
   const int __init_index = (__interleave_layout == tma_interleave_layout::none) ? 1 : 0;
   for (int __i = __init_index; __i < __rank; ++__i)
   {
-    const auto __max_elem_stride = static_cast<int>(::cuda::std::min(__tensor_sizes[__i], uint64_t{8}));
+    const auto __max_elem_stride = static_cast<int>(::cuda::std::__vmin(__tensor_sizes[__i], uint64_t{8}));
     const auto __elem_stride     = __elem_strides[__rank - 1 - __i];
     if (__elem_stride <= 0 || __elem_stride > __max_elem_stride)
     {

--- a/libcudacxx/include/cuda/std/__algorithm/clamp.h
+++ b/libcudacxx/include/cuda/std/__algorithm/clamp.h
@@ -21,6 +21,8 @@
 #endif // no system header
 
 #include <cuda/std/__algorithm/comp.h>
+#include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__algorithm/min.h>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -39,6 +41,12 @@ template <class _Tp>
 {
   _CCCL_ASSERT(!(__hi < __lo), "Bad bounds passed to cuda::std::clamp");
   return __v < __lo ? __lo : __hi < __v ? __hi : __v;
+}
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __vclamp(_Tp __v, _Tp __lo, _Tp __hi) noexcept
+{
+  return ::cuda::std::__vmax(__lo, ::cuda::std::__vmin(__v, __hi));
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/clamp.h
+++ b/libcudacxx/include/cuda/std/__algorithm/clamp.h
@@ -44,7 +44,7 @@ template <class _Tp>
 }
 
 //! @brief Internal version of clamp that works with values instead of references. Can be used with extended arithmetic
-//!        types. Should be preferred as it produces better optimized code with nvcc.
+//!        types. Should be preferred as it produces better optimized code with nvcc (see nvbug 5455679).
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __clamp(_Tp __v, _Tp __lo, _Tp __hi) noexcept
 {

--- a/libcudacxx/include/cuda/std/__algorithm/clamp.h
+++ b/libcudacxx/include/cuda/std/__algorithm/clamp.h
@@ -43,10 +43,12 @@ template <class _Tp>
   return __v < __lo ? __lo : __hi < __v ? __hi : __v;
 }
 
+//! @brief Internal version of clamp that works with values instead of references. Can be used with extended arithmetic
+//!        types. Should be preferred as it produces better optimized code with nvcc.
 template <class _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp __vclamp(_Tp __v, _Tp __lo, _Tp __hi) noexcept
+[[nodiscard]] _CCCL_API constexpr _Tp __clamp(_Tp __v, _Tp __lo, _Tp __hi) noexcept
 {
-  return ::cuda::std::__vmax(__lo, ::cuda::std::__vmin(__v, __hi));
+  return ::cuda::std::__max(__lo, ::cuda::std::__min(__v, __hi));
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/max.h
+++ b/libcudacxx/include/cuda/std/__algorithm/max.h
@@ -58,8 +58,10 @@ template <class _Tp>
   return *::cuda::std::max_element(__t.begin(), __t.end(), __less{});
 }
 
+//! @brief Internal version of max that works with values instead of references. Can be used with extended arithmetic
+//!        types. Should be preferred as it produces better optimized code with nvcc.
 template <class _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp __vmax(_Tp __a, _Tp __b) noexcept
+[[nodiscard]] _CCCL_API constexpr _Tp __max(_Tp __a, _Tp __b) noexcept
 {
   static_assert(__is_extended_arithmetic_v<_Tp>);
   if constexpr (is_integral_v<_Tp>)

--- a/libcudacxx/include/cuda/std/__algorithm/max.h
+++ b/libcudacxx/include/cuda/std/__algorithm/max.h
@@ -70,15 +70,17 @@ template <class _Tp>
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT
     {
-      if constexpr (sizeof(_Tp) < sizeof(int))
-      {
-        using _Up = __make_nbit_int_t<32, is_signed_v<_Tp>>;
-        return static_cast<_Tp>(::cuda::std::__max(static_cast<_Up>(__a), static_cast<_Up>(__b)));
-      }
-      else if constexpr (sizeof(_Tp) <= sizeof(long long))
-      {
-        return ::max(__a, __b);
-      }
+      NV_IF_TARGET(NV_IS_DEVICE, ({
+                     if constexpr (sizeof(_Tp) < sizeof(int))
+                     {
+                       using _Up = __make_nbit_int_t<32, is_signed_v<_Tp>>;
+                       return static_cast<_Tp>(::cuda::std::__max(static_cast<_Up>(__a), static_cast<_Up>(__b)));
+                     }
+                     else if constexpr (sizeof(_Tp) <= sizeof(long long))
+                     {
+                       return ::max(__a, __b);
+                     }
+                   }))
     }
     return (__a < __b) ? __b : __a;
   }

--- a/libcudacxx/include/cuda/std/__algorithm/max.h
+++ b/libcudacxx/include/cuda/std/__algorithm/max.h
@@ -23,6 +23,9 @@
 #include <cuda/std/__algorithm/comp.h>
 #include <cuda/std/__algorithm/comp_ref_type.h>
 #include <cuda/std/__algorithm/max_element.h>
+#include <cuda/std/__cmath/min_max.h>
+#include <cuda/std/__type_traits/is_extended_arithmetic.h>
+#include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/initializer_list>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -53,6 +56,20 @@ template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp max(initializer_list<_Tp> __t)
 {
   return *::cuda::std::max_element(__t.begin(), __t.end(), __less{});
+}
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __vmax(_Tp __a, _Tp __b) noexcept
+{
+  static_assert(__is_extended_arithmetic_v<_Tp>);
+  if constexpr (is_integral_v<_Tp>)
+  {
+    return (__a < __b) ? __b : __a;
+  }
+  else
+  {
+    return ::cuda::std::fmax(__a, __b);
+  }
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/max.h
+++ b/libcudacxx/include/cuda/std/__algorithm/max.h
@@ -26,6 +26,8 @@
 #include <cuda/std/__cmath/min_max.h>
 #include <cuda/std/__type_traits/is_extended_arithmetic.h>
 #include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_signed.h>
+#include <cuda/std/__type_traits/make_nbit_int.h>
 #include <cuda/std/initializer_list>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -59,13 +61,25 @@ template <class _Tp>
 }
 
 //! @brief Internal version of max that works with values instead of references. Can be used with extended arithmetic
-//!        types. Should be preferred as it produces better optimized code with nvcc.
+//!        types. Should be preferred as it produces better optimized code with nvcc (see nvbug 5455679).
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __max(_Tp __a, _Tp __b) noexcept
 {
   static_assert(__is_extended_arithmetic_v<_Tp>);
   if constexpr (is_integral_v<_Tp>)
   {
+    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+    {
+      if constexpr (sizeof(_Tp) < sizeof(int))
+      {
+        using _Up = __make_nbit_int_t<32, is_signed_v<_Tp>>;
+        return static_cast<_Tp>(::cuda::std::__max(static_cast<_Up>(__a), static_cast<_Up>(__b)));
+      }
+      else if constexpr (sizeof(_Tp) <= sizeof(long long))
+      {
+        return ::max(__a, __b);
+      }
+    }
     return (__a < __b) ? __b : __a;
   }
   else

--- a/libcudacxx/include/cuda/std/__algorithm/min.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min.h
@@ -70,17 +70,17 @@ template <class _Tp>
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT
     {
-      NV_IF_TARGET(NV_IS_DEVICE({
-        if constexpr (sizeof(_Tp) < sizeof(int))
-        {
-          using _Up = __make_nbit_int_t<32, is_signed_v<_Tp>>;
-          return static_cast<_Tp>(::cuda::std::__min(static_cast<_Up>(__a), static_cast<_Up>(__b)));
-        }
-        else if constexpr (sizeof(_Tp) <= sizeof(long long))
-        {
-          return ::min(__a, __b);
-        }
-      }))
+      NV_IF_TARGET(NV_IS_DEVICE, ({
+                     if constexpr (sizeof(_Tp) < sizeof(int))
+                     {
+                       using _Up = __make_nbit_int_t<32, is_signed_v<_Tp>>;
+                       return static_cast<_Tp>(::cuda::std::__min(static_cast<_Up>(__a), static_cast<_Up>(__b)));
+                     }
+                     else if constexpr (sizeof(_Tp) <= sizeof(long long))
+                     {
+                       return ::min(__a, __b);
+                     }
+                   }))
     }
     return (__b < __a) ? __b : __a;
   }

--- a/libcudacxx/include/cuda/std/__algorithm/min.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min.h
@@ -23,6 +23,9 @@
 #include <cuda/std/__algorithm/comp.h>
 #include <cuda/std/__algorithm/comp_ref_type.h>
 #include <cuda/std/__algorithm/min_element.h>
+#include <cuda/std/__cmath/min_max.h>
+#include <cuda/std/__type_traits/is_extended_arithmetic.h>
+#include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/initializer_list>
 
 #include <cuda/std/__cccl/prologue.h>
@@ -53,6 +56,20 @@ template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp min(initializer_list<_Tp> __t)
 {
   return *::cuda::std::min_element(__t.begin(), __t.end(), __less{});
+}
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API constexpr _Tp __vmin(_Tp __a, _Tp __b) noexcept
+{
+  static_assert(__is_extended_arithmetic_v<_Tp>);
+  if constexpr (is_integral_v<_Tp>)
+  {
+    return (__b < __a) ? __b : __a;
+  }
+  else
+  {
+    return ::cuda::std::fmin(__a, __b);
+  }
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__algorithm/min.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min.h
@@ -58,8 +58,10 @@ template <class _Tp>
   return *::cuda::std::min_element(__t.begin(), __t.end(), __less{});
 }
 
+//! @brief Internal version of min that works with values instead of references. Can be used with extended arithmetic
+//!        types. Should be preferred as it produces better optimized code with nvcc.
 template <class _Tp>
-[[nodiscard]] _CCCL_API constexpr _Tp __vmin(_Tp __a, _Tp __b) noexcept
+[[nodiscard]] _CCCL_API constexpr _Tp __min(_Tp __a, _Tp __b) noexcept
 {
   static_assert(__is_extended_arithmetic_v<_Tp>);
   if constexpr (is_integral_v<_Tp>)

--- a/libcudacxx/include/cuda/std/__algorithm/min.h
+++ b/libcudacxx/include/cuda/std/__algorithm/min.h
@@ -70,15 +70,17 @@ template <class _Tp>
   {
     _CCCL_IF_NOT_CONSTEVAL_DEFAULT
     {
-      if constexpr (sizeof(_Tp) < sizeof(int))
-      {
-        using _Up = __make_nbit_int_t<32, is_signed_v<_Tp>>;
-        return static_cast<_Tp>(::cuda::std::__min(static_cast<_Up>(__a), static_cast<_Up>(__b)));
-      }
-      else if constexpr (sizeof(_Tp) <= sizeof(long long))
-      {
-        return ::min(__a, __b);
-      }
+      NV_IF_TARGET(NV_IS_DEVICE({
+        if constexpr (sizeof(_Tp) < sizeof(int))
+        {
+          using _Up = __make_nbit_int_t<32, is_signed_v<_Tp>>;
+          return static_cast<_Tp>(::cuda::std::__min(static_cast<_Up>(__a), static_cast<_Up>(__b)));
+        }
+        else if constexpr (sizeof(_Tp) <= sizeof(long long))
+        {
+          return ::min(__a, __b);
+        }
+      }))
     }
     return (__b < __a) ? __b : __a;
   }

--- a/libcudacxx/include/cuda/std/__bit/integral.h
+++ b/libcudacxx/include/cuda/std/__bit/integral.h
@@ -84,7 +84,7 @@ _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
       // The result is computed as max(1, bit_width(__t - 1)) because it is more efficient than the ternary operator
       NV_IF_TARGET(NV_IS_DEVICE, //
                    (auto __shift = ::cuda::ptx::shl(_Up{1}, __width); // 2^(ceil(log2(__t - 1)))
-                    auto __ret   = static_cast<_Tp>(::cuda::std::max(_Up{1}, __shift)); //
+                    auto __ret   = static_cast<_Tp>(::cuda::std::__vmax(_Up{1}, __shift)); //
                     _CCCL_ASSUME(__ret >= __t);
                     return __ret;))
     }

--- a/libcudacxx/include/cuda/std/__bit/integral.h
+++ b/libcudacxx/include/cuda/std/__bit/integral.h
@@ -84,7 +84,7 @@ _CCCL_REQUIRES(::cuda::std::__cccl_is_unsigned_integer_v<_Tp>)
       // The result is computed as max(1, bit_width(__t - 1)) because it is more efficient than the ternary operator
       NV_IF_TARGET(NV_IS_DEVICE, //
                    (auto __shift = ::cuda::ptx::shl(_Up{1}, __width); // 2^(ceil(log2(__t - 1)))
-                    auto __ret   = static_cast<_Tp>(::cuda::std::__vmax(_Up{1}, __shift)); //
+                    auto __ret   = static_cast<_Tp>(::cuda::std::__max(_Up{1}, __shift)); //
                     _CCCL_ASSUME(__ret >= __t);
                     return __ret;))
     }

--- a/libcudacxx/include/cuda/std/__cccl/epilogue.h
+++ b/libcudacxx/include/cuda/std/__cccl/epilogue.h
@@ -317,12 +317,28 @@ _CCCL_DIAG_POP
 #  undef _CCCL_POP_MACRO_min
 #endif
 
+#if defined(__min)
+#  error \
+    "cccl internal error: macro `__min` was redefined between <cuda/std/__cccl/prologue.h> and <cuda/std/__cccl/epilogue.h>"
+#elif defined(_CCCL_POP_MACRO___min)
+#  pragma pop_macro("__min")
+#  undef _CCCL_POP_MACRO___min
+#endif
+
 #if defined(max)
 #  error \
     "cccl internal error: macro `max` was redefined between <cuda/std/__cccl/prologue.h> and <cuda/std/__cccl/epilogue.h>"
 #elif defined(_CCCL_POP_MACRO_max)
 #  pragma pop_macro("max")
 #  undef _CCCL_POP_MACRO_max
+#endif
+
+#if defined(__max)
+#  error \
+    "cccl internal error: macro `__max` was redefined between <cuda/std/__cccl/prologue.h> and <cuda/std/__cccl/epilogue.h>"
+#elif defined(_CCCL_POP_MACRO___max)
+#  pragma pop_macro("__max")
+#  undef _CCCL_POP_MACRO___max
 #endif
 
 #if defined(interface)

--- a/libcudacxx/include/cuda/std/__cccl/prologue.h
+++ b/libcudacxx/include/cuda/std/__cccl/prologue.h
@@ -244,11 +244,23 @@
 #  define _CCCL_POP_MACRO_min
 #endif // defined(min)
 
+#if defined(__min)
+#  pragma push_macro("__min")
+#  undef __min
+#  define _CCCL_POP_MACRO___min
+#endif // defined(__min)
+
 #if defined(max)
 #  pragma push_macro("max")
 #  undef max
 #  define _CCCL_POP_MACRO_max
 #endif // defined(max)
+
+#if defined(__max)
+#  pragma push_macro("__max")
+#  undef __max
+#  define _CCCL_POP_MACRO___max
+#endif // defined(__max)
 
 #if defined(interface)
 #  pragma push_macro("interface")

--- a/libcudacxx/include/cuda/std/__format/format_integral.h
+++ b/libcudacxx/include/cuda/std/__format/format_integral.h
@@ -150,7 +150,7 @@ template <class _Tp, class _CharT, class _FmtCtx>
     __out_it                  = ::cuda::std::__fmt_copy(__array, __first, ::cuda::std::move(__out_it));
     __specs.__alignment_      = ::cuda::std::to_underlying(__fmt_spec_alignment::__right);
     __specs.__fill_.__data[0] = _CharT{'0'};
-    __specs.__width_ -= ::cuda::std::__vmin(static_cast<uint32_t>(__last - __first), __specs.__width_);
+    __specs.__width_ -= ::cuda::std::__min(static_cast<uint32_t>(__last - __first), __specs.__width_);
   }
 
   if (__specs.__std_.__type_ != __fmt_spec_type::__hexadecimal_upper_case)

--- a/libcudacxx/include/cuda/std/__format/format_integral.h
+++ b/libcudacxx/include/cuda/std/__format/format_integral.h
@@ -150,7 +150,7 @@ template <class _Tp, class _CharT, class _FmtCtx>
     __out_it                  = ::cuda::std::__fmt_copy(__array, __first, ::cuda::std::move(__out_it));
     __specs.__alignment_      = ::cuda::std::to_underlying(__fmt_spec_alignment::__right);
     __specs.__fill_.__data[0] = _CharT{'0'};
-    __specs.__width_ -= ::cuda::std::min(static_cast<uint32_t>(__last - __first), __specs.__width_);
+    __specs.__width_ -= ::cuda::std::__vmin(static_cast<uint32_t>(__last - __first), __specs.__width_);
   }
 
   if (__specs.__std_.__type_ != __fmt_spec_type::__hexadecimal_upper_case)

--- a/libcudacxx/include/cuda/std/__format/format_spec_parser.h
+++ b/libcudacxx/include/cuda/std/__format/format_spec_parser.h
@@ -1254,7 +1254,7 @@ __fmt_estimate_column_width(basic_string_view<_CharT> __str, size_t __maximum, _
   // When Unicode isn't supported assume ASCII and every code unit is one code
   // point. In ASCII the estimated column width is always one. Thus there's no
   // need for rounding.
-  size_t __width = ::cuda::std::__vmin(__str.size(), __maximum);
+  size_t __width = ::cuda::std::__min(__str.size(), __maximum);
   return {__width, __str.begin() + __width};
 }
 

--- a/libcudacxx/include/cuda/std/__format/format_spec_parser.h
+++ b/libcudacxx/include/cuda/std/__format/format_spec_parser.h
@@ -1254,7 +1254,7 @@ __fmt_estimate_column_width(basic_string_view<_CharT> __str, size_t __maximum, _
   // When Unicode isn't supported assume ASCII and every code unit is one code
   // point. In ASCII the estimated column width is always one. Thus there's no
   // need for rounding.
-  size_t __width = ::cuda::std::min(__str.size(), __maximum);
+  size_t __width = ::cuda::std::__vmin(__str.size(), __maximum);
   return {__width, __str.begin() + __width};
 }
 

--- a/libcudacxx/include/cuda/std/__random/philox_engine.h
+++ b/libcudacxx/include/cuda/std/__random/philox_engine.h
@@ -254,7 +254,7 @@ public:
   _CCCL_API constexpr void discard(unsigned long long __z) noexcept
   {
     // Advance __j_ until we are at n - 1
-    auto __advance = ::cuda::std::__vmin(__z, static_cast<unsigned long long>(word_count - 1 - __j_));
+    auto __advance = ::cuda::std::__min(__z, static_cast<unsigned long long>(word_count - 1 - __j_));
     __j_ += static_cast<::cuda::std::size_t>(__advance);
     __z -= __advance;
 

--- a/libcudacxx/include/cuda/std/__random/philox_engine.h
+++ b/libcudacxx/include/cuda/std/__random/philox_engine.h
@@ -254,7 +254,7 @@ public:
   _CCCL_API constexpr void discard(unsigned long long __z) noexcept
   {
     // Advance __j_ until we are at n - 1
-    auto __advance = ::cuda::std::min(__z, static_cast<unsigned long long>(word_count - 1 - __j_));
+    auto __advance = ::cuda::std::__vmin(__z, static_cast<unsigned long long>(word_count - 1 - __j_));
     __j_ += static_cast<::cuda::std::size_t>(__advance);
     __z -= __advance;
 

--- a/libcudacxx/include/cuda/std/__random/seed_seq.h
+++ b/libcudacxx/include/cuda/std/__random/seed_seq.h
@@ -137,7 +137,7 @@ public:
     // https://en.cppreference.com/w/cpp/numeric/random/seed_seq/generate.html
     const result_type __z = static_cast<result_type>(__size_);
     const result_type __n = static_cast<result_type>(::cuda::std::distance(__begin, __end));
-    const result_type __m = ::cuda::std::__vmax(__z + 1, __n);
+    const result_type __m = ::cuda::std::__max(__z + 1, __n);
     const result_type __t = (__n >= 623) ? 11 : (__n >= 68) ? 7 : (__n >= 39) ? 5 : (__n >= 7) ? 3 : (__n - 1) / 2;
     const result_type __p = (__n - __t) / 2;
     const result_type __q = __p + __t;

--- a/libcudacxx/include/cuda/std/__random/seed_seq.h
+++ b/libcudacxx/include/cuda/std/__random/seed_seq.h
@@ -137,7 +137,7 @@ public:
     // https://en.cppreference.com/w/cpp/numeric/random/seed_seq/generate.html
     const result_type __z = static_cast<result_type>(__size_);
     const result_type __n = static_cast<result_type>(::cuda::std::distance(__begin, __end));
-    const result_type __m = ::cuda::std::max(__z + 1, __n);
+    const result_type __m = ::cuda::std::__vmax(__z + 1, __n);
     const result_type __t = (__n >= 623) ? 11 : (__n >= 68) ? 7 : (__n >= 39) ? 5 : (__n >= 7) ? 3 : (__n - 1) / 2;
     const result_type __p = (__n - __t) / 2;
     const result_type __q = __p + __t;

--- a/libcudacxx/include/cuda/std/__string/helper_functions.h
+++ b/libcudacxx/include/cuda/std/__string/helper_functions.h
@@ -149,7 +149,7 @@ template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 _CCCL_API constexpr _SizeT
 __cccl_str_rfind(const _CharT* __p, _SizeT __sz, const _CharT* __s, _SizeT __pos, _SizeT __n) noexcept
 {
-  __pos = ::cuda::std::__vmin(__pos, __sz);
+  __pos = ::cuda::std::__min(__pos, __sz);
   if (__n < __sz - __pos)
   {
     __pos += __n;

--- a/libcudacxx/include/cuda/std/__string/helper_functions.h
+++ b/libcudacxx/include/cuda/std/__string/helper_functions.h
@@ -149,7 +149,7 @@ template <class _CharT, class _SizeT, class _Traits, _SizeT __npos>
 _CCCL_API constexpr _SizeT
 __cccl_str_rfind(const _CharT* __p, _SizeT __sz, const _CharT* __s, _SizeT __pos, _SizeT __n) noexcept
 {
-  __pos = ::cuda::std::min(__pos, __sz);
+  __pos = ::cuda::std::__vmin(__pos, __sz);
   if (__n < __sz - __pos)
   {
     __pos += __n;

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -266,7 +266,7 @@ protected:
 
   _CCCL_API constexpr __bitset& operator<<=(size_t __pos) noexcept
   {
-    __pos = ::cuda::std::__vmin(__pos, _Size);
+    __pos = ::cuda::std::__min(__pos, _Size);
     ::cuda::std::copy_backward(__make_iter(0), __make_iter(_Size - __pos), __make_iter(_Size));
     ::cuda::std::fill_n(__make_iter(0), __pos, false);
     return *this;
@@ -274,7 +274,7 @@ protected:
 
   _CCCL_API constexpr __bitset& operator>>=(size_t __pos) noexcept
   {
-    __pos = ::cuda::std::__vmin(__pos, _Size);
+    __pos = ::cuda::std::__min(__pos, _Size);
     ::cuda::std::copy(__make_iter(__pos), __make_iter(_Size), __make_iter(0));
     ::cuda::std::fill_n(__make_iter(_Size - __pos), __pos, false);
     return *this;
@@ -678,7 +678,7 @@ public:
   _CCCL_API constexpr explicit bitset(
     const _CharT* __str, size_t __n = static_cast<size_t>(-1), _CharT __zero = _CharT('0'), _CharT __one = _CharT('1'))
   {
-    size_t __rlen = ::cuda::std::__vmin(__n, char_traits<_CharT>::length(__str));
+    size_t __rlen = ::cuda::std::__min(__n, char_traits<_CharT>::length(__str));
     __init_from_cstr(__str, __rlen, __zero, __one);
   }
 
@@ -695,7 +695,7 @@ public:
       ::cuda::std::__throw_out_of_range("bitset string pos out of range");
     }
 
-    size_t __rlen = ::cuda::std::__vmin(__n, __str.size() - __pos);
+    size_t __rlen = ::cuda::std::__min(__n, __str.size() - __pos);
     __init_from_cstr(__str.data() + __pos, __rlen, __zero, __one);
   }
 
@@ -713,7 +713,7 @@ public:
       ::cuda::std::__throw_out_of_range("bitset string pos out of range");
     }
 
-    size_t __rlen = ::cuda::std::__vmin(__n, __str.size() - __pos);
+    size_t __rlen = ::cuda::std::__min(__n, __str.size() - __pos);
     __init_from_cstr(__str.data() + __pos, __rlen, __zero, __one);
   }
 #endif // defined(_LIBCUDACXX_HAS_STRING)
@@ -921,7 +921,7 @@ private:
       }
     }
 
-    size_t __mp = ::cuda::std::__vmin(__size, _Size);
+    size_t __mp = ::cuda::std::__min(__size, _Size);
     size_t __i  = 0;
     for (; __i < __mp; ++__i)
     {

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -266,7 +266,7 @@ protected:
 
   _CCCL_API constexpr __bitset& operator<<=(size_t __pos) noexcept
   {
-    __pos = ::cuda::std::min(__pos, _Size);
+    __pos = ::cuda::std::__vmin(__pos, _Size);
     ::cuda::std::copy_backward(__make_iter(0), __make_iter(_Size - __pos), __make_iter(_Size));
     ::cuda::std::fill_n(__make_iter(0), __pos, false);
     return *this;
@@ -274,7 +274,7 @@ protected:
 
   _CCCL_API constexpr __bitset& operator>>=(size_t __pos) noexcept
   {
-    __pos = ::cuda::std::min(__pos, _Size);
+    __pos = ::cuda::std::__vmin(__pos, _Size);
     ::cuda::std::copy(__make_iter(__pos), __make_iter(_Size), __make_iter(0));
     ::cuda::std::fill_n(__make_iter(_Size - __pos), __pos, false);
     return *this;
@@ -678,7 +678,7 @@ public:
   _CCCL_API constexpr explicit bitset(
     const _CharT* __str, size_t __n = static_cast<size_t>(-1), _CharT __zero = _CharT('0'), _CharT __one = _CharT('1'))
   {
-    size_t __rlen = ::cuda::std::min(__n, char_traits<_CharT>::length(__str));
+    size_t __rlen = ::cuda::std::__vmin(__n, char_traits<_CharT>::length(__str));
     __init_from_cstr(__str, __rlen, __zero, __one);
   }
 
@@ -695,7 +695,7 @@ public:
       ::cuda::std::__throw_out_of_range("bitset string pos out of range");
     }
 
-    size_t __rlen = ::cuda::std::min(__n, __str.size() - __pos);
+    size_t __rlen = ::cuda::std::__vmin(__n, __str.size() - __pos);
     __init_from_cstr(__str.data() + __pos, __rlen, __zero, __one);
   }
 
@@ -713,7 +713,7 @@ public:
       ::cuda::std::__throw_out_of_range("bitset string pos out of range");
     }
 
-    size_t __rlen = ::cuda::std::min(__n, __str.size() - __pos);
+    size_t __rlen = ::cuda::std::__vmin(__n, __str.size() - __pos);
     __init_from_cstr(__str.data() + __pos, __rlen, __zero, __one);
   }
 #endif // defined(_LIBCUDACXX_HAS_STRING)
@@ -921,7 +921,7 @@ private:
       }
     }
 
-    size_t __mp = ::cuda::std::min(__size, _Size);
+    size_t __mp = ::cuda::std::__vmin(__size, _Size);
     size_t __i  = 0;
     for (; __i < __mp; ++__i)
     {

--- a/libcudacxx/include/cuda/std/string_view
+++ b/libcudacxx/include/cuda/std/string_view
@@ -359,7 +359,7 @@ public:
     {
       ::cuda::std::__throw_out_of_range("string_view::copy");
     }
-    const auto __rlen = ::cuda::std::min(__n, __size_ - __pos);
+    const auto __rlen = ::cuda::std::__vmin(__n, __size_ - __pos);
     _Traits::copy(__s, __data_ + __pos, __rlen);
     return __rlen;
   }
@@ -373,14 +373,14 @@ public:
     {
       ::cuda::std::__throw_out_of_range("string_view::substr");
     }
-    return basic_string_view{__assume_valid{}, __data_ + __pos, ::cuda::std::min(__n, __size_ - __pos)};
+    return basic_string_view{__assume_valid{}, __data_ + __pos, ::cuda::std::__vmin(__n, __size_ - __pos)};
   }
 
   // compare
 
   [[nodiscard]] _CCCL_API constexpr int compare(basic_string_view __sv) const noexcept
   {
-    const auto __rlen = ::cuda::std::min(__size_, __sv.__size_);
+    const auto __rlen = ::cuda::std::__vmin(__size_, __sv.__size_);
     int __retval      = _Traits::compare(__data_, __sv.__data_, __rlen);
     if (__retval == 0) // first __rlen chars matched
     {

--- a/libcudacxx/include/cuda/std/string_view
+++ b/libcudacxx/include/cuda/std/string_view
@@ -359,7 +359,7 @@ public:
     {
       ::cuda::std::__throw_out_of_range("string_view::copy");
     }
-    const auto __rlen = ::cuda::std::__vmin(__n, __size_ - __pos);
+    const auto __rlen = ::cuda::std::__min(__n, __size_ - __pos);
     _Traits::copy(__s, __data_ + __pos, __rlen);
     return __rlen;
   }
@@ -373,14 +373,14 @@ public:
     {
       ::cuda::std::__throw_out_of_range("string_view::substr");
     }
-    return basic_string_view{__assume_valid{}, __data_ + __pos, ::cuda::std::__vmin(__n, __size_ - __pos)};
+    return basic_string_view{__assume_valid{}, __data_ + __pos, ::cuda::std::__min(__n, __size_ - __pos)};
   }
 
   // compare
 
   [[nodiscard]] _CCCL_API constexpr int compare(basic_string_view __sv) const noexcept
   {
-    const auto __rlen = ::cuda::std::__vmin(__size_, __sv.__size_);
+    const auto __rlen = ::cuda::std::__min(__size_, __sv.__size_);
     int __retval      = _Traits::compare(__data_, __sv.__data_, __rlen);
     if (__retval == 0) // first __rlen chars matched
     {


### PR DESCRIPTION
I've heard several times already that `cuda::std::(min|max|clamp)` are problematic because they return reference and not value.

This PR introduces internal variants that always return value.