### PR TITLE
Add DeviceTransform benchmarks from pytorch

### DIFF
--- a/cub/benchmarks/bench/transform/pytorch.cu
+++ b/cub/benchmarks/bench/transform/pytorch.cu
@@ -71,7 +71,7 @@ struct relu_op
   template <typename T>
   _CCCL_API auto operator()(T value) const
   {
-    return static_cast<T>(::cuda::std::max(static_cast<opmath_t>(value), opmath_t{0}));
+    return static_cast<T>(static_cast<opmath_t>(value) > opmath_t{0} ? static_cast<opmath_t>(value) : opmath_t{0});
   }
 };
 BENCHMARK_UNARY(relu);


### PR DESCRIPTION
B200
```
## relu

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|-------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    378x |  25.881 us | 4.41% |   6.292 us | 5.26% |  10.416G |  41.662 GB/s |  0.54% | 244597x |   2.044 us |
|   F16 |   2^20 = 1048576 |    434x |  27.487 us | 3.64% |   8.174 us | 1.93% | 128.281G | 513.122 GB/s |  6.69% | 230018x |   2.174 us |
|   F16 |  2^24 = 16777216 |    348x |  37.931 us | 2.59% |  18.454 us | 0.29% | 909.161G |   3.637 TB/s | 47.40% |  49436x |  10.114 us |
|   F16 | 2^28 = 268435456 |    444x | 183.373 us | 0.68% | 163.846 us | 0.15% |   1.638T |   6.553 TB/s | 85.42% |   3194x | 156.563 us |
|  BF16 |     2^16 = 65536 |    322x |  25.877 us | 3.68% |   6.157 us | 2.65% |  10.644G |  42.574 GB/s |  0.55% | 245565x |   2.036 us |
|  BF16 |   2^20 = 1048576 |    412x |  27.730 us | 3.45% |   8.191 us | 1.84% | 128.016G | 512.063 GB/s |  6.67% | 198591x |   2.518 us |
|  BF16 |  2^24 = 16777216 |    302x |  38.326 us | 2.57% |  18.446 us | 0.42% | 909.532G |   3.638 TB/s | 47.42% |  47451x |  10.537 us |
|  BF16 | 2^28 = 268435456 |    394x | 183.547 us | 0.58% | 163.694 us | 0.30% |   1.640T |   6.559 TB/s | 85.49% |   3182x | 157.159 us |
|   F32 |     2^16 = 65536 |    370x |  25.712 us | 3.82% |   6.174 us | 3.99% |  10.615G |  84.923 GB/s |  1.11% | 244736x |   2.045 us |
|   F32 |   2^20 = 1048576 |    310x |  27.786 us | 3.12% |   8.185 us | 1.31% | 128.108G |   1.025 TB/s | 13.36% | 198892x |   2.514 us |
|   F32 |  2^24 = 16777216 |    492x |  46.613 us | 2.27% |  26.729 us | 1.66% | 627.676G |   5.021 TB/s | 65.45% |  25089x |  19.930 us |
|   F32 | 2^28 = 268435456 |    404x | 335.546 us | 0.43% | 315.767 us | 0.35% | 850.106G |   6.801 TB/s | 88.64% |   1671x | 308.880 us |

## sigmoid

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|-------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    324x |  25.938 us | 4.20% |   6.185 us | 4.28% |  10.596G |  42.384 GB/s |  0.55% | 244064x |   2.049 us |
|   F16 |   2^20 = 1048576 |    306x |  27.891 us | 3.59% |   8.185 us | 0.82% | 128.113G | 512.451 GB/s |  6.68% | 169731x |   2.946 us |
|   F16 |  2^24 = 16777216 |    370x |  46.248 us | 1.91% |  26.631 us | 0.31% | 629.992G |   2.520 TB/s | 32.84% |  24496x |  20.412 us |
|   F16 | 2^28 = 268435456 |    412x | 320.385 us | 0.44% | 300.541 us | 0.27% | 893.175G |   3.573 TB/s | 46.57% |   1723x | 294.603 us |
|  BF16 |     2^16 = 65536 |    496x |  25.726 us | 3.47% |   6.155 us | 2.01% |  10.647G |  42.588 GB/s |  0.56% | 245522x |   2.037 us |
|  BF16 |   2^20 = 1048576 |    390x |  27.514 us | 3.46% |   8.181 us | 1.64% | 128.169G | 512.678 GB/s |  6.68% | 169393x |   2.952 us |
|  BF16 |  2^24 = 16777216 |    330x |  46.409 us | 2.15% |  26.635 us | 0.47% | 629.897G |   2.520 TB/s | 32.84% |  24278x |  20.596 us |
|  BF16 | 2^28 = 268435456 |    442x | 320.930 us | 0.35% | 301.414 us | 0.22% | 890.587G |   3.562 TB/s | 46.43% |   1714x | 296.348 us |
|   F32 |     2^16 = 65536 |    342x |  25.620 us | 3.75% |   6.168 us | 3.32% |  10.625G |  84.998 GB/s |  1.11% | 245452x |   2.037 us |
|   F32 |   2^20 = 1048576 |    368x |  27.921 us | 3.49% |   8.183 us | 1.85% | 128.140G |   1.025 TB/s | 13.36% | 172129x |   2.905 us |
|   F32 |  2^24 = 16777216 |    716x |  50.586 us | 2.00% |  30.738 us | 0.81% | 545.815G |   4.367 TB/s | 56.91% |  19987x |  25.017 us |
|   F32 | 2^28 = 268435456 |    372x | 379.122 us | 0.40% | 359.370 us | 0.26% | 746.961G |   5.976 TB/s | 77.89% |   1454x | 353.836 us |

## tanh

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|-------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    416x |  25.778 us | 3.97% |   6.161 us | 2.07% |  10.637G |  42.550 GB/s |  0.55% | 244062x |   2.049 us |
|   F16 |   2^20 = 1048576 |    320x |  27.575 us | 3.08% |   8.180 us | 0.60% | 128.183G | 512.732 GB/s |  6.68% | 180554x |   2.769 us |
|   F16 |  2^24 = 16777216 |    330x |  44.248 us | 2.06% |  24.577 us | 0.29% | 682.648G |   2.731 TB/s | 35.59% |  27511x |  18.175 us |
|   F16 | 2^28 = 268435456 |    368x | 289.161 us | 0.46% | 269.528 us | 0.35% | 995.946G |   3.984 TB/s | 51.92% |   1919x | 263.881 us |
|  BF16 |     2^16 = 65536 |    318x |  25.675 us | 3.56% |   6.145 us | 2.06% |  10.665G |  42.660 GB/s |  0.56% | 245848x |   2.034 us |
|  BF16 |   2^20 = 1048576 |    336x |  27.844 us | 4.53% |   8.185 us | 1.23% | 128.109G | 512.435 GB/s |  6.68% | 180224x |   2.774 us |
|  BF16 |  2^24 = 16777216 |    406x |  44.391 us | 2.38% |  24.586 us | 0.46% | 682.389G |   2.730 TB/s | 35.58% |  27187x |  18.391 us |
|  BF16 | 2^28 = 268435456 |    428x | 291.116 us | 0.49% | 271.441 us | 0.34% | 988.928G |   3.956 TB/s | 51.56% |   1906x | 265.762 us |
|   F32 |     2^16 = 65536 |    450x |  25.758 us | 4.59% |   6.194 us | 4.97% |  10.581G |  84.650 GB/s |  1.10% | 242362x |   2.063 us |
|   F32 |   2^20 = 1048576 |    396x |  27.770 us | 3.32% |   8.198 us | 1.99% | 127.912G |   1.023 TB/s | 13.34% | 181753x |   2.751 us |
|   F32 |  2^24 = 16777216 |    370x |  48.943 us | 2.71% |  29.211 us | 3.10% | 574.338G |   4.595 TB/s | 59.89% |  20543x |  24.339 us |
|   F32 | 2^28 = 268435456 |    346x | 375.059 us | 0.39% | 355.341 us | 0.27% | 755.430G |   6.043 TB/s | 78.77% |   1471x | 349.734 us |

## gelu

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|-------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    376x |  25.751 us | 3.78% |   6.191 us | 4.67% |  10.586G |  42.345 GB/s |  0.55% | 244748x |   2.043 us |
|   F16 |   2^20 = 1048576 |    330x |  27.590 us | 3.08% |   8.190 us | 0.72% | 128.030G | 512.121 GB/s |  6.67% | 158030x |   3.164 us |
|   F16 |  2^24 = 16777216 |    368x |  51.211 us | 2.59% |  31.415 us | 3.07% | 534.047G |   2.136 TB/s | 27.84% |  19743x |  25.327 us |
|   F16 | 2^28 = 268435456 |    402x | 398.858 us | 0.25% | 379.105 us | 0.13% | 708.077G |   2.832 TB/s | 36.92% |   1369x | 373.831 us |
|  BF16 |     2^16 = 65536 |    324x |  25.634 us | 3.66% |   6.164 us | 3.08% |  10.632G |  42.527 GB/s |  0.55% | 245108x |   2.040 us |
|  BF16 |   2^20 = 1048576 |    342x |  27.828 us | 6.75% |   8.183 us | 0.84% | 128.146G | 512.585 GB/s |  6.68% | 158569x |   3.153 us |
|  BF16 |  2^24 = 16777216 |    312x |  50.860 us | 2.54% |  31.137 us | 2.61% | 538.828G |   2.155 TB/s | 28.09% |  19776x |  25.284 us |
|  BF16 | 2^28 = 268435456 |    492x | 398.264 us | 0.26% | 378.669 us | 0.15% | 708.892G |   2.836 TB/s | 36.96% |   1366x | 372.659 us |
|   F32 |     2^16 = 65536 |    450x |  25.743 us | 3.71% |   6.190 us | 4.99% |  10.588G |  84.702 GB/s |  1.10% | 244678x |   2.044 us |
|   F32 |   2^20 = 1048576 |    346x |  27.768 us | 3.50% |   8.196 us | 2.77% | 127.935G |   1.023 TB/s | 13.34% | 159201x |   3.141 us |
|   F32 |  2^24 = 16777216 |    326x |  52.518 us | 1.85% |  32.792 us | 0.78% | 511.626G |   4.093 TB/s | 53.35% |  18012x |  27.760 us |
|   F32 | 2^28 = 268435456 |    418x | 418.462 us | 0.34% | 398.696 us | 0.23% | 673.283G |   5.386 TB/s | 70.20% |   1307x | 392.466 us |

## sin

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|-------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    546x |  25.680 us | 3.69% |   6.177 us | 3.89% |  10.610G |  42.442 GB/s |  0.55% | 244828x |   2.042 us |
|   F16 |   2^20 = 1048576 |    316x |  27.545 us | 3.12% |   8.180 us | 0.67% | 128.181G | 512.723 GB/s |  6.68% | 164148x |   3.046 us |
|   F16 |  2^24 = 16777216 |    360x |  50.363 us | 3.14% |  30.628 us | 1.45% | 547.771G |   2.191 TB/s | 28.56% |  21320x |  23.452 us |
|   F16 | 2^28 = 268435456 |    386x | 373.099 us | 0.40% | 353.412 us | 0.28% | 759.554G |   3.038 TB/s | 39.60% |   1467x | 347.650 us |
|  BF16 |     2^16 = 65536 |    364x |  25.773 us | 4.00% |   6.177 us | 4.12% |  10.610G |  42.440 GB/s |  0.55% | 245277x |   2.039 us |
|  BF16 |   2^20 = 1048576 |    356x |  27.557 us | 3.16% |   8.187 us | 1.13% | 128.074G | 512.298 GB/s |  6.68% | 164019x |   3.048 us |
|  BF16 |  2^24 = 16777216 |    316x |  48.543 us | 1.75% |  28.689 us | 0.39% | 584.792G |   2.339 TB/s | 30.49% |  22511x |  22.212 us |
|  BF16 | 2^28 = 268435456 |    474x | 349.316 us | 0.61% | 329.647 us | 0.16% | 814.311G |   3.257 TB/s | 42.45% |   1567x | 323.772 us |
|   F32 |     2^16 = 65536 |    344x |  25.772 us | 3.71% |   6.217 us | 6.16% |  10.541G |  84.329 GB/s |  1.10% | 243835x |   2.051 us |
|   F32 |   2^20 = 1048576 |    330x |  27.728 us | 4.20% |   8.180 us | 2.02% | 128.182G |   1.025 TB/s | 13.37% | 169177x |   2.955 us |
|   F32 |  2^24 = 16777216 |    378x |  51.778 us | 3.48% |  31.761 us | 3.22% | 528.234G |   4.226 TB/s | 55.08% |  18980x |  26.345 us |
|   F32 | 2^28 = 268435456 |    548x | 399.716 us | 0.34% | 380.075 us | 0.24% | 706.269G |   5.650 TB/s | 73.64% |   1376x | 374.077 us |

## exp

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|-------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    318x |  25.851 us | 3.90% |   6.179 us | 4.31% |  10.606G |  42.422 GB/s |  0.55% | 243673x |   2.052 us |
|   F16 |   2^20 = 1048576 |    476x |  27.780 us | 4.12% |   8.185 us | 1.11% | 128.115G | 512.458 GB/s |  6.68% | 186866x |   2.676 us |
|   F16 |  2^24 = 16777216 |    548x |  42.292 us | 2.21% |  22.539 us | 0.41% | 744.365G |   2.977 TB/s | 38.81% |  31037x |  16.110 us |
|   F16 | 2^28 = 268435456 |    410x | 255.732 us | 0.47% | 236.014 us | 0.34% |   1.137T |   4.549 TB/s | 59.30% |   2176x | 230.705 us |
|  BF16 |     2^16 = 65536 |    374x |  25.821 us | 3.69% |   6.161 us | 2.75% |  10.637G |  42.549 GB/s |  0.55% | 238824x |   2.094 us |
|  BF16 |   2^20 = 1048576 |    416x |  27.917 us | 4.08% |   8.180 us | 1.93% | 128.191G | 512.766 GB/s |  6.68% | 191030x |   2.617 us |
|  BF16 |  2^24 = 16777216 |    316x |  40.381 us | 2.56% |  20.496 us | 0.26% | 818.548G |   3.274 TB/s | 42.68% |  39672x |  12.604 us |
|  BF16 | 2^28 = 268435456 |    652x | 215.983 us | 0.49% | 196.424 us | 0.25% |   1.367T |   5.466 TB/s | 71.25% |   2649x | 190.212 us |
|   F32 |     2^16 = 65536 |    348x |  25.809 us | 3.90% |   6.171 us | 3.69% |  10.619G |  84.956 GB/s |  1.11% | 245587x |   2.036 us |
|   F32 |   2^20 = 1048576 |    304x |  27.806 us | 3.09% |   8.171 us | 0.57% | 128.325G |   1.027 TB/s | 13.38% | 190212x |   2.629 us |
|   F32 |  2^24 = 16777216 |    306x |  46.977 us | 2.92% |  27.046 us | 3.11% | 620.330G |   4.963 TB/s | 64.68% |  22884x |  21.850 us |
|   F32 | 2^28 = 268435456 |    640x | 339.973 us | 0.39% | 320.278 us | 0.29% | 838.133G |   6.705 TB/s | 87.39% |   1628x | 315.594 us |

## add

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    492x |  25.735 us | 3.75% |   6.166 us |  3.35% |  10.629G |  63.774 GB/s |  0.83% | 250451x |   1.996 us |
|   F16 |   2^20 = 1048576 |    358x |  27.546 us | 3.33% |   8.180 us |  0.71% | 128.180G | 769.083 GB/s | 10.02% | 192214x |   2.601 us |
|   F16 |  2^24 = 16777216 |    374x |  43.007 us | 3.25% |  23.033 us |  3.85% | 728.410G |   4.370 TB/s | 56.96% |  32799x |  15.245 us |
|   F16 | 2^28 = 268435456 |    402x | 259.515 us | 0.46% | 239.643 us |  0.17% |   1.120T |   6.721 TB/s | 87.60% |   2178x | 231.734 us |
|  BF16 |     2^16 = 65536 |    316x |  26.090 us | 3.89% |   6.245 us |  6.92% |  10.494G |  62.961 GB/s |  0.82% | 246306x |   2.030 us |
|  BF16 |   2^20 = 1048576 |    322x |  27.942 us | 3.36% |   8.167 us |  0.60% | 128.391G | 770.346 GB/s | 10.04% | 192381x |   2.599 us |
|  BF16 |  2^24 = 16777216 |    342x |  42.999 us | 3.10% |  22.949 us |  3.67% | 731.072G |   4.386 TB/s | 57.17% |  32761x |  15.263 us |
|  BF16 | 2^28 = 268435456 |    302x | 259.616 us | 0.43% | 239.696 us |  0.15% |   1.120T |   6.719 TB/s | 87.58% |   2179x | 231.620 us |
|   F32 |     2^16 = 65536 |    360x |  26.217 us | 4.65% |   6.480 us | 11.60% |  10.114G | 121.363 GB/s |  1.58% | 250443x |   1.996 us |
|   F32 |   2^20 = 1048576 |    394x |  29.367 us | 5.03% |   9.568 us | 10.08% | 109.590G |   1.315 TB/s | 17.14% | 190970x |   2.618 us |
|   F32 |  2^24 = 16777216 |    556x |  57.493 us | 2.72% |  37.731 us |  2.71% | 444.657G |   5.336 TB/s | 69.55% |  16477x |  30.347 us |
|   F32 | 2^28 = 268435456 |    458x | 474.310 us | 0.25% | 454.567 us |  0.15% | 590.530G |   7.086 TB/s | 92.36% |   1158x | 444.899 us |

## sub

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    396x |  25.854 us | 4.07% |   6.232 us |  6.44% |  10.516G |  63.099 GB/s |  0.82% | 248695x |   2.011 us |
|   F16 |   2^20 = 1048576 |    382x |  27.813 us | 3.31% |   8.178 us |  0.93% | 128.212G | 769.274 GB/s | 10.03% | 192379x |   2.599 us |
|   F16 |  2^24 = 16777216 |    330x |  43.006 us | 3.26% |  22.994 us |  3.79% | 729.640G |   4.378 TB/s | 57.06% |  32779x |  15.254 us |
|   F16 | 2^28 = 268435456 |    378x | 259.494 us | 0.40% | 239.673 us |  0.17% |   1.120T |   6.720 TB/s | 87.59% |   2155x | 232.076 us |
|  BF16 |     2^16 = 65536 |    330x |  26.070 us | 4.69% |   6.246 us |  6.69% |  10.492G |  62.951 GB/s |  0.82% | 246305x |   2.030 us |
|  BF16 |   2^20 = 1048576 |    414x |  27.941 us | 3.96% |   8.192 us |  1.75% | 128.000G | 768.000 GB/s | 10.01% | 192013x |   2.604 us |
|  BF16 |  2^24 = 16777216 |    382x |  42.757 us | 2.83% |  22.926 us |  3.55% | 731.810G |   4.391 TB/s | 57.23% |  32778x |  15.254 us |
|  BF16 | 2^28 = 268435456 |    490x | 259.530 us | 0.41% | 239.665 us |  0.18% |   1.120T |   6.720 TB/s | 87.59% |   2178x | 231.589 us |
|   F32 |     2^16 = 65536 |    372x |  26.007 us | 4.63% |   6.394 us | 10.41% |  10.249G | 122.989 GB/s |  1.60% | 249334x |   2.005 us |
|   F32 |   2^20 = 1048576 |    428x |  29.421 us | 4.62% |   9.634 us |  9.71% | 108.838G |   1.306 TB/s | 17.02% | 190896x |   2.619 us |
|   F32 |  2^24 = 16777216 |    324x |  57.643 us | 2.49% |  37.675 us |  2.68% | 445.316G |   5.344 TB/s | 69.65% |  16469x |  30.361 us |
|   F32 | 2^28 = 268435456 |    456x | 474.415 us | 0.24% | 454.620 us |  0.15% | 590.462G |   7.086 TB/s | 92.35% |   1158x | 444.908 us |

## mul

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    390x |  25.726 us | 3.66% |   6.171 us |  3.40% |  10.619G |  63.716 GB/s |  0.83% | 248949x |   2.008 us |
|   F16 |   2^20 = 1048576 |    402x |  27.955 us | 3.20% |   8.179 us |  0.95% | 128.198G | 769.188 GB/s | 10.03% | 191714x |   2.608 us |
|   F16 |  2^24 = 16777216 |    910x |  42.868 us | 3.59% |  22.954 us |  3.65% | 730.900G |   4.385 TB/s | 57.16% |  32759x |  15.263 us |
|   F16 | 2^28 = 268435456 |    440x | 259.267 us | 0.40% | 239.656 us |  0.18% |   1.120T |   6.721 TB/s | 87.59% |   2184x | 232.470 us |
|  BF16 |     2^16 = 65536 |    458x |  26.424 us | 4.79% |   6.552 us | 11.85% |  10.003G |  60.018 GB/s |  0.78% | 247059x |   2.024 us |
|  BF16 |   2^20 = 1048576 |    518x |  28.069 us | 4.10% |   8.188 us |  1.27% | 128.055G | 768.330 GB/s | 10.01% | 191944x |   2.605 us |
|  BF16 |  2^24 = 16777216 |    512x |  43.029 us | 2.93% |  22.974 us |  3.72% | 730.284G |   4.382 TB/s | 57.11% |  32770x |  15.258 us |
|  BF16 | 2^28 = 268435456 |    414x | 259.711 us | 0.43% | 239.718 us |  0.15% |   1.120T |   6.719 TB/s | 87.57% |   2182x | 232.035 us |
|   F32 |     2^16 = 65536 |    352x |  26.586 us | 5.39% |   6.764 us | 13.60% |   9.688G | 116.259 GB/s |  1.52% | 247375x |   2.021 us |
|   F32 |   2^20 = 1048576 |    348x |  29.237 us | 5.23% |   9.383 us | 10.84% | 111.753G |   1.341 TB/s | 17.48% | 190940x |   2.619 us |
|   F32 |  2^24 = 16777216 |    342x |  57.605 us | 2.67% |  37.644 us |  2.67% | 445.685G |   5.348 TB/s | 69.71% |  16466x |  30.368 us |
|   F32 | 2^28 = 268435456 |    312x | 474.230 us | 0.26% | 454.534 us |  0.17% | 590.573G |   7.087 TB/s | 92.37% |   1157x | 444.905 us |

## div

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    380x |  25.873 us | 3.55% |   6.200 us |  5.08% |  10.570G |  63.419 GB/s |  0.83% | 249692x |   2.002 us |
|   F16 |   2^20 = 1048576 |    418x |  27.718 us | 3.39% |   8.180 us |  0.88% | 128.181G | 769.085 GB/s | 10.02% | 176206x |   2.838 us |
|   F16 |  2^24 = 16777216 |    362x |  46.485 us | 2.38% |  26.634 us |  0.49% | 629.924G |   3.780 TB/s | 49.26% |  26041x |  19.201 us |
|   F16 | 2^28 = 268435456 |    378x | 300.578 us | 0.32% | 280.746 us |  0.14% | 956.151G |   5.737 TB/s | 74.77% |   1864x | 274.420 us |
|  BF16 |     2^16 = 65536 |    368x |  26.039 us | 4.51% |   6.234 us |  6.84% |  10.512G |  63.073 GB/s |  0.82% | 244605x |   2.044 us |
|  BF16 |   2^20 = 1048576 |    560x |  27.702 us | 3.61% |   8.191 us |  1.25% | 128.021G | 768.123 GB/s | 10.01% | 177232x |   2.821 us |
|  BF16 |  2^24 = 16777216 |    512x |  46.593 us | 2.30% |  26.639 us |  0.42% | 629.803G |   3.779 TB/s | 49.25% |  25150x |  19.881 us |
|  BF16 | 2^28 = 268435456 |    514x | 319.113 us | 0.37% | 299.400 us |  0.22% | 896.578G |   5.379 TB/s | 70.12% |   1740x | 294.109 us |
|   F32 |     2^16 = 65536 |    334x |  25.997 us | 4.50% |   6.388 us | 10.26% |  10.259G | 123.105 GB/s |  1.60% | 248808x |   2.010 us |
|   F32 |   2^20 = 1048576 |    494x |  29.406 us | 4.81% |   9.595 us |  9.89% | 109.279G |   1.311 TB/s | 17.09% | 176982x |   2.825 us |
|   F32 |  2^24 = 16777216 |    370x |  58.760 us | 1.70% |  38.921 us |  0.24% | 431.057G |   5.173 TB/s | 67.42% |  16110x |  31.038 us |
|   F32 | 2^28 = 268435456 |    432x | 486.946 us | 0.24% | 467.166 us |  0.13% | 574.604G |   6.895 TB/s | 89.87% |   1117x | 459.329 us |

## le

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|-------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    360x |  25.828 us | 4.01% |   6.183 us | 4.66% |  10.599G |  63.593 GB/s |  0.83% | 246184x |   2.031 us |
|   F16 |   2^20 = 1048576 |    352x |  27.892 us | 4.02% |   8.184 us | 1.16% | 128.125G | 768.751 GB/s | 10.02% | 190924x |   2.619 us |
|   F16 |  2^24 = 16777216 |    396x |  43.908 us | 3.03% |  24.022 us | 3.88% | 698.399G |   4.190 TB/s | 54.62% |  31617x |  15.815 us |
|   F16 | 2^28 = 268435456 |    648x | 263.525 us | 0.47% | 243.648 us | 0.21% |   1.102T |   6.610 TB/s | 86.16% |   2146x | 235.640 us |
|  BF16 |     2^16 = 65536 |    334x |  25.965 us | 3.98% |   6.225 us | 6.24% |  10.528G |  63.166 GB/s |  0.82% | 246293x |   2.030 us |
|  BF16 |   2^20 = 1048576 |    446x |  27.636 us | 3.32% |   8.186 us | 1.45% | 128.090G | 768.538 GB/s | 10.02% | 190889x |   2.619 us |
|  BF16 |  2^24 = 16777216 |    458x |  43.937 us | 3.00% |  24.035 us | 3.82% | 698.039G |   4.188 TB/s | 54.59% |  31586x |  15.830 us |
|  BF16 | 2^28 = 268435456 |    580x | 263.604 us | 0.41% | 243.697 us | 0.20% |   1.102T |   6.609 TB/s | 86.14% |   2143x | 235.628 us |
|   F32 |     2^16 = 65536 |    358x |  25.997 us | 4.15% |   6.296 us | 8.28% |  10.410G | 124.916 GB/s |  1.63% | 248946x |   2.008 us |
|   F32 |   2^20 = 1048576 |    390x |  28.236 us | 5.20% |   8.640 us | 9.97% | 121.370G |   1.456 TB/s | 18.98% | 191162x |   2.616 us |
|   F32 |  2^24 = 16777216 |    400x |  57.442 us | 2.34% |  37.737 us | 2.71% | 444.578G |   5.335 TB/s | 69.53% |  16468x |  30.364 us |
|   F32 | 2^28 = 268435456 |    360x | 474.359 us | 0.25% | 454.590 us | 0.15% | 590.500G |   7.086 TB/s | 92.36% |   1141x | 444.975 us |

## ge

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    444x |  25.761 us | 4.04% |   6.203 us |  5.38% |  10.565G |  63.391 GB/s |  0.83% | 246115x |   2.032 us |
|   F16 |   2^20 = 1048576 |    504x |  27.714 us | 3.20% |   8.181 us |  1.14% | 128.172G | 769.031 GB/s | 10.02% | 190668x |   2.622 us |
|   F16 |  2^24 = 16777216 |    340x |  44.236 us | 2.92% |  24.156 us |  3.49% | 694.524G |   4.167 TB/s | 54.31% |  31598x |  15.824 us |
|   F16 | 2^28 = 268435456 |    406x | 263.373 us | 0.43% | 243.617 us |  0.22% |   1.102T |   6.611 TB/s | 86.17% |   2138x | 235.823 us |
|  BF16 |     2^16 = 65536 |    392x |  25.992 us | 4.08% |   6.246 us |  6.95% |  10.493G |  62.959 GB/s |  0.82% | 245418x |   2.037 us |
|  BF16 |   2^20 = 1048576 |    360x |  27.586 us | 3.34% |   8.187 us |  0.72% | 128.083G | 768.500 GB/s | 10.02% | 190465x |   2.625 us |
|  BF16 |  2^24 = 16777216 |    314x |  44.154 us | 3.23% |  24.097 us |  3.70% | 696.233G |   4.177 TB/s | 54.45% |  31584x |  15.831 us |
|  BF16 | 2^28 = 268435456 |    500x | 263.419 us | 0.43% | 243.644 us |  0.19% |   1.102T |   6.611 TB/s | 86.16% |   2147x | 235.825 us |
|   F32 |     2^16 = 65536 |    306x |  26.163 us | 4.17% |   6.355 us |  9.58% |  10.312G | 123.741 GB/s |  1.61% | 248133x |   2.015 us |
|   F32 |   2^20 = 1048576 |    380x |  28.632 us | 5.25% |   9.090 us | 11.33% | 115.350G |   1.384 TB/s | 18.04% | 191224x |   2.615 us |
|   F32 |  2^24 = 16777216 |    324x |  57.716 us | 2.29% |  37.709 us |  2.71% | 444.912G |   5.339 TB/s | 69.59% |  16473x |  30.353 us |
|   F32 | 2^28 = 268435456 |    402x | 474.495 us | 0.28% | 454.642 us |  0.15% | 590.433G |   7.085 TB/s | 92.35% |   1158x | 444.983 us |

## fmin

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    378x |  25.859 us | 3.59% |   6.152 us |  2.13% |  10.653G |  63.918 GB/s |  0.83% | 246359x |   2.030 us |
|   F16 |   2^20 = 1048576 |    316x |  27.696 us | 3.22% |   8.185 us |  0.91% | 128.106G | 768.637 GB/s | 10.02% | 192421x |   2.598 us |
|   F16 |  2^24 = 16777216 |    436x |  43.214 us | 3.81% |  23.423 us |  4.38% | 716.258G |   4.298 TB/s | 56.01% |  31391x |  15.928 us |
|   F16 | 2^28 = 268435456 |    428x | 269.575 us | 0.47% | 249.759 us |  0.25% |   1.075T |   6.449 TB/s | 84.05% |   2088x | 243.522 us |
|  BF16 |     2^16 = 65536 |    344x |  25.846 us | 5.03% |   6.198 us |  4.99% |  10.573G |  63.439 GB/s |  0.83% | 246427x |   2.029 us |
|  BF16 |   2^20 = 1048576 |    426x |  27.638 us | 3.53% |   8.184 us |  0.86% | 128.120G | 768.719 GB/s | 10.02% | 192932x |   2.592 us |
|  BF16 |  2^24 = 16777216 |    318x |  43.224 us | 3.16% |  23.297 us |  4.26% | 720.142G |   4.321 TB/s | 56.32% |  31406x |  15.921 us |
|  BF16 | 2^28 = 268435456 |    376x | 269.607 us | 0.38% | 249.752 us |  0.23% |   1.075T |   6.449 TB/s | 84.05% |   2095x | 243.524 us |
|   F32 |     2^16 = 65536 |    432x |  25.752 us | 3.74% |   6.220 us |  6.09% |  10.536G | 126.436 GB/s |  1.65% | 249299x |   2.006 us |
|   F32 |   2^20 = 1048576 |    326x |  28.743 us | 6.01% |   8.934 us | 11.10% | 117.369G |   1.408 TB/s | 18.36% | 191134x |   2.616 us |
|   F32 |  2^24 = 16777216 |    340x |  57.790 us | 6.55% |  37.721 us |  2.70% | 444.775G |   5.337 TB/s | 69.57% |  16465x |  30.369 us |
|   F32 | 2^28 = 268435456 |    408x | 474.436 us | 0.25% | 454.590 us |  0.13% | 590.500G |   7.086 TB/s | 92.36% |   1157x | 444.989 us |

## fmax

### [0] NVIDIA B200

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    308x |  25.880 us | 3.59% |   6.188 us |  4.80% |  10.591G |  63.543 GB/s |  0.83% | 247837x |   2.017 us |
|   F16 |   2^20 = 1048576 |    366x |  27.936 us | 3.06% |   8.185 us |  1.67% | 128.113G | 768.681 GB/s | 10.02% | 192193x |   2.602 us |
|   F16 |  2^24 = 16777216 |    440x |  44.509 us | 2.30% |  24.541 us |  1.46% | 683.630G |   4.102 TB/s | 53.46% |  31356x |  15.946 us |
|   F16 | 2^28 = 268435456 |    392x | 269.674 us | 0.46% | 249.861 us |  0.18% |   1.074T |   6.446 TB/s | 84.02% |   2090x | 243.564 us |
|  BF16 |     2^16 = 65536 |    312x |  25.863 us | 4.84% |   6.252 us |  7.51% |  10.482G |  62.892 GB/s |  0.82% | 246508x |   2.028 us |
|  BF16 |   2^20 = 1048576 |    350x |  27.896 us | 3.71% |   8.188 us |  1.26% | 128.057G | 768.343 GB/s | 10.01% | 193123x |   2.589 us |
|  BF16 |  2^24 = 16777216 |    312x |  44.494 us | 2.69% |  24.570 us |  0.95% | 682.846G |   4.097 TB/s | 53.40% |  31346x |  15.952 us |
|  BF16 | 2^28 = 268435456 |    378x | 269.830 us | 0.45% | 249.838 us |  0.23% |   1.074T |   6.447 TB/s | 84.02% |   2087x | 243.537 us |
|   F32 |     2^16 = 65536 |    314x |  25.921 us | 4.33% |   6.350 us |  9.57% |  10.320G | 123.840 GB/s |  1.61% | 249522x |   2.005 us |
|   F32 |   2^20 = 1048576 |    418x |  28.586 us | 5.34% |   9.155 us | 11.27% | 114.533G |   1.374 TB/s | 17.91% | 190964x |   2.618 us |
|   F32 |  2^24 = 16777216 |    432x |  57.573 us | 2.45% |  37.706 us |  2.69% | 444.943G |   5.339 TB/s | 69.59% |  16478x |  30.344 us |
|   F32 | 2^28 = 268435456 |    374x | 474.246 us | 0.22% | 454.600 us |  0.13% | 590.487G |   7.086 TB/s | 92.36% |   1158x | 444.985 us |
```

RTX5090
```
## relu

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|--------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    338x |  10.848 us | 13.89% |   4.105 us |  2.20% |  15.966G |  63.863 GB/s |  3.56% | 221730x |   2.255 us |
|   F16 |   2^20 = 1048576 |    318x |  11.849 us |  8.61% |   5.173 us | 19.79% | 202.685G | 810.739 GB/s | 45.24% | 227939x |   2.194 us |
|   F16 |  2^24 = 16777216 |    450x |  51.050 us |  2.91% |  44.451 us |  2.29% | 377.434G |   1.510 TB/s | 84.24% |  41490x |  12.057 us |
|   F16 | 2^28 = 268435456 |    366x | 712.592 us |  0.37% | 705.717 us |  0.17% | 380.372G |   1.521 TB/s | 84.90% |    749x | 702.977 us |
|  BF16 |     2^16 = 65536 |    370x |   9.397 us |  8.27% |   2.698 us | 35.22% |  24.288G |  97.152 GB/s |  5.42% | 227389x |   2.199 us |
|  BF16 |   2^20 = 1048576 |    304x |  12.826 us |  7.40% |   6.142 us |  0.99% | 170.734G | 682.936 GB/s | 38.11% | 220541x |   2.267 us |
|  BF16 |  2^24 = 16777216 |    312x |  52.366 us |  1.99% |  44.677 us |  2.11% | 375.523G |   1.502 TB/s | 83.82% |  41089x |  12.173 us |
|  BF16 | 2^28 = 268435456 |    332x | 714.473 us |  0.42% | 706.337 us |  0.16% | 380.039G |   1.520 TB/s | 84.82% |    747x | 703.983 us |
|   F32 |     2^16 = 65536 |     12x |  11.124 us |  8.23% |   4.096 us |  0.00% |  16.000G | 128.000 GB/s |  7.14% | 234289x |   2.175 us |
|   F32 |   2^20 = 1048576 |    378x |  14.372 us |  7.76% |   6.765 us | 13.90% | 154.995G |   1.240 TB/s | 69.19% | 225989x |   2.213 us |
|   F32 |  2^24 = 16777216 |    318x |  97.330 us |  2.25% |  89.414 us |  1.18% | 187.635G |   1.501 TB/s | 83.76% |   7138x |  71.367 us |
|   F32 | 2^28 = 268435456 |    300x |   1.423 ms |  0.38% |   1.415 ms |  0.09% | 189.689G |   1.518 TB/s | 84.68% |    372x |   1.407 ms |

## sigmoid

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|--------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    356x |  11.459 us | 11.31% |   4.098 us |  2.17% |  15.992G |  63.966 GB/s |  3.57% | 231760x |   2.182 us |
|   F16 |   2^20 = 1048576 |    484x |  13.402 us |  7.81% |   6.145 us |  1.00% | 170.626G | 682.505 GB/s | 38.08% | 219782x |   2.280 us |
|   F16 |  2^24 = 16777216 |    338x |  53.343 us |  2.95% |  45.750 us |  2.14% | 366.714G |   1.467 TB/s | 81.85% |  36136x |  13.882 us |
|   F16 | 2^28 = 268435456 |    406x | 714.721 us |  0.88% | 706.345 us |  0.17% | 380.034G |   1.520 TB/s | 84.82% |    744x | 702.827 us |
|  BF16 |     2^16 = 65536 |    366x |  11.178 us | 14.07% |   4.092 us |  1.70% |  16.015G |  64.060 GB/s |  3.57% | 226742x |   2.220 us |
|  BF16 |   2^20 = 1048576 |    320x |  12.985 us |  5.58% |   6.148 us |  1.24% | 170.564G | 682.256 GB/s | 38.07% | 227226x |   2.200 us |
|  BF16 |  2^24 = 16777216 |    380x |  52.404 us |  1.59% |  45.127 us |  1.60% | 371.775G |   1.487 TB/s | 82.98% |  36033x |  13.921 us |
|  BF16 | 2^28 = 268435456 |    366x | 714.624 us |  0.46% | 706.561 us |  0.16% | 379.918G |   1.520 TB/s | 84.80% |    744x | 703.394 us |
|   F32 |     2^16 = 65536 |     12x |  11.311 us |  6.25% |   4.096 us |  0.00% |  16.000G | 128.000 GB/s |  7.14% | 226549x |   2.207 us |
|   F32 |   2^20 = 1048576 |    328x |  14.563 us |  7.85% |   7.140 us | 14.55% | 146.849G |   1.175 TB/s | 65.55% | 206097x |   2.426 us |
|   F32 |  2^24 = 16777216 |    354x |  97.263 us |  2.47% |  89.878 us |  1.14% | 186.666G |   1.493 TB/s | 83.33% |   6945x |  72.097 us |
|   F32 | 2^28 = 268435456 |    318x |   1.423 ms |  0.25% |   1.415 ms |  0.09% | 189.707G |   1.518 TB/s | 84.68% |    372x |   1.408 ms |

## tanh

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|--------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    282x |  11.223 us | 11.23% |   4.090 us |  2.26% |  16.023G |  64.092 GB/s |  3.58% | 224328x |   2.254 us |
|   F16 |   2^20 = 1048576 |     12x |  13.448 us |  6.01% |   6.144 us |  0.00% | 170.667G | 682.667 GB/s | 38.09% | 220064x |   2.273 us |
|   F16 |  2^24 = 16777216 |    354x |  52.626 us |  2.13% |  45.153 us |  1.45% | 371.564G |   1.486 TB/s | 82.93% |  37172x |  13.500 us |
|   F16 | 2^28 = 268435456 |    376x | 714.482 us |  0.81% | 705.685 us |  0.16% | 380.390G |   1.522 TB/s | 84.90% |    747x | 702.624 us |
|  BF16 |     2^16 = 65536 |    462x |  11.202 us |  9.40% |   4.079 us |  2.58% |  16.066G |  64.263 GB/s |  3.59% | 227463x |   2.198 us |
|  BF16 |   2^20 = 1048576 |    364x |  12.110 us |  6.67% |   5.115 us | 19.82% | 205.004G | 820.017 GB/s | 45.76% | 227369x |   2.247 us |
|  BF16 |  2^24 = 16777216 |    394x |  52.576 us |  2.17% |  44.893 us |  1.76% | 373.714G |   1.495 TB/s | 83.41% |  37150x |  13.507 us |
|  BF16 | 2^28 = 268435456 |    478x | 713.903 us |  0.25% | 706.124 us |  0.16% | 380.153G |   1.521 TB/s | 84.85% |    747x | 703.537 us |
|   F32 |     2^16 = 65536 |     62x |  11.426 us | 12.66% |   4.067 us |  3.13% |  16.114G | 128.910 GB/s |  7.19% | 229954x |   2.210 us |
|   F32 |   2^20 = 1048576 |    372x |  14.708 us |  8.59% |   6.996 us | 14.34% | 149.881G |   1.199 TB/s | 66.91% | 217699x |   2.297 us |
|   F32 |  2^24 = 16777216 |    458x |  97.244 us |  1.27% |  89.979 us |  1.02% | 186.457G |   1.492 TB/s | 83.23% |   7048x |  70.956 us |
|   F32 | 2^28 = 268435456 |    302x |   1.426 ms |  2.09% |   1.416 ms |  0.10% | 189.613G |   1.517 TB/s | 84.64% |    372x |   1.406 ms |

## gelu

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|--------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    818x |  11.532 us | 13.47% |   4.090 us |  2.71% |  16.024G |  64.098 GB/s |  3.58% | 216702x |   2.307 us |
|   F16 |   2^20 = 1048576 |    306x |  12.895 us |  6.04% |   6.134 us |  2.73% | 170.946G | 683.784 GB/s | 38.15% | 223901x |   2.262 us |
|   F16 |  2^24 = 16777216 |    602x |  52.433 us |  1.91% |  44.855 us |  1.77% | 374.033G |   1.496 TB/s | 83.48% |  28894x |  17.337 us |
|   F16 | 2^28 = 268435456 |    358x | 715.558 us |  0.82% | 707.196 us |  0.15% | 379.577G |   1.518 TB/s | 84.72% |    747x | 702.778 us |
|  BF16 |     2^16 = 65536 |     12x |  11.066 us |  7.23% |   4.096 us |  0.00% |  16.000G |  64.000 GB/s |  3.57% | 215129x |   2.334 us |
|  BF16 |   2^20 = 1048576 |    134x |  13.052 us |  5.52% |   6.155 us |  2.95% | 170.369G | 681.475 GB/s | 38.03% | 215547x |   2.320 us |
|  BF16 |  2^24 = 16777216 |    384x |  52.635 us |  2.77% |  44.988 us |  1.81% | 372.925G |   1.492 TB/s | 83.24% |  28885x |  17.343 us |
|  BF16 | 2^28 = 268435456 |    380x | 715.727 us |  0.71% | 707.242 us |  0.17% | 379.553G |   1.518 TB/s | 84.72% |    747x | 703.238 us |
|   F32 |     2^16 = 65536 |    374x |  11.083 us |  8.60% |   4.082 us |  2.94% |  16.056G | 128.451 GB/s |  7.17% | 224751x |   2.225 us |
|   F32 |   2^20 = 1048576 |    310x |  14.549 us |  8.14% |   6.835 us | 14.05% | 153.408G |   1.227 TB/s | 68.48% | 193520x |   2.584 us |
|   F32 |  2^24 = 16777216 |    374x |  97.769 us |  6.10% |  90.027 us |  1.05% | 186.358G |   1.491 TB/s | 83.19% |   6945x |  72.175 us |
|   F32 | 2^28 = 268435456 |    466x |   1.424 ms |  0.25% |   1.416 ms |  0.09% | 189.607G |   1.517 TB/s | 84.64% |    467x |   1.407 ms |

## sin

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|--------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    404x |  11.309 us | 11.43% |   4.099 us |  2.21% |  15.988G |  63.951 GB/s |  3.57% | 228230x |   2.214 us |
|   F16 |   2^20 = 1048576 |    466x |  13.091 us |  7.57% |   6.142 us |  1.72% | 170.724G | 682.896 GB/s | 38.11% | 225241x |   2.220 us |
|   F16 |  2^24 = 16777216 |    378x |  51.316 us |  1.95% |  43.808 us |  2.34% | 382.975G |   1.532 TB/s | 85.48% |  30885x |  16.210 us |
|   F16 | 2^28 = 268435456 |    310x | 715.601 us |  0.76% | 706.957 us |  0.14% | 379.705G |   1.519 TB/s | 84.75% |    747x | 702.535 us |
|  BF16 |     2^16 = 65536 |     12x |  11.159 us |  7.71% |   4.096 us |  0.00% |  16.000G |  64.000 GB/s |  3.57% | 221517x |   2.257 us |
|  BF16 |   2^20 = 1048576 |    458x |  13.085 us |  6.46% |   6.146 us |  2.63% | 170.618G | 682.473 GB/s | 38.08% | 222378x |   2.248 us |
|  BF16 |  2^24 = 16777216 |    362x |  52.565 us |  9.66% |  44.594 us |  2.13% | 376.225G |   1.505 TB/s | 83.97% |  33251x |  15.072 us |
|  BF16 | 2^28 = 268435456 |    338x | 715.787 us |  0.72% | 707.381 us |  0.15% | 379.478G |   1.518 TB/s | 84.70% |    744x | 703.482 us |
|   F32 |     2^16 = 65536 |     12x |  11.499 us |  7.13% |   4.096 us |  0.00% |  16.000G | 128.000 GB/s |  7.14% | 230531x |   2.182 us |
|   F32 |   2^20 = 1048576 |    310x |  14.887 us | 11.86% |   7.255 us | 13.95% | 144.533G |   1.156 TB/s | 64.52% | 193798x |   2.580 us |
|   F32 |  2^24 = 16777216 |    368x |  97.962 us |  1.44% |  90.988 us |  1.38% | 184.389G |   1.475 TB/s | 82.31% |   7056x |  70.867 us |
|   F32 | 2^28 = 268435456 |    340x |   1.424 ms |  0.23% |   1.416 ms |  0.09% | 189.587G |   1.517 TB/s | 84.63% |    371x |   1.407 ms |

## exp

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|--------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    688x |  11.236 us | 12.78% |   4.098 us |  2.51% |  15.993G |  63.973 GB/s |  3.57% | 224797x |   2.224 us |
|   F16 |   2^20 = 1048576 |    520x |  13.175 us |  7.38% |   6.136 us |  1.56% | 170.903G | 683.612 GB/s | 38.15% | 231324x |   2.162 us |
|   F16 |  2^24 = 16777216 |    400x |  51.206 us |  1.87% |  43.967 us |  2.34% | 381.588G |   1.526 TB/s | 85.17% |  38443x |  13.053 us |
|   F16 | 2^28 = 268435456 |    304x | 714.901 us |  0.18% | 707.290 us |  0.16% | 379.527G |   1.518 TB/s | 84.71% |    747x | 702.568 us |
|  BF16 |     2^16 = 65536 |     22x |  10.943 us |  6.62% |   4.070 us |  3.02% |  16.103G |  64.412 GB/s |  3.59% | 230984x |   2.165 us |
|  BF16 |   2^20 = 1048576 |    302x |  12.946 us |  5.96% |   6.133 us |  1.65% | 170.973G | 683.893 GB/s | 38.16% | 231403x |   2.161 us |
|  BF16 |  2^24 = 16777216 |    404x |  51.876 us |  2.64% |  44.344 us |  2.24% | 378.342G |   1.513 TB/s | 84.45% |  40082x |  12.488 us |
|  BF16 | 2^28 = 268435456 |    430x | 715.135 us |  1.03% | 706.839 us |  0.15% | 379.769G |   1.519 TB/s | 84.76% |    747x | 703.058 us |
|   F32 |     2^16 = 65536 |    696x |  11.306 us | 12.51% |   4.087 us |  3.31% |  16.033G | 128.266 GB/s |  7.16% | 224518x |   2.235 us |
|   F32 |   2^20 = 1048576 |    300x |  14.630 us |  7.96% |   6.923 us | 14.27% | 151.461G |   1.212 TB/s | 67.61% | 219500x |   2.278 us |
|   F32 |  2^24 = 16777216 |    302x |  98.596 us |  2.26% |  91.328 us |  1.29% | 183.702G |   1.470 TB/s | 82.00% |   7138x |  73.016 us |
|   F32 | 2^28 = 268435456 |    384x |   1.426 ms |  1.54% |   1.416 ms |  0.09% | 189.584G |   1.517 TB/s | 84.63% |    385x |   1.408 ms |

## add

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|--------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    352x |  11.231 us | 13.99% |   4.093 us |  2.76% |  16.012G |  96.072 GB/s |  5.36% | 221565x |   2.283 us |
|   F16 |   2^20 = 1048576 |    364x |  14.306 us |  7.05% |   6.968 us | 14.22% | 150.492G | 902.953 GB/s | 50.38% | 220154x |   2.271 us |
|   F16 |  2^24 = 16777216 |    318x |  73.260 us |  1.90% |  65.765 us |  1.09% | 255.108G |   1.531 TB/s | 85.41% |  31292x |  16.327 us |
|   F16 | 2^28 = 268435456 |    354x |   1.037 ms |  0.47% |   1.028 ms |  0.11% | 261.072G |   1.566 TB/s | 87.41% |    513x |   1.022 ms |
|  BF16 |     2^16 = 65536 |     12x |  11.720 us | 13.85% |   4.096 us |  0.00% |  16.000G |  96.000 GB/s |  5.36% | 221331x |   2.276 us |
|  BF16 |   2^20 = 1048576 |    456x |  14.379 us |  6.39% |   6.968 us | 14.35% | 150.480G | 902.880 GB/s | 50.38% | 215533x |   2.320 us |
|  BF16 |  2^24 = 16777216 |    546x |  74.450 us |  1.42% |  67.054 us |  1.38% | 250.205G |   1.501 TB/s | 83.77% |  27393x |  18.404 us |
|  BF16 | 2^28 = 268435456 |    414x |   1.037 ms |  0.41% |   1.029 ms |  0.12% | 260.927G |   1.566 TB/s | 87.36% |    513x |   1.022 ms |
|   F32 |     2^16 = 65536 |    302x |  11.624 us |  7.50% |   4.147 us |  7.81% |  15.802G | 189.626 GB/s | 10.58% | 213190x |   2.345 us |
|   F32 |   2^20 = 1048576 |    330x |  17.420 us |  6.88% |   9.729 us |  9.18% | 107.781G |   1.293 TB/s | 72.17% | 187221x |   2.671 us |
|   F32 |  2^24 = 16777216 |     44x | 138.965 us |  0.87% | 131.337 us |  0.55% | 127.742G |   1.533 TB/s | 85.54% |   4508x | 114.444 us |
|   F32 | 2^28 = 268435456 |    310x |   2.064 ms |  0.48% |   2.055 ms |  0.08% | 130.627G |   1.568 TB/s | 87.47% |    311x |   2.046 ms |

## sub

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|--------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    358x |  11.080 us |  8.38% |   4.082 us |  3.08% |  16.054G |  96.326 GB/s |  5.37% | 221271x |   2.260 us |
|   F16 |   2^20 = 1048576 |    384x |  14.496 us |  5.80% |   6.903 us | 14.24% | 151.911G | 911.464 GB/s | 50.86% | 216238x |   2.326 us |
|   F16 |  2^24 = 16777216 |    330x |  74.586 us |  1.35% |  67.055 us |  1.37% | 250.201G |   1.501 TB/s | 83.77% |  28078x |  17.995 us |
|   F16 | 2^28 = 268435456 |    500x |   1.038 ms |  0.89% |   1.029 ms |  0.12% | 260.929G |   1.566 TB/s | 87.36% |    513x |   1.022 ms |
|  BF16 |     2^16 = 65536 |    308x |  11.166 us |  8.21% |   4.077 us |  2.79% |  16.073G |  96.440 GB/s |  5.38% | 223344x |   2.263 us |
|  BF16 |   2^20 = 1048576 |     56x |  14.802 us | 19.82% |   6.159 us |  1.31% | 170.239G |   1.021 TB/s | 57.00% | 219659x |   2.302 us |
|  BF16 |  2^24 = 16777216 |    402x |  74.664 us |  1.44% |  67.249 us |  1.26% | 249.480G |   1.497 TB/s | 83.53% |  33071x |  15.428 us |
|  BF16 | 2^28 = 268435456 |    302x |   1.037 ms |  0.84% |   1.029 ms |  0.12% | 260.914G |   1.565 TB/s | 87.35% |    512x |   1.022 ms |
|   F32 |     2^16 = 65536 |    352x |  11.142 us |  9.84% |   4.096 us |  5.17% |  15.999G | 191.987 GB/s | 10.71% | 213450x |   2.349 us |
|   F32 |   2^20 = 1048576 |    388x |  18.279 us |  9.80% |  10.244 us |  1.20% | 102.356G |   1.228 TB/s | 68.54% | 189914x |   2.638 us |
|   F32 |  2^24 = 16777216 |    374x | 138.507 us |  0.83% | 130.994 us |  0.62% | 128.077G |   1.537 TB/s | 85.76% |   4355x | 115.905 us |
|   F32 | 2^28 = 268435456 |    490x |   2.063 ms |  0.23% |   2.055 ms |  0.08% | 130.644G |   1.568 TB/s | 87.48% |    491x |   2.046 ms |

## mul

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |     12x |  11.083 us | 8.66% |   4.096 us |  0.00% |  16.000G |  96.000 GB/s |  5.36% | 221033x |   2.262 us |
|   F16 |   2^20 = 1048576 |    322x |  14.440 us | 7.11% |   6.955 us | 14.42% | 150.772G | 904.629 GB/s | 50.48% | 224856x |   2.260 us |
|   F16 |  2^24 = 16777216 |    306x |  74.598 us | 4.22% |  67.005 us |  1.48% | 250.388G |   1.502 TB/s | 83.83% |  27177x |  18.583 us |
|   F16 | 2^28 = 268435456 |    566x |   1.037 ms | 0.32% |   1.029 ms |  0.12% | 260.941G |   1.566 TB/s | 87.36% |    567x |   1.022 ms |
|  BF16 |     2^16 = 65536 |    328x |  11.129 us | 9.19% |   4.071 us |  3.71% |  16.098G |  96.589 GB/s |  5.39% | 216327x |   2.334 us |
|  BF16 |   2^20 = 1048576 |    522x |  13.689 us | 6.16% |   6.134 us |  2.51% | 170.940G |   1.026 TB/s | 57.23% | 218207x |   2.291 us |
|  BF16 |  2^24 = 16777216 |    332x |  74.305 us | 1.73% |  66.878 us |  1.52% | 250.861G |   1.505 TB/s | 83.99% |  33070x |  15.452 us |
|  BF16 | 2^28 = 268435456 |    360x |   1.037 ms | 0.66% |   1.029 ms |  0.13% | 260.939G |   1.566 TB/s | 87.36% |    513x |   1.022 ms |
|   F32 |     2^16 = 65536 |    412x |  11.069 us | 9.87% |   4.083 us |  5.03% |  16.050G | 192.595 GB/s | 10.75% | 220423x |   2.268 us |
|   F32 |   2^20 = 1048576 |    278x |  17.813 us | 4.45% |  10.239 us |  1.38% | 102.406G |   1.229 TB/s | 68.57% | 189449x |   2.647 us |
|   F32 |  2^24 = 16777216 |     12x | 138.630 us | 0.54% | 131.072 us |  0.00% | 128.000G |   1.536 TB/s | 85.71% |   4355x | 118.043 us |
|   F32 | 2^28 = 268435456 |    406x |   2.063 ms | 0.20% |   2.055 ms |  0.08% | 130.631G |   1.568 TB/s | 87.47% |    407x |   2.045 ms |

## div

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|--------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |     12x |  11.550 us | 10.28% |   4.096 us |  0.00% |  16.000G |  96.000 GB/s |  5.36% | 218522x |   2.288 us |
|   F16 |   2^20 = 1048576 |    336x |  14.758 us |  8.81% |   7.069 us | 14.24% | 148.329G | 889.977 GB/s | 49.66% | 219088x |   2.282 us |
|   F16 |  2^24 = 16777216 |    358x |  74.918 us |  2.22% |  67.296 us |  1.22% | 249.306G |   1.496 TB/s | 83.47% |  25690x |  19.758 us |
|   F16 | 2^28 = 268435456 |    486x |   1.037 ms |  0.35% |   1.029 ms |  0.12% | 260.903G |   1.565 TB/s | 87.35% |    515x |   1.022 ms |
|  BF16 |     2^16 = 65536 |    336x |  11.173 us |  9.44% |   4.075 us |  3.38% |  16.082G |  96.494 GB/s |  5.38% | 221987x |   2.256 us |
|  BF16 |   2^20 = 1048576 |    352x |  14.507 us |  8.46% |   7.259 us | 13.90% | 144.452G | 866.711 GB/s | 48.36% | 224469x |   2.245 us |
|  BF16 |  2^24 = 16777216 |    572x |  75.579 us | 17.59% |  67.594 us |  1.07% | 248.205G |   1.489 TB/s | 83.10% |  31562x |  16.239 us |
|  BF16 | 2^28 = 268435456 |    300x |   1.037 ms |  0.25% |   1.029 ms |  0.13% | 260.850G |   1.565 TB/s | 87.33% |    513x |   1.022 ms |
|   F32 |     2^16 = 65536 |    308x |  11.188 us | 11.86% |   4.101 us |  4.74% |  15.981G | 191.767 GB/s | 10.70% | 218011x |   2.301 us |
|   F32 |   2^20 = 1048576 |    324x |  17.843 us |  6.53% |  10.246 us |  1.37% | 102.337G |   1.228 TB/s | 68.52% | 181147x |   2.762 us |
|   F32 |  2^24 = 16777216 |    378x | 139.333 us |  3.03% | 131.053 us |  0.68% | 128.018G |   1.536 TB/s | 85.72% |   4283x | 116.792 us |
|   F32 | 2^28 = 268435456 |    312x |   2.063 ms |  0.22% |   2.055 ms |  0.08% | 130.647G |   1.568 TB/s | 87.48% |    313x |   2.045 ms |

## le

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|--------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |     12x |  11.822 us |  3.54% |   4.096 us |  0.00% |  16.000G |  96.000 GB/s |  5.36% | 204368x |   2.447 us |
|   F16 |   2^20 = 1048576 |    384x |  14.773 us |  9.13% |   6.992 us | 14.21% | 149.963G | 899.776 GB/s | 50.21% | 211770x |   2.361 us |
|   F16 |  2^24 = 16777216 |    362x |  74.828 us |  1.67% |  67.539 us |  1.24% | 248.408G |   1.490 TB/s | 83.17% |  33276x |  15.401 us |
|   F16 | 2^28 = 268435456 |    322x |   1.037 ms |  0.44% |   1.028 ms |  0.13% | 261.007G |   1.566 TB/s | 87.38% |    512x |   1.023 ms |
|  BF16 |     2^16 = 65536 |    320x |  11.251 us | 10.63% |   4.098 us |  2.60% |  15.992G |  95.953 GB/s |  5.35% | 213178x |   2.354 us |
|  BF16 |   2^20 = 1048576 |    348x |  14.393 us |  9.43% |   6.883 us | 14.27% | 152.340G | 914.040 GB/s | 51.00% | 214303x |   2.334 us |
|  BF16 |  2^24 = 16777216 |     12x |  74.556 us |  0.57% |  67.584 us |  0.00% | 248.242G |   1.489 TB/s | 83.11% |  31106x |  16.349 us |
|  BF16 | 2^28 = 268435456 |    324x |   1.037 ms |  0.44% |   1.028 ms |  0.11% | 261.062G |   1.566 TB/s | 87.40% |    513x |   1.022 ms |
|   F32 |     2^16 = 65536 |    324x |  11.306 us |  9.48% |   4.086 us |  3.79% |  16.038G | 192.455 GB/s | 10.74% | 220845x |   2.275 us |
|   F32 |   2^20 = 1048576 |     12x |  18.153 us |  3.85% |  10.240 us |  0.00% | 102.400G |   1.229 TB/s | 68.57% | 190378x |   2.631 us |
|   F32 |  2^24 = 16777216 |    318x | 138.385 us |  0.74% | 130.953 us |  0.61% | 128.116G |   1.537 TB/s | 85.79% |   4508x | 116.086 us |
|   F32 | 2^28 = 268435456 |    318x |   2.064 ms |  0.83% |   2.055 ms |  0.08% | 130.643G |   1.568 TB/s | 87.48% |    319x |   2.045 ms |

## ge

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |    318x |  11.164 us | 9.74% |   4.100 us |  4.13% |  15.986G |  95.918 GB/s |  5.35% | 218620x |   2.304 us |
|   F16 |   2^20 = 1048576 |    548x |  14.434 us | 6.42% |   7.181 us | 14.15% | 146.022G | 876.130 GB/s | 48.89% | 213885x |   2.338 us |
|   F16 |  2^24 = 16777216 |    372x |  74.753 us | 1.44% |  67.431 us |  0.99% | 248.806G |   1.493 TB/s | 83.30% |  33443x |  15.350 us |
|   F16 | 2^28 = 268435456 |    302x |   1.036 ms | 0.22% |   1.028 ms |  0.13% | 261.032G |   1.566 TB/s | 87.39% |    512x |   1.023 ms |
|  BF16 |     2^16 = 65536 |    328x |  10.982 us | 8.62% |   4.080 us |  2.74% |  16.062G |  96.374 GB/s |  5.38% | 217107x |   2.303 us |
|  BF16 |   2^20 = 1048576 |    332x |  14.421 us | 8.43% |   7.021 us | 14.41% | 149.340G | 896.040 GB/s | 50.00% | 221284x |   2.289 us |
|  BF16 |  2^24 = 16777216 |    364x |  75.075 us | 1.65% |  67.665 us |  0.93% | 247.946G |   1.488 TB/s | 83.01% |  30797x |  16.525 us |
|  BF16 | 2^28 = 268435456 |    412x |   1.036 ms | 0.44% |   1.028 ms |  0.12% | 261.108G |   1.567 TB/s | 87.42% |    512x |   1.022 ms |
|   F32 |     2^16 = 65536 |     12x |  11.372 us | 7.80% |   4.096 us |  0.00% |  16.000G | 192.000 GB/s | 10.71% | 218236x |   2.291 us |
|   F32 |   2^20 = 1048576 |    302x |  17.873 us | 7.78% |  10.235 us |  0.87% | 102.450G |   1.229 TB/s | 68.60% | 186831x |   2.676 us |
|   F32 |  2^24 = 16777216 |    300x | 138.613 us | 1.19% | 131.009 us |  0.65% | 128.061G |   1.537 TB/s | 85.75% |   4508x | 114.682 us |
|   F32 | 2^28 = 268435456 |    322x |   2.063 ms | 0.29% |   2.055 ms |  0.08% | 130.635G |   1.568 TB/s | 87.47% |    323x |   2.045 ms |

## fmin

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |     12x |  11.442 us | 6.38% |   4.096 us |  0.00% |  16.000G |  96.000 GB/s |  5.36% | 216777x |   2.318 us |
|   F16 |   2^20 = 1048576 |    362x |  14.429 us | 6.14% |   7.047 us | 14.35% | 148.803G | 892.821 GB/s | 49.82% | 219806x |   2.275 us |
|   F16 |  2^24 = 16777216 |    366x |  74.514 us | 5.29% |  66.411 us |  1.54% | 252.627G |   1.516 TB/s | 84.58% |  33510x |  15.287 us |
|   F16 | 2^28 = 268435456 |    302x |   1.037 ms | 0.57% |   1.029 ms |  0.12% | 260.981G |   1.566 TB/s | 87.38% |    513x |   1.022 ms |
|  BF16 |     2^16 = 65536 |    330x |  11.223 us | 8.73% |   4.087 us |  2.10% |  16.034G |  96.203 GB/s |  5.37% | 218831x |   2.318 us |
|  BF16 |   2^20 = 1048576 |    514x |  14.460 us | 5.83% |   7.177 us | 14.15% | 146.099G | 876.595 GB/s | 48.91% | 220218x |   2.332 us |
|  BF16 |  2^24 = 16777216 |    428x |  74.027 us | 1.58% |  66.611 us |  1.54% | 251.867G |   1.511 TB/s | 84.32% |  31096x |  16.397 us |
|  BF16 | 2^28 = 268435456 |    840x |   1.036 ms | 0.48% |   1.028 ms |  0.12% | 261.037G |   1.566 TB/s | 87.39% |    841x |   1.023 ms |
|   F32 |     2^16 = 65536 |    436x |  11.081 us | 8.74% |   4.160 us | 10.05% |  15.754G | 189.046 GB/s | 10.55% | 214652x |   2.329 us |
|   F32 |   2^20 = 1048576 |    326x |  18.141 us | 8.39% |  10.256 us |  1.75% | 102.244G |   1.227 TB/s | 68.46% | 190925x |   2.635 us |
|   F32 |  2^24 = 16777216 |    360x | 138.243 us | 0.86% | 130.629 us |  0.74% | 128.434G |   1.541 TB/s | 86.00% |   4508x | 114.922 us |
|   F32 | 2^28 = 268435456 |    378x |   2.064 ms | 1.50% |   2.055 ms |  0.08% | 130.654G |   1.568 TB/s | 87.49% |    379x |   2.046 ms |

## fmax

### [0] NVIDIA GeForce RTX 5090

| T{ct} |   Elements{io}   | Samples |  CPU Time  | Noise |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil | Samples | Batch GPU  |
|-------|------------------|---------|------------|-------|------------|--------|----------|--------------|--------|---------|------------|
|   F16 |     2^16 = 65536 |     12x |  10.826 us | 7.90% |   4.096 us |  0.00% |  16.000G |  96.000 GB/s |  5.36% | 217367x |   2.316 us |
|   F16 |   2^20 = 1048576 |    366x |  14.357 us | 8.16% |   6.931 us | 14.28% | 151.298G | 907.788 GB/s | 50.65% | 224480x |   2.260 us |
|   F16 |  2^24 = 16777216 |    360x |  73.665 us | 1.46% |  66.255 us |  1.50% | 253.223G |   1.519 TB/s | 84.78% |  33390x |  15.385 us |
|   F16 | 2^28 = 268435456 |    320x |   1.037 ms | 0.58% |   1.028 ms |  0.12% | 261.030G |   1.566 TB/s | 87.39% |    513x |   1.022 ms |
|  BF16 |     2^16 = 65536 |    426x |  11.051 us | 9.38% |   4.075 us |  3.27% |  16.081G |  96.487 GB/s |  5.38% | 221184x |   2.273 us |
|  BF16 |   2^20 = 1048576 |    370x |  14.167 us | 5.90% |   6.854 us | 13.99% | 152.986G | 917.917 GB/s | 51.22% | 219687x |   2.276 us |
|  BF16 |  2^24 = 16777216 |    338x |  73.266 us | 1.37% |  65.858 us |  1.13% | 254.748G |   1.528 TB/s | 85.29% |  31161x |  16.362 us |
|  BF16 | 2^28 = 268435456 |    318x |   1.036 ms | 0.28% |   1.028 ms |  0.12% | 261.199G |   1.567 TB/s | 87.45% |    513x |   1.022 ms |
|   F32 |     2^16 = 65536 |     12x |  10.960 us | 6.80% |   4.096 us |  0.00% |  16.000G | 192.000 GB/s | 10.71% | 221902x |   2.253 us |
|   F32 |   2^20 = 1048576 |     12x |  17.795 us | 3.78% |  10.240 us |  0.00% | 102.400G |   1.229 TB/s | 68.57% | 191026x |   2.635 us |
|   F32 |  2^24 = 16777216 |    408x | 137.017 us | 0.90% | 129.478 us |  0.69% | 129.576G |   1.555 TB/s | 86.76% |   4508x | 114.549 us |
|   F32 | 2^28 = 268435456 |    354x |   2.062 ms | 0.22% |   2.054 ms |  0.08% | 130.689G |   1.568 TB/s | 87.51% |    355x |   2.046 ms |

```