### PR TITLE
cuda.compute: Fix struct comparison (ordering matters)

### DIFF
--- a/python/cuda_cccl/cuda/compute/types.py
+++ b/python/cuda_cccl/cuda/compute/types.py
@@ -89,11 +89,11 @@ class StructTypeDescriptor(TypeDescriptor):
         # Compare by fields (TypeDescriptors) to correctly distinguish structs
         # with different pointer pointee types, which have identical numpy dtypes
         # (both uint64) but different semantics.
-        return self._fields == other._fields
+        # Must compare as ordered items because field order matters for struct layout.
+        return list(self._fields.items()) == list(other._fields.items())
 
     def __hash__(self):
-        # Convert to a hashable tuple of (name, type_descriptor) pairs
-        return hash(tuple(sorted((k, v) for k, v in self._fields.items())))
+        return hash(tuple(self._fields.items()))
 
 
 class PointerTypeDescriptor(TypeDescriptor):


### PR DESCRIPTION
## Description

Fixes a bug that leads to examples failing in CI (depending on whether two particular tests are run on the same worker).

For posterity, a reliable reproducer of the issue was:

```python
pytest tests/test_examples.py -v -k "nested_struct_tuple_construction or running_average"
```

Since these two tests create structs with the same members (but different order), and the first struct would be incorrectly retrieved from a cache during the execution of the second test.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
