### PR TITLE
Move host stdlib wrappers to `<cuda/std/__host_stdlib>` directory

### DIFF
--- a/cub/cub/detail/ptx-json-parser.cuh
+++ b/cub/cub/detail/ptx-json-parser.cuh
@@ -5,7 +5,7 @@
 
 #include <cub/config.cuh>
 
-#include <cuda/std/__cccl/algorithm_wrapper.h>
+#include <cuda/std/__host_stdlib/algorithm>
 
 #include <format>
 #include <string_view>

--- a/cub/cub/util_allocator.cuh
+++ b/cub/cub/util_allocator.cuh
@@ -22,11 +22,11 @@
 #include <cub/util_debug.cuh>
 #include <cub/util_namespace.cuh>
 
+#include <cuda/std/__host_stdlib/math.h>
+
 #include <map>
 #include <mutex>
 #include <set>
-
-#include <math.h>
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/test/cmake/check_source_files.cmake
+++ b/cub/test/cmake/check_source_files.cmake
@@ -64,9 +64,9 @@ endif()
 # stdpar library.
 #
 # The headers following headers should be used instead:
-# <algorithm> -> <cuda/std/__cccl/algorithm_wrapper.h>
-# <memory>    -> <cuda/std/__cccl/memory_wrapper.h>
-# <numeric>   -> <cuda/std/__cccl/numeric_wrapper.h>
+# <algorithm> -> <cuda/std/__host_stdlib/algorithm>
+# <memory>    -> <cuda/std/__host_stdlib/memory>
+# <numeric>   -> <cuda/std/__host_stdlib/numeric>
 #
 set(
   stdpar_header_exclusions
@@ -143,21 +143,21 @@ foreach (src ${cub_srcs})
 
     if (NOT algorithm_count EQUAL 0)
       message(
-        "'${src}' includes the <algorithm> header. Replace with <cuda/std/__cccl/algorithm_wrapper.h>."
+        "'${src}' includes the <algorithm> header. Replace with <cuda/std/__host_stdlib/algorithm>."
       )
       set(found_errors 1)
     endif()
 
     if (NOT memory_count EQUAL 0)
       message(
-        "'${src}' includes the <memory> header. Replace with <cuda/std/__cccl/memory_wrapper.h>."
+        "'${src}' includes the <memory> header. Replace with <cuda/std/__host_stdlib/memory>."
       )
       set(found_errors 1)
     endif()
 
     if (NOT numeric_count EQUAL 0)
       message(
-        "'${src}' includes the <numeric> header. Replace with <cuda/std/__cccl/numeric_wrapper.h>."
+        "'${src}' includes the <numeric> header. Replace with <cuda/std/__host_stdlib/numeric>."
       )
       set(found_errors 1)
     endif()

--- a/cudax/include/cuda/experimental/__cuco/__hyperloglog/hyperloglog_impl.cuh
+++ b/cudax/include/cuda/experimental/__cuco/__hyperloglog/hyperloglog_impl.cuh
@@ -32,6 +32,7 @@
 #include <cuda/std/__bit/countr.h>
 #include <cuda/std/__bit/integral.h>
 #include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__host_stdlib/stdexcept>
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__memory/pointer_traits.h>
@@ -43,8 +44,6 @@
 #include <cuda/experimental/__cuco/__utility/strong_type.cuh>
 #include <cuda/experimental/__cuco/hash_functions.cuh>
 #include <cuda/experimental/memory_resource.cuh>
-
-#include <stdexcept>
 
 #include <cooperative_groups.h>
 

--- a/cudax/include/cuda/experimental/__cuco/hyperloglog.cuh
+++ b/cudax/include/cuda/experimental/__cuco/hyperloglog.cuh
@@ -26,6 +26,7 @@
 #include <cuda/std/__bit/countr.h>
 #include <cuda/std/__cccl/assert.h>
 #include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__host_stdlib/stdexcept>
 #include <cuda/std/__utility/forward.h>
 
 #include <cuda/experimental/__cuco/hash_functions.cuh>
@@ -33,8 +34,6 @@
 #include <cuda/experimental/container.cuh>
 #include <cuda/experimental/memory_resource.cuh>
 #include <cuda/experimental/stream.cuh>
-
-#include <stdexcept>
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/cudax/include/cuda/experimental/__cufile/exception.cuh
+++ b/cudax/include/cuda/experimental/__cufile/exception.cuh
@@ -21,10 +21,10 @@
 
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/__exception/terminate.h>
+#include <cuda/std/__host_stdlib/stdexcept>
 #include <cuda/std/source_location>
 
 #include <cstdio>
-#include <stdexcept>
 
 #include <cufile.h>
 

--- a/libcudacxx/include/cuda/__device/physical_device.h
+++ b/libcudacxx/include/cuda/__device/physical_device.h
@@ -26,8 +26,8 @@
 #  include <cuda/__device/device_ref.h>
 #  include <cuda/__driver/driver_api.h>
 #  include <cuda/__fwd/devices.h>
-#  include <cuda/std/__cccl/memory_wrapper.h>
 #  include <cuda/std/__cstddef/types.h>
+#  include <cuda/std/__host_stdlib/memory>
 #  include <cuda/std/span>
 #  include <cuda/std/string_view>
 

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -25,6 +25,7 @@
 
 #  include <cuda/std/__cstddef/types.h>
 #  include <cuda/std/__exception/cuda_error.h>
+#  include <cuda/std/__host_stdlib/stdexcept>
 #  include <cuda/std/__internal/namespaces.h>
 #  include <cuda/std/__limits/numeric_limits.h>
 #  include <cuda/std/__type_traits/always_false.h>
@@ -34,8 +35,6 @@
 #  else
 #    include <dlfcn.h>
 #  endif
-
-#  include <stdexcept>
 
 #  include <cuda.h>
 

--- a/libcudacxx/include/cuda/__mdspan/dlpack_to_mdspan.h
+++ b/libcudacxx/include/cuda/__mdspan/dlpack_to_mdspan.h
@@ -29,15 +29,12 @@
 #  include <cuda/__memory/is_aligned.h>
 #  include <cuda/std/__cstddef/types.h>
 #  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__host_stdlib/stdexcept>
 #  include <cuda/std/__type_traits/is_same.h>
 #  include <cuda/std/__utility/cmp.h>
 #  include <cuda/std/array>
 #  include <cuda/std/cstdint>
 #  include <cuda/std/mdspan>
-
-#  if !_CCCL_COMPILER(NVRTC)
-#    include <stdexcept>
-#  endif // !_CCCL_COMPILER(NVRTC)
 
 #  include <dlpack/dlpack.h>
 //

--- a/libcudacxx/include/cuda/__mdspan/mdspan_to_dlpack.h
+++ b/libcudacxx/include/cuda/__mdspan/mdspan_to_dlpack.h
@@ -30,6 +30,7 @@
 #  include <cuda/std/__cstddef/types.h>
 #  include <cuda/std/__exception/exception_macros.h>
 #  include <cuda/std/__fwd/complex.h>
+#  include <cuda/std/__host_stdlib/stdexcept>
 #  include <cuda/std/__limits/numeric_limits.h>
 #  include <cuda/std/__type_traits/always_false.h>
 #  include <cuda/std/__type_traits/is_pointer.h>
@@ -40,8 +41,6 @@
 #  include <cuda/std/array>
 #  include <cuda/std/cstdint>
 #  include <cuda/std/mdspan>
-
-#  include <stdexcept>
 
 #  include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/__numeric/narrow.h
+++ b/libcudacxx/include/cuda/__numeric/narrow.h
@@ -20,11 +20,8 @@
 #  pragma system_header
 #endif // no system header
 
-#if !_CCCL_COMPILER(NVRTC)
-#  include <stdexcept>
-#endif // !_CCCL_COMPILER(NVRTC)
-
 #include <cuda/std/__exception/terminate.h>
+#include <cuda/std/__host_stdlib/stdexcept>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__type_traits/is_signed.h>

--- a/libcudacxx/include/cuda/__nvtx/nvtx3.h
+++ b/libcudacxx/include/cuda/__nvtx/nvtx3.h
@@ -653,7 +653,7 @@
 #ifndef NVTX3_CPP_DEFINITIONS_V1_0
 #  define NVTX3_CPP_DEFINITIONS_V1_0
 
-#  include <cuda/std/__cccl/memory_wrapper.h>
+#  include <cuda/std/__host_stdlib/memory>
 
 #  include <cstddef>
 #  include <string>

--- a/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
+++ b/libcudacxx/include/cuda/__tma/make_tma_descriptor.h
@@ -30,12 +30,11 @@
 #  include <cuda/std/__algorithm/min.h>
 #  include <cuda/std/__cstddef/types.h>
 #  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__host_stdlib/stdexcept>
 #  include <cuda/std/__utility/unreachable.h>
 #  include <cuda/std/array>
 #  include <cuda/std/cstdint>
 #  include <cuda/std/span>
-
-#  include <stdexcept>
 
 #  include <driver_types.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/error_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/error_functions.h
@@ -23,11 +23,8 @@
 
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/is_integral.h>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/exponential_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/exponential_functions.h
@@ -25,6 +25,7 @@
 #include <cuda/std/__cmath/isinf.h>
 #include <cuda/std/__cmath/isnan.h>
 #include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_integral.h>
@@ -32,10 +33,6 @@
 #include <cuda/std/__type_traits/promote.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/fdim.h
+++ b/libcudacxx/include/cuda/std/__cmath/fdim.h
@@ -23,11 +23,8 @@
 
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/is_integral.h>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/fma.h
+++ b/libcudacxx/include/cuda/std/__cmath/fma.h
@@ -22,14 +22,11 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/promote.h>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/fpclassify.h
+++ b/libcudacxx/include/cuda/std/__cmath/fpclassify.h
@@ -26,12 +26,9 @@
 #include <cuda/std/__cmath/isnan.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/limits>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -51,9 +48,7 @@
 #  ifndef FP_NORMAL
 #    define FP_NORMAL 4
 #  endif // ! FP_NORMAL
-#else // ^^^ _CCCL_COMPILER(NVRTC) ^^^ ^/  vvv !_CCCL_COMPILER(NVRTC) vvv
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
+#endif // _CCCL_COMPILER(NVRTC)
 
 #ifndef FP_ILOGB0
 #  define FP_ILOGB0 (-INT_MAX - 1)

--- a/libcudacxx/include/cuda/std/__cmath/gamma.h
+++ b/libcudacxx/include/cuda/std/__cmath/gamma.h
@@ -22,14 +22,11 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_integral.h>
 
 #include <nv/target>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/hyperbolic_functions.h
@@ -22,14 +22,11 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_integral.h>
 
 #include <nv/target>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/hypot.h
+++ b/libcudacxx/include/cuda/std/__cmath/hypot.h
@@ -26,6 +26,7 @@
 #include <cuda/std/__cmath/min_max.h>
 #include <cuda/std/__cmath/roots.h>
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_integral.h>
@@ -33,10 +34,6 @@
 #include <cuda/std/limits>
 
 #include <nv/target>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/inverse_hyperbolic_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/inverse_hyperbolic_functions.h
@@ -22,14 +22,11 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_integral.h>
 
 #include <nv/target>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/inverse_trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/inverse_trigonometric_functions.h
@@ -22,16 +22,13 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/promote.h>
 
 #include <nv/target>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/isfinite.h
+++ b/libcudacxx/include/cuda/std/__cmath/isfinite.h
@@ -26,11 +26,8 @@
 #include <cuda/std/__cmath/isnan.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/is_integral.h>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/isinf.h
+++ b/libcudacxx/include/cuda/std/__cmath/isinf.h
@@ -24,13 +24,10 @@
 #include <cuda/std/__cmath/isnan.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/is_floating_point.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/limits>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/isnan.h
+++ b/libcudacxx/include/cuda/std/__cmath/isnan.h
@@ -23,12 +23,9 @@
 
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/is_floating_point.h>
 #include <cuda/std/__type_traits/is_integral.h>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/logarithms.h
+++ b/libcudacxx/include/cuda/std/__cmath/logarithms.h
@@ -26,6 +26,7 @@
 #include <cuda/std/__cmath/isinf.h>
 #include <cuda/std/__cmath/isnan.h>
 #include <cuda/std/__floating_point/fp.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_extended_arithmetic.h>
 #include <cuda/std/__type_traits/is_integral.h>
@@ -33,10 +34,6 @@
 #include <cuda/std/limits>
 
 #include <nv/target>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/remainder.h
+++ b/libcudacxx/include/cuda/std/__cmath/remainder.h
@@ -22,14 +22,11 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/promote.h>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/roots.h
+++ b/libcudacxx/include/cuda/std/__cmath/roots.h
@@ -22,12 +22,9 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_integral.h>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/rounding_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/rounding_functions.h
@@ -22,15 +22,12 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/promote.h>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/traits.h
+++ b/libcudacxx/include/cuda/std/__cmath/traits.h
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__cmath/isnan.h>
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_arithmetic.h>
 #include <cuda/std/__type_traits/is_extended_arithmetic.h>
@@ -32,10 +33,6 @@
 #include <cuda/std/__type_traits/promote.h>
 
 #include <nv/target>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__cmath/trigonometric_functions.h
+++ b/libcudacxx/include/cuda/std/__cmath/trigonometric_functions.h
@@ -22,15 +22,12 @@
 #endif // no system header
 
 #include <cuda/std/__floating_point/cuda_fp_types.h>
+#include <cuda/std/__host_stdlib/math.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/cstdint>
 
 #include <nv/target>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__exception/cuda_error.h
+++ b/libcudacxx/include/cuda/std/__exception/cuda_error.h
@@ -23,11 +23,11 @@
 
 #include <cuda/std/__exception/exception_macros.h>
 #include <cuda/std/__exception/msg_storage.h>
+#include <cuda/std/__host_stdlib/stdexcept>
 #include <cuda/std/source_location>
 
 #if !_CCCL_COMPILER(NVRTC)
 #  include <cstdio>
-#  include <stdexcept>
 #endif // !_CCCL_COMPILER(NVRTC)
 
 #include <cuda/std/__cccl/prologue.h>

--- a/libcudacxx/include/cuda/std/__exception/throw_error.h
+++ b/libcudacxx/include/cuda/std/__exception/throw_error.h
@@ -23,10 +23,7 @@
 #endif // no system header
 
 #include <cuda/std/__exception/terminate.h>
-
-#if _CCCL_HAS_EXCEPTIONS()
-#  include <stdexcept>
-#endif // _LIBCUDACXX_HAS_STRING
+#include <cuda/std/__host_stdlib/stdexcept>
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__format/format_error.h
+++ b/libcudacxx/include/cuda/std/__format/format_error.h
@@ -22,13 +22,11 @@
 
 #include <cuda/std/__exception/terminate.h>
 
-#if !_CCCL_COMPILER(NVRTC)
-#  if __cpp_lib_format >= 201907L
-#    include <format>
-#  else // ^^^ __cpp_lib_format >= 201907L ^^^ / vvv __cpp_lib_format < 201907L vvv
-#    include <stdexcept>
-#  endif // ^^^ __cpp_lib_format < 201907L ^^^
-#endif // !_CCCL_COMPILER(NVRTC)
+#if __cpp_lib_format >= 201907L
+#  include <format>
+#else // ^^^ __cpp_lib_format >= 201907L ^^^ / vvv __cpp_lib_format < 201907L vvv
+#  include <cuda/std/__host_stdlib/stdexcept>
+#endif // ^^^ __cpp_lib_format < 201907L ^^^
 
 #include <cuda/std/__cccl/prologue.h>
 

--- a/libcudacxx/include/cuda/std/__host_stdlib/algorithm
+++ b/libcudacxx/include/cuda/std/__host_stdlib/algorithm
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD__CCCL_NUMERIC_WRAPPER_H
-#define _CUDA_STD__CCCL_NUMERIC_WRAPPER_H
+#ifndef _CUDA_STD___HOST_STDLIB_ALGORITHM
+#define _CUDA_STD___HOST_STDLIB_ALGORITHM
 
 #include <cuda/std/detail/__config>
 
@@ -21,7 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
-// When a compiler uses CCCL components as part of its implementation of
+// When nvc++ uses CCCL components as part of its implementation of
 // Standard C++ algorithms, a cycle of included files may result when CCCL code
 // tries to use a standard algorithm. The THRUST_INCLUDING_ALGORITHMS_HEADER macro
 // is defined only when CCCL is including an algorithms-related header, giving
@@ -29,8 +29,8 @@
 
 #if !_CCCL_COMPILER(NVRTC)
 #  define THRUST_INCLUDING_ALGORITHMS_HEADER
-#  include <numeric>
+#  include <algorithm>
 #  undef THRUST_INCLUDING_ALGORITHMS_HEADER
 #endif // !_CCCL_COMPILER(NVRTC)
 
-#endif // _CUDA_STD__CCCL_NUMERIC_WRAPPER_H
+#endif // _CUDA_STD___HOST_STDLIB_ALGORITHM

--- a/libcudacxx/include/cuda/std/__host_stdlib/math.h
+++ b/libcudacxx/include/cuda/std/__host_stdlib/math.h
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___HOST_STDLIB_MATH_H
+#define _CUDA_STD___HOST_STDLIB_MATH_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+#  include <math.h>
+
+// Standard C++ library comes with it's own <math.h> C++ compatible header. However, if the include paths are jumbled,
+// it might happen that the original C <math.h> is found first. This is a problem because C headers define many of the
+// math functions as macros which would change our definitions. So, we check whether any of the functions are defined
+// as a macro to distinguish the C++ copatibility header from the C header.
+#  if defined(fabs) || defined(fmod) || defined(remainder) || defined(remquo) || defined(fma) || defined(fmax)      \
+    || defined(fmin) || defined(fdim) || defined(exp) || defined(exp2) || defined(expm1) || defined(log)            \
+    || defined(log10) || defined(log2) || defined(log1p) || defined(pow) || defined(sqrt) || defined(cbrt)          \
+    || defined(hypot) || defined(sin) || defined(cos) || defined(tan) || defined(asin) || defined(acos)             \
+    || defined(atan) || defined(atan2) || defined(sinh) || defined(cosh) || defined(tanh) || defined(asinh)         \
+    || defined(acosh) || defined(atanh) || defined(erf) || defined(erfc) || defined(tgamma) || defined(lgamma)      \
+    || defined(ceil) || defined(floor) || defined(trunc) || defined(round) || defined(lround) || defined(llround)   \
+    || defined(nearbyint) || defined(rint) || defined(lrint) || defined(llrint) || defined(frexp) || defined(ldexp) \
+    || defined(scalbn) || defined(scalbln) || defined(ilogb) || defined(logb) || defined(nextafter)                 \
+    || defined(nexttoward) || defined(copysign) || defined(fpclassify) || defined(isfinite) || defined(isinf)       \
+    || defined(isnan) || defined(isnormal) || defined(signbit) || defined(isgreater) || defined(isgreaterequal)     \
+    || defined(isless) || defined(islessequal) || defined(islessgreater) || defined(isunordered)
+#    error \
+      "libcu++ requires the C++ compatibility <math.h> header, not the C <math.h> header. Please, check your include paths."
+#  endif // math functions defined as macros
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___HOST_STDLIB_MATH_H

--- a/libcudacxx/include/cuda/std/__host_stdlib/memory
+++ b/libcudacxx/include/cuda/std/__host_stdlib/memory
@@ -4,12 +4,12 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD__CCCL_MEMORY_WRAPPER_H
-#define _CUDA_STD__CCCL_MEMORY_WRAPPER_H
+#ifndef _CUDA_STD___HOST_STDLIB_MEMORY
+#define _CUDA_STD___HOST_STDLIB_MEMORY
 
 #include <cuda/std/detail/__config>
 
@@ -33,4 +33,4 @@
 #  undef THRUST_INCLUDING_ALGORITHMS_HEADER
 #endif // !_CCCL_COMPILER(NVRTC)
 
-#endif // _CUDA_STD__CCCL_MEMORY_WRAPPER_H
+#endif // _CUDA_STD___HOST_STDLIB_MEMORY

--- a/libcudacxx/include/cuda/std/__host_stdlib/numeric
+++ b/libcudacxx/include/cuda/std/__host_stdlib/numeric
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___HOST_STDLIB_NUMERIC
+#define _CUDA_STD___HOST_STDLIB_NUMERIC
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+// When a compiler uses CCCL components as part of its implementation of
+// Standard C++ algorithms, a cycle of included files may result when CCCL code
+// tries to use a standard algorithm. The THRUST_INCLUDING_ALGORITHMS_HEADER macro
+// is defined only when CCCL is including an algorithms-related header, giving
+// the compiler a chance to detect and break the cycle of includes.
+
+#if !_CCCL_COMPILER(NVRTC)
+#  define THRUST_INCLUDING_ALGORITHMS_HEADER
+#  include <numeric>
+#  undef THRUST_INCLUDING_ALGORITHMS_HEADER
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___HOST_STDLIB_NUMERIC

--- a/libcudacxx/include/cuda/std/__host_stdlib/stdexcept
+++ b/libcudacxx/include/cuda/std/__host_stdlib/stdexcept
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_STD__CCCL_ALGORITHM_WRAPPER_H
-#define _CUDA_STD__CCCL_ALGORITHM_WRAPPER_H
+#ifndef _CUDA_STD___HOST_STDLIB_STDEXCEPT
+#define _CUDA_STD___HOST_STDLIB_STDEXCEPT
 
 #include <cuda/std/detail/__config>
 
@@ -21,16 +21,8 @@
 #  pragma system_header
 #endif // no system header
 
-// When nvc++ uses CCCL components as part of its implementation of
-// Standard C++ algorithms, a cycle of included files may result when CCCL code
-// tries to use a standard algorithm. The THRUST_INCLUDING_ALGORITHMS_HEADER macro
-// is defined only when CCCL is including an algorithms-related header, giving
-// the compiler a chance to detect and break the cycle of includes.
-
 #if !_CCCL_COMPILER(NVRTC)
-#  define THRUST_INCLUDING_ALGORITHMS_HEADER
-#  include <algorithm>
-#  undef THRUST_INCLUDING_ALGORITHMS_HEADER
+#  include <stdexcept>
 #endif // !_CCCL_COMPILER(NVRTC)
 
-#endif // _CUDA_STD__CCCL_ALGORITHM_WRAPPER_H
+#endif // _CUDA_STD___HOST_STDLIB_STDEXCEPT

--- a/libcudacxx/include/cuda/std/__memory/addressof.h
+++ b/libcudacxx/include/cuda/std/__memory/addressof.h
@@ -39,8 +39,8 @@
 #    include <bits/move.h>
 #  elif _CCCL_HOST_STD_LIB(LIBCXX) && __has_include(<__memory/addressof.h>)
 #    include <__memory/addressof.h>
-#  elif !_CCCL_COMPILER(NVRTC)
-#    include <cuda/std/__cccl/memory_wrapper.h>
+#  else
+#    include <cuda/std/__host_stdlib/memory>
 #  endif
 #endif // _CCCL_HAS_BUILTIN_STD_ADDRESSOF()
 

--- a/libcudacxx/include/cuda/std/__memory/allocator.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator.h
@@ -34,7 +34,7 @@
 #include <cuda/std/cstddef>
 
 #ifdef _CCCL_HAS_CONSTEXPR_ALLOCATION
-#  include <cuda/std/__cccl/memory_wrapper.h>
+#  include <cuda/std/__host_stdlib/memory>
 #endif // _CCCL_HAS_CONSTEXPR_ALLOCATION
 
 #include <cuda/std/__cccl/prologue.h>

--- a/libcudacxx/include/cuda/std/__memory/construct_at.h
+++ b/libcudacxx/include/cuda/std/__memory/construct_at.h
@@ -40,7 +40,7 @@
 #include <cuda/std/__utility/move.h>
 
 #if _CCCL_STD_VER >= 2020 // need to backfill ::std::construct_at
-#  include <cuda/std/__cccl/memory_wrapper.h>
+#  include <cuda/std/__host_stdlib/memory>
 
 #  ifndef __cpp_lib_constexpr_dynamic_alloc
 namespace std

--- a/libcudacxx/include/cuda/std/cmath
+++ b/libcudacxx/include/cuda/std/cmath
@@ -20,9 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
-#if !_CCCL_COMPILER(NVRTC)
-#  include <math.h>
-#endif // !_CCCL_COMPILER(NVRTC)
+#include <cuda/std/__host_stdlib/math.h>
 
 #if _CCCL_COMPILER(NVHPC)
 #  include <cmath>

--- a/libcudacxx/test/cmake/check_source_files.cmake
+++ b/libcudacxx/test/cmake/check_source_files.cmake
@@ -33,15 +33,15 @@ list(FILTER libcudacxx_srcs EXCLUDE REGEX "^include/cuda/std/detail/libcxx/")
 # their C++ standard library implementations.
 #
 # The following headers should be used instead:
-# <algorithm> -> <cuda/std/__cccl/algorithm_wrapper.h>
-# <memory>    -> <cuda/std/__cccl/memory_wrapper.h>
-# <numeric>   -> <cuda/std/__cccl/numeric_wrapper.h>
+# <algorithm> -> <cuda/std/__host_stdlib/algorithm>
+# <memory>    -> <cuda/std/__host_stdlib/memory>
+# <numeric>   -> <cuda/std/__host_stdlib/numeric>
 #
 set(
   stdpar_header_exclusions
-  include/cuda/std/__cccl/algorithm_wrapper.h
-  include/cuda/std/__cccl/memory_wrapper.h
-  include/cuda/std/__cccl/numeric_wrapper.h
+  include/cuda/std/__host_stdlib/algorithm
+  include/cuda/std/__host_stdlib/memory
+  include/cuda/std/__host_stdlib/numeric
 )
 
 set(algorithm_regex "#[ \t]*include[ \t]+<algorithm>")
@@ -82,21 +82,21 @@ foreach (src ${libcudacxx_srcs})
 
     if (NOT algorithm_count EQUAL 0)
       message(
-        "'${src}' includes the <algorithm> header. Replace with <cuda/std/__cccl/algorithm_wrapper.h>."
+        "'${src}' includes the <algorithm> header. Replace with <cuda/std/__host_stdlib/algorithm>."
       )
       set(found_errors 1)
     endif()
 
     if (NOT memory_count EQUAL 0)
       message(
-        "'${src}' includes the <memory> header. Replace with <cuda/std/__cccl/memory_wrapper.h>."
+        "'${src}' includes the <memory> header. Replace with <cuda/std/__host_stdlib/memory>."
       )
       set(found_errors 1)
     endif()
 
     if (NOT numeric_count EQUAL 0)
       message(
-        "'${src}' includes the <numeric> header. Replace with <cuda/std/__cccl/numeric_wrapper.h>."
+        "'${src}' includes the <numeric> header. Replace with <cuda/std/__host_stdlib/numeric>."
       )
       set(found_errors 1)
     endif()

--- a/thrust/testing/cmake/check_source_files.cmake
+++ b/thrust/testing/cmake/check_source_files.cmake
@@ -62,9 +62,9 @@ endif()
 # stdpar library.
 #
 # The headers following headers should be used instead:
-# <algorithm> -> <cuda/std/__cccl/algorithm_wrapper.h>
-# <memory>    -> <cuda/std/__cccl/memory_wrapper.h>
-# <numeric>   -> <cuda/std/__cccl/numeric_wrapper.h>
+# <algorithm> -> <cuda/std/__host_stdlib/algorithm>
+# <memory>    -> <cuda/std/__host_stdlib/memory>
+# <numeric>   -> <cuda/std/__host_stdlib/numeric>
 #
 set(
   stdpar_header_exclusions
@@ -150,21 +150,21 @@ foreach (src ${thrust_srcs})
 
     if (NOT algorithm_count EQUAL 0)
       message(
-        "'${src}' includes the <algorithm> header. Replace with <cuda/std/__cccl/algorithm_wrapper.h>."
+        "'${src}' includes the <algorithm> header. Replace with <cuda/std/__host_stdlib/algorithm>."
       )
       set(found_errors 1)
     endif()
 
     if (NOT memory_count EQUAL 0)
       message(
-        "'${src}' includes the <memory> header. Replace with <cuda/std/__cccl/memory_wrapper.h>."
+        "'${src}' includes the <memory> header. Replace with <cuda/std/__host_stdlib/memory>."
       )
       set(found_errors 1)
     endif()
 
     if (NOT numeric_count EQUAL 0)
       message(
-        "'${src}' includes the <numeric> header. Replace with <cuda/std/__cccl/numeric_wrapper.h>."
+        "'${src}' includes the <numeric> header. Replace with <cuda/std/__host_stdlib/numeric>."
       )
       set(found_errors 1)
     endif()

--- a/thrust/thrust/allocate_unique.h
+++ b/thrust/thrust/allocate_unique.h
@@ -18,7 +18,7 @@
 #include <thrust/detail/raw_pointer_cast.h>
 #include <thrust/detail/type_deduction.h>
 
-#include <cuda/std/__cccl/memory_wrapper.h>
+#include <cuda/std/__host_stdlib/memory>
 #include <cuda/std/__memory/allocator_traits.h>
 #include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/__utility/move.h>

--- a/thrust/thrust/detail/allocator/copy_construct_range.h
+++ b/thrust/thrust/detail/allocator/copy_construct_range.h
@@ -34,7 +34,7 @@
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/zip_iterator.h>
 
-#include <cuda/std/__cccl/memory_wrapper.h>
+#include <cuda/std/__host_stdlib/memory>
 #include <cuda/std/__iterator/advance.h>
 #include <cuda/std/__iterator/distance.h>
 #include <cuda/std/__memory/allocator_traits.h>

--- a/thrust/thrust/detail/allocator/destroy_range.h
+++ b/thrust/thrust/detail/allocator/destroy_range.h
@@ -31,7 +31,7 @@
 #include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/for_each.h>
 
-#include <cuda/std/__cccl/memory_wrapper.h>
+#include <cuda/std/__host_stdlib/memory>
 #include <cuda/std/__memory/allocator_traits.h>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/detail/allocator/fill_construct_range.h
+++ b/thrust/thrust/detail/allocator/fill_construct_range.h
@@ -32,7 +32,7 @@
 #include <thrust/for_each.h>
 #include <thrust/uninitialized_fill.h>
 
-#include <cuda/std/__cccl/memory_wrapper.h>
+#include <cuda/std/__host_stdlib/memory>
 #include <cuda/std/__memory/allocator_traits.h>
 
 THRUST_NAMESPACE_BEGIN

--- a/thrust/thrust/detail/contiguous_storage.h
+++ b/thrust/thrust/detail/contiguous_storage.h
@@ -29,12 +29,11 @@
 #include <thrust/detail/execution_policy.h>
 #include <thrust/iterator/detail/normal_iterator.h>
 
+#include <cuda/std/__host_stdlib/stdexcept>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__memory/allocator_traits.h>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/__utility/swap.h>
-
-#include <stdexcept>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/detail/contiguous_storage.inl
+++ b/thrust/thrust/detail/contiguous_storage.inl
@@ -32,12 +32,11 @@
 #include <thrust/detail/allocator/value_initialize_range.h>
 #include <thrust/detail/contiguous_storage.h>
 
+#include <cuda/std/__host_stdlib/stdexcept>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/__utility/swap.h>
 
 #include <nv/target>
-
-#include <stdexcept> // for std::runtime_error
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/detail/event_error.h
+++ b/thrust/thrust/detail/event_error.h
@@ -32,7 +32,7 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/system/error_code.h>
 
-#include <stdexcept>
+#include <cuda/std/__host_stdlib/stdexcept>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/detail/internal_functional.h
+++ b/thrust/thrust/detail/internal_functional.h
@@ -41,7 +41,7 @@
 #include <cuda/__iterator/tabulate_output_iterator.h>
 #include <cuda/__iterator/transform_input_output_iterator.h>
 #include <cuda/__iterator/transform_output_iterator.h>
-#include <cuda/std/__cccl/memory_wrapper.h> // for ::new
+#include <cuda/std/__host_stdlib/memory>
 #include <cuda/std/__new/device_new.h>
 #include <cuda/std/__tuple_dir/get.h>
 #include <cuda/std/__tuple_dir/tuple_element.h>

--- a/thrust/thrust/detail/memory_algorithms.h
+++ b/thrust/thrust/detail/memory_algorithms.h
@@ -20,7 +20,7 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/iterator/iterator_traits.h>
 
-#include <cuda/std/__cccl/memory_wrapper.h>
+#include <cuda/std/__host_stdlib/memory>
 #include <cuda/std/__memory/addressof.h>
 #include <cuda/std/__memory/allocator_traits.h>
 #include <cuda/std/__new/device_new.h>

--- a/thrust/thrust/detail/temporary_array.h
+++ b/thrust/thrust/detail/temporary_array.h
@@ -46,7 +46,7 @@ THRUST_NAMESPACE_END
 #include <thrust/iterator/detail/tagged_iterator.h>
 #include <thrust/iterator/iterator_traits.h>
 
-#include <cuda/std/__cccl/memory_wrapper.h>
+#include <cuda/std/__host_stdlib/memory>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/type_identity.h>
 

--- a/thrust/thrust/detail/vector_base.inl
+++ b/thrust/thrust/detail/vector_base.inl
@@ -37,6 +37,7 @@
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__functional/operations.h>
+#include <cuda/std/__host_stdlib/stdexcept>
 #include <cuda/std/__iterator/advance.h>
 #include <cuda/std/__iterator/distance.h>
 #include <cuda/std/__iterator/next.h>
@@ -47,8 +48,6 @@
 #include <cuda/std/__type_traits/is_trivially_constructible.h>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/initializer_list>
-
-#include <stdexcept>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/host_vector.h
+++ b/thrust/thrust/host_vector.h
@@ -32,7 +32,7 @@
 #endif // no system header
 #include <thrust/detail/vector_base.h>
 
-#include <cuda/std/__cccl/memory_wrapper.h>
+#include <cuda/std/__host_stdlib/memory>
 #include <cuda/std/__utility/move.h>
 #include <cuda/std/initializer_list>
 

--- a/thrust/thrust/mr/disjoint_pool.h
+++ b/thrust/thrust/mr/disjoint_pool.h
@@ -45,7 +45,7 @@
 #include <cuda/__cmath/pow2.h>
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
-#include <cuda/std/__cccl/algorithm_wrapper.h>
+#include <cuda/std/__host_stdlib/algorithm>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
 

--- a/thrust/thrust/mr/pool.h
+++ b/thrust/thrust/mr/pool.h
@@ -39,7 +39,7 @@
 
 #include <cuda/__cmath/ilog.h>
 #include <cuda/__cmath/pow2.h>
-#include <cuda/std/__cccl/algorithm_wrapper.h>
+#include <cuda/std/__host_stdlib/algorithm>
 #include <cuda/std/cassert>
 #include <cuda/std/cstdint>
 

--- a/thrust/thrust/system/system_error.h
+++ b/thrust/thrust/system/system_error.h
@@ -30,9 +30,11 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/system/error_code.h>
 
-#include <stdexcept>
+#include <cuda/std/__host_stdlib/stdexcept>
+
 #include <string>
 
 THRUST_NAMESPACE_BEGIN


### PR DESCRIPTION
As there are more host stdlib headers that we would like to indirectly include (need to be wrapped by macro, checked, ...), I'd like to move all of these wrappers to a single location.