### PR TITLE
Fix non default constructible input types test for cub::FindIf

### DIFF
--- a/cub/test/catch2_test_device_find_if.cu
+++ b/cub/test/catch2_test_device_find_if.cu
@@ -237,7 +237,7 @@ struct index_to_value
   }
 };
 
-static_assert(cuda::std::is_default_constructible_v<NotDefaultConstructible> == false,
+static_assert(!cuda::std::is_default_constructible_v<NotDefaultConstructible>,
               "NotDefaultConstructible should not be default constructible");
 
 C2H_TEST("Device find_if works with non default constructible types", "[device][find_if]")


### PR DESCRIPTION
Fixes  #7337 test by

- Making `NonDefaultConstructible` actually non default constructible
- Making test input iterator raw so that vectorized path is taken `ConsumeTile(..., attempt_vectorization=true)` so test covers the faulty code.

The source code fix was correct. It's just that the added test was not covering it.