### PR TITLE
Support `cp_async_bulk_ignore_oob` in DeviceTransform

### DIFF
--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -782,15 +782,13 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   const Offset offset   = static_cast<Offset>(blockIdx.x) * tile_size;
   const int valid_items = (::cuda::std::min) (num_items - offset, static_cast<Offset>(tile_size));
 
-  const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
-  if (inner_blocks)
+#if __cccl_ptx_isa >= 920
+  if constexpr (bulk_copy_alignment == 16)
   {
-    // use one thread to setup the entire bulk copy
+    // use one thread to set up the entire bulk copy
     if (cuda::device::__block_elect_one())
     {
       ptx::mbarrier_init(&bar, 1);
-      // an update to the CUDA memory model blesses skipping the following fence
-      // ptx::fence_proxy_async(ptx::space_shared);
 
       char* smem                         = smem_base;
       ::cuda::std::uint32_t total_copied = 0;
@@ -798,10 +796,10 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // turning this lambda into a function does not change SASS
       auto bulk_copy_tile = [&](auto aligned_ptr) {
         using T         = typename decltype(aligned_ptr)::value_type;
-        const char* src = aligned_ptr.ptr + offset * sizeof(T);
+        const char* src = aligned_ptr.ptr + offset * unsigned{sizeof(T)}; // compute expression in U32 if Offset==I32
         char* dst       = smem;
-        _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(src), "");
-        _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(dst), "");
+        _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % bulk_copy_alignment == 0, "");
+        _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % bulk_copy_alignment == 0, "");
 
         // TODO(bgruber): we could precompute bytes_to_copy on the host
         int bytes_to_copy;
@@ -816,12 +814,14 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
           bytes_to_copy = int{sizeof(T)} * tile_size;
         }
 
-        ::cuda::ptx::cp_async_bulk(
-          ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ::cuda::ptx::space_shared_t, ::cuda::ptx::space_cluster_t>{},
+        ::cuda::ptx::cp_async_bulk_ignore_oob(
+          ::cuda::ptx::space_shared,
           ::cuda::ptx::space_global,
           dst,
           src,
           bytes_to_copy,
+          /* ignore left */ aligned_ptr.head_padding,
+          /* ignore right */ 16 - aligned_ptr.head_padding, // because the tile size is a multiple of 16
           &bar);
         total_copied += bytes_to_copy;
 
@@ -845,49 +845,116 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
     }
   }
   else
+#endif // __cccl_ptx_isa >= 920
   {
-    const bool elected = cuda::device::__block_elect_one();
-    if (elected)
+    static_assert(bulk_copy_alignment == 123);
+    const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
+    if (inner_blocks)
     {
-      ptx::mbarrier_init(&bar, 1);
-      // an update to the CUDA memory model blesses skipping the following fence
-      // ptx::fence_proxy_async(ptx::space_shared);
+      // use one thread to set up the entire bulk copy
+      if (cuda::device::__block_elect_one())
+      {
+        ptx::mbarrier_init(&bar, 1);
+        // an update to the CUDA memory model blesses skipping the following fence
+        // ptx::fence_proxy_async(ptx::space_shared);
+
+        char* smem                         = smem_base;
+        ::cuda::std::uint32_t total_copied = 0;
+
+        // turning this lambda into a function does not change SASS
+        auto bulk_copy_tile = [&](auto aligned_ptr) {
+          using T         = typename decltype(aligned_ptr)::value_type;
+          const char* src = aligned_ptr.ptr + offset * sizeof(T);
+          char* dst       = smem;
+          _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(src), "");
+          _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(dst), "");
+
+          // TODO(bgruber): we could precompute bytes_to_copy on the host
+          int bytes_to_copy;
+          if constexpr (alignof(T) < bulk_copy_size_multiple)
+          {
+            bytes_to_copy =
+              ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * tile_size, bulk_copy_size_multiple);
+          }
+          else
+          {
+            _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
+            bytes_to_copy = int{sizeof(T)} * tile_size;
+          }
+
+          ::cuda::ptx::cp_async_bulk(
+            ::cuda::std::
+              conditional_t<__cccl_ptx_isa >= 860, ::cuda::ptx::space_shared_t, ::cuda::ptx::space_cluster_t>{},
+            ::cuda::ptx::space_global,
+            dst,
+            src,
+            bytes_to_copy,
+            &bar);
+          total_copied += bytes_to_copy;
+
+          smem += tile_padding + int{sizeof(T)} * tile_size;
+          _CCCL_ASSERT(bytes_to_copy <= int{sizeof(T)} * tile_size + bulk_copy_alignment, "");
+        };
+
+        // only elected thread waits, but other threads wait on the barrier fulfilled by the bulk copy later
+        _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+        // Order of evaluation is left-to-right
+        (..., bulk_copy_tile(aligned_ptrs));
+
+        // TODO(ahendriksen): this could only have ptx::sem_relaxed, but this is not available yet
+        ptx::mbarrier_arrive_expect_tx(ptx::sem_release, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
+
+        // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
+        // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
+        // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we
+        // decided to omit PREEXIT here. See #5249 for details. _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+      }
     }
-
-    // use all threads to copy the head and tail bytes, use the elected thread to start the bulk copy
-    char* smem                         = smem_base;
-    ::cuda::std::uint32_t total_copied = 0;
-
-    // turning this lambda into a function does not change SASS
-    auto bulk_copy_tile_fallback = [&](auto aligned_ptr) {
-      using T = typename decltype(aligned_ptr)::value_type;
-
-      _CCCL_ASSERT(alignof(T) < bulk_copy_alignment || aligned_ptr.head_padding == 0, "");
-      const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;
-
-      const char* src = aligned_ptr.ptr + offset * sizeof(T) + head_padding;
-      char* dst       = smem + head_padding;
-      _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(src), "");
-      _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(dst), "");
-      const int bytes_to_copy = int{sizeof(T)} * valid_items;
-      bulk_copy_maybe_unaligned<bulk_copy_alignment>(
-        dst, src, bytes_to_copy, aligned_ptr.head_padding, bar, total_copied, elected);
-
-      // add padding to account for this tile's head padding
-      smem += tile_padding + int{sizeof(T)} * tile_size;
-    };
-
-    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-    // Order of evaluation is left-to-right
-    (..., bulk_copy_tile_fallback(aligned_ptrs));
-
-    if (elected)
+    else
     {
-      // TODO(ahendriksen): this could only have ptx::sem_relaxed, but this is not available yet
-      ptx::mbarrier_arrive_expect_tx(ptx::sem_release, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
-    }
+      const bool elected = cuda::device::__block_elect_one();
+      if (elected)
+      {
+        ptx::mbarrier_init(&bar, 1);
+        // an update to the CUDA memory model blesses skipping the following fence
+        // ptx::fence_proxy_async(ptx::space_shared);
+      }
 
-    // _CCCL_PDL_TRIGGER_NEXT_LAUNCH(); // disabled, see comment on previous _CCCL_PDL_TRIGGER_NEXT_LAUNCH
+      // use all threads to copy the head and tail bytes, use the elected thread to start the bulk copy
+      char* smem                         = smem_base;
+      ::cuda::std::uint32_t total_copied = 0;
+
+      // turning this lambda into a function does not change SASS
+      auto bulk_copy_tile_fallback = [&](auto aligned_ptr) {
+        using T = typename decltype(aligned_ptr)::value_type;
+
+        _CCCL_ASSERT(alignof(T) < bulk_copy_alignment || aligned_ptr.head_padding == 0, "");
+        const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;
+
+        const char* src = aligned_ptr.ptr + offset * sizeof(T) + head_padding;
+        char* dst = smem + head_padding;
+        _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(src), "");
+        _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(dst), "");
+        const int bytes_to_copy = int{sizeof(T)} * valid_items;
+        bulk_copy_maybe_unaligned<bulk_copy_alignment>(
+          dst, src, bytes_to_copy, aligned_ptr.head_padding, bar, total_copied, elected);
+
+        // add padding to account for this tile's head padding
+        smem += tile_padding + int{sizeof(T)} * tile_size;
+      };
+
+      _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+      // Order of evaluation is left-to-right
+      (..., bulk_copy_tile_fallback(aligned_ptrs));
+
+      if (elected)
+      {
+        // TODO(ahendriksen): this could only have ptx::sem_relaxed, but this is not available yet
+        ptx::mbarrier_arrive_expect_tx(ptx::sem_release, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
+      }
+
+      // _CCCL_PDL_TRIGGER_NEXT_LAUNCH(); // disabled, see comment on previous _CCCL_PDL_TRIGGER_NEXT_LAUNCH
+    }
   }
 
   // move the whole index and iterator to the block/thread index, to reduce arithmetic in the loops below
@@ -920,7 +987,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   }
 
   // all threads wait for bulk copy
-  __syncthreads(); // TODO: ahendriksen said this is not needed, but compute-sanitizer disagrees
+  __syncthreads();
   while (!ptx::mbarrier_try_wait_parity(&bar, 0))
     ;
 

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -834,8 +834,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // Order of evaluation is left-to-right
       (..., bulk_copy_tile(aligned_ptrs));
 
-      // TODO(ahendriksen): this could only have ptx::sem_relaxed, but this is not available yet
-      ptx::mbarrier_arrive_expect_tx(ptx::sem_release, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
+      ptx::mbarrier_arrive_expect_tx(ptx::sem_relaxed, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
 
       // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
       // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
@@ -901,8 +900,13 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
         // Order of evaluation is left-to-right
         (..., bulk_copy_tile(aligned_ptrs));
 
-        // TODO(ahendriksen): this could only have ptx::sem_relaxed, but this is not available yet
-        ptx::mbarrier_arrive_expect_tx(ptx::sem_release, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
+        // we can use ptx::sem_relaxed when available
+        ptx::mbarrier_arrive_expect_tx(
+          ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
+          ptx::scope_cta,
+          ptx::space_shared,
+          &bar,
+          total_copied);
 
         // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
         // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
@@ -949,7 +953,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
       if (elected)
       {
-        // TODO(ahendriksen): this could only have ptx::sem_relaxed, but this is not available yet
+        // we need sem_release to also release the manual stores to SMEM
         ptx::mbarrier_arrive_expect_tx(ptx::sem_release, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
       }
 

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -805,15 +805,21 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
         // TODO(bgruber): we could precompute bytes_to_copy on the host
         int bytes_to_copy;
+        int head_padding;
+        int tail_padding;
         if constexpr (alignof(T) < bulk_copy_size_multiple)
         {
+          head_padding = aligned_ptr.head_padding;
+          tail_padding = head_padding > 0 ? 16 - aligned_ptr.head_padding : 0; // tile size % 16 == 0
           bytes_to_copy =
-            ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * tile_size, bulk_copy_size_multiple);
+            ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * valid_items, bulk_copy_size_multiple);
         }
         else
         {
           _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
-          bytes_to_copy = int{sizeof(T)} * tile_size;
+          head_padding  = 0;
+          tail_padding  = 0;
+          bytes_to_copy = int{sizeof(T)} * valid_items;
         }
 
         ::cuda::ptx::cp_async_bulk_ignore_oob(
@@ -822,8 +828,8 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
           dst,
           src,
           bytes_to_copy,
-          /* ignore left */ aligned_ptr.head_padding,
-          /* ignore right */ 16 - aligned_ptr.head_padding, // because the tile size is a multiple of 16
+          /* ignore left */ head_padding,
+          /* ignore right */ tail_padding,
           &bar);
         total_copied += bytes_to_copy;
 
@@ -838,10 +844,8 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
       ptx::mbarrier_arrive_expect_tx(ptx::sem_relaxed, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
 
-      // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
-      // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
-      // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we decided
-      // to omit PREEXIT here. See #5249 for details.
+      // Triggering the next kernel launch here led to slowdowns in the non .ignore_oob path (see comments there), but
+      // we can revisit this.
       // _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
     }
   }

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -783,6 +783,8 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   const int valid_items = (::cuda::std::min) (num_items - offset, static_cast<Offset>(tile_size));
 
 #if __cccl_ptx_isa >= 920
+  // TODO(bgruber): the .ignore_oob variant of UBLKCP only supports up to 15 ignore bytes. We should figure out if it's
+  // beneficial on Hopper to reduce the alignment from 128 to 16 but use the .ignore_oob variant.
   if constexpr (bulk_copy_alignment == 16)
   {
     // use one thread to set up the entire bulk copy
@@ -846,7 +848,6 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   else
 #endif // __cccl_ptx_isa >= 920
   {
-    static_assert(bulk_copy_alignment == 123);
     const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
     if (inner_blocks)
     {

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -798,7 +798,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // turning this lambda into a function does not change SASS
       auto bulk_copy_tile = [&](auto aligned_ptr) {
         using T         = typename decltype(aligned_ptr)::value_type;
-        const char* src = aligned_ptr.ptr + offset * unsigned{sizeof(T)}; // compute expression in U32 if Offset==I32
+        const char* src = aligned_ptr.ptr + offset * sizeof(T);
         char* dst       = smem;
         _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % bulk_copy_alignment == 0, "");
         _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % bulk_copy_alignment == 0, "");
@@ -939,7 +939,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
         const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;
 
         const char* src = aligned_ptr.ptr + offset * sizeof(T) + head_padding;
-        char* dst = smem + head_padding;
+        char* dst       = smem + head_padding;
         _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(src), "");
         _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(dst), "");
         const int bytes_to_copy = int{sizeof(T)} * valid_items;

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -782,15 +782,15 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   const Offset offset   = static_cast<Offset>(blockIdx.x) * tile_size;
   const int valid_items = (::cuda::std::min) (num_items - offset, static_cast<Offset>(tile_size));
 
-#if __cccl_ptx_isa >= 920
-  // TODO(bgruber): the .ignore_oob variant of UBLKCP only supports up to 15 ignore bytes. We should figure out if it's
-  // beneficial on Hopper to reduce the alignment from 128 to 16 but use the .ignore_oob variant.
-  if constexpr (bulk_copy_alignment == 16)
+  const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
+  if (inner_blocks)
   {
     // use one thread to set up the entire bulk copy
     if (cuda::device::__block_elect_one())
     {
       ptx::mbarrier_init(&bar, 1);
+      // an update to the CUDA memory model blesses skipping the following fence
+      // ptx::fence_proxy_async(ptx::space_shared);
 
       char* smem                         = smem_base;
       ::cuda::std::uint32_t total_copied = 0;
@@ -805,31 +805,23 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
         // TODO(bgruber): we could precompute bytes_to_copy on the host
         int bytes_to_copy;
-        int head_padding;
-        int tail_padding;
         if constexpr (alignof(T) < bulk_copy_size_multiple)
         {
-          head_padding = aligned_ptr.head_padding;
-          tail_padding = head_padding > 0 ? 16 - aligned_ptr.head_padding : 0; // tile size % 16 == 0
           bytes_to_copy =
-            ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * valid_items, bulk_copy_size_multiple);
+            ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * tile_size, bulk_copy_size_multiple);
         }
         else
         {
           _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
-          head_padding  = 0;
-          tail_padding  = 0;
-          bytes_to_copy = int{sizeof(T)} * valid_items;
+          bytes_to_copy = int{sizeof(T)} * tile_size;
         }
 
-        ::cuda::ptx::cp_async_bulk_ignore_oob(
-          ::cuda::ptx::space_shared,
+        ::cuda::ptx::cp_async_bulk(
+          ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ::cuda::ptx::space_shared_t, ::cuda::ptx::space_cluster_t>{},
           ::cuda::ptx::space_global,
           dst,
           src,
           bytes_to_copy,
-          /* ignore left */ head_padding,
-          /* ignore right */ tail_padding,
           &bar);
         total_copied += bytes_to_copy;
 
@@ -842,25 +834,31 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // Order of evaluation is left-to-right
       (..., bulk_copy_tile(aligned_ptrs));
 
-      ptx::mbarrier_arrive_expect_tx(ptx::sem_relaxed, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
+      // we can use ptx::sem_relaxed when available
+      ptx::mbarrier_arrive_expect_tx(
+        ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
+        ptx::scope_cta,
+        ptx::space_shared,
+        &bar,
+        total_copied);
 
-      // Triggering the next kernel launch here led to slowdowns in the non .ignore_oob path (see comments there), but
-      // we can revisit this.
-      // _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+      // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
+      // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
+      // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we
+      // decided to omit PREEXIT here. See #5249 for details. _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
     }
   }
   else
-#endif // __cccl_ptx_isa >= 920
   {
-    const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
-    if (inner_blocks)
+#if __cccl_ptx_isa >= 920
+    // TODO(bgruber): the .ignore_oob variant of UBLKCP only supports up to 15 ignore bytes. We should figure out if
+    // it's beneficial on Hopper to reduce the alignment from 128 to 16 but use the .ignore_oob variant.
+    if constexpr (bulk_copy_alignment == 16)
     {
       // use one thread to set up the entire bulk copy
       if (cuda::device::__block_elect_one())
       {
         ptx::mbarrier_init(&bar, 1);
-        // an update to the CUDA memory model blesses skipping the following fence
-        // ptx::fence_proxy_async(ptx::space_shared);
 
         char* smem                         = smem_base;
         ::cuda::std::uint32_t total_copied = 0;
@@ -875,24 +873,31 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
           // TODO(bgruber): we could precompute bytes_to_copy on the host
           int bytes_to_copy;
+          int head_padding;
+          int tail_padding;
           if constexpr (alignof(T) < bulk_copy_size_multiple)
           {
+            head_padding = aligned_ptr.head_padding;
+            tail_padding = head_padding > 0 ? 16 - aligned_ptr.head_padding : 0; // tile size % 16 == 0
             bytes_to_copy =
-              ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * tile_size, bulk_copy_size_multiple);
+              ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * valid_items, bulk_copy_size_multiple);
           }
           else
           {
             _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
-            bytes_to_copy = int{sizeof(T)} * tile_size;
+            head_padding  = 0;
+            tail_padding  = 0;
+            bytes_to_copy = int{sizeof(T)} * valid_items;
           }
 
-          ::cuda::ptx::cp_async_bulk(
-            ::cuda::std::
-              conditional_t<__cccl_ptx_isa >= 860, ::cuda::ptx::space_shared_t, ::cuda::ptx::space_cluster_t>{},
+          ::cuda::ptx::cp_async_bulk_ignore_oob(
+            ::cuda::ptx::space_shared,
             ::cuda::ptx::space_global,
             dst,
             src,
             bytes_to_copy,
+            /* ignore left */ head_padding,
+            /* ignore right */ tail_padding,
             &bar);
           total_copied += bytes_to_copy;
 
@@ -905,21 +910,15 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
         // Order of evaluation is left-to-right
         (..., bulk_copy_tile(aligned_ptrs));
 
-        // we can use ptx::sem_relaxed when available
-        ptx::mbarrier_arrive_expect_tx(
-          ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
-          ptx::scope_cta,
-          ptx::space_shared,
-          &bar,
-          total_copied);
+        ptx::mbarrier_arrive_expect_tx(ptx::sem_relaxed, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
 
-        // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
-        // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
-        // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we
-        // decided to omit PREEXIT here. See #5249 for details. _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+        // Triggering the next kernel launch here led to slowdowns in the non .ignore_oob path (see comments there), but
+        // we can revisit this.
+        // _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
       }
     }
     else
+#endif // __cccl_ptx_isa >= 920
     {
       const bool elected = cuda::device::__block_elect_one();
       if (elected)

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -845,7 +845,8 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
       // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
       // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we
-      // decided to omit PREEXIT here. See #5249 for details. _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+      // decided to omit PREEXIT here. See #5249 for details.
+      // _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
     }
   }
   else
@@ -863,7 +864,6 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
         char* smem                         = smem_base;
         ::cuda::std::uint32_t total_copied = 0;
 
-        // turning this lambda into a function does not change SASS
         auto bulk_copy_tile = [&](auto aligned_ptr) {
           using T         = typename decltype(aligned_ptr)::value_type;
           const char* src = aligned_ptr.ptr + offset * sizeof(T);
@@ -877,10 +877,9 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
           int tail_padding;
           if constexpr (alignof(T) < bulk_copy_size_multiple)
           {
-            head_padding = aligned_ptr.head_padding;
-            tail_padding = head_padding > 0 ? 16 - aligned_ptr.head_padding : 0; // tile size % 16 == 0
-            bytes_to_copy =
-              ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * valid_items, bulk_copy_size_multiple);
+            head_padding  = aligned_ptr.head_padding;
+            tail_padding  = head_padding > 0 ? 16 - head_padding : 0; // tile size % 16 == 0
+            bytes_to_copy = ::cuda::round_up(head_padding + int{sizeof(T)} * valid_items, bulk_copy_size_multiple);
           }
           else
           {

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -782,15 +782,13 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   const Offset offset   = static_cast<Offset>(blockIdx.x) * tile_size;
   const int valid_items = (::cuda::std::min) (num_items - offset, static_cast<Offset>(tile_size));
 
-  const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
-  if (inner_blocks)
+#if __cccl_ptx_isa >= 920
+  if constexpr (bulk_copy_alignment == 16)
   {
     // use one thread to set up the entire bulk copy
     if (cuda::device::__block_elect_one())
     {
       ptx::mbarrier_init(&bar, 1);
-      // an update to the CUDA memory model blesses skipping the following fence
-      // ptx::fence_proxy_async(ptx::space_shared);
 
       char* smem                         = smem_base;
       ::cuda::std::uint32_t total_copied = 0;
@@ -798,10 +796,10 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // turning this lambda into a function does not change SASS
       auto bulk_copy_tile = [&](auto aligned_ptr) {
         using T         = typename decltype(aligned_ptr)::value_type;
-        const char* src = aligned_ptr.ptr + offset * sizeof(T);
+        const char* src = aligned_ptr.ptr + offset * unsigned{sizeof(T)}; // compute expression in U32 if Offset==I32
         char* dst       = smem;
-        _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(src), "");
-        _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(dst), "");
+        _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % bulk_copy_alignment == 0, "");
+        _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % bulk_copy_alignment == 0, "");
 
         // TODO(bgruber): we could precompute bytes_to_copy on the host
         int bytes_to_copy;
@@ -816,12 +814,14 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
           bytes_to_copy = int{sizeof(T)} * tile_size;
         }
 
-        ::cuda::ptx::cp_async_bulk(
-          ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ::cuda::ptx::space_shared_t, ::cuda::ptx::space_cluster_t>{},
+        ::cuda::ptx::cp_async_bulk_ignore_oob(
+          ::cuda::ptx::space_shared,
           ::cuda::ptx::space_global,
           dst,
           src,
           bytes_to_copy,
+          /* ignore left */ aligned_ptr.head_padding,
+          /* ignore right */ 16 - aligned_ptr.head_padding, // because the tile size is a multiple of 16
           &bar);
         total_copied += bytes_to_copy;
 
@@ -834,12 +834,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // Order of evaluation is left-to-right
       (..., bulk_copy_tile(aligned_ptrs));
 
-      ptx::mbarrier_arrive_expect_tx(
-        ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
-        ptx::scope_cta,
-        ptx::space_shared,
-        &bar,
-        total_copied);
+      ptx::mbarrier_arrive_expect_tx(::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{}, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
 
       // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
       // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
@@ -849,53 +844,120 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
     }
   }
   else
+#endif // __cccl_ptx_isa >= 920
   {
-    const bool elected = cuda::device::__block_elect_one();
-    if (elected)
+    static_assert(bulk_copy_alignment == 123);
+    const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
+    if (inner_blocks)
     {
-      ptx::mbarrier_init(&bar, 1);
-      // an update to the CUDA memory model blesses skipping the following fence
-      // ptx::fence_proxy_async(ptx::space_shared);
-    }
+      // use one thread to set up the entire bulk copy
+      if (cuda::device::__block_elect_one())
+      {
+        ptx::mbarrier_init(&bar, 1);
+        // an update to the CUDA memory model blesses skipping the following fence
+        // ptx::fence_proxy_async(ptx::space_shared);
 
-    // use all threads to copy the head and tail bytes, use the elected thread to start the bulk copy
-    char* smem                         = smem_base;
-    ::cuda::std::uint32_t total_copied = 0;
+        char* smem                         = smem_base;
+        ::cuda::std::uint32_t total_copied = 0;
 
-    // turning this lambda into a function does not change SASS
-    auto bulk_copy_tile_fallback = [&](auto aligned_ptr) {
-      using T = typename decltype(aligned_ptr)::value_type;
+        // turning this lambda into a function does not change SASS
+        auto bulk_copy_tile = [&](auto aligned_ptr) {
+          using T         = typename decltype(aligned_ptr)::value_type;
+          const char* src = aligned_ptr.ptr + offset * sizeof(T);
+          char* dst       = smem;
+          _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(src), "");
+          _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(dst), "");
 
-      _CCCL_ASSERT(alignof(T) < bulk_copy_alignment || aligned_ptr.head_padding == 0, "");
-      const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;
+          // TODO(bgruber): we could precompute bytes_to_copy on the host
+          int bytes_to_copy;
+          if constexpr (alignof(T) < bulk_copy_size_multiple)
+          {
+            bytes_to_copy =
+              ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * tile_size, bulk_copy_size_multiple);
+          }
+          else
+          {
+            _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
+            bytes_to_copy = int{sizeof(T)} * tile_size;
+          }
 
-      const char* src = aligned_ptr.ptr + offset * sizeof(T) + head_padding;
-      char* dst       = smem + head_padding;
-      _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(src), "");
-      _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(dst), "");
-      const int bytes_to_copy = int{sizeof(T)} * valid_items;
-      bulk_copy_maybe_unaligned<bulk_copy_alignment>(
-        dst, src, bytes_to_copy, aligned_ptr.head_padding, bar, total_copied, elected);
+          ::cuda::ptx::cp_async_bulk(
+            ::cuda::std::
+              conditional_t<__cccl_ptx_isa >= 860, ::cuda::ptx::space_shared_t, ::cuda::ptx::space_cluster_t>{},
+            ::cuda::ptx::space_global,
+            dst,
+            src,
+            bytes_to_copy,
+            &bar);
+          total_copied += bytes_to_copy;
 
-      // add padding to account for this tile's head padding
-      smem += tile_padding + int{sizeof(T)} * tile_size;
-    };
+          smem += tile_padding + int{sizeof(T)} * tile_size;
+          _CCCL_ASSERT(bytes_to_copy <= int{sizeof(T)} * tile_size + bulk_copy_alignment, "");
+        };
 
-    _CCCL_PDL_GRID_DEPENDENCY_SYNC();
-    // Order of evaluation is left-to-right
-    (..., bulk_copy_tile_fallback(aligned_ptrs));
+        // only elected thread waits, but other threads wait on the barrier fulfilled by the bulk copy later
+        _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+        // Order of evaluation is left-to-right
+        (..., bulk_copy_tile(aligned_ptrs));
 
-    if (elected)
-    {
-      ptx::mbarrier_arrive_expect_tx(
+        ptx::mbarrier_arrive_expect_tx(
         ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
         ptx::scope_cta,
         ptx::space_shared,
         &bar,
         total_copied);
-    }
 
-    // _CCCL_PDL_TRIGGER_NEXT_LAUNCH(); // disabled, see comment on previous _CCCL_PDL_TRIGGER_NEXT_LAUNCH
+        // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
+        // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
+        // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we
+        // decided to omit PREEXIT here. See #5249 for details. _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+      }
+    }
+    else
+    {
+      const bool elected = cuda::device::__block_elect_one();
+      if (elected)
+      {
+        ptx::mbarrier_init(&bar, 1);
+        // an update to the CUDA memory model blesses skipping the following fence
+        // ptx::fence_proxy_async(ptx::space_shared);
+      }
+
+      // use all threads to copy the head and tail bytes, use the elected thread to start the bulk copy
+      char* smem                         = smem_base;
+      ::cuda::std::uint32_t total_copied = 0;
+
+      // turning this lambda into a function does not change SASS
+      auto bulk_copy_tile_fallback = [&](auto aligned_ptr) {
+        using T = typename decltype(aligned_ptr)::value_type;
+
+        _CCCL_ASSERT(alignof(T) < bulk_copy_alignment || aligned_ptr.head_padding == 0, "");
+        const int head_padding = alignof(T) < bulk_copy_alignment ? aligned_ptr.head_padding : 0;
+
+        const char* src = aligned_ptr.ptr + offset * sizeof(T) + head_padding;
+        char* dst = smem + head_padding;
+        _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(src), "");
+        _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<alignof(T)>(dst), "");
+        const int bytes_to_copy = int{sizeof(T)} * valid_items;
+        bulk_copy_maybe_unaligned<bulk_copy_alignment>(
+          dst, src, bytes_to_copy, aligned_ptr.head_padding, bar, total_copied, elected);
+
+        // add padding to account for this tile's head padding
+        smem += tile_padding + int{sizeof(T)} * tile_size;
+      };
+
+      _CCCL_PDL_GRID_DEPENDENCY_SYNC();
+      // Order of evaluation is left-to-right
+      (..., bulk_copy_tile_fallback(aligned_ptrs));
+
+      if (elected)
+      {
+        ptx::mbarrier_arrive_expect_tx(
+        ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{}, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
+      }
+
+      // _CCCL_PDL_TRIGGER_NEXT_LAUNCH(); // disabled, see comment on previous _CCCL_PDL_TRIGGER_NEXT_LAUNCH
+    }
   }
 
   // move the whole index and iterator to the block/thread index, to reduce arithmetic in the loops below
@@ -928,7 +990,7 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   }
 
   // all threads wait for bulk copy
-  __syncthreads(); // TODO: ahendriksen said this is not needed, but compute-sanitizer disagrees
+  __syncthreads();
   while (!ptx::mbarrier_try_wait_parity(&bar, 0))
     ;
 

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -805,15 +805,21 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
         // TODO(bgruber): we could precompute bytes_to_copy on the host
         int bytes_to_copy;
+        int head_padding;
+        int tail_padding;
         if constexpr (alignof(T) < bulk_copy_size_multiple)
         {
+          head_padding = aligned_ptr.head_padding;
+          tail_padding = head_padding > 0 ? 16 - aligned_ptr.head_padding : 0; // tile size % 16 == 0
           bytes_to_copy =
-            ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * tile_size, bulk_copy_size_multiple);
+            ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * valid_items, bulk_copy_size_multiple);
         }
         else
         {
           _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
-          bytes_to_copy = int{sizeof(T)} * tile_size;
+          head_padding  = 0;
+          tail_padding  = 0;
+          bytes_to_copy = int{sizeof(T)} * valid_items;
         }
 
         ::cuda::ptx::cp_async_bulk_ignore_oob(
@@ -822,8 +828,8 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
           dst,
           src,
           bytes_to_copy,
-          /* ignore left */ aligned_ptr.head_padding,
-          /* ignore right */ 16 - aligned_ptr.head_padding, // because the tile size is a multiple of 16
+          /* ignore left */ head_padding,
+          /* ignore right */ tail_padding,
           &bar);
         total_copied += bytes_to_copy;
 
@@ -838,10 +844,8 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
       ptx::mbarrier_arrive_expect_tx(::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{}, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
 
-      // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
-      // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
-      // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we decided
-      // to omit PREEXIT here. See #5249 for details.
+      // Triggering the next kernel launch here led to slowdowns in the non .ignore_oob path (see comments there), but
+      // we can revisit this.
       // _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
     }
   }

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -870,8 +870,8 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
           using T         = typename decltype(aligned_ptr)::value_type;
           const char* src = aligned_ptr.ptr + offset * sizeof(T);
           char* dst       = smem;
-          _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % bulk_copy_alignment == 0, "");
-          _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % bulk_copy_alignment == 0, "");
+          _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(src), "");
+          _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(dst), "");
 
           // TODO(bgruber): we could precompute bytes_to_copy on the host
           int bytes_to_copy;
@@ -905,7 +905,6 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
         // Order of evaluation is left-to-right
         (..., bulk_copy_tile(aligned_ptrs));
 
-        // we can use ptx::sem_relaxed when available
         ptx::mbarrier_arrive_expect_tx(
           ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
           ptx::scope_cta,

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -782,15 +782,15 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   const Offset offset   = static_cast<Offset>(blockIdx.x) * tile_size;
   const int valid_items = (::cuda::std::min) (num_items - offset, static_cast<Offset>(tile_size));
 
-#if __cccl_ptx_isa >= 920
-  // TODO(bgruber): the .ignore_oob variant of UBLKCP only supports up to 15 ignore bytes. We should figure out if it's
-  // beneficial on Hopper to reduce the alignment from 128 to 16 but use the .ignore_oob variant.
-  if constexpr (bulk_copy_alignment == 16)
+  const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
+  if (inner_blocks)
   {
     // use one thread to set up the entire bulk copy
     if (cuda::device::__block_elect_one())
     {
       ptx::mbarrier_init(&bar, 1);
+      // an update to the CUDA memory model blesses skipping the following fence
+      // ptx::fence_proxy_async(ptx::space_shared);
 
       char* smem                         = smem_base;
       ::cuda::std::uint32_t total_copied = 0;
@@ -805,31 +805,23 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
         // TODO(bgruber): we could precompute bytes_to_copy on the host
         int bytes_to_copy;
-        int head_padding;
-        int tail_padding;
         if constexpr (alignof(T) < bulk_copy_size_multiple)
         {
-          head_padding = aligned_ptr.head_padding;
-          tail_padding = head_padding > 0 ? 16 - aligned_ptr.head_padding : 0; // tile size % 16 == 0
           bytes_to_copy =
-            ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * valid_items, bulk_copy_size_multiple);
+            ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * tile_size, bulk_copy_size_multiple);
         }
         else
         {
           _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
-          head_padding  = 0;
-          tail_padding  = 0;
-          bytes_to_copy = int{sizeof(T)} * valid_items;
+          bytes_to_copy = int{sizeof(T)} * tile_size;
         }
 
-        ::cuda::ptx::cp_async_bulk_ignore_oob(
-          ::cuda::ptx::space_shared,
+        ::cuda::ptx::cp_async_bulk(
+          ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ::cuda::ptx::space_shared_t, ::cuda::ptx::space_cluster_t>{},
           ::cuda::ptx::space_global,
           dst,
           src,
           bytes_to_copy,
-          /* ignore left */ head_padding,
-          /* ignore right */ tail_padding,
           &bar);
         total_copied += bytes_to_copy;
 
@@ -842,25 +834,31 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // Order of evaluation is left-to-right
       (..., bulk_copy_tile(aligned_ptrs));
 
-      ptx::mbarrier_arrive_expect_tx(::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{}, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
+      // we can use ptx::sem_relaxed when available
+      ptx::mbarrier_arrive_expect_tx(
+        ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
+        ptx::scope_cta,
+        ptx::space_shared,
+        &bar,
+        total_copied);
 
-      // Triggering the next kernel launch here led to slowdowns in the non .ignore_oob path (see comments there), but
-      // we can revisit this.
-      // _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+      // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
+      // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
+      // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we
+      // decided to omit PREEXIT here. See #5249 for details. _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
     }
   }
   else
-#endif // __cccl_ptx_isa >= 920
   {
-    const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
-    if (inner_blocks)
+#if __cccl_ptx_isa >= 920
+    // TODO(bgruber): the .ignore_oob variant of UBLKCP only supports up to 15 ignore bytes. We should figure out if
+    // it's beneficial on Hopper to reduce the alignment from 128 to 16 but use the .ignore_oob variant.
+    if constexpr (bulk_copy_alignment == 16)
     {
       // use one thread to set up the entire bulk copy
       if (cuda::device::__block_elect_one())
       {
         ptx::mbarrier_init(&bar, 1);
-        // an update to the CUDA memory model blesses skipping the following fence
-        // ptx::fence_proxy_async(ptx::space_shared);
 
         char* smem                         = smem_base;
         ::cuda::std::uint32_t total_copied = 0;
@@ -875,24 +873,31 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
 
           // TODO(bgruber): we could precompute bytes_to_copy on the host
           int bytes_to_copy;
+          int head_padding;
+          int tail_padding;
           if constexpr (alignof(T) < bulk_copy_size_multiple)
           {
+            head_padding = aligned_ptr.head_padding;
+            tail_padding = head_padding > 0 ? 16 - aligned_ptr.head_padding : 0; // tile size % 16 == 0
             bytes_to_copy =
-              ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * tile_size, bulk_copy_size_multiple);
+              ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * valid_items, bulk_copy_size_multiple);
           }
           else
           {
             _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
-            bytes_to_copy = int{sizeof(T)} * tile_size;
+            head_padding  = 0;
+            tail_padding  = 0;
+            bytes_to_copy = int{sizeof(T)} * valid_items;
           }
 
-          ::cuda::ptx::cp_async_bulk(
-            ::cuda::std::
-              conditional_t<__cccl_ptx_isa >= 860, ::cuda::ptx::space_shared_t, ::cuda::ptx::space_cluster_t>{},
+          ::cuda::ptx::cp_async_bulk_ignore_oob(
+            ::cuda::ptx::space_shared,
             ::cuda::ptx::space_global,
             dst,
             src,
             bytes_to_copy,
+            /* ignore left */ head_padding,
+            /* ignore right */ tail_padding,
             &bar);
           total_copied += bytes_to_copy;
 
@@ -905,20 +910,15 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
         // Order of evaluation is left-to-right
         (..., bulk_copy_tile(aligned_ptrs));
 
-        ptx::mbarrier_arrive_expect_tx(
-        ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
-        ptx::scope_cta,
-        ptx::space_shared,
-        &bar,
-        total_copied);
+        ptx::mbarrier_arrive_expect_tx(ptx::sem_relaxed, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
 
-        // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
-        // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
-        // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we
-        // decided to omit PREEXIT here. See #5249 for details. _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
+        // Triggering the next kernel launch here led to slowdowns in the non .ignore_oob path (see comments there), but
+        // we can revisit this.
+        // _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
       }
     }
     else
+#endif // __cccl_ptx_isa >= 920
     {
       const bool elected = cuda::device::__block_elect_one();
       if (elected)

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -782,46 +782,54 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
   const Offset offset   = static_cast<Offset>(blockIdx.x) * tile_size;
   const int valid_items = (::cuda::std::min) (num_items - offset, static_cast<Offset>(tile_size));
 
-  const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
-  if (inner_blocks)
+#if __cccl_ptx_isa >= 920
+  // TODO(bgruber): the .ignore_oob variant of UBLKCP only supports up to 15 ignore bytes. We should figure out if
+  // it's beneficial on Hopper to reduce the alignment from 128 to 16 but use the .ignore_oob variant.
+  if constexpr (bulk_copy_alignment == 16)
   {
-    // use one thread to set up the entire bulk copy
+    // .ignore_oob protects the first and last tiles from reading before/past the allocation. For all other tiles,
+    // head_padding and tail_padding are always 0, so this degenerates to an ordinary full-tile bulk copy. This lets
+    // every block, regardless of position in the grid, share the same single code path.
     if (cuda::device::__block_elect_one())
     {
       ptx::mbarrier_init(&bar, 1);
-      // an update to the CUDA memory model blesses skipping the following fence
-      // ptx::fence_proxy_async(ptx::space_shared);
 
       char* smem                         = smem_base;
       ::cuda::std::uint32_t total_copied = 0;
 
-      // turning this lambda into a function does not change SASS
       auto bulk_copy_tile = [&](auto aligned_ptr) {
         using T         = typename decltype(aligned_ptr)::value_type;
         const char* src = aligned_ptr.ptr + offset * sizeof(T);
         char* dst       = smem;
-        _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % bulk_copy_alignment == 0, "");
-        _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % bulk_copy_alignment == 0, "");
+        _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(src), "");
+        _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(dst), "");
 
         // TODO(bgruber): we could precompute bytes_to_copy on the host
         int bytes_to_copy;
+        int head_padding;
+        int tail_padding;
         if constexpr (alignof(T) < bulk_copy_size_multiple)
         {
-          bytes_to_copy =
-            ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * tile_size, bulk_copy_size_multiple);
+          head_padding  = aligned_ptr.head_padding;
+          tail_padding  = head_padding > 0 ? 16 - head_padding : 0; // tile size % 16 == 0
+          bytes_to_copy = ::cuda::round_up(head_padding + int{sizeof(T)} * valid_items, bulk_copy_size_multiple);
         }
         else
         {
           _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
-          bytes_to_copy = int{sizeof(T)} * tile_size;
+          head_padding  = 0;
+          tail_padding  = 0;
+          bytes_to_copy = int{sizeof(T)} * valid_items;
         }
 
-        ::cuda::ptx::cp_async_bulk(
-          ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ::cuda::ptx::space_shared_t, ::cuda::ptx::space_cluster_t>{},
+        ::cuda::ptx::cp_async_bulk_ignore_oob(
+          ::cuda::ptx::space_shared,
           ::cuda::ptx::space_global,
           dst,
           src,
           bytes_to_copy,
+          /* ignore left */ head_padding,
+          /* ignore right */ tail_padding,
           &bar);
         total_copied += bytes_to_copy;
 
@@ -834,69 +842,57 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       // Order of evaluation is left-to-right
       (..., bulk_copy_tile(aligned_ptrs));
 
-      // we can use ptx::sem_relaxed when available
-      ptx::mbarrier_arrive_expect_tx(
-        ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
-        ptx::scope_cta,
-        ptx::space_shared,
-        &bar,
-        total_copied);
+      ptx::mbarrier_arrive_expect_tx(ptx::sem_relaxed, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
 
-      // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
-      // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
-      // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we
-      // decided to omit PREEXIT here. See #5249 for details.
+      // Triggering the next kernel launch here led to slowdowns in the non .ignore_oob path (see comments there), but
+      // we can revisit this.
       // _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
     }
   }
   else
+#endif // __cccl_ptx_isa >= 920
   {
-#if __cccl_ptx_isa >= 920
-    // TODO(bgruber): the .ignore_oob variant of UBLKCP only supports up to 15 ignore bytes. We should figure out if
-    // it's beneficial on Hopper to reduce the alignment from 128 to 16 but use the .ignore_oob variant.
-    if constexpr (bulk_copy_alignment == 16)
+    const bool inner_blocks = 0 < blockIdx.x && blockIdx.x + 2 < gridDim.x;
+    if (inner_blocks)
     {
       // use one thread to set up the entire bulk copy
       if (cuda::device::__block_elect_one())
       {
         ptx::mbarrier_init(&bar, 1);
+        // an update to the CUDA memory model blesses skipping the following fence
+        // ptx::fence_proxy_async(ptx::space_shared);
 
         char* smem                         = smem_base;
         ::cuda::std::uint32_t total_copied = 0;
 
+        // turning this lambda into a function does not change SASS
         auto bulk_copy_tile = [&](auto aligned_ptr) {
           using T         = typename decltype(aligned_ptr)::value_type;
           const char* src = aligned_ptr.ptr + offset * sizeof(T);
           char* dst       = smem;
-          _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(src), "");
-          _CCCL_ASSERT(::cuda::std::is_sufficiently_aligned<bulk_copy_alignment>(dst), "");
+          _CCCL_ASSERT(reinterpret_cast<uintptr_t>(src) % bulk_copy_alignment == 0, "");
+          _CCCL_ASSERT(reinterpret_cast<uintptr_t>(dst) % bulk_copy_alignment == 0, "");
 
           // TODO(bgruber): we could precompute bytes_to_copy on the host
           int bytes_to_copy;
-          int head_padding;
-          int tail_padding;
           if constexpr (alignof(T) < bulk_copy_size_multiple)
           {
-            head_padding  = aligned_ptr.head_padding;
-            tail_padding  = head_padding > 0 ? 16 - head_padding : 0; // tile size % 16 == 0
-            bytes_to_copy = ::cuda::round_up(head_padding + int{sizeof(T)} * valid_items, bulk_copy_size_multiple);
+            bytes_to_copy =
+              ::cuda::round_up(aligned_ptr.head_padding + int{sizeof(T)} * tile_size, bulk_copy_size_multiple);
           }
           else
           {
             _CCCL_ASSERT(aligned_ptr.head_padding == 0, "");
-            head_padding  = 0;
-            tail_padding  = 0;
-            bytes_to_copy = int{sizeof(T)} * valid_items;
+            bytes_to_copy = int{sizeof(T)} * tile_size;
           }
 
-          ::cuda::ptx::cp_async_bulk_ignore_oob(
-            ::cuda::ptx::space_shared,
+          ::cuda::ptx::cp_async_bulk(
+            ::cuda::std::
+              conditional_t<__cccl_ptx_isa >= 860, ::cuda::ptx::space_shared_t, ::cuda::ptx::space_cluster_t>{},
             ::cuda::ptx::space_global,
             dst,
             src,
             bytes_to_copy,
-            /* ignore left */ head_padding,
-            /* ignore right */ tail_padding,
             &bar);
           total_copied += bytes_to_copy;
 
@@ -909,15 +905,22 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
         // Order of evaluation is left-to-right
         (..., bulk_copy_tile(aligned_ptrs));
 
-        ptx::mbarrier_arrive_expect_tx(ptx::sem_relaxed, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
+        // we can use ptx::sem_relaxed when available
+        ptx::mbarrier_arrive_expect_tx(
+          ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
+          ptx::scope_cta,
+          ptx::space_shared,
+          &bar,
+          total_copied);
 
-        // Triggering the next kernel launch here led to slowdowns in the non .ignore_oob path (see comments there), but
-        // we can revisit this.
+        // Triggering the next kernel launch here lets the SM ramp up the next kernel while we wait for the bulk copy.
+        // Also, the uniform code path should reduce traffic to the CWD (only one thread in a block needs to trigger).
+        // However, benchmarks showed up to 20% slowdown on B200 (among strong improvements in batch mode), so we
+        // decided to omit PREEXIT here. See #5249 for details.
         // _CCCL_PDL_TRIGGER_NEXT_LAUNCH();
       }
     }
     else
-#endif // __cccl_ptx_isa >= 920
     {
       const bool elected = cuda::device::__block_elect_one();
       if (elected)
@@ -957,7 +960,11 @@ _CCCL_DEVICE void transform_kernel_ublkcp(
       if (elected)
       {
         ptx::mbarrier_arrive_expect_tx(
-        ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{}, ptx::scope_cta, ptx::space_shared, &bar, total_copied);
+          ::cuda::std::conditional_t<__cccl_ptx_isa >= 860, ptx::sem_relaxed_t, ptx::sem_release_t>{},
+          ptx::scope_cta,
+          ptx::space_shared,
+          &bar,
+          total_copied);
       }
 
       // _CCCL_PDL_TRIGGER_NEXT_LAUNCH(); // disabled, see comment on previous _CCCL_PDL_TRIGGER_NEXT_LAUNCH

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -224,9 +224,10 @@ struct uncommon_plus
 C2H_TEST("DeviceTransform::Transform uncommon types", "[device][transform]", uncommon_types)
 {
   using type = c2h::get<0, TestType>;
-  CAPTURE(c2h::type_name<type>());
 
   const int num_items = GENERATE(0, 1, 100, 1'000, 100'000); // try to hit the small and full tile code paths
+  CAPTURE(num_items, c2h::type_name<type>());
+
   c2h::device_vector<int8_t> a(num_items, thrust::default_init); // put some bytes at the front, so SMEM has to handle
                                                                  // padding between tiles to align them
   c2h::device_vector<type> b(num_items, thrust::default_init);

--- a/cub/test/catch2_test_device_transform.cu
+++ b/cub/test/catch2_test_device_transform.cu
@@ -229,9 +229,10 @@ struct uncommon_plus
 CUB_TEST("DeviceTransform::Transform uncommon types", "[device][transform]", CUB_SMALL, uncommon_types)
 {
   using type = c2h::get<0, TestType>;
-  CAPTURE(c2h::type_name<type>());
 
   const int num_items = GENERATE(0, 1, 100, 1'000, 100'000); // try to hit the small and full tile code paths
+  CAPTURE(num_items, c2h::type_name<type>());
+
   c2h::device_vector<int8_t> a(num_items, thrust::default_init); // put some bytes at the front, so SMEM has to handle
                                                                  // padding between tiles to align them
   c2h::device_vector<type> b(num_items, thrust::default_init);


### PR DESCRIPTION
Fixes: #7167

```
## [0] NVIDIA B200

|  T{ct}  |  Aligned  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|-----------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   I8    |    yes    |      2^16      |   6.458 us |       8.94% |   6.354 us |       7.18% | -0.104 us |  -1.61% |  🔵 SAME  |
|   I8    |    no     |      2^16      |   6.589 us |       7.33% |   6.562 us |       6.83% | -0.026 us |  -0.40% |  🔵 SAME  |
|   I8    |    yes    |      2^20      |   8.007 us |       5.15% |   7.968 us |       7.16% | -0.038 us |  -0.48% |  🔵 SAME  |
|   I8    |    no     |      2^20      |   7.758 us |       7.37% |   7.755 us |       8.32% | -0.002 us |  -0.03% |  🔵 SAME  |
|   I8    |    yes    |      2^24      |  12.204 us |       3.30% |  12.198 us |       3.21% | -0.006 us |  -0.05% |  🔵 SAME  |
|   I8    |    no     |      2^24      |  15.431 us |       4.79% |  15.228 us |       4.86% | -0.203 us |  -1.32% |  🔵 SAME  |
|   I8    |    yes    |      2^28      |  84.821 us |       1.14% |  84.567 us |       1.05% | -0.254 us |  -0.30% |  🔵 SAME  |
|   I8    |    no     |      2^28      | 122.864 us |       0.35% | 121.400 us |       0.74% | -1.464 us |  -1.19% |  🟢 FAST  |
|   I8    |    yes    |      2^32      |   1.234 ms |       0.14% |   1.234 ms |       0.14% | -0.073 us |  -0.01% |  🔵 SAME  |
|   I8    |    no     |      2^32      |   1.909 ms |       1.66% |   1.900 ms |       1.85% | -9.571 us |  -0.50% |  🔵 SAME  |
|   I16   |    yes    |      2^16      |   6.810 us |      10.92% |   6.763 us |      10.42% | -0.047 us |  -0.69% |  🔵 SAME  |
|   I16   |    no     |      2^16      |   6.323 us |       6.46% |   6.332 us |       6.96% |  0.010 us |   0.16% |  🔵 SAME  |
|   I16   |    yes    |      2^20      |   8.030 us |       5.59% |   8.070 us |       4.67% |  0.041 us |   0.51% |  🔵 SAME  |
|   I16   |    no     |      2^20      |   8.029 us |       5.51% |   8.108 us |       3.83% |  0.079 us |   0.98% |  🔵 SAME  |
|   I16   |    yes    |      2^24      |  17.691 us |       4.98% |  17.489 us |       5.51% | -0.202 us |  -1.14% |  🔵 SAME  |
|   I16   |    no     |      2^24      |  18.539 us |       2.13% |  18.514 us |       1.92% | -0.025 us |  -0.13% |  🔵 SAME  |
|   I16   |    yes    |      2^28      | 161.385 us |       0.62% | 161.515 us |       0.64% |  0.130 us |   0.08% |  🔵 SAME  |
|   I16   |    no     |      2^28      | 168.093 us |       0.27% | 167.609 us |       0.42% | -0.484 us |  -0.29% |  🟢 FAST  |
|   I16   |    yes    |      2^32      |   2.454 ms |       0.09% |   2.455 ms |       0.09% |  0.711 us |   0.03% |  🔵 SAME  |
|   I16   |    no     |      2^32      |   2.705 ms |       1.79% |   2.697 ms |       1.76% | -7.531 us |  -0.28% |  🔵 SAME  |
|   F32   |    yes    |      2^16      |   7.157 us |       0.92% |   6.600 us |       8.20% | -0.557 us |  -7.78% |  🟢 FAST  |
|   F32   |    no     |      2^16      |   6.746 us |       8.78% |   6.393 us |       7.52% | -0.353 us |  -5.23% |  🔵 SAME  |
|   F32   |    yes    |      2^20      |   8.392 us |       4.91% |   8.323 us |       4.36% | -0.069 us |  -0.82% |  🔵 SAME  |
|   F32   |    no     |      2^20      |   8.364 us |       4.60% |   8.294 us |       3.89% | -0.070 us |  -0.83% |  🔵 SAME  |
|   F32   |    yes    |      2^24      |  26.862 us |       2.02% |  26.796 us |       1.79% | -0.066 us |  -0.25% |  🔵 SAME  |
|   F32   |    no     |      2^24      |  27.136 us |       2.89% |  27.046 us |       2.74% | -0.090 us |  -0.33% |  🔵 SAME  |
|   F32   |    yes    |      2^28      | 314.433 us |       0.33% | 314.356 us |       0.34% | -0.077 us |  -0.02% |  🔵 SAME  |
|   F32   |    no     |      2^28      | 315.167 us |       0.38% | 315.156 us |       0.38% | -0.011 us |  -0.00% |  🔵 SAME  |
|   F32   |    yes    |      2^32      |   4.917 ms |       0.07% |   4.917 ms |       0.09% |  0.746 us |   0.02% |  🔵 SAME  |
|   F32   |    no     |      2^32      |   4.923 ms |       0.08% |   4.921 ms |       0.10% | -2.370 us |  -0.05% |  🔵 SAME  |
|   F64   |    yes    |      2^16      |   6.580 us |      10.86% |   6.438 us |       8.33% | -0.142 us |  -2.16% |  🔵 SAME  |
|   F64   |    no     |      2^16      |   6.524 us |      10.34% |   6.356 us |       8.07% | -0.168 us |  -2.57% |  🔵 SAME  |
|   F64   |    yes    |      2^20      |   9.968 us |       6.08% |   9.822 us |       7.73% | -0.147 us |  -1.47% |  🔵 SAME  |
|   F64   |    no     |      2^20      |  10.083 us |       3.94% |  10.082 us |       4.75% | -0.001 us |  -0.01% |  🔵 SAME  |
|   F64   |    yes    |      2^24      |  46.625 us |       1.92% |  46.479 us |       2.13% | -0.146 us |  -0.31% |  🔵 SAME  |
|   F64   |    no     |      2^24      |  46.359 us |       2.03% |  46.204 us |       2.04% | -0.155 us |  -0.33% |  🔵 SAME  |
|   F64   |    yes    |      2^28      | 621.240 us |       0.22% | 621.310 us |       0.20% |  0.070 us |   0.01% |  🔵 SAME  |
|   F64   |    no     |      2^28      | 624.037 us |       0.24% | 623.993 us |       0.24% | -0.044 us |  -0.01% |  🔵 SAME  |
|   F64   |    yes    |      2^32      |   9.825 ms |       0.05% |   9.826 ms |       0.05% |  0.800 us |   0.01% |  🔵 SAME  |
|   F64   |    no     |      2^32      |   9.860 ms |       0.09% |   9.862 ms |       0.09% |  2.385 us |   0.02% |  🔵 SAME  |
|  I128   |    yes    |      2^16      |   6.912 us |      12.65% |   6.850 us |      12.83% | -0.063 us |  -0.91% |  🔵 SAME  |
|  I128   |    no     |      2^16      |   6.986 us |      13.45% |   6.713 us |      12.90% | -0.273 us |  -3.91% |  🔵 SAME  |
|  I128   |    yes    |      2^20      |  12.190 us |       3.64% |  12.218 us |       2.69% |  0.027 us |   0.23% |  🔵 SAME  |
|  I128   |    no     |      2^20      |  12.420 us |       3.36% |  12.345 us |       2.74% | -0.076 us |  -0.61% |  🔵 SAME  |
|  I128   |    yes    |      2^24      |  84.726 us |       1.12% |  84.743 us |       1.14% |  0.017 us |   0.02% |  🔵 SAME  |
|  I128   |    no     |      2^24      |  85.099 us |       1.14% |  85.059 us |       1.19% | -0.040 us |  -0.05% |  🔵 SAME  |
|  I128   |    yes    |      2^28      |   1.235 ms |       0.14% |   1.235 ms |       0.14% |  0.083 us |   0.01% |  🔵 SAME  |
|  I128   |    no     |      2^28      |   1.240 ms |       0.16% |   1.240 ms |       0.16% |  0.090 us |   0.01% |  🔵 SAME  |
|  I128   |    yes    |      2^32      |  19.657 ms |       0.04% |  19.666 ms |       0.07% |  8.594 us |   0.04% |  🔴 SLOW  |
|  I128   |    no     |      2^32      |  19.713 ms |       0.09% |  19.715 ms |       0.04% |  1.930 us |   0.01% |  🔵 SAME  |

# add

## [0] NVIDIA B200

|  T{ct}  |  Aligned  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|-----------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    yes    |      2^16      |   6.823 us |      11.48% |   6.658 us |      10.29% |  -0.165 us |  -2.42% |  🔵 SAME  |
|   I8    |    no     |      2^16      |   7.678 us |      10.47% |   6.311 us |       6.29% |  -1.367 us | -17.80% |  🟢 FAST  |
|   I8    |    yes    |      2^20      |   8.011 us |       5.17% |   8.087 us |       4.07% |   0.076 us |   0.95% |  🔵 SAME  |
|   I8    |    no     |      2^20      |   8.273 us |       5.57% |   8.112 us |       3.65% |  -0.161 us |  -1.95% |  🔵 SAME  |
|   I8    |    yes    |      2^24      |  15.012 us |       5.84% |  14.872 us |       5.55% |  -0.140 us |  -0.93% |  🔵 SAME  |
|   I8    |    no     |      2^24      |  16.930 us |       5.02% |  16.558 us |       2.83% |  -0.372 us |  -2.20% |  🔵 SAME  |
|   I8    |    yes    |      2^28      | 122.906 us |       0.32% | 122.804 us |       0.32% |  -0.102 us |  -0.08% |  🔵 SAME  |
|   I8    |    no     |      2^28      | 149.590 us |       0.31% | 149.263 us |       0.44% |  -0.327 us |  -0.22% |  🔵 SAME  |
|   I8    |    yes    |      2^32      |   1.786 ms |       0.05% |   1.785 ms |       0.29% |  -1.039 us |  -0.06% |  🟢 FAST  |
|   I8    |    no     |      2^32      |   2.373 ms |       1.69% |   2.375 ms |       1.74% |   2.587 us |   0.11% |  🔵 SAME  |
|   I16   |    yes    |      2^16      |   7.169 us |       0.76% |   7.032 us |       8.50% |  -0.137 us |  -1.92% |  🟢 FAST  |
|   I16   |    no     |      2^16      |   7.704 us |       7.40% |   6.330 us |       7.62% |  -1.374 us | -17.84% |  🟢 FAST  |
|   I16   |    yes    |      2^20      |   8.316 us |       4.16% |   8.303 us |       4.07% |  -0.013 us |  -0.16% |  🔵 SAME  |
|   I16   |    no     |      2^20      |   8.318 us |       4.22% |   8.235 us |       4.36% |  -0.083 us |  -1.00% |  🔵 SAME  |
|   I16   |    yes    |      2^24      |  22.690 us |       1.65% |  22.593 us |       1.14% |  -0.097 us |  -0.43% |  🔵 SAME  |
|   I16   |    no     |      2^24      |  24.553 us |       1.37% |  24.428 us |       1.95% |  -0.126 us |  -0.51% |  🔵 SAME  |
|   I16   |    yes    |      2^28      | 235.281 us |       0.25% | 235.201 us |       0.29% |  -0.080 us |  -0.03% |  🔵 SAME  |
|   I16   |    no     |      2^28      | 248.625 us |       0.37% | 247.760 us |       0.21% |  -0.865 us |  -0.35% |  🟢 FAST  |
|   I16   |    yes    |      2^32      |   3.594 ms |       0.02% |   3.594 ms |       0.02% |   0.350 us |   0.01% |  🔵 SAME  |
|   I16   |    no     |      2^32      |   3.867 ms |       0.45% |   3.857 ms |       0.44% |  -9.243 us |  -0.24% |  🔵 SAME  |
|   F32   |    yes    |      2^16      |   6.771 us |      11.98% |   6.491 us |       9.33% |  -0.280 us |  -4.14% |  🔵 SAME  |
|   F32   |    no     |      2^16      |   7.650 us |      10.38% |   6.422 us |       8.07% |  -1.228 us | -16.06% |  🟢 FAST  |
|   F32   |    yes    |      2^20      |   9.418 us |       9.83% |   9.294 us |      10.50% |  -0.124 us |  -1.32% |  🔵 SAME  |
|   F32   |    no     |      2^20      |  10.058 us |       4.70% |   9.733 us |       8.10% |  -0.324 us |  -3.23% |  🔵 SAME  |
|   F32   |    yes    |      2^24      |  37.539 us |       2.42% |  37.440 us |       2.28% |  -0.099 us |  -0.26% |  🔵 SAME  |
|   F32   |    no     |      2^24      |  38.810 us |       1.01% |  38.777 us |       1.17% |  -0.033 us |  -0.08% |  🔵 SAME  |
|   F32   |    yes    |      2^28      | 455.305 us |       0.25% | 455.536 us |       0.26% |   0.231 us |   0.05% |  🔵 SAME  |
|   F32   |    no     |      2^28      | 459.032 us |       0.15% | 457.203 us |       0.18% |  -1.829 us |  -0.40% |  🟢 FAST  |
|   F32   |    yes    |      2^32      |   7.208 ms |       0.07% |   7.209 ms |       0.07% |   1.133 us |   0.02% |  🔵 SAME  |
|   F32   |    no     |      2^32      |   7.160 ms |       0.01% |   7.146 ms |       0.01% | -14.304 us |  -0.20% |  🟢 FAST  |
|   F64   |    yes    |      2^16      |   7.078 us |      12.99% |   6.700 us |      11.92% |  -0.378 us |  -5.34% |  🔵 SAME  |
|   F64   |    no     |      2^16      |   8.026 us |       5.02% |   6.700 us |      12.63% |  -1.327 us | -16.53% |  🟢 FAST  |
|   F64   |    yes    |      2^20      |  11.373 us |       8.30% |  11.194 us |       8.85% |  -0.179 us |  -1.58% |  🔵 SAME  |
|   F64   |    no     |      2^20      |  12.169 us |       3.32% |  11.846 us |       6.61% |  -0.323 us |  -2.65% |  🔵 SAME  |
|   F64   |    yes    |      2^24      |  65.584 us |       0.52% |  65.589 us |       0.55% |   0.005 us |   0.01% |  🔵 SAME  |
|   F64   |    no     |      2^24      |  65.598 us |       0.53% |  65.562 us |       0.51% |  -0.036 us |  -0.06% |  🔵 SAME  |
|   F64   |    yes    |      2^28      | 910.677 us |       0.22% | 910.865 us |       0.23% |   0.189 us |   0.02% |  🔵 SAME  |
|   F64   |    no     |      2^28      | 911.688 us |       0.18% | 912.058 us |       0.19% |   0.370 us |   0.04% |  🔵 SAME  |
|   F64   |    yes    |      2^32      |  14.412 ms |       0.13% |  14.409 ms |       0.14% |  -2.284 us |  -0.02% |  🔵 SAME  |
|   F64   |    no     |      2^32      |  14.454 ms |       0.03% |  14.470 ms |       0.04% |  16.597 us |   0.11% |  🔴 SLOW  |
|  I128   |    yes    |      2^16      |   8.179 us |       5.77% |   8.079 us |       6.44% |  -0.100 us |  -1.22% |  🔵 SAME  |
|  I128   |    no     |      2^16      |   7.582 us |      11.29% |   7.342 us |      12.85% |  -0.240 us |  -3.17% |  🔵 SAME  |
|  I128   |    yes    |      2^20      |  14.701 us |       4.61% |  14.738 us |       4.84% |   0.036 us |   0.25% |  🔵 SAME  |
|  I128   |    no     |      2^20      |  14.914 us |       5.67% |  14.689 us |       4.99% |  -0.225 us |  -1.51% |  🔵 SAME  |
|  I128   |    yes    |      2^24      | 121.352 us |       0.69% | 120.917 us |       0.30% |  -0.435 us |  -0.36% |  🟢 FAST  |
|  I128   |    no     |      2^24      | 122.869 us |       0.24% | 122.717 us |       0.39% |  -0.152 us |  -0.12% |  🔵 SAME  |
|  I128   |    yes    |      2^28      |   1.806 ms |       0.11% |   1.807 ms |       0.11% |   1.208 us |   0.07% |  🔵 SAME  |
|  I128   |    no     |      2^28      |   1.801 ms |       0.30% |   1.807 ms |       0.14% |   5.811 us |   0.32% |  🔴 SLOW  |

# triad

## [0] NVIDIA B200

|  T{ct}  |  Aligned  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|-----------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    yes    |      2^16      |   6.671 us |      11.08% |   6.615 us |      10.76% |  -0.056 us |  -0.84% |  🔵 SAME  |
|   I8    |    no     |      2^16      |   7.051 us |      13.51% |   6.319 us |       6.32% |  -0.733 us | -10.39% |  🟢 FAST  |
|   I8    |    yes    |      2^20      |   8.037 us |       4.82% |   8.094 us |       4.11% |   0.056 us |   0.70% |  🔵 SAME  |
|   I8    |    no     |      2^20      |   8.238 us |       5.42% |   8.119 us |       4.16% |  -0.119 us |  -1.44% |  🔵 SAME  |
|   I8    |    yes    |      2^24      |  15.342 us |       6.16% |  15.029 us |       6.09% |  -0.313 us |  -2.04% |  🔵 SAME  |
|   I8    |    no     |      2^24      |  18.294 us |       2.32% |  18.287 us |       2.44% |  -0.007 us |  -0.04% |  🔵 SAME  |
|   I8    |    yes    |      2^28      | 122.866 us |       0.34% | 122.789 us |       0.31% |  -0.077 us |  -0.06% |  🔵 SAME  |
|   I8    |    no     |      2^28      | 161.770 us |       0.28% | 159.822 us |       0.27% |  -1.948 us |  -1.20% |  🟢 FAST  |
|   I8    |    yes    |      2^32      |   1.785 ms |       0.18% |   1.792 ms |       0.40% |   7.312 us |   0.41% |  🔴 SLOW  |
|   I8    |    no     |      2^32      |   2.487 ms |       0.86% |   2.480 ms |       1.06% |  -6.831 us |  -0.27% |  🔵 SAME  |
|   I16   |    yes    |      2^16      |   6.703 us |      11.58% |   6.351 us |       7.33% |  -0.352 us |  -5.26% |  🔵 SAME  |
|   I16   |    no     |      2^16      |   7.629 us |      10.82% |   6.275 us |       6.11% |  -1.354 us | -17.75% |  🟢 FAST  |
|   I16   |    yes    |      2^20      |   8.343 us |       4.87% |   8.252 us |       3.84% |  -0.091 us |  -1.09% |  🔵 SAME  |
|   I16   |    no     |      2^20      |   8.360 us |       4.88% |   8.298 us |       3.67% |  -0.061 us |  -0.73% |  🔵 SAME  |
|   I16   |    yes    |      2^24      |  22.700 us |       1.91% |  22.611 us |       1.41% |  -0.089 us |  -0.39% |  🔵 SAME  |
|   I16   |    no     |      2^24      |  24.676 us |       1.41% |  24.584 us |       1.12% |  -0.092 us |  -0.37% |  🔵 SAME  |
|   I16   |    yes    |      2^28      | 239.445 us |       0.18% | 237.790 us |       0.24% |  -1.654 us |  -0.69% |  🟢 FAST  |
|   I16   |    no     |      2^28      | 249.365 us |       0.32% | 245.825 us |       0.12% |  -3.540 us |  -1.42% |  🟢 FAST  |
|   I16   |    yes    |      2^32      |   3.676 ms |       0.03% |   3.662 ms |       0.02% | -14.012 us |  -0.38% |  🟢 FAST  |
|   I16   |    no     |      2^32      |   3.865 ms |       0.40% |   3.820 ms |       0.44% | -44.475 us |  -1.15% |  🟢 FAST  |
|   F32   |    yes    |      2^16      |   6.842 us |      11.41% |   6.453 us |       9.45% |  -0.389 us |  -5.69% |  🔵 SAME  |
|   F32   |    no     |      2^16      |   8.014 us |       5.15% |   6.438 us |       9.00% |  -1.576 us | -19.67% |  🟢 FAST  |
|   F32   |    yes    |      2^20      |   9.449 us |       9.70% |   9.236 us |      10.54% |  -0.213 us |  -2.26% |  🔵 SAME  |
|   F32   |    no     |      2^20      |  10.081 us |       4.21% |  10.035 us |       5.10% |  -0.046 us |  -0.46% |  🔵 SAME  |
|   F32   |    yes    |      2^24      |  37.056 us |       1.16% |  36.966 us |       0.88% |  -0.089 us |  -0.24% |  🔵 SAME  |
|   F32   |    no     |      2^24      |  38.749 us |       1.18% |  38.621 us |       1.60% |  -0.129 us |  -0.33% |  🔵 SAME  |
|   F32   |    yes    |      2^28      | 454.427 us |       0.30% | 454.694 us |       0.32% |   0.268 us |   0.06% |  🔵 SAME  |
|   F32   |    no     |      2^28      | 460.054 us |       0.20% | 458.652 us |       0.09% |  -1.403 us |  -0.30% |  🟢 FAST  |
|   F32   |    yes    |      2^32      |   7.210 ms |       0.06% |   7.210 ms |       0.05% |   0.845 us |   0.01% |  🔵 SAME  |
|   F32   |    no     |      2^32      |   7.174 ms |       0.02% |   7.154 ms |       0.01% | -19.727 us |  -0.27% |  🟢 FAST  |
|   F64   |    yes    |      2^16      |   7.136 us |      13.41% |   6.858 us |      12.86% |  -0.278 us |  -3.90% |  🔵 SAME  |
|   F64   |    no     |      2^16      |   7.971 us |       5.95% |   6.793 us |      13.20% |  -1.179 us | -14.78% |  🟢 FAST  |
|   F64   |    yes    |      2^20      |  10.779 us |       7.74% |  10.593 us |       6.50% |  -0.186 us |  -1.72% |  🔵 SAME  |
|   F64   |    no     |      2^20      |  11.609 us |       7.53% |  10.504 us |       5.82% |  -1.104 us |  -9.51% |  🟢 FAST  |
|   F64   |    yes    |      2^24      |  65.752 us |       0.96% |  65.809 us |       1.20% |   0.057 us |   0.09% |  🔵 SAME  |
|   F64   |    no     |      2^24      |  65.547 us |       0.57% |  65.518 us |       0.72% |  -0.030 us |  -0.05% |  🔵 SAME  |
|   F64   |    yes    |      2^28      | 908.911 us |       0.23% | 909.480 us |       0.22% |   0.569 us |   0.06% |  🔵 SAME  |
|   F64   |    no     |      2^28      | 912.155 us |       0.18% | 912.545 us |       0.18% |   0.391 us |   0.04% |  🔵 SAME  |
|   F64   |    yes    |      2^32      |  14.423 ms |       0.03% |  14.419 ms |       0.08% |  -4.293 us |  -0.03% |  🔵 SAME  |
|   F64   |    no     |      2^32      |  14.457 ms |       0.06% |  14.466 ms |       0.06% |   8.848 us |   0.06% |  🔴 SLOW  |
|  I128   |    yes    |      2^16      |   8.125 us |       6.07% |   8.082 us |       6.19% |  -0.043 us |  -0.53% |  🔵 SAME  |
|  I128   |    no     |      2^16      |   7.736 us |      10.04% |   7.578 us |      11.56% |  -0.157 us |  -2.03% |  🔵 SAME  |
|  I128   |    yes    |      2^20      |  14.872 us |       5.41% |  14.789 us |       5.18% |  -0.083 us |  -0.56% |  🔵 SAME  |
|  I128   |    no     |      2^20      |  15.319 us |       6.25% |  15.109 us |       6.16% |  -0.211 us |  -1.37% |  🔵 SAME  |
|  I128   |    yes    |      2^24      | 121.905 us |       0.79% | 121.243 us |       0.63% |  -0.662 us |  -0.54% |  🔵 SAME  |
|  I128   |    no     |      2^24      | 122.910 us |       0.28% | 122.821 us |       0.30% |  -0.089 us |  -0.07% |  🔵 SAME  |
|  I128   |    yes    |      2^28      |   1.807 ms |       0.15% |   1.809 ms |       0.15% |   2.184 us |   0.12% |  🔵 SAME  |
|  I128   |    no     |      2^28      |   1.806 ms |       0.14% |   1.809 ms |       0.12% |   2.910 us |   0.16% |  🔴 SLOW  |

# nstream

## [0] NVIDIA B200

|  T{ct}  |  Aligned  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|-----------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |    yes    |      2^16      |   6.861 us |      12.73% |   6.640 us |      11.90% |   -0.220 us |  -3.21% |  🔵 SAME  |
|   I8    |    no     |      2^16      |   8.101 us |       4.59% |   6.309 us |       6.76% |   -1.792 us | -22.12% |  🟢 FAST  |
|   I8    |    yes    |      2^20      |   8.082 us |       5.25% |   8.070 us |       4.93% |   -0.012 us |  -0.15% |  🔵 SAME  |
|   I8    |    no     |      2^20      |   8.424 us |       5.87% |   8.211 us |       4.04% |   -0.213 us |  -2.53% |  🔵 SAME  |
|   I8    |    yes    |      2^24      |  18.457 us |       2.02% |  18.382 us |       2.06% |   -0.074 us |  -0.40% |  🔵 SAME  |
|   I8    |    no     |      2^24      |  22.364 us |       2.36% |  20.641 us |       2.06% |   -1.723 us |  -7.70% |  🟢 FAST  |
|   I8    |    yes    |      2^28      | 164.534 us |       0.55% | 163.881 us |       0.20% |   -0.653 us |  -0.40% |  🟢 FAST  |
|   I8    |    no     |      2^28      | 222.712 us |       0.41% | 213.015 us |       0.22% |   -9.697 us |  -4.35% |  🟢 FAST  |
|   I8    |    yes    |      2^32      |   2.467 ms |       0.02% |   2.450 ms |       0.03% |  -16.633 us |  -0.67% |  🟢 FAST  |
|   I8    |    no     |      2^32      |   3.480 ms |       0.47% |   3.372 ms |       0.57% | -107.986 us |  -3.10% |  🟢 FAST  |
|   I16   |    yes    |      2^16      |   6.736 us |      12.11% |   6.441 us |       9.44% |   -0.295 us |  -4.38% |  🔵 SAME  |
|   I16   |    no     |      2^16      |   8.146 us |       5.46% |   6.327 us |       7.95% |   -1.820 us | -22.34% |  🟢 FAST  |
|   I16   |    yes    |      2^20      |   8.376 us |       4.92% |   8.297 us |       3.98% |   -0.078 us |  -0.93% |  🔵 SAME  |
|   I16   |    no     |      2^20      |  10.041 us |       5.57% |   8.287 us |       3.91% |   -1.754 us | -17.47% |  🟢 FAST  |
|   I16   |    yes    |      2^24      |  28.687 us |       1.37% |  28.617 us |       1.11% |   -0.070 us |  -0.24% |  🔵 SAME  |
|   I16   |    no     |      2^24      |  30.381 us |       2.36% |  28.772 us |       1.19% |   -1.609 us |  -5.30% |  🟢 FAST  |
|   I16   |    yes    |      2^28      | 313.131 us |       0.16% | 313.062 us |       0.21% |   -0.070 us |  -0.02% |  🔵 SAME  |
|   I16   |    no     |      2^28      | 329.011 us |       0.29% | 325.658 us |       0.18% |   -3.353 us |  -1.02% |  🟢 FAST  |
|   I16   |    yes    |      2^32      |   4.826 ms |       0.02% |   4.830 ms |       0.01% |    3.700 us |   0.08% |  🔴 SLOW  |
|   I16   |    no     |      2^32      |   5.162 ms |       0.40% |   5.144 ms |       0.44% |  -18.613 us |  -0.36% |  🔵 SAME  |
|   F32   |    yes    |      2^16      |   7.350 us |      11.44% |   6.955 us |      13.25% |   -0.394 us |  -5.36% |  🔵 SAME  |
|   F32   |    no     |      2^16      |   8.080 us |       6.01% |   6.527 us |      10.49% |   -1.553 us | -19.22% |  🟢 FAST  |
|   F32   |    yes    |      2^20      |  10.247 us |       3.65% |  10.247 us |       2.95% |    0.001 us |   0.01% |  🔵 SAME  |
|   F32   |    no     |      2^20      |  10.806 us |       7.63% |  10.334 us |       3.14% |   -0.472 us |  -4.37% |  🟢 FAST  |
|   F32   |    yes    |      2^24      |  47.443 us |       1.37% |  47.480 us |       1.50% |    0.037 us |   0.08% |  🔵 SAME  |
|   F32   |    no     |      2^24      |  49.048 us |       1.05% |  47.653 us |       1.76% |   -1.395 us |  -2.84% |  🟢 FAST  |
|   F32   |    yes    |      2^28      | 600.649 us |       0.14% | 600.570 us |       0.14% |   -0.080 us |  -0.01% |  🔵 SAME  |
|   F32   |    no     |      2^28      | 608.855 us |       0.14% | 605.581 us |       0.15% |   -3.274 us |  -0.54% |  🟢 FAST  |
|   F32   |    yes    |      2^32      |   9.428 ms |       0.01% |   9.444 ms |       0.01% |   15.466 us |   0.16% |  🔴 SLOW  |
|   F32   |    no     |      2^32      |   9.572 ms |       0.01% |   9.527 ms |       0.01% |  -45.452 us |  -0.47% |  🟢 FAST  |
|   F64   |    yes    |      2^16      |   8.011 us |       6.21% |   7.872 us |       9.05% |   -0.139 us |  -1.74% |  🔵 SAME  |
|   F64   |    no     |      2^16      |   8.264 us |       5.01% |   7.262 us |      13.32% |   -1.002 us | -12.12% |  🟢 FAST  |
|   F64   |    yes    |      2^20      |  12.419 us |       2.89% |  12.421 us |       2.92% |    0.003 us |   0.02% |  🔵 SAME  |
|   F64   |    no     |      2^20      |  13.835 us |       5.81% |  12.420 us |       2.99% |   -1.415 us | -10.23% |  🟢 FAST  |
|   F64   |    yes    |      2^24      |  85.667 us |       0.91% |  85.209 us |       1.12% |   -0.458 us |  -0.53% |  🔵 SAME  |
|   F64   |    no     |      2^24      |  86.107 us |       0.45% |  85.478 us |       0.99% |   -0.629 us |  -0.73% |  🟢 FAST  |
|   F64   |    yes    |      2^28      |   1.192 ms |       0.03% |   1.190 ms |       0.04% |   -2.246 us |  -0.19% |  🟢 FAST  |
|   F64   |    no     |      2^28      |   1.196 ms |       0.06% |   1.192 ms |       0.03% |   -4.395 us |  -0.37% |  🟢 FAST  |
|   F64   |    yes    |      2^32      |  18.822 ms |       0.00% |  18.798 ms |       0.00% |  -23.450 us |  -0.12% |  🟢 FAST  |
|   F64   |    no     |      2^32      |  19.011 ms |       0.01% |  18.961 ms |       0.01% |  -49.897 us |  -0.26% |  🟢 FAST  |
|  I128   |    yes    |      2^16      |   8.178 us |       6.81% |   8.236 us |       5.64% |    0.059 us |   0.72% |  🔵 SAME  |
|  I128   |    no     |      2^16      |   8.017 us |       5.23% |   8.101 us |       3.88% |    0.084 us |   1.05% |  🔵 SAME  |
|  I128   |    yes    |      2^20      |  18.340 us |       2.01% |  18.331 us |       2.06% |   -0.009 us |  -0.05% |  🔵 SAME  |
|  I128   |    no     |      2^20      |  18.316 us |       2.22% |  18.369 us |       1.78% |    0.053 us |   0.29% |  🔵 SAME  |
|  I128   |    yes    |      2^24      | 157.752 us |       0.23% | 157.715 us |       0.20% |   -0.037 us |  -0.02% |  🔵 SAME  |
|  I128   |    no     |      2^24      | 157.785 us |       0.25% | 157.733 us |       0.24% |   -0.052 us |  -0.03% |  🔵 SAME  |
|  I128   |    yes    |      2^28      |   2.357 ms |       0.04% |   2.357 ms |       0.04% |    0.011 us |   0.00% |  🔵 SAME  |
|  I128   |    no     |      2^28      |   2.362 ms |       0.06% |   2.362 ms |       0.06% |    0.071 us |   0.00% |  🔵 SAME  |
```