### PR TITLE
Improves error handling in CUB algorithms using `thrust::triple_chevron` calls

### DIFF
--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -426,11 +426,9 @@ struct DispatchReduceByKey
 #endif // CUB_DEBUG_LOG
 
       // Invoke init_kernel to initialize tile descriptors
-      THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(init_grid_size, INIT_KERNEL_THREADS, 0, stream)
-        .doit(init_kernel, tile_state, num_tiles, d_num_runs_out);
-
-      // Check for failure to launch
-      error = CubDebug(cudaPeekAtLastError());
+      error = CubDebug(
+        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(init_grid_size, INIT_KERNEL_THREADS, 0, stream)
+          .doit(init_kernel, tile_state, num_tiles, d_num_runs_out));
       if (cudaSuccess != error)
       {
         break;
@@ -483,23 +481,21 @@ struct DispatchReduceByKey
 #endif // CUB_DEBUG_LOG
 
         // Invoke reduce_by_key_kernel
-        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(scan_grid_size, block_threads, 0, stream)
-          .doit(reduce_by_key_kernel,
-                d_keys_in,
-                d_unique_out,
-                d_values_in,
-                d_aggregates_out,
-                d_num_runs_out,
-                tile_state,
-                start_tile,
-                equality_op,
-                reduction_op,
-                num_items,
-                streaming_context_t{},
-                cub::detail::vsmem_t{allocations[1]});
-
-        // Check for failure to launch
-        error = CubDebug(cudaPeekAtLastError());
+        error = CubDebug(
+          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(scan_grid_size, block_threads, 0, stream)
+            .doit(reduce_by_key_kernel,
+                  d_keys_in,
+                  d_unique_out,
+                  d_values_in,
+                  d_aggregates_out,
+                  d_num_runs_out,
+                  tile_state,
+                  start_tile,
+                  equality_op,
+                  reduction_op,
+                  num_items,
+                  streaming_context_t{},
+                  cub::detail::vsmem_t{allocations[1]}));
         if (cudaSuccess != error)
         {
           break;

--- a/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
@@ -190,10 +190,10 @@ struct dispatch_t
             ActivePolicyT::SingleTilePolicy::ITEMS_PER_THREAD);
 #endif
     // Invoke single_reduce_sweep_kernel
-    THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(1, ActivePolicyT::SingleTilePolicy::BLOCK_THREADS, 0, stream)
-      .doit(single_tile_kernel, d_in, d_out, static_cast<int>(num_items), reduction_op, init, transform_op);
-    // Check for failure to launch
-    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    if (const auto error = CubDebug(
+          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
+            1, ActivePolicyT::SingleTilePolicy::BLOCK_THREADS, 0, stream)
+            .doit(single_tile_kernel, d_in, d_out, static_cast<int>(num_items), reduction_op, init, transform_op)))
     {
       return error;
     }
@@ -309,18 +309,16 @@ struct dispatch_t
               reduce_config.sm_occupancy);
 #endif // CUB_DETAIL_DEBUG_ENABLE_LOG
 
-      THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
-        current_grid_size, ActivePolicyT::ReducePolicy::BLOCK_THREADS, 0, stream)
-        .doit(reduce_kernel,
-              d_in,
-              d_chunk_block_reductions,
-              num_current_items,
-              reduction_op,
-              transform_op,
-              current_grid_size);
-
-      // Check for failure to launch
-      if (const auto error = CubDebug(cudaPeekAtLastError()))
+      if (const auto error = CubDebug(
+            THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
+              current_grid_size, ActivePolicyT::ReducePolicy::BLOCK_THREADS, 0, stream)
+              .doit(reduce_kernel,
+                    d_in,
+                    d_chunk_block_reductions,
+                    num_current_items,
+                    reduction_op,
+                    transform_op,
+                    current_grid_size)))
       {
         return error;
       }
@@ -347,17 +345,16 @@ struct dispatch_t
 #endif // CUB_DETAIL_DEBUG_ENABLE_LOG
 
     // Invoke DeterministicDeviceReduceSingleTileKernel
-    THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(1, ActivePolicyT::SingleTilePolicy::BLOCK_THREADS, 0, stream)
-      .doit(single_tile_kernel,
-            d_block_reductions,
-            d_out,
-            reduce_grid_size, // triple_chevron is not type safe, make sure to use int
-            reduction_op,
-            init,
-            ::cuda::std::identity{});
-
-    // Check for failure to launch
-    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    if (const auto error = CubDebug(
+          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
+            1, ActivePolicyT::SingleTilePolicy::BLOCK_THREADS, 0, stream)
+            .doit(single_tile_kernel,
+                  d_block_reductions,
+                  d_out,
+                  reduce_grid_size, // triple_chevron is not type safe, make sure to use int
+                  reduction_op,
+                  init,
+                  ::cuda::std::identity{})))
     {
       return error;
     }

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -383,11 +383,9 @@ struct DispatchScanByKey
 #endif // CUB_DEBUG_LOG
 
     // Invoke init_kernel to initialize tile descriptors
-    THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(init_grid_size, INIT_KERNEL_THREADS, 0, stream)
-      .doit(init_kernel, tile_state, d_keys_in, d_keys_prev_in, static_cast<OffsetT>(tile_size), num_tiles);
-
-    // Check for failure to launch
-    if (const auto error = CubDebug(cudaPeekAtLastError()))
+    if (const auto error = CubDebug(
+          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(init_grid_size, INIT_KERNEL_THREADS, 0, stream)
+            .doit(init_kernel, tile_state, d_keys_in, d_keys_prev_in, static_cast<OffsetT>(tile_size), num_tiles)))
     {
       return error;
     }
@@ -421,21 +419,19 @@ struct DispatchScanByKey
 #endif // CUB_DEBUG_LOG
 
       // Invoke scan_kernel
-      THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(scan_grid_size, Policy::BLOCK_THREADS, 0, stream)
-        .doit(scan_kernel,
-              d_keys_in,
-              d_keys_prev_in,
-              d_values_in,
-              d_values_out,
-              tile_state,
-              start_tile,
-              equality_op,
-              scan_op,
-              init_value,
-              num_items);
-
-      // Check for failure to launch
-      if (const auto error = CubDebug(cudaPeekAtLastError()))
+      if (const auto error = CubDebug(
+            THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(scan_grid_size, Policy::BLOCK_THREADS, 0, stream)
+              .doit(scan_kernel,
+                    d_keys_in,
+                    d_keys_prev_in,
+                    d_values_in,
+                    d_values_out,
+                    tile_state,
+                    start_tile,
+                    equality_op,
+                    scan_op,
+                    init_value,
+                    num_items)))
       {
         return error;
       }

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -655,11 +655,9 @@ struct DispatchSelectIf
 #endif
 
         // Invoke scan_init_kernel to initialize tile descriptors
-        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(init_grid_size, INIT_KERNEL_THREADS, 0, stream)
-          .doit(scan_init_kernel, tile_status, current_num_tiles, d_num_selected_out);
-
-        // Check for failure to launch
-        error = CubDebug(cudaPeekAtLastError());
+        error = CubDebug(
+          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(init_grid_size, INIT_KERNEL_THREADS, 0, stream)
+            .doit(scan_init_kernel, tile_status, current_num_tiles, d_num_selected_out));
         if (cudaSuccess != error)
         {
           return error;
@@ -703,22 +701,20 @@ struct DispatchSelectIf
 #endif
 
         // Invoke select_if_kernel
-        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(current_num_tiles, block_threads, 0, stream)
-          .doit(select_if_kernel,
-                d_in,
-                d_flags,
-                d_selected_out,
-                d_num_selected_out,
-                tile_status,
-                select_op,
-                equality_op,
-                static_cast<per_partition_offset_t>(current_num_items),
-                current_num_tiles,
-                streaming_context,
-                cub::detail::vsmem_t{allocations[1]});
-
-        // Check for failure to launch
-        error = CubDebug(cudaPeekAtLastError());
+        error = CubDebug(
+          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(current_num_tiles, block_threads, 0, stream)
+            .doit(select_if_kernel,
+                  d_in,
+                  d_flags,
+                  d_selected_out,
+                  d_num_selected_out,
+                  tile_status,
+                  select_op,
+                  equality_op,
+                  static_cast<per_partition_offset_t>(current_num_items),
+                  current_num_tiles,
+                  streaming_context,
+                  cub::detail::vsmem_t{allocations[1]}));
         if (cudaSuccess != error)
         {
           return error;

--- a/cub/cub/device/dispatch/dispatch_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_topk.cuh
@@ -437,47 +437,55 @@ struct DispatchTopK
         const auto topk_first_pass_grid_size = ::cuda::std::min(first_pass_kernel_max_occupancy, num_tiles);
 
         // Compute histogram of the first pass
-        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(topk_first_pass_grid_size, block_threads, 0, stream)
-          .doit(
-            topk_first_pass_kernel,
-            d_keys_in,
-            d_keys_out,
-            d_values_in,
-            d_values_out,
-            in_buf,
-            in_idx_buf,
-            out_buf,
-            out_idx_buf,
-            counter,
-            histogram,
-            num_items,
-            k,
-            candidate_buffer_length,
-            extract_bin_op,
-            identify_candidates_op,
-            pass);
+        error = CubDebug(
+          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(topk_first_pass_grid_size, block_threads, 0, stream)
+            .doit(topk_first_pass_kernel,
+                  d_keys_in,
+                  d_keys_out,
+                  d_values_in,
+                  d_values_out,
+                  in_buf,
+                  in_idx_buf,
+                  out_buf,
+                  out_idx_buf,
+                  counter,
+                  histogram,
+                  num_items,
+                  k,
+                  candidate_buffer_length,
+                  extract_bin_op,
+                  identify_candidates_op,
+                  pass));
+        if (cudaSuccess != error)
+        {
+          return error;
+        }
       }
       else
       {
-        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(topk_grid_size, block_threads, 0, stream)
-          .doit(
-            topk_kernel,
-            d_keys_in,
-            d_keys_out,
-            d_values_in,
-            d_values_out,
-            in_buf,
-            in_idx_buf,
-            out_buf,
-            out_idx_buf,
-            counter,
-            histogram,
-            num_items,
-            k,
-            candidate_buffer_length,
-            extract_bin_op,
-            identify_candidates_op,
-            pass);
+        error = CubDebug(
+          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(topk_grid_size, block_threads, 0, stream)
+            .doit(topk_kernel,
+                  d_keys_in,
+                  d_keys_out,
+                  d_values_in,
+                  d_values_out,
+                  in_buf,
+                  in_idx_buf,
+                  out_buf,
+                  out_idx_buf,
+                  counter,
+                  histogram,
+                  num_items,
+                  k,
+                  candidate_buffer_length,
+                  extract_bin_op,
+                  identify_candidates_op,
+                  pass));
+        if (cudaSuccess != error)
+        {
+          return error;
+        }
       }
     }
 
@@ -490,20 +498,25 @@ struct DispatchTopK
     }
     const auto last_filter_kernel_max_occupancy = static_cast<unsigned int>(last_filter_kernel_blocks_per_sm * num_sms);
     const auto last_filter_grid_size            = ::cuda::std::min(last_filter_kernel_max_occupancy, num_tiles);
-    THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(last_filter_grid_size, block_threads, 0, stream)
-      .doit(topk_last_filter_kernel,
-            d_keys_in,
-            d_keys_out,
-            d_values_in,
-            d_values_out,
-            out_buf,
-            out_idx_buf,
-            counter,
-            num_items,
-            k,
-            candidate_buffer_length,
-            identify_candidates_op,
-            pass);
+    error                                       = CubDebug(
+      THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(last_filter_grid_size, block_threads, 0, stream)
+        .doit(topk_last_filter_kernel,
+              d_keys_in,
+              d_keys_out,
+              d_values_in,
+              d_values_out,
+              out_buf,
+              out_idx_buf,
+              counter,
+              num_items,
+              k,
+              candidate_buffer_length,
+              identify_candidates_op,
+              pass));
+    if (cudaSuccess != error)
+    {
+      return error;
+    }
 
     // pass==num_passes to align with the usage of identify_candidates_op in previous passes.
     return error;


### PR DESCRIPTION
## Description

This PR addresses feedback on another PR ([see comment](https://github.com/NVIDIA/cccl/pull/6980#discussion_r2688182865)), where it's pointed out that:

> tripple chevron can return an error that's coming from a launch failure and isn't reported by subsequent keep at last error. I'd suggest to catch it with `auto error = CubDebug(THRUST_NS_QUALIFIER::cuda_cub...`. 

Basically, `thrust::triple_chevron` does a `cudaPeekAtLastError`, so we can also drop those redundant calls, where applicable.
