### PR TITLE
Fix double destroy in vector

### DIFF
--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -165,8 +165,8 @@ vector_base<T, Alloc>& vector_base<T, Alloc>::operator=(const vector_base& v)
   {
     m_storage.destroy_on_allocator_mismatch(v.m_storage, begin(), end());
     m_storage.deallocate_on_allocator_mismatch(v.m_storage);
-
     m_storage.propagate_allocator(v.m_storage);
+    m_size = 0;
 
     assign(v.begin(), v.end());
   } // end if

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -165,8 +165,14 @@ vector_base<T, Alloc>& vector_base<T, Alloc>::operator=(const vector_base& v)
   {
     m_storage.destroy_on_allocator_mismatch(v.m_storage, begin(), end());
     m_storage.deallocate_on_allocator_mismatch(v.m_storage);
+    if constexpr (thrust::detail::allocator_traits<Alloc>::propagate_on_container_copy_assignment::value)
+    {
+      if (m_storage.get_allocator() != v.m_storage.get_allocator())
+      {
+        m_size = 0;
+      }
+    }
     m_storage.propagate_allocator(v.m_storage);
-    m_size = 0;
 
     assign(v.begin(), v.end());
   } // end if


### PR DESCRIPTION
We were not resetting the `vector::m_size` member after destroying the old storage, only `vector::m_storage::m_size`. Then in `range_assign` we would call `m_storage.destroy(begin(), end());` but `end()` takes into account `vector::m_size` and not `vector::m_storage::m_size`.

Consequently we would try to delete the old elements again, even if the storage was already deallocated, passing a `nullptr` to `destroy_at`

This started to fail because with the rework of `allocator_traits` in another PR we are actually checking in `cuda::std::__destroy_at` whether the passed pointer is valid.
