### PR TITLE
Avoid compile errors from math function like macros

### DIFF
--- a/libcudacxx/include/cuda/std/__cmath/fpclassify.h
+++ b/libcudacxx/include/cuda/std/__cmath/fpclassify.h
@@ -70,6 +70,27 @@
 #  endif // !__FP_LOGBNAN_MIN
 #endif // !FP_ILOGBNAN
 
+#if !_CCCL_COMPILER(NVRTC)
+// This function may or may not be implemented as a function macro so we need to handle that case
+#  ifdef fpclassify
+
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API int __cccl_fpclassify_runtime(_Tp __x) noexcept
+{
+  return fpclassify(__x);
+}
+#    pragma push_macro("fpclassify")
+#    undef fpclassify
+#    define _CCCL_POP_MACRO_fpclassify
+#  else // ^^^ Function Macro fpclassify ^^^ / vvv No function macro fpclassify vvv
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API int __cccl_fpclassify_runtime(_Tp __x) noexcept
+{
+  return ::fpclassify(__x);
+}
+#  endif // No function macro fpclassify
+#endif // _CCCL_COMPILER(NVRTC)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if _CCCL_CHECK_BUILTIN(builtin_fpclassify) || _CCCL_COMPILER(GCC)
@@ -126,7 +147,7 @@ template <class _Tp>
 #else // ^^^ _CCCL_BUILTIN_FPCLASSIFY ^^^ / vvv !_CCCL_BUILTIN_FPCLASSIFY vvv
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    NV_IF_TARGET(NV_IS_HOST, (return ::fpclassify(__x);))
+    NV_IF_TARGET(NV_IS_HOST, (return ::__cccl_fpclassify_runtime(__x);))
   }
   return ::cuda::std::__fpclassify_impl(__x);
 #endif // !_CCCL_BUILTIN_FPCLASSIFY
@@ -139,7 +160,7 @@ template <class _Tp>
 #else // ^^^ _CCCL_BUILTIN_FPCLASSIFY ^^^ / vvv !_CCCL_BUILTIN_FPCLASSIFY vvv
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    NV_IF_TARGET(NV_IS_HOST, (return ::fpclassify(__x);))
+    NV_IF_TARGET(NV_IS_HOST, (return ::__cccl_fpclassify_runtime(__x);))
   }
   return ::cuda::std::__fpclassify_impl(__x);
 #endif // !_CCCL_BUILTIN_FPCLASSIFY
@@ -153,7 +174,7 @@ template <class _Tp>
 #  else // ^^^ _CCCL_BUILTIN_FPCLASSIFY ^^^ / vvv !_CCCL_BUILTIN_FPCLASSIFY vvv
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    NV_IF_TARGET(NV_IS_HOST, (return ::fpclassify(__x);))
+    NV_IF_TARGET(NV_IS_HOST, (return ::__cccl_fpclassify_runtime(__x);))
   }
   return ::cuda::std::__fpclassify_impl(__x);
 #  endif // !_CCCL_BUILTIN_FPCLASSIFY
@@ -224,6 +245,11 @@ _CCCL_REQUIRES(is_integral_v<_Tp>)
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD
+
+#ifdef _CCCL_POP_MACRO_fpclassify
+#  pragma pop_macro("fpclassify")
+#  undef _CCCL_POP_MACRO_fpclassify
+#endif
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -34,6 +34,25 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+// This function may or may not be implemented as a function macro so we need to handle that case
+#ifdef isinf
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API bool __cccl_isinf_runtime(_Tp __x) noexcept
+{
+  return isinf(__x);
+}
+#  pragma push_macro("isinf")
+#  undef isinf
+#  define _CCCL_POP_MACRO_isinf
+#else // ^^^ Function Macro isinf ^^^ / vvv No function macro isinf vvv
+template <class _Tp>
+[[nodiscard]] _CCCL_API bool __cccl_isinf_runtime(_Tp __x) noexcept
+{
+  return ::isinf(__x);
+}
+#endif // No function macro isinf
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if _CCCL_CHECK_BUILTIN(builtin_isinf) || _CCCL_COMPILER(GCC)
@@ -46,7 +65,7 @@ template <class _Tp>
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    return ::isinf(__x);
+    return ::__cccl_isinf_runtime(__x);
   }
   if (::cuda::std::isnan(__x))
   {
@@ -69,7 +88,7 @@ template <class _Tp>
 #elif _CCCL_HAS_CONSTEXPR_BIT_CAST()
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    return ::isinf(__x);
+    return ::__cccl_isinf_runtime(__x);
   }
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<float>) == __fp_exp_mask_of_v<float>;
 #else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
@@ -91,7 +110,7 @@ template <class _Tp>
 #elif _CCCL_HAS_CONSTEXPR_BIT_CAST()
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    return ::isinf(__x);
+    return ::__cccl_isinf_runtime(__x);
   }
   return (::cuda::std::__fp_get_storage(__x) & __fp_exp_mant_mask_of_v<double>) == __fp_exp_mask_of_v<double>;
 #else // ^^^ _CCCL_HAS_CONSTEXPR_BIT_CAST() ^^^ / vvv !_CCCL_HAS_CONSTEXPR_BIT_CAST() vvv
@@ -197,6 +216,11 @@ _CCCL_REQUIRES(is_integral_v<_Tp>)
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD
+
+#ifdef _CCCL_POP_MACRO_isinf
+#  pragma pop_macro("isinf")
+#  undef _CCCL_POP_MACRO_isinf
+#endif
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/isnan.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnan.h
@@ -32,6 +32,25 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+// This function may or may not be implemented as a function macro so we need to handle that case
+#ifdef isnan
+
+template <class _Tp>
+[[nodiscard]] _CCCL_API bool __cccl_isnan_runtime(_Tp __x) noexcept
+{
+  return isnan(__x);
+}
+#  pragma push_macro("isnan")
+#  undef isnan
+#  define _CCCL_POP_MACRO_isnan
+#else // ^^^ Function Macro isnan ^^^ / vvv No function macro isnan vvv
+template <class _Tp>
+[[nodiscard]] _CCCL_API bool __cccl_isnan_runtime(_Tp __x) noexcept
+{
+  return ::isnan(__x);
+}
+#endif // No function macro isnan
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if _CCCL_CHECK_BUILTIN(builtin_isnan) || _CCCL_COMPILER(GCC)
@@ -44,7 +63,7 @@ template <class _Tp>
   static_assert(is_floating_point_v<_Tp>, "Only standard floating-point types are supported");
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
-    return ::isnan(__x);
+    return ::__cccl_isnan_runtime(__x);
   }
   return __x != __x;
 }
@@ -178,6 +197,11 @@ _CCCL_REQUIRES(is_integral_v<_Tp>)
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD
+
+#ifdef _CCCL_POP_MACRO_isnan
+#  pragma pop_macro("isnan")
+#  undef _CCCL_POP_MACRO_isnan
+#endif
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/isnormal.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnormal.h
@@ -28,6 +28,14 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+// This function may or may not be implemented as a function macro so we need to handle that case
+#ifdef isnormal
+// No fallback implementation as we go through fpclassify anyhow
+#  pragma push_macro("isnormal")
+#  undef isnormal
+#  define _CCCL_POP_MACRO_isnormal
+#endif // isnormal
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if _CCCL_CHECK_BUILTIN(builtin_isnormal) || _CCCL_COMPILER(GCC)
@@ -132,6 +140,11 @@ _CCCL_REQUIRES(is_integral_v<_Tp>)
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD
+
+#ifdef _CCCL_POP_MACRO_isnormal
+#  pragma pop_macro("isnormal")
+#  undef _CCCL_POP_MACRO_isnormal
+#endif
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/signbit.h
+++ b/libcudacxx/include/cuda/std/__cmath/signbit.h
@@ -29,6 +29,14 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+// This function may or may not be implemented as a function macro so we need to handle that case
+#ifdef signbit
+// No fallback implementation as we implement it natively anyhow
+#  pragma push_macro("signbit")
+#  undef signbit
+#  define _CCCL_POP_MACRO_signbit
+#endif // signbit
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 _CCCL_TEMPLATE(class _Tp)
@@ -50,6 +58,11 @@ _CCCL_REQUIRES(__is_extended_arithmetic_v<_Tp>)
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD
+
+#ifdef _CCCL_POP_MACRO_signbit
+#  pragma pop_macro("signbit")
+#  undef _CCCL_POP_MACRO_signbit
+#endif
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/traits.h
+++ b/libcudacxx/include/cuda/std/__cmath/traits.h
@@ -39,6 +39,112 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+#if !_CCCL_COMPILER(NVRTC)
+// This function may or may not be implemented as a function macro so we need to handle that case
+#  ifdef isgreater
+
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API bool __cccl_isgreater_runtime(_Tp __x, _Tp __y) noexcept
+{
+  return isgreater(__x, __y);
+}
+#    pragma push_macro("isgreater")
+#    undef isgreater
+#    define _CCCL_POP_MACRO_isgreater
+#  else // ^^^ Function Macro isgreater ^^^ / vvv No function macro isgreater vvv
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API bool __cccl_isgreater_runtime(_Tp __x, _Tp __y) noexcept
+{
+  return ::isgreater(__x, __y);
+}
+#  endif // No function macro isgreater
+
+// This function may or may not be implemented as a function macro so we need to handle that case
+#  ifdef isgreaterequal
+
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API bool __cccl_isgreaterequal_runtime(_Tp __x, _Tp __y) noexcept
+{
+  return isgreaterequal(__x, __y);
+}
+#    pragma push_macro("isgreaterequal")
+#    undef isgreaterequal
+#    define _CCCL_POP_MACRO_isgreaterequal
+#  else // ^^^ Function Macro isgreaterequal ^^^ / vvv No function macro isgreaterequal vvv
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API bool __cccl_isgreaterequal_runtime(_Tp __x, _Tp __y) noexcept
+{
+  return ::isgreaterequal(__x, __y);
+}
+#  endif // No function macro isgreaterequal
+
+// This function may or may not be implemented as a function macro so we need to handle that case
+#  ifdef isless
+
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API bool __cccl_isless_runtime(_Tp __x, _Tp __y) noexcept
+{
+  return isless(__x, __y);
+}
+#    pragma push_macro("isless")
+#    undef isless
+#    define _CCCL_POP_MACRO_isless
+#  else // ^^^ Function Macro isless ^^^ / vvv No function macro isless vvv
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API bool __cccl_isless_runtime(_Tp __x, _Tp __y) noexcept
+{
+  return ::isless(__x, __y);
+}
+#  endif // No function macro isless
+
+// This function may or may not be implemented as a function macro so we need to handle that case
+#  ifdef islessequal
+
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API bool __cccl_islessequal_runtime(_Tp __x, _Tp __y) noexcept
+{
+  return islessequal(__x, __y);
+}
+#    pragma push_macro("islessequal")
+#    undef islessequal
+#    define _CCCL_POP_MACRO_islessequal
+#  else // ^^^ Function Macro islessequal ^^^ / vvv No function macro islessequal vvv
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API bool __cccl_islessequal_runtime(_Tp __x, _Tp __y) noexcept
+{
+  return ::islessequal(__x, __y);
+}
+#  endif // No function macro islessequal
+
+// This function may or may not be implemented as a function macro so we need to handle that case
+#  ifdef islessgreater
+
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API bool __cccl_islessgreater_runtime(_Tp __x, _Tp __y) noexcept
+{
+  return islessgreater(__x, __y);
+}
+#    pragma push_macro("islessgreater")
+#    undef islessgreater
+#    define _CCCL_POP_MACRO_islessgreater
+#  else // ^^^ Function Macro islessgreater ^^^ / vvv No function macro islessgreater vvv
+template <class _Tp>
+[[nodiscard]] _CCCL_HOST_API bool __cccl_islessgreater_runtime(_Tp __x, _Tp __y) noexcept
+{
+  return ::islessgreater(__x, __y);
+}
+#  endif // No function macro islessgreater
+
+// This function may or may not be implemented as a function macro so we need to handle that case
+#  ifdef isunordered
+// No fallback implementation
+#    pragma push_macro("isunordered")
+#    undef isunordered
+#    define _CCCL_POP_MACRO_isunordered
+#  endif // Function macro isunordered
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 // isgreater
@@ -64,7 +170,7 @@ template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 #  if defined(_CCCL_BUILTIN_ISGREATER)
   return _CCCL_BUILTIN_ISGREATER(__x, __y);
 #  else // ^^^ _CCCL_BUILTIN_ISGREATER ^^^ / vvv !_CCCL_BUILTIN_ISGREATER vvv
-  return ::isgreater(__x, __y);
+  return ::__cccl_isgreater_runtime(__x, __y);
 #  endif // !_CCCL_BUILTIN_ISGREATER
 }
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -101,7 +207,7 @@ template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 #  if defined(_CCCL_BUILTIN_ISGREATEREQUAL)
   return _CCCL_BUILTIN_ISGREATEREQUAL(__x, __y);
 #  else // ^^^ _CCCL_BUILTIN_ISGREATEREQUAL ^^^ / vvv !_CCCL_BUILTIN_ISGREATEREQUAL vvv
-  return ::isgreaterequal(__x, __y);
+  return ::__cccl_isgreaterequal_runtime(__x, __y);
 #  endif // !_CCCL_BUILTIN_ISGREATEREQUAL
 }
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -138,7 +244,7 @@ template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 #  if defined(_CCCL_BUILTIN_ISLESS)
   return _CCCL_BUILTIN_ISLESS(__x, __y);
 #  else // ^^^ _CCCL_BUILTIN_ISLESS ^^^ / vvv !_CCCL_BUILTIN_ISLESS vvv
-  return ::isless(__x, __y);
+  return ::__cccl_isless_runtime(__x, __y);
 #  endif // !_CCCL_BUILTIN_ISLESS
 }
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -175,7 +281,7 @@ template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 #  if defined(_CCCL_BUILTIN_ISLESSEQUAL)
   return _CCCL_BUILTIN_ISLESSEQUAL(__x, __y);
 #  else // ^^^ _CCCL_BUILTIN_ISLESSEQUAL ^^^ / vvv !_CCCL_BUILTIN_ISLESSEQUAL vvv
-  return ::islessequal(__x, __y);
+  return ::__cccl_islessequal_runtime(__x, __y);
 #  endif // !_CCCL_BUILTIN_ISLESSEQUAL
 }
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -212,7 +318,7 @@ template <class _A1, enable_if_t<__is_extended_arithmetic_v<_A1>, int> = 0>
 #  if defined(_CCCL_BUILTIN_ISLESSGREATER)
   return _CCCL_BUILTIN_ISLESSGREATER(__x, __y);
 #  else // ^^^ _CCCL_BUILTIN_ISLESSGREATER ^^^ / vvv !_CCCL_BUILTIN_ISLESSGREATER vvv
-  return ::islessgreater(__x, __y);
+  return ::__cccl_islessgreater_runtime(__x, __y);
 #  endif // !_CCCL_BUILTIN_ISLESSGREATER
 }
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -236,6 +342,36 @@ template <class _A1, class _A2, enable_if_t<__is_extended_arithmetic_v<_A1> && _
 }
 
 _CCCL_END_NAMESPACE_CUDA_STD
+
+#ifdef _CCCL_POP_MACRO_isgreater
+#  pragma pop_macro("isgreater")
+#  undef _CCCL_POP_MACRO_isgreater
+#endif
+
+#ifdef _CCCL_POP_MACRO_isgreaterequal
+#  pragma pop_macro("isgreaterequal")
+#  undef _CCCL_POP_MACRO_isgreaterequal
+#endif
+
+#ifdef _CCCL_POP_MACRO_isless
+#  pragma pop_macro("isless")
+#  undef _CCCL_POP_MACRO_isless
+#endif
+
+#ifdef _CCCL_POP_MACRO_islessequal
+#  pragma pop_macro("islessequal")
+#  undef _CCCL_POP_MACRO_islessequal
+#endif
+
+#ifdef _CCCL_POP_MACRO_islessgreater
+#  pragma pop_macro("islessgreater")
+#  undef _CCCL_POP_MACRO_islessgreater
+#endif
+
+#ifdef _CCCL_POP_MACRO_isunordered
+#  pragma pop_macro("isunordered")
+#  undef _CCCL_POP_MACRO_isunordered
+#endif
 
 #include <cuda/std/__cccl/epilogue.h>
 


### PR DESCRIPTION
Some libc implementation implement certain functions as macros

This might break our build because the definition of the function might clash with the macro and also we cannot qualify a macro, so ::isgreater will fail if isgreater is a macro.

To work around this we need to temporarily push / pop the macros and define the fallbacks accordingly.

This is fine because the functions themself can only be called through `cuda::std::isgreater` which avoids the macro issue
