### PR TITLE
Optimize `cuda::sub_overflow`

### DIFF
--- a/libcudacxx/include/cuda/__numeric/sub_overflow.h
+++ b/libcudacxx/include/cuda/__numeric/sub_overflow.h
@@ -80,11 +80,11 @@ template <typename _Tp>
   const auto __sub = ::cuda::__sub_as_unsigned<_Tp>(__lhs, __rhs);
   if constexpr (::cuda::std::is_signed_v<_Tp>)
   {
-    return overflow_result<_Tp>{__sub, (__sub > __lhs) == (__rhs >= _Tp{0})};
+    return {__sub, (__sub > __lhs) == (__rhs >= _Tp{0})};
   }
   else
   {
-    return overflow_result<_Tp>{__sub, __sub > __lhs};
+    return {__sub, __sub > __lhs};
   }
 }
 
@@ -102,7 +102,7 @@ template <class _Tp>
     {
       constexpr auto __max         = uint32_t{::cuda::std::numeric_limits<_Tp>::max()};
       const auto __result_enlarged = uint32_t{__lhs} - uint32_t{__rhs};
-      return overflow_result<_Tp>{static_cast<_Tp>(__result_enlarged), __result_enlarged > __max};
+      return {static_cast<_Tp>(__result_enlarged), __result_enlarged > __max};
     }
     else if constexpr (sizeof(_Tp) == sizeof(uint32_t))
     {
@@ -112,7 +112,7 @@ template <class _Tp>
           "subc.u32 %1, 0, 0;"
           : "=r"(__result), "=r"(__overflow)
           : "r"(__lhs), "r"(__rhs));
-      return overflow_result<_Tp>{__result, static_cast<bool>(__overflow)};
+      return {__result, static_cast<bool>(__overflow)};
     }
     else if constexpr (sizeof(_Tp) == sizeof(uint64_t))
     {
@@ -122,7 +122,7 @@ template <class _Tp>
           "subc.u32 %1, 0, 0;"
           : "=l"(__result), "=r"(__overflow)
           : "l"(__lhs), "l"(__rhs));
-      return overflow_result<_Tp>{__result, static_cast<bool>(__overflow)};
+      return {__result, static_cast<bool>(__overflow)};
     }
 #  if _CCCL_HAS_INT128()
     else if constexpr (sizeof(_Tp) == sizeof(__uint128_t))
@@ -138,8 +138,7 @@ template <class _Tp>
             "l"(static_cast<uint64_t>(__lhs)),
             "l"(static_cast<uint64_t>(__rhs >> 64)),
             "l"(static_cast<uint64_t>(__rhs)));
-      return overflow_result<_Tp>{
-        (static_cast<__uint128_t>(__result_hi) << 64) | __result_lo, static_cast<bool>(__overflow)};
+      return {(static_cast<__uint128_t>(__result_hi) << 64) | __result_lo, static_cast<bool>(__overflow)};
     }
 #  endif // _CCCL_HAS_INT128()
     else
@@ -156,8 +155,7 @@ template <class _Tp>
       constexpr auto __max         = int32_t{::cuda::std::numeric_limits<_Tp>::max()};
       constexpr auto __min         = int32_t{::cuda::std::numeric_limits<_Tp>::min()};
       const auto __result_enlarged = int32_t{__lhs} - int32_t{__rhs};
-      return overflow_result<_Tp>{
-        static_cast<_Tp>(__result_enlarged), __result_enlarged > __max || __result_enlarged < __min};
+      return {static_cast<_Tp>(__result_enlarged), __result_enlarged > __max || __result_enlarged < __min};
     }
 #  if _CCCL_HAS_INT128()
     else if constexpr (sizeof(_Tp) == sizeof(__int128_t))


### PR DESCRIPTION
This PR optimizes `cuda::sub_overflow` implementation for unsigned types.

See the SASS comparison:
- unsigned: https://godbolt.org/z/onxKn8nnK
- signed: https://godbolt.org/z/dzKG3qd4M

Note: I need to find out whether the old implementation wasn't better for signed 32-bit and 64-bit types.