### PR TITLE
Implement parallel `cuda::std::replace`

### DIFF
--- a/libcudacxx/benchmarks/bench/replace/basic.cu
+++ b/libcudacxx/benchmarks/bench/replace/basic.cu
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/stream_ref>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc{};
+  auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(alloc);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               cuda::std::replace(policy.with_stream(launch.get_stream().get_stream()), in.begin(), in.end(), 42, 1337);
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/libcudacxx/benchmarks/bench/replace_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/replace_if/basic.cu
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/stream_ref>
+
+#include "nvbench_helper.cuh"
+
+struct equal_to_42
+{
+  template <class T>
+  __device__ constexpr bool operator()(const T& val) const noexcept
+  {
+    return val == static_cast<T>(42);
+  }
+};
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc{};
+  auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(alloc);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               cuda::std::replace_if(
+                 policy.with_stream(launch.get_stream().get_stream()), in.begin(), in.end(), equal_to_42{}, 1337);
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/libcudacxx/include/cuda/std/__pstl/replace.h
+++ b/libcudacxx/include/cuda/std/__pstl/replace.h
@@ -1,0 +1,127 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_REPLACE_H
+#define _CUDA_STD___PSTL_REPLACE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__algorithm/replace.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/invoke.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_comparable.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/transform.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class _Tp>
+struct __replace_compare_eq
+{
+  _Tp __old_value_;
+
+  _CCCL_HOST_API constexpr __replace_compare_eq(const _Tp& __old_value) noexcept(is_nothrow_copy_constructible_v<_Tp>)
+      : __old_value_(__old_value)
+  {}
+
+  template <class _Up>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr bool operator()(const _Up& __value) const
+    noexcept(__is_cpp17_nothrow_equality_comparable_v<_Tp, _Up>)
+  {
+    return static_cast<bool>(__old_value_ == __value);
+  }
+};
+
+template <class _Tp>
+struct __replace_return_value
+{
+  _Tp __new_value_;
+
+  _CCCL_HOST_API constexpr __replace_return_value(const _Tp& __new_value) noexcept(is_nothrow_copy_constructible_v<_Tp>)
+      : __new_value_(__new_value)
+  {}
+
+  template <class _Up>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr _Tp operator()(const _Up&) const
+    noexcept(is_nothrow_copy_constructible_v<_Tp>)
+  {
+    return __new_value_;
+  }
+};
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _Tp = iter_value_t<_InputIterator>)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+_CCCL_HOST_API void replace(
+  [[maybe_unused]] const _Policy& __policy,
+  _InputIterator __first,
+  _InputIterator __last,
+  const _Tp& __old_value,
+  const _Tp& __new_value)
+{
+  static_assert(__is_cpp17_equality_comparable_v<_Tp, iter_reference_t<_InputIterator>>,
+                "cuda::std::replace requires T to be comparable with iter_reference_t<InputIterator>");
+
+  if (__first == __last)
+  {
+    return;
+  }
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    (void) __dispatch(
+      __policy,
+      __first,
+      ::cuda::std::move(__last),
+      ::cuda::std::move(__first),
+      __replace_return_value{__new_value},
+      __replace_compare_eq{__old_value});
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::replace requires at least one selected backend");
+    ::cuda::std::replace(::cuda::std::move(__first), ::cuda::std::move(__last), __old_value, __new_value);
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_REPLACE_H

--- a/libcudacxx/include/cuda/std/__pstl/replace_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/replace_if.h
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_REPLACE_IF_H
+#define _CUDA_STD___PSTL_REPLACE_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__algorithm/replace_if.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/invoke.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__pstl/replace.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/transform.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _UnaryPred, class _Tp = iter_value_t<_InputIterator>)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+_CCCL_HOST_API void replace_if(
+  [[maybe_unused]] const _Policy& __policy,
+  _InputIterator __first,
+  _InputIterator __last,
+  _UnaryPred __pred,
+  const _Tp& __new_value)
+{
+  static_assert(indirect_unary_predicate<_UnaryPred, _InputIterator>,
+                "cuda::std::replace_if: UnaryPred must satisfy indirect_unary_predicate<InputIterator>");
+
+  if (__first == __last)
+  {
+    return;
+  }
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    (void) __dispatch(
+      __policy,
+      __first,
+      ::cuda::std::move(__last),
+      ::cuda::std::move(__first),
+      __replace_return_value{__new_value},
+      __pred);
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::replace_if requires at least one selected backend");
+    ::cuda::std::replace_if(
+      ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred), __new_value);
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_REPLACE_IF_H

--- a/libcudacxx/include/cuda/std/__pstl_algorithm
+++ b/libcudacxx/include/cuda/std/__pstl_algorithm
@@ -24,6 +24,8 @@
 #include <cuda/std/__pstl/for_each.h>
 #include <cuda/std/__pstl/for_each_n.h>
 #include <cuda/std/__pstl/reduce.h>
+#include <cuda/std/__pstl/replace.h>
+#include <cuda/std/__pstl/replace_if.h>
 #include <cuda/std/__pstl/transform.h>
 
 // [algorithm.syn]

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace.cu
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template <class Policy, class InputIterator,class T = iter_value_t<InputIterator>>
+// void replace(const Policy& policy,
+//                 InputIterator first,
+//                 InputIterator last,
+//                 const T& old_value,
+//                 const T& new_value);
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/logical.h>
+#include <thrust/sequence.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 1000;
+
+struct not_42
+{
+  __device__ constexpr bool operator()(const int val) const noexcept
+  {
+    return val == 42;
+  }
+};
+
+C2H_TEST("cuda::std::replace", "[parallel algorithm]")
+{
+  thrust::device_vector<int> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    thrust::sequence(input.begin(), input.end(), 0);
+
+    const auto policy = cuda::execution::__cub_par_unseq;
+
+    cuda::std::replace(policy, input.begin(), input.end(), 42, 1);
+    CHECK(thrust::none_of(input.begin(), input.end(), not_42{}));
+  }
+
+  SECTION("with provided stream")
+  {
+    thrust::sequence(input.begin(), input.end(), 0);
+
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+
+    cuda::std::replace(policy, input.begin(), input.end(), 42, 1);
+    CHECK(thrust::none_of(input.begin(), input.end(), not_42{}));
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    thrust::sequence(input.begin(), input.end(), 0);
+
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+
+    cuda::std::replace(policy, input.begin(), input.end(), 42, 1);
+    CHECK(thrust::none_of(input.begin(), input.end(), not_42{}));
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    thrust::sequence(input.begin(), input.end(), 0);
+
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+
+    cuda::std::replace(policy, input.begin(), input.end(), 42, 1);
+    CHECK(thrust::none_of(input.begin(), input.end(), not_42{}));
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_if.cu
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template <class Policy, class InputIterator, class UnaryPred, class T = iter_value_t<InputIterator>>
+// void replace_if(const Policy& policy,
+//                 InputIterator first,
+//                 InputIterator last,
+//                 UnaryPred pred,
+//                 const T& new_value);
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/logical.h>
+#include <thrust/sequence.h>
+
+#include <cuda/cmath>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 1000;
+
+struct is_power_of_2
+{
+  __device__ constexpr bool operator()(const int val) const noexcept
+  {
+    return cuda::is_power_of_two(val);
+  }
+};
+
+C2H_TEST("cuda::std::replace_if", "[parallel algorithm]")
+{
+  thrust::device_vector<int> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    thrust::sequence(input.begin(), input.end(), 0);
+
+    const auto policy = cuda::execution::__cub_par_unseq;
+    cuda::std::replace_if(policy, input.begin(), input.end(), is_power_of_2{}, 1337);
+    CHECK(thrust::none_of(input.begin(), input.end(), is_power_of_2{}));
+  }
+
+  SECTION("with provided stream")
+  {
+    thrust::sequence(input.begin(), input.end(), 0);
+
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    cuda::std::replace_if(policy, input.begin(), input.end(), is_power_of_2{}, 1337);
+    CHECK(thrust::none_of(input.begin(), input.end(), is_power_of_2{}));
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    thrust::sequence(input.begin(), input.end(), 0);
+
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    cuda::std::replace_if(policy, input.begin(), input.end(), is_power_of_2{}, 1337);
+    CHECK(thrust::none_of(input.begin(), input.end(), is_power_of_2{}));
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    thrust::sequence(input.begin(), input.end(), 0);
+
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    cuda::std::replace_if(policy, input.begin(), input.end(), is_power_of_2{}, 1337);
+    CHECK(thrust::none_of(input.begin(), input.end(), is_power_of_2{}));
+  }
+}


### PR DESCRIPTION
This implements the `replace` algorithm for the cuda backend.

* `std::replace` see https://en.cppreference.com/w/cpp/algorithm/replace.html
* `std::replace_if` see https://en.cppreference.com/w/cpp/algorithm/replace.html

It provides tests and benchmarks similar to Thrust and some boilerplate for libcu++

The functionality is publicly available yet and implemented in a private internal header

Fixes #7375
