### PR TITLE
Implement parallel `cuda::std::generate`

### DIFF
--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -36,6 +36,9 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_unsigned.h>
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes") // __visibility__ attribute ignored
+
 CUB_NAMESPACE_BEGIN
 
 /******************************************************************************
@@ -539,3 +542,5 @@ struct DispatchScanByKey
 };
 
 CUB_NAMESPACE_END
+
+_CCCL_DIAG_POP

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -40,6 +40,9 @@
 
 #include <nv/target>
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes") // __visibility__ attribute ignored
+
 CUB_NAMESPACE_BEGIN
 
 namespace detail::select
@@ -825,3 +828,5 @@ struct DispatchSelectIf
 };
 
 CUB_NAMESPACE_END
+
+_CCCL_DIAG_POP

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -52,6 +52,7 @@
 // On Windows, the `if CUB_DETAIL_CONSTEXPR_ISH` results in `warning C4702: unreachable code`.
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_MSVC(4702)
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes") // __visibility__ attribute ignored
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -53,6 +53,9 @@
 #include <cuda/std/expected>
 #include <cuda/std/tuple>
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes") // __visibility__ attribute ignored
+
 CUB_NAMESPACE_BEGIN
 
 namespace detail::transform
@@ -1082,3 +1085,5 @@ __launch_bounds__(get_block_threads<PolicySelector>) CUB_DETAIL_KERNEL_ATTRIBUTE
 } // namespace detail::transform
 
 CUB_NAMESPACE_END
+
+_CCCL_DIAG_POP

--- a/cub/cub/device/dispatch/kernels/kernel_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_unique_by_key.cuh
@@ -16,6 +16,9 @@
 #include <cub/agent/agent_unique_by_key.cuh>
 #include <cub/util_vsmem.cuh>
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes") // __visibility__ attribute ignored
+
 CUB_NAMESPACE_BEGIN
 
 /******************************************************************************
@@ -173,3 +176,5 @@ __launch_bounds__(int(
 } // namespace detail::unique_by_key
 
 CUB_NAMESPACE_END
+
+_CCCL_DIAG_POP

--- a/libcudacxx/benchmarks/bench/generate/basic.cu
+++ b/libcudacxx/benchmarks/bench/generate/basic.cu
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/stream_ref>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+struct generator
+{
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE auto operator()() const -> T
+  {
+    return 42;
+  }
+};
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> output(elements, thrust::no_init);
+
+  state.add_element_count(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc{};
+  auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(alloc);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               cuda::std::generate(
+                 policy.with_stream(launch.get_stream().get_stream()), output.begin(), output.end(), generator<T>{});
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/libcudacxx/benchmarks/bench/generate_n/basic.cu
+++ b/libcudacxx/benchmarks/bench/generate_n/basic.cu
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/stream_ref>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+struct generator
+{
+  _CCCL_DEVICE_API _CCCL_FORCEINLINE auto operator()() const -> T
+  {
+    return 42;
+  }
+};
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> output(elements, thrust::no_init);
+
+  state.add_element_count(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc{};
+  auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(alloc);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               cuda::std::generate_n(
+                 policy.with_stream(launch.get_stream().get_stream()), output.begin(), elements, generator<T>{});
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
@@ -23,7 +23,13 @@
 
 #if _CCCL_HAS_BACKEND_CUDA()
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+
 #  include <cub/device/device_for.cuh>
+
+_CCCL_DIAG_POP
 
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
@@ -69,7 +75,6 @@ struct __pstl_dispatch<__pstl_algorithm::__for_each_n, __execution_backend::__cu
       __stream.get());
 
     __stream.sync();
-
     return __first + __count;
   }
 

--- a/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_CUDA_GENERATE_H
+#define _CUDA_STD___PSTL_CUDA_GENERATE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_BACKEND_CUDA()
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+
+#  include <cub/device/device_transform.cuh>
+
+_CCCL_DIAG_POP
+
+#  include <cuda/__execution/policy.h>
+#  include <cuda/__functional/call_or.h>
+#  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/__stream/get_stream.h>
+#  include <cuda/__stream/stream_ref.h>
+#  include <cuda/std/__algorithm/generate_n.h>
+#  include <cuda/std/__exception/cuda_error.h>
+#  include <cuda/std/__execution/env.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__new/bad_alloc.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__utility/move.h>
+#  include <cuda/std/tuple>
+
+#  include <cuda_runtime.h>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+template <>
+struct __pstl_dispatch<__pstl_algorithm::__generate_n, __execution_backend::__cuda>
+{
+  template <class _Policy, class _OutputIterator, class _UnaryOp>
+  [[nodiscard]] _CCCL_HOST_API static _OutputIterator
+  __par_impl(const _Policy& __policy, _OutputIterator __result, const int64_t __count, _UnaryOp __func)
+  {
+    auto __stream    = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    const auto __ret = __result + __count;
+
+    // We pass the policy as an environment to device_transform
+    _CCCL_TRY_CUDA_API(
+      ::cub::DeviceTransform::Generate,
+      "__pstl_cuda_generate: call to cub device_transform::Generate failed",
+      ::cuda::std::move(__result),
+      __count,
+      ::cuda::std::move(__func),
+      __stream);
+
+    __stream.sync();
+    return __ret;
+  }
+
+  _CCCL_TEMPLATE(class _Policy, class _OutputIterator, class _Size, class _UnaryOp)
+  _CCCL_REQUIRES(__has_forward_traversal<_OutputIterator>)
+  [[nodiscard]] _CCCL_HOST_API _OutputIterator
+  operator()([[maybe_unused]] const _Policy& __policy, _OutputIterator __result, _Size __count, _UnaryOp __func) const
+  {
+    if constexpr (::cuda::std::__has_random_access_traversal<_OutputIterator>)
+    {
+      try
+      {
+        return __par_impl(__policy, ::cuda::std::move(__result), __count, ::cuda::std::move(__func));
+      }
+      catch (const ::cuda::cuda_error& __err)
+      {
+        if (__err.status() == cudaErrorMemoryAllocation)
+        {
+          ::cuda::std::__throw_bad_alloc();
+        }
+        else
+        {
+          throw __err;
+        }
+      }
+    }
+    else
+    {
+      static_assert(__always_false_v<_Policy>,
+                    "__pstl_cuda_generate: CUDA backend of cuda::std::generate requires at least random access "
+                    "iterators");
+      return ::cuda::std::generate_n(::cuda::std::move(__result), __count, ::cuda::std::move(__func));
+    }
+  }
+};
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif /// _CCCL_HAS_BACKEND_CUDA()
+
+#endif // _CUDA_STD___PSTL_CUDA_GENERATE_H

--- a/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
@@ -25,6 +25,7 @@
 
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
 
 #  include <cub/device/device_reduce.cuh>
 

--- a/libcudacxx/include/cuda/std/__pstl/dispatch.h
+++ b/libcudacxx/include/cuda/std/__pstl/dispatch.h
@@ -33,6 +33,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 enum class __pstl_algorithm
 {
   __for_each_n,
+  __generate_n,
   __reduce,
   __transform,
 };

--- a/libcudacxx/include/cuda/std/__pstl/generate.h
+++ b/libcudacxx/include/cuda/std/__pstl/generate.h
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_GENERATE_H
+#define _CUDA_STD___PSTL_GENERATE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__iterator/counting_iterator.h>
+#  include <cuda/std/__algorithm/generate.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/incrementable_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_callable.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/generate_n.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _Generator)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+_CCCL_HOST_API void
+generate([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, _Generator __gen)
+{
+  static_assert(indirectly_writable<_InputIterator, invoke_result_t<_Generator>>,
+                "cuda::std::generate requires InputIterator to be indirectly writable with the return value of "
+                "Generator");
+
+  if (__first == __last)
+  {
+    return;
+  }
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__generate_n, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    const auto __count = ::cuda::std::distance(__first, __last);
+    (void) __dispatch(__policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__gen));
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::generate requires at least one selected backend");
+    ::cuda::std::generate(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__gen));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_GENERATE_H

--- a/libcudacxx/include/cuda/std/__pstl/generate_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/generate_n.h
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_GENERATE_N_H
+#define _CUDA_STD___PSTL_GENERATE_N_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__iterator/counting_iterator.h>
+#  include <cuda/std/__algorithm/generate_n.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__pstl/generate.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_callable.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/generate_n.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _Size, class _Generator)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+_CCCL_HOST_API _InputIterator
+generate_n([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _Size __count, _Generator __gen)
+{
+  static_assert(indirectly_writable<_InputIterator, invoke_result_t<_Generator>>,
+                "cuda::std::generate_n requires InputIterator to be indirectly writable with the return value of "
+                "Generator");
+
+  if (__count == 0)
+  {
+    return __first;
+  }
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__generate_n, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    return __dispatch(__policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__gen));
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::generate_n requires at least one selected backend");
+    return ::cuda::std::generate_n(::cuda::std::move(__first), __count, ::cuda::std::move(__gen));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_GENERATE_N_H

--- a/libcudacxx/include/cuda/std/__pstl_algorithm
+++ b/libcudacxx/include/cuda/std/__pstl_algorithm
@@ -23,6 +23,8 @@
 
 #include <cuda/std/__pstl/for_each.h>
 #include <cuda/std/__pstl/for_each_n.h>
+#include <cuda/std/__pstl/generate.h>
+#include <cuda/std/__pstl/generate_n.h>
 #include <cuda/std/__pstl/reduce.h>
 #include <cuda/std/__pstl/transform.h>
 

--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -40,6 +40,10 @@ if (NOT LIBCUDACXX_TEST_WITH_NVRTC)
         cccl.c2h.main
     )
 
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+      target_compile_options(${target_name} PRIVATE "-Wno-attributes")
+    endif()
+
     add_dependencies(${c2h_all_target} ${target_name})
 
     add_test(NAME ${target_name} COMMAND ${target_name})

--- a/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_memory_resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_memory_resource.pass.cpp
@@ -18,6 +18,8 @@
 #include <cuda/std/type_traits>
 #include <cuda/stream>
 
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes") // __visibility__ attribute ignored
+
 struct test_resource
 {
   __host__ __device__ void* allocate_sync(std::size_t, std::size_t)

--- a/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_stream.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_stream.pass.cpp
@@ -20,6 +20,8 @@
 
 #include <nv/target>
 
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes") // __visibility__ attribute ignored
+
 template <class Policy>
 void test(Policy pol)
 {

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate.cu
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template <class Policy, class InputIterator, class Generator>
+// void generate(const Policy& policy,
+//               InputIterator first,
+//               InputIterator last,
+//               Generator gen);
+
+#include <thrust/device_vector.h>
+#include <thrust/equal.h>
+#include <thrust/execution_policy.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 1000;
+
+struct gen_val
+{
+  int val_;
+  __device__ constexpr int operator()() const noexcept
+  {
+    return val_;
+  }
+};
+
+C2H_TEST("cuda::std::generate", "[parallel algorithm]")
+{
+  thrust::device_vector<int> output(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    cuda::std::generate(policy, output.begin(), output.end(), gen_val{42});
+    CHECK(thrust::equal(output.begin(), output.end(), cuda::constant_iterator{42}));
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    cuda::std::generate(policy, output.begin(), output.end(), gen_val{42});
+    CHECK(thrust::equal(output.begin(), output.end(), cuda::constant_iterator{42}));
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    cuda::std::generate(policy, output.begin(), output.end(), gen_val{1337});
+    CHECK(thrust::equal(output.begin(), output.end(), cuda::constant_iterator{1337}));
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    cuda::std::generate(policy, output.begin(), output.end(), gen_val{42});
+    CHECK(thrust::equal(output.begin(), output.end(), cuda::constant_iterator{42}));
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate_n.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate_n.cu
@@ -1,0 +1,77 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template <class Policy, class InputIterator, class Generator>
+// void generate_n(const Policy& policy,
+//               InputIterator first,
+//               InputIterator last,
+//               Generator gen);
+
+#include <thrust/device_vector.h>
+#include <thrust/equal.h>
+#include <thrust/execution_policy.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 1000;
+
+struct gen_val
+{
+  int val_;
+  __device__ constexpr int operator()() const noexcept
+  {
+    return val_;
+  }
+};
+
+C2H_TEST("cuda::std::generate_n", "[parallel algorithm]")
+{
+  thrust::device_vector<int> output(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    cuda::std::generate_n(policy, output.begin(), size, gen_val{42});
+    CHECK(thrust::equal(output.begin(), output.end(), cuda::constant_iterator{42}));
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    cuda::std::generate_n(policy, output.begin(), size, gen_val{42});
+    CHECK(thrust::equal(output.begin(), output.end(), cuda::constant_iterator{42}));
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    cuda::std::generate_n(policy, output.begin(), size, gen_val{1337});
+    CHECK(thrust::equal(output.begin(), output.end(), cuda::constant_iterator{1337}));
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    cuda::std::generate_n(policy, output.begin(), size, gen_val{42});
+    CHECK(thrust::equal(output.begin(), output.end(), cuda::constant_iterator{42}));
+  }
+}

--- a/thrust/thrust/system/cuda/detail/assign_value.h
+++ b/thrust/thrust/system/cuda/detail/assign_value.h
@@ -22,6 +22,9 @@
 
 #  include <nv/target>
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes") // __visibility__ attribute ignored
+
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
@@ -107,5 +110,9 @@ _CCCL_HOST_DEVICE void assign_value(cross_system<System1, System2>& systems, Poi
                (*thrust::raw_pointer_cast(dst) = *thrust::raw_pointer_cast(src);));
 }
 } // namespace cuda_cub
+
 THRUST_NAMESPACE_END
+
+_CCCL_DIAG_POP
+
 #endif // _CCCL_CUDA_COMPILATION()

--- a/thrust/thrust/system/cuda/detail/iter_swap.h
+++ b/thrust/thrust/system/cuda/detail/iter_swap.h
@@ -24,6 +24,9 @@
 
 #  include <nv/target>
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes") // __visibility__ attribute ignored
+
 THRUST_NAMESPACE_BEGIN
 namespace cuda_cub
 {
@@ -62,5 +65,9 @@ inline _CCCL_HOST_DEVICE void iter_swap(thrust::cuda::execution_policy<DerivedPo
 
 } // end iter_swap()
 } // namespace cuda_cub
+
 THRUST_NAMESPACE_END
+
+_CCCL_DIAG_POP
+
 #endif // _CCCL_CUDA_COMPILATION()


### PR DESCRIPTION
This implements the `generate{_n}` algorithms for the cuda backend.

* `std::generate` see https://en.cppreference.com/w/cpp/algorithm/generate.html
* `std::generate_n` see https://en.cppreference.com/w/cpp/algorithm/generate_n.html

It provides tests and benchmarks similar to Thrust and some boilerplate for libcu++

The functionality is publicly available yet and implemented in a private internal header

Fixes #7371
