### PR TITLE
Use arch dispatch workaround on GCC 8-9 as well

### DIFF
--- a/cub/cub/device/dispatch/dispatch_radix_sort.cuh
+++ b/cub/cub/device/dispatch/dispatch_radix_sort.cuh
@@ -1153,8 +1153,8 @@ public:
       return __invoke_single_tile(kernel_source.RadixSortSingleTileKernel(), policy.single_tile);
     }
 
-#if _CCCL_COMPILER(GCC, <, 8)
-    // gcc 7 fails to use `policy` in a constant expression, so we just compute it again inplace
+#if _CCCL_COMPILER(GCC, <, 10)
+    // gcc 7-9 fail to use `policy` in a constant expression, so we just compute it again inplace
     if CUB_DETAIL_CONSTEXPR_ISH (PolicyGetter{}().use_onesweep)
 #else // _CCCL_COMPILER(GCC, <, 8)
     if CUB_DETAIL_CONSTEXPR_ISH (policy.use_onesweep)


### PR DESCRIPTION
(Maybe) fixes: NVBug 5838921
(Maybe) fixes: the GCC 8-9 nightlies, for example: https://github.com/NVIDIA/cccl/actions/runs/21273651915/job/61228805687#step:4:1358