### PR TITLE
Drop partial specialization in friend functions of `fast_mod_div`

### DIFF
--- a/libcudacxx/include/cuda/__cmath/fast_modulo_division.h
+++ b/libcudacxx/include/cuda/__cmath/fast_modulo_division.h
@@ -97,7 +97,7 @@ public:
 
   template <typename _Lhs>
   [[nodiscard]] _CCCL_API friend ::cuda::std::common_type_t<_Tp, _Lhs>
-  operator/(_Lhs __dividend, fast_mod_div<_Tp> __divisor1) noexcept
+  operator/(_Lhs __dividend, fast_mod_div __divisor1) noexcept
   {
     using ::cuda::std::is_same_v;
     using ::cuda::std::is_signed_v;
@@ -142,7 +142,7 @@ public:
 
   template <typename _Lhs>
   [[nodiscard]] _CCCL_API friend ::cuda::std::common_type_t<_Tp, _Lhs>
-  operator%(_Lhs __dividend, fast_mod_div<_Tp> __divisor1) noexcept
+  operator%(_Lhs __dividend, fast_mod_div __divisor1) noexcept
   {
     return __dividend - (__dividend / __divisor1) * __divisor1.__divisor;
   }
@@ -163,8 +163,9 @@ private:
  * Non-member functions
  **********************************************************************************************************************/
 
-template <typename _Tp, typename _Lhs>
-[[nodiscard]] _CCCL_API ::cuda::std::pair<_Tp, _Lhs> div(_Tp __dividend, fast_mod_div<_Lhs> __divisor) noexcept
+template <typename _Tp, typename _Lhs, bool _DivisorIsNeverOne>
+[[nodiscard]] _CCCL_API ::cuda::std::pair<_Tp, _Lhs>
+div(_Tp __dividend, fast_mod_div<_Lhs, _DivisorIsNeverOne> __divisor) noexcept
 {
   auto __quotient  = __dividend / __divisor;
   auto __remainder = __dividend - __quotient * __divisor;

--- a/libcudacxx/test/libcudacxx/cuda/cmath/fast_modulo_division.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/cmath/fast_modulo_division.pass.cpp
@@ -95,6 +95,15 @@ __host__ __device__ void test_cpp_semantic()
   assert(cuda::div(5, div) == (cuda::std::pair<int, int>{1, 2}));
 }
 
+__host__ __device__ void test_divisor_is_never_one()
+{
+  cuda::fast_mod_div<int, true> div{3};
+  assert(div == 3);
+  assert(3 % div == 0);
+  assert(div + 1 == 4);
+  assert(cuda::div(5, div) == (cuda::std::pair<int, int>{1, 2}));
+}
+
 __host__ __device__ bool test()
 {
   test<int8_t, int8_t>();
@@ -115,8 +124,10 @@ __host__ __device__ bool test()
 #if _CCCL_HAS_INT128()
   test<int64_t, uint64_t>();
 #endif // _CCCL_HAS_INT128()
-  //
+
   test_cpp_semantic();
+  test_divisor_is_never_one();
+
   return true;
 }
 


### PR DESCRIPTION
We cannot use a partial specialization of the base class in a friend function, because that will generate ambiguous symbols if the class is ever insantiated more than once with the same set of partial types.

Authored-by: Osayamen Aimuyo <59263949+osayamenja@users.noreply.github.com>

[BUG+FIX]: Compilation Issue with fast_modulo_div Fixes #7347
