### PR TITLE
Implement parallel `cuda::std::find`

### DIFF
--- a/libcudacxx/benchmarks/bench/find/basic.cu
+++ b/libcudacxx/benchmarks/bench/find/basic.cu
@@ -1,0 +1,62 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/stream_ref>
+
+#include "nvbench_helper.cuh"
+
+struct equal_to_val
+{
+  size_t val_;
+
+  constexpr equal_to_val(const size_t val) noexcept
+      : val_(val)
+  {}
+
+  template <class T>
+  __device__ constexpr bool operator()(const T& val) const noexcept
+  {
+    return val == val_;
+  }
+};
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  T val = 1;
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = static_cast<std::size_t>(elements * common_prefix);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::fill(dinput.begin(), dinput.begin() + mismatch_point, T{0});
+  thrust::fill(dinput.begin() + mismatch_point, dinput.end(), val);
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+  auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(alloc);
+
+  state.exec(
+    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      (void) cuda::std::find(policy.with_stream(launch.get_stream().get_stream()), dinput.begin(), dinput.end(), val);
+    });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});

--- a/libcudacxx/benchmarks/bench/find_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/find_if/basic.cu
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/stream_ref>
+
+#include "nvbench_helper.cuh"
+
+template <class T>
+struct equal_to_val
+{
+  T val_;
+
+  constexpr equal_to_val(const T& val) noexcept
+      : val_(val)
+  {}
+
+  __device__ constexpr bool operator()(const T& val) const noexcept
+  {
+    return val == val_;
+  }
+};
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  T val = 1;
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = static_cast<std::size_t>(elements * common_prefix);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::fill(dinput.begin(), dinput.begin() + mismatch_point, T{0});
+  thrust::fill(dinput.begin() + mismatch_point, dinput.end(), val);
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+  auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(alloc);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               (void) cuda::std::find_if(
+                 policy.with_stream(launch.get_stream().get_stream()), dinput.begin(), dinput.end(), equal_to_val{val});
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});

--- a/libcudacxx/benchmarks/bench/find_if_not/basic.cu
+++ b/libcudacxx/benchmarks/bench/find_if_not/basic.cu
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/stream_ref>
+
+#include "nvbench_helper.cuh"
+
+template <class T>
+struct not_equal_to_val
+{
+  T val_;
+
+  constexpr not_equal_to_val(const T& val) noexcept
+      : val_(val)
+  {}
+
+  __device__ constexpr bool operator()(const T& val) const noexcept
+  {
+    return !(val == val_);
+  }
+};
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  T val = 1;
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = static_cast<std::size_t>(elements * common_prefix);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::fill(dinput.begin(), dinput.begin() + mismatch_point, T{0});
+  thrust::fill(dinput.begin() + mismatch_point, dinput.end(), val);
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+  auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(alloc);
+
+  state.exec(
+    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      (void) cuda::std::find_if_not(
+        policy.with_stream(launch.get_stream().get_stream()), dinput.begin(), dinput.end(), not_equal_to_val{val});
+    });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});

--- a/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
@@ -1,0 +1,190 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_CUDA_FIND_IF_H
+#define _CUDA_STD___PSTL_CUDA_FIND_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_BACKEND_CUDA()
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+
+#  include <cub/device/device_find.cuh>
+
+_CCCL_DIAG_POP
+
+#  include <cuda/__execution/policy.h>
+#  include <cuda/__functional/call_or.h>
+#  include <cuda/__memory_pool/device_memory_pool.h>
+#  include <cuda/__memory_resource/get_memory_resource.h>
+#  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/__stream/get_stream.h>
+#  include <cuda/__stream/stream_ref.h>
+#  include <cuda/std/__algorithm/find_if.h>
+#  include <cuda/std/__exception/cuda_error.h>
+#  include <cuda/std/__execution/env.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__memory/addressof.h>
+#  include <cuda/std/__new/bad_alloc.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  include <cuda_runtime.h>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+template <>
+struct __pstl_dispatch<__pstl_algorithm::__find_if, __execution_backend::__cuda>
+{
+  //! Ensures we properly deallocate the memory allocated for the result
+  template <class _Tp, class _Resource>
+  struct __allocation_guard
+  {
+    ::cuda::stream_ref __stream_;
+    _Resource& __resource_;
+    _Tp* __ptr_;
+
+    _CCCL_HOST_API __allocation_guard(::cuda::stream_ref __stream, _Resource& __resource, size_t __num_bytes)
+        : __stream_(__stream)
+        , __resource_(__resource)
+        , __ptr_(static_cast<_Tp*>(__resource_.allocate(__stream_, sizeof(_Tp) + __num_bytes, alignof(_Tp))))
+    {}
+
+    _CCCL_HOST_API ~__allocation_guard()
+    {
+      __resource_.deallocate(__stream_, __ptr_, sizeof(_Tp), alignof(_Tp));
+    }
+
+    [[nodiscard]] _CCCL_HOST_API _Tp* __get_result_iter()
+    {
+      return __ptr_;
+    }
+
+    [[nodiscard]] _CCCL_HOST_API void* __get_temp_storage()
+    {
+      return static_cast<void*>(__ptr_ + 1);
+    }
+  };
+
+  template <class _Policy, class _Iter, class _UnaryOp>
+  [[nodiscard]] _CCCL_HOST_API static _Iter
+  __par_impl([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _UnaryOp __pred)
+  {
+    const auto __num_items = ::cuda::std::distance(__first, __last);
+    using __offset_type    = remove_cvref_t<decltype(__num_items)>;
+    __offset_type __ret;
+
+    // Determine temporary device storage requirements for find_if
+    void* __temp_storage = nullptr;
+    size_t __num_bytes   = 0;
+    _CCCL_TRY_CUDA_API(
+      ::cub::DeviceFind::FindIf,
+      "__pstl_cuda_find_if: determining temporary storage failed",
+      __temp_storage,
+      __num_bytes,
+      __first,
+      static_cast<__offset_type*>(nullptr),
+      __pred,
+      __num_items);
+
+    // Allocate memory for result
+    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __resource = ::cuda::__call_or(
+      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    {
+      __allocation_guard<__offset_type, decltype(__resource)> __guard{__stream, __resource, __num_bytes};
+
+      // Run the find operation
+      _CCCL_TRY_CUDA_API(
+        ::cub::DeviceFind::FindIf,
+        "__pstl_cuda_find_if: cub::DeviceFind failed",
+        __guard.__get_temp_storage(),
+        __num_bytes,
+        ::cuda::std::move(__first),
+        __guard.__get_result_iter(),
+        ::cuda::std::move(__pred),
+        __num_items,
+        __stream.get());
+
+      // Copy the result back from storage
+      _CCCL_TRY_CUDA_API(
+        ::cudaMemcpyAsync,
+        "__pstl_cuda_find_if: copy of result from device to host failed",
+        ::cuda::std::addressof(__ret),
+        __guard.__ptr_,
+        sizeof(__offset_type),
+        ::cudaMemcpyDefault,
+        __stream.get());
+    }
+
+    // Need to sync before reading __ret
+    __stream.sync();
+    return __first + __ret;
+  }
+
+  template <class _Policy, class _Iter, class _UnaryOp>
+  [[nodiscard]] _CCCL_HOST_API _Iter
+  operator()([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _UnaryOp __pred) const
+  {
+    if constexpr (::cuda::std::__has_random_access_traversal<_Iter>)
+    {
+      try
+      {
+        return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+      }
+      catch (const ::cuda::cuda_error& __err)
+      {
+        if (__err.status() == cudaErrorMemoryAllocation)
+        {
+          ::cuda::std::__throw_bad_alloc();
+        }
+        else
+        {
+          throw __err;
+        }
+      }
+    }
+    else
+    {
+      static_assert(__always_false_v<_Policy>,
+                    "__pstl_dispatch: CUDA backend of cuda::std::find_if requires at least random access iterators");
+      return ::cuda::std::find_if(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+    }
+  }
+};
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif /// _CCCL_HAS_BACKEND_CUDA()
+
+#endif // _CUDA_STD___PSTL_CUDA_FIND_IF_H

--- a/libcudacxx/include/cuda/std/__pstl/dispatch.h
+++ b/libcudacxx/include/cuda/std/__pstl/dispatch.h
@@ -32,6 +32,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 enum class __pstl_algorithm
 {
+  __find_if,
   __for_each_n,
   __generate_n,
   __reduce,

--- a/libcudacxx/include/cuda/std/__pstl/find.h
+++ b/libcudacxx/include/cuda/std/__pstl/find.h
@@ -1,0 +1,99 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_FIND_H
+#define _CUDA_STD___PSTL_FIND_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__algorithm/find.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_comparable.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/find_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class _Tp>
+struct __find_compare_eq
+{
+  _Tp __val_;
+
+  _CCCL_API constexpr __find_compare_eq(const _Tp& __val) noexcept(is_nothrow_copy_constructible_v<_Tp>)
+      : __val_(__val)
+  {}
+
+  template <class _Up>
+  [[nodiscard]] _CCCL_API _CCCL_FORCEINLINE constexpr bool operator()(const _Up& __rhs) const
+    noexcept(__is_cpp17_nothrow_equality_comparable_v<_Tp, _Up>)
+  {
+    return static_cast<bool>(__val_ == __rhs);
+  }
+};
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _Iter, class _Tp)
+_CCCL_REQUIRES(__has_forward_traversal<_Iter> _CCCL_AND is_execution_policy_v<_Policy>)
+[[nodiscard]] _CCCL_HOST_API _Iter
+find([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, const _Tp& __val)
+{
+  static_assert(__is_cpp17_equality_comparable_v<_Tp, iter_value_t<_Iter>>,
+                "Parallel cuda::std::find requires that T is equality comparable with iter_value_t<Iter>");
+
+  if (__first == __last)
+  {
+    return __first;
+  }
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    return __dispatch(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), __find_compare_eq{__val});
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::find requires at least one selected backend");
+    return ::cuda::std::find(::cuda::std::move(__first), ::cuda::std::move(__last), __val);
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_FIND_IF_H

--- a/libcudacxx/include/cuda/std/__pstl/find_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/find_if.h
@@ -1,0 +1,80 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_FIND_IF_H
+#define _CUDA_STD___PSTL_FIND_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__algorithm/find_if.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/find_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _Iter, class _UnaryOp)
+_CCCL_REQUIRES(__has_forward_traversal<_Iter> _CCCL_AND is_execution_policy_v<_Policy>)
+[[nodiscard]] _CCCL_HOST_API _Iter
+find_if([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _UnaryOp __pred)
+{
+  static_assert(indirect_unary_predicate<_UnaryOp, _Iter>,
+                "cuda::std::find_if: UnaryOp must satisfy indirect_unary_predicate<Iter>");
+
+  if (__first == __last)
+  {
+    return __first;
+  }
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    return __dispatch(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::find_if requires at least one selected backend");
+    return ::cuda::std::find_if(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_FIND_IF_H

--- a/libcudacxx/include/cuda/std/__pstl/find_if_not.h
+++ b/libcudacxx/include/cuda/std/__pstl/find_if_not.h
@@ -1,0 +1,82 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_FIND_IF_NOT_H
+#define _CUDA_STD___PSTL_FIND_IF_NOT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__algorithm/find_if_not.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/not_fn.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/find_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _Iter, class _UnaryOp)
+_CCCL_REQUIRES(__has_forward_traversal<_Iter> _CCCL_AND is_execution_policy_v<_Policy>)
+[[nodiscard]] _CCCL_HOST_API _Iter
+find_if_not([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _UnaryOp __pred)
+{
+  static_assert(indirect_unary_predicate<_UnaryOp, _Iter>,
+                "cuda::std::find_if: UnaryOp must satisfy indirect_unary_predicate<Iter>");
+
+  if (__first == __last)
+  {
+    return __first;
+  }
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    return __dispatch(
+      __policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::not_fn(::cuda::std::move(__pred)));
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::find_if_not requires at least one selected backend");
+    return ::cuda::std::find_if_not(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_FIND_IF_NOT_H

--- a/libcudacxx/include/cuda/std/__pstl_algorithm
+++ b/libcudacxx/include/cuda/std/__pstl_algorithm
@@ -23,6 +23,9 @@
 
 #include <cuda/std/__pstl/count.h>
 #include <cuda/std/__pstl/count_if.h>
+#include <cuda/std/__pstl/find.h>
+#include <cuda/std/__pstl/find_if.h>
+#include <cuda/std/__pstl/find_if_not.h>
 #include <cuda/std/__pstl/for_each.h>
 #include <cuda/std/__pstl/for_each_n.h>
 #include <cuda/std/__pstl/generate.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl.find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl.find.pass.cpp
@@ -1,0 +1,57 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+// XFAIL: true
+
+// template<class ExecutionPolicy, class ForwardIterator, class T>
+// void find(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, T val);
+
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/algorithm>
+#include <cuda/std/cassert>
+
+#include "test_execution_policies.h"
+#include "test_iterators.h"
+#include "test_macros.h"
+
+EXECUTION_POLICY_SFINAE_TEST(find);
+
+static_assert(!sfinae_test_find<int, int*, int*, int>);
+static_assert(sfinae_test_find<cuda::std::execution::parallel_policy, int*, int*, int>);
+
+int data[100];
+
+template <class Iter>
+struct Test
+{
+  template <class Policy>
+  void operator()(Policy&& policy)
+  {
+    int sizes[] = {0, 1, 2, 100};
+    for (auto size : sizes)
+    {
+      cuda::std::iota(data, data + size, 1);
+      const auto res = cuda::std::find(policy, Iter(data), Iter(data + size), size);
+      assert(res == Iter(data + size));
+    }
+  }
+};
+
+__host__ void test()
+{
+  types::find(types::forward_iterator_list<int*>{}, TestIteratorWithPolicies<Test>{});
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, test();)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl.find_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl.find_if.pass.cpp
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+// XFAIL: true
+
+// template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
+// void find_if(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred);
+
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/algorithm>
+#include <cuda/std/cassert>
+
+#include "test_execution_policies.h"
+#include "test_iterators.h"
+#include "test_macros.h"
+
+EXECUTION_POLICY_SFINAE_TEST(find_if);
+
+static_assert(!sfinae_test_find_if<int, int*, int*, bool (*)(int)>);
+static_assert(sfinae_test_find_if<cuda::std::execution::parallel_policy, int*, int*, bool (*)(int)>);
+
+int data[100];
+
+template <class Iter>
+struct Test
+{
+  template <class Policy>
+  void operator()(Policy&& policy)
+  {
+    int sizes[] = {0, 1, 2, 100};
+    for (auto size : sizes)
+    {
+      cuda::std::iota(data, data + size, 1);
+      const auto res = cuda::std::find_if(policy, Iter(data), Iter(data + size), [size](const int v) {
+        return v == size;
+      });
+      assert(res == Iter(data + size));
+    }
+  }
+};
+
+__host__ void test()
+{
+  types::find(types::forward_iterator_list<int*>{}, TestIteratorWithPolicies<Test>{});
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, test();)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl.find_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl.find_if_not.pass.cpp
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+// XFAIL: true
+
+// template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
+// void find_if_not(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred);
+
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/algorithm>
+#include <cuda/std/cassert>
+
+#include "test_execution_policies.h"
+#include "test_iterators.h"
+#include "test_macros.h"
+
+EXECUTION_POLICY_SFINAE_TEST(find_if_not);
+
+static_assert(!sfinae_test_find_if_not<int, int*, int*, bool (*)(int)>);
+static_assert(sfinae_test_find_if_not<cuda::std::execution::parallel_policy, int*, int*, bool (*)(int)>);
+
+int data[100];
+
+template <class Iter>
+struct Test
+{
+  template <class Policy>
+  void operator()(Policy&& policy)
+  {
+    int sizes[] = {0, 1, 2, 100};
+    for (auto size : sizes)
+    {
+      cuda::std::iota(data, data + size, 1);
+      const auto res = cuda::std::find_if_not(policy, Iter(data), Iter(data + size), [size](const int v) {
+        return v != size;
+      });
+      assert(res == Iter(data + size));
+    }
+  }
+};
+
+__host__ void test()
+{
+  types::find(types::forward_iterator_list<int*>{}, TestIteratorWithPolicies<Test>{});
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, test();)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find.cu
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, class ForwardIterator, class T>
+// void find(ExecutionPolicy&& exec ForwardIterator first, ForwardIterator last, T val);
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr size_t size = 1000;
+
+template <class Policy>
+void test_find(const Policy& policy)
+{
+  const size_t expected = 42;
+
+  { // empty should not access anything
+    const auto res = cuda::std::find(policy, static_cast<size_t*>(nullptr), static_cast<size_t*>(nullptr), expected);
+    CHECK(res == nullptr);
+  }
+
+  { // same type
+    const auto res =
+      cuda::std::find(policy, cuda::counting_iterator{size_t{0}}, cuda::counting_iterator{size}, expected);
+    CHECK(res == cuda::counting_iterator{expected});
+  }
+
+  { // convertible type
+    const auto res = cuda::std::find(
+      policy, cuda::counting_iterator{size_t{0}}, cuda::counting_iterator{size}, static_cast<int>(expected));
+    CHECK(res == cuda::counting_iterator{expected});
+  }
+}
+
+C2H_TEST("cuda::std::find", "[parallel algorithm]")
+{
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    test_find(policy);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    test_find(policy);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    test_find(policy);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    test_find(policy);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if.cu
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
+// void find_if(ExecutionPolicy&& exec ForwardIterator first, ForwardIterator last, UnaryPredicate pred);
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr size_t size = 1000;
+
+template <class T = int>
+struct equal_to_val
+{
+  T val_;
+
+  constexpr equal_to_val(const T val) noexcept
+      : val_(val)
+  {}
+
+  template <class U>
+  __device__ constexpr bool operator()(const U& val) const noexcept
+  {
+    return static_cast<T>(val) == val_;
+  }
+};
+
+template <class Policy>
+void test_find_if(const Policy& policy)
+{
+  const size_t expected = 42;
+
+  { // empty should not access anything
+    const auto res =
+      cuda::std::find_if(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), equal_to_val{expected});
+    CHECK(res == nullptr);
+  }
+
+  { // same type
+    const auto res = cuda::std::find_if(
+      policy, cuda::counting_iterator{size_t{0}}, cuda::counting_iterator{size}, equal_to_val<size_t>{expected});
+    CHECK(res == cuda::counting_iterator{expected});
+  }
+
+  { // convertible type
+    const auto res = cuda::std::find_if(
+      policy,
+      cuda::counting_iterator{size_t{0}},
+      cuda::counting_iterator{size},
+      equal_to_val<int>{static_cast<int>(expected)});
+    CHECK(res == cuda::counting_iterator{expected});
+  }
+}
+
+C2H_TEST("cuda::std::find_if", "[parallel algorithm]")
+{
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    test_find_if(policy);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    test_find_if(policy);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    test_find_if(policy);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    test_find_if(policy);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if_not.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if_not.cu
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
+// void find_if_not(ExecutionPolicy&& exec ForwardIterator first, ForwardIterator last, UnaryPredicate pred);
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr size_t size = 1000;
+
+template <class T = int>
+struct not_equal_to_val
+{
+  T val_;
+
+  constexpr not_equal_to_val(const T val) noexcept
+      : val_(val)
+  {}
+
+  template <class U>
+  __device__ constexpr bool operator()(const U& val) const noexcept
+  {
+    return !(static_cast<T>(val) == val_);
+  }
+};
+
+template <class Policy>
+void test_find_if_not(const Policy& policy)
+{
+  const size_t expected = 42;
+
+  { // empty should not access anything
+    const auto res = cuda::std::find_if_not(
+      policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), not_equal_to_val{expected});
+    CHECK(res == nullptr);
+  }
+
+  { // same type
+    const auto res = cuda::std::find_if_not(
+      policy, cuda::counting_iterator{size_t{0}}, cuda::counting_iterator{size}, not_equal_to_val<size_t>{expected});
+    CHECK(res == cuda::counting_iterator{expected});
+  }
+
+  { // convertible type
+    const auto res = cuda::std::find_if_not(
+      policy,
+      cuda::counting_iterator{size_t{0}},
+      cuda::counting_iterator{size},
+      not_equal_to_val<int>{static_cast<int>(expected)});
+    CHECK(res == cuda::counting_iterator{expected});
+  }
+}
+
+C2H_TEST("cuda::std::find_if_not", "[parallel algorithm]")
+{
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    test_find_if_not(policy);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    test_find_if_not(policy);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    test_find_if_not(policy);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    test_find_if_not(policy);
+  }
+}


### PR DESCRIPTION
This implements the `find` family of algorithms for the cuda backend.

We reuse `cub::devic_find_if` to implement

* `cuda::std::find`
* `cuda::std::find_if`
* `cuda::std::find_if_not`

This adds tests and benchmarks similar to the one Thrust provides as well as some boilerplate for libcu+++.

The functions are currently not user visible in a private header

Fixes #7380