### PR TITLE
BACKPORT: make the abi of `__basic_any` compatible between c++17 and c++20

### DIFF
--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_base.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_base.h
@@ -60,24 +60,7 @@ _CCCL_CONCEPT __is_basic_any =
   );
 // clang-format on
 
-#if _CCCL_HAS_CONCEPTS()
-template <class _Interface, int = 0>
-struct __basic_any_base : __interface_of<_Interface>
-{
-private:
-  template <class>
-  friend struct __basic_any;
-  friend struct __basic_any_access;
-
-  static constexpr size_t __size_  = __buffer_size(_Interface::size);
-  static constexpr size_t __align_ = __buffer_align(_Interface::align);
-
-  __tagged_ptr<__vptr_for<_Interface>> __vptr_{};
-  alignas(__align_)::cuda::std::byte __buffer_[__size_];
-};
-#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
-// Without concepts, we need a base class to correctly implement movability
-// and copyability.
+// We need a base class to correctly implement movability and copyability.
 template <class _Interface, int = __extension_of<_Interface, __imovable<>> + __extension_of<_Interface, __icopyable<>>>
 struct __basic_any_base;
 
@@ -139,7 +122,6 @@ struct __basic_any_base<_Interface, 0> : __basic_any_base<_Interface, 2> // immo
   auto operator=(__basic_any_base&&) noexcept -> __basic_any_base& = delete;
   auto operator=(__basic_any_base const&) -> __basic_any_base&     = delete;
 };
-#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_ref.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_ref.h
@@ -60,7 +60,6 @@ struct __ireference : ::cuda::std::remove_const_t<_Interface>
   using interface _CCCL_NODEBUG_ALIAS = ::cuda::std::remove_const_t<_Interface>;
 };
 
-#if !_CCCL_HAS_CONCEPTS()
 //!
 //! A base class for __basic_any<__ireference<_Interface>> that provides a
 //! conversion to __basic_any<__ireference<_Interface const>>. Only used
@@ -79,7 +78,6 @@ struct __basic_any_reference_conversion_base
 template <class _Interface>
 struct __basic_any_reference_conversion_base<_Interface const>
 {};
-#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
 _CCCL_DIAG_PUSH
 // "operator __basic_any<...> will not be called for implicit or explicit conversions"
@@ -100,9 +98,7 @@ _CCCL_BEGIN_NV_DIAG_SUPPRESS(554)
 template <class _Interface>
 struct _CCCL_DECLSPEC_EMPTY_BASES __basic_any<__ireference<_Interface>>
     : __interface_of<__ireference<_Interface>>
-#if !_CCCL_HAS_CONCEPTS()
     , __basic_any_reference_conversion_base<_Interface>
-#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 {
   static_assert(::cuda::std::is_class_v<_Interface>, "expecting a class type");
   using interface_type                 = ::cuda::std::remove_const_t<_Interface>;
@@ -113,16 +109,6 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __basic_any<__ireference<_Interface>>
 
   auto operator=(__basic_any&&) -> __basic_any&      = delete;
   auto operator=(__basic_any const&) -> __basic_any& = delete;
-
-#if _CCCL_HAS_CONCEPTS()
-  //! \brief A non-const __basic_any reference can be implicitly converted to a
-  //! const __basic_any reference.
-  [[nodiscard]] _CCCL_API operator __basic_any<__ireference<_Interface const>>() const noexcept
-    requires(!__is_const_ref)
-  {
-    return __basic_any<__ireference<_Interface const>>(*this);
-  }
-#endif // _CCCL_HAS_CONCEPTS()
 
   //! \brief Returns a const reference to the type_info for the decayed type
   //! of the type-erased object.

--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
@@ -134,32 +134,10 @@ public:
     __emplace_from<_Up>(static_cast<_Fn&&>(__fn), static_cast<_Args&&>(__args)...);
   }
 
-#if _CCCL_HAS_CONCEPTS() || defined(_CCCL_DOXYGEN_INVOKED)
-  //! @brief Move constructs a `__basic_any` object.
-  //! @pre `_Interface` must extend `__imovable<>`.
-  //! @post `__other.has_value() == false` and `has_value()` is `true` if and
-  //! only if `__other.has_value()` was `true`.
-  _CCCL_API __basic_any(__basic_any&& __other) noexcept
-    requires(__movable)
-  {
-    __convert_from(::cuda::std::move(__other));
-  }
-
-  //! @brief Copy constructs a `__basic_any` object.
-  //! @pre `_Interface` must extend `__icopyable<>`.
-  //! @post `has_value() == __other.has_value()`. If `_Interface` extends
-  //! `__iequality_comparable<>`, then `*this == __other` is `true`.
-  _CCCL_API __basic_any(__basic_any const& __other)
-    requires(__copyable)
-  {
-    __convert_from(__other);
-  }
-#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
-  // Without real concepts, we use base classes to implement movability and
-  // copyability. All we need here is to accept the default implementations.
+  // We use base classes to implement movability and copyability. All we need here is to
+  // accept the default implementations.
   __basic_any(__basic_any&& __other)      = default;
   __basic_any(__basic_any const& __other) = default;
-#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
   //! @brief Converting constructor that move constructs from a compatible
   //! `__basic_any` object.
@@ -213,32 +191,10 @@ public:
     reset();
   }
 
-#if _CCCL_HAS_CONCEPTS() || defined(_CCCL_DOXYGEN_INVOKED)
-  //! @brief Move assigns a `__basic_any` object.
-  //! @pre `_Interface` must extend `__imovable<>`.
-  //! @post `__other.has_value() == false` and `has_value()` is `true` if and
-  //! only if `__other.has_value()` was `true`.
-  _CCCL_API __basic_any& operator=(__basic_any&& __other) noexcept
-    requires(__extension_of<_Interface, __imovable<>>)
-  {
-    return __assign_from(::cuda::std::move(__other));
-  }
-
-  //! @brief Copy assigns a `__basic_any` object.
-  //! @pre `_Interface` must extend `__icopyable<>`.
-  //! @post `has_value() == __other.has_value()`. If `_Interface` extends
-  //! `__iequality_comparable<>`, then `*this == __other` is `true`.
-  _CCCL_API __basic_any& operator=(__basic_any const& __other)
-    requires(__extension_of<_Interface, __icopyable<>>)
-  {
-    return __assign_from(__other);
-  }
-#else // ^^^ _CCCL_HAS_CONCEPTS() ^^^ / vvv !_CCCL_HAS_CONCEPTS() vvv
-  // Without real concepts, we use base classes to implement movability and
-  // copyability. All we need here is to accept the default implementations.
+  // We use base classes to implement movability and copyability. All we need here is to
+  // accept the default implementations.
   auto operator=(__basic_any&& __other) -> __basic_any&      = default;
   auto operator=(__basic_any const& __other) -> __basic_any& = default;
-#endif // ^^^ !_CCCL_HAS_CONCEPTS() ^^^
 
   //! @brief Converting move assignment operator from a compatible `__basic_any`
   //! object.


### PR DESCRIPTION
## Description

backporting #7401 to branch/3.2.x

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
