### PR TITLE
Always enable host's `<optional>`

### DIFF
--- a/libcudacxx/include/cuda/std/__optional/bad_optional_access.h
+++ b/libcudacxx/include/cuda/std/__optional/bad_optional_access.h
@@ -22,53 +22,19 @@
 #endif // no system header
 
 #if _CCCL_HAS_EXCEPTIONS()
-#  ifdef __cpp_lib_optional
-#    include <optional>
-#  else // ^^^ __cpp_lib_optional ^^^ / vvv !__cpp_lib_optional vvv
-#    include <exception>
-#  endif // !__cpp_lib_optional
-#endif // _CCCL_HAS_EXCEPTIONS()
 
-#include <cuda/std/__exception/terminate.h>
+#  include <optional>
 
-#include <nv/target>
+#  include <cuda/std/__cccl/prologue.h>
 
-#include <cuda/std/__cccl/prologue.h>
-
-#if _CCCL_HAS_EXCEPTIONS()
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_NOVERSION
 
-#  ifdef __cpp_lib_optional
-
-using ::std::bad_optional_access;
-
-#  else // ^^^ __cpp_lib_optional ^^^ / vvv !__cpp_lib_optional vvv
-class _CCCL_TYPE_VISIBILITY_DEFAULT bad_optional_access : public ::std::exception
-{
-public:
-  const char* what() const noexcept override
-  {
-    return "bad access to cuda::std::optional";
-  }
-};
-#  endif // !__cpp_lib_optional
+using bad_optional_access CCCL_DEPRECATED_BECAUSE("use std::bad_optional_access instead") = ::std::bad_optional_access;
 
 _CCCL_END_NAMESPACE_CUDA_STD_NOVERSION
+
+#  include <cuda/std/__cccl/epilogue.h>
+
 #endif // _CCCL_HAS_EXCEPTIONS()
-
-_CCCL_BEGIN_NAMESPACE_CUDA_STD
-
-[[noreturn]] _CCCL_API inline void __throw_bad_optional_access()
-{
-#if _CCCL_HAS_EXCEPTIONS()
-  NV_IF_ELSE_TARGET(NV_IS_HOST, (throw ::cuda::std::bad_optional_access();), (::cuda::std::terminate();))
-#else // ^^^ !_CCCL_HAS_EXCEPTIONS() ^^^ / vvv _CCCL_HAS_EXCEPTIONS() vvv
-  ::cuda::std::terminate();
-#endif // _CCCL_HAS_EXCEPTIONS()
-}
-
-_CCCL_END_NAMESPACE_CUDA_STD
-
-#include <cuda/std/__cccl/epilogue.h>
 
 #endif // _CUDA_STD___OPTIONAL_BAD_OPTIONAL_ACCESS_H

--- a/libcudacxx/include/cuda/std/__optional/optional.h
+++ b/libcudacxx/include/cuda/std/__optional/optional.h
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__concepts/invocable.h>
+#include <cuda/std/__exception/exception_macros.h>
 #include <cuda/std/__functional/invoke.h>
 #include <cuda/std/__fwd/optional.h>
 #include <cuda/std/__memory/addressof.h>
@@ -378,7 +379,7 @@ public:
   {
     if (!this->has_value())
     {
-      __throw_bad_optional_access();
+      _CCCL_THROW(std::bad_optional_access);
     }
     return this->__get();
   }
@@ -387,7 +388,7 @@ public:
   {
     if (!this->has_value())
     {
-      __throw_bad_optional_access();
+      _CCCL_THROW(std::bad_optional_access);
     }
     return this->__get();
   }
@@ -396,7 +397,7 @@ public:
   {
     if (!this->has_value())
     {
-      __throw_bad_optional_access();
+      _CCCL_THROW(std::bad_optional_access);
     }
     return ::cuda::std::move(this->__get());
   }
@@ -405,7 +406,7 @@ public:
   {
     if (!this->has_value())
     {
-      __throw_bad_optional_access();
+      _CCCL_THROW(std::bad_optional_access);
     }
     return ::cuda::std::move(this->__get());
   }

--- a/libcudacxx/include/cuda/std/__optional/optional_ref.h
+++ b/libcudacxx/include/cuda/std/__optional/optional_ref.h
@@ -23,6 +23,7 @@
 
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__concepts/invocable.h>
+#include <cuda/std/__exception/exception_macros.h>
 #include <cuda/std/__functional/invoke.h>
 #include <cuda/std/__fwd/optional.h>
 #include <cuda/std/__memory/addressof.h>
@@ -247,7 +248,7 @@ public:
     }
     else
     {
-      __throw_bad_optional_access();
+      _CCCL_THROW(std::bad_optional_access);
     }
   }
 


### PR DESCRIPTION
According to [cppreference](https://cppreference.com/w/cpp/17.html) all our supported host standard libraries should implement `std::optional`. That means we should be able to include it unconditionally.

That also means, that we can deprecate the `cuda::std::bad_optional_access` and just make it an alias to the `std::` variant.