### PR TITLE
Fix DeviceReduce env test for rfa

### DIFF
--- a/cub/cub/detail/rfa.cuh
+++ b/cub/cub/detail/rfa.cuh
@@ -686,21 +686,6 @@ public:
     binned_renorm();
   }
 };
-
-_CCCL_TEMPLATE(typename FType = float)
-_CCCL_REQUIRES(::cuda::std::is_floating_point_v<FType>)
-struct rfa_float_transform_t
-{
-  _CCCL_DEVICE FType operator()(FType accum) const
-  {
-    return accum;
-  }
-
-  _CCCL_DEVICE FType operator()(ReproducibleFloatingAccumulator<FType> accum) const
-  {
-    return accum.conv_to_fp();
-  }
-};
 } // namespace detail::rfa
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_deterministic.cuh
@@ -108,9 +108,10 @@ template <typename InputIteratorT,
           typename OutputIteratorT,
           typename OffsetT,
           typename InitT,
-          typename TransformOpT = ::cuda::std::identity,
-          typename AccumT       = accum_t<InitT, InputIteratorT, TransformOpT>,
-          typename PolicyHub    = policy_hub<AccumT, OffsetT, ::cuda::std::plus<>>>
+          typename TransformOpT          = ::cuda::std::identity,
+          typename AccumT                = accum_t<InitT, InputIteratorT, TransformOpT>,
+          typename PolicyHub             = policy_hub<AccumT, OffsetT, ::cuda::std::plus<>>,
+          typename KernelLauncherFactory = CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY>
 struct dispatch_t
 {
   using deterministic_add_t = deterministic_sum_t<AccumT>;
@@ -153,6 +154,8 @@ struct dispatch_t
 
   TransformOpT transform_op = {};
 
+  KernelLauncherFactory launcher_factory;
+
   //---------------------------------------------------------------------------
   // Small-problem (single tile) invocation
   //---------------------------------------------------------------------------
@@ -191,8 +194,7 @@ struct dispatch_t
 #endif
     // Invoke single_reduce_sweep_kernel
     if (const auto error = CubDebug(
-          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
-            1, ActivePolicyT::SingleTilePolicy::BLOCK_THREADS, 0, stream)
+          launcher_factory(1, ActivePolicyT::SingleTilePolicy::BLOCK_THREADS, 0, stream)
             .doit(single_tile_kernel, d_in, d_out, static_cast<int>(num_items), reduction_op, init, transform_op)))
     {
       return error;
@@ -310,8 +312,7 @@ struct dispatch_t
 #endif // CUB_DETAIL_DEBUG_ENABLE_LOG
 
       if (const auto error = CubDebug(
-            THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
-              current_grid_size, ActivePolicyT::ReducePolicy::BLOCK_THREADS, 0, stream)
+            launcher_factory(current_grid_size, ActivePolicyT::ReducePolicy::BLOCK_THREADS, 0, stream)
               .doit(reduce_kernel,
                     d_in,
                     d_chunk_block_reductions,
@@ -346,8 +347,7 @@ struct dispatch_t
 
     // Invoke DeterministicDeviceReduceSingleTileKernel
     if (const auto error = CubDebug(
-          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
-            1, ActivePolicyT::SingleTilePolicy::BLOCK_THREADS, 0, stream)
+          launcher_factory(1, ActivePolicyT::SingleTilePolicy::BLOCK_THREADS, 0, stream)
             .doit(single_tile_kernel,
                   d_block_reductions,
                   d_out,
@@ -442,9 +442,10 @@ struct dispatch_t
     InputIteratorT d_in,
     OutputIteratorT d_out,
     OffsetT num_items,
-    InitT init                = {},
-    cudaStream_t stream       = {},
-    TransformOpT transform_op = {})
+    InitT init                             = {},
+    cudaStream_t stream                    = {},
+    TransformOpT transform_op              = {},
+    KernelLauncherFactory launcher_factory = {})
   {
     // Get PTX version
     int ptx_version = 0;
@@ -466,7 +467,8 @@ struct dispatch_t
       init,
       stream,
       ptx_version,
-      transform_op};
+      transform_op,
+      launcher_factory};
 
     // Dispatch to chained policy
     return CubDebug(PolicyHub::MaxPolicy::Invoke(ptx_version, dispatch));

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -248,8 +248,7 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
       using deterministic_add_t   = cub::detail::rfa::deterministic_sum_t<accumulator_t>;
       using reduction_op_t        = deterministic_add_t;
       using deterministic_accum_t = deterministic_add_t::DeterministicAcc;
-      using output_it_t =
-        cuda::transform_output_iterator<cub::detail::rfa::rfa_float_transform_t<accumulator_t>, decltype(d_out.begin())>;
+      using output_it_t           = decltype(d_out.begin());
 
       using dispatch_t = cub::detail::rfa::
         dispatch_t<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, transform_t, accumulator_t>;
@@ -257,28 +256,29 @@ C2H_TEST("Device reduce uses environment", "[reduce][device]", requirements)
       REQUIRE(
         cudaSuccess == dispatch_t::Dispatch(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, init));
 
+      auto k1 = cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
+        policy_t,
+        decltype(d_in),
+        output_it_t,
+        reduction_op_t,
+        init_t,
+        deterministic_accum_t,
+        transform_t>;
+      auto k2 = cub::detail::reduce::
+        DeterministicDeviceReduceKernel<policy_t, decltype(d_in), reduction_op_t, deterministic_accum_t, transform_t>;
+      auto k3 = cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
+        policy_t,
+        deterministic_accum_t*,
+        output_it_t,
+        reduction_op_t,
+        init_t,
+        deterministic_accum_t,
+        transform_t>;
+      // TODO(bgruber): enable this when we have Catch2 3.13+
+      // UNSCOPED_CAPTURE(c2h::type_name<decltype(k1)>(), c2h::type_name<decltype(k2)>(),
+      // c2h::type_name<decltype(k3)>());
       return cuda::std::array<void*, 3>{
-        reinterpret_cast<void*>(
-          cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
-            policy_t,
-            decltype(d_in),
-            output_it_t,
-            reduction_op_t,
-            init_t,
-            deterministic_accum_t,
-            transform_t>),
-        reinterpret_cast<void*>(
-          cub::detail::reduce::
-            DeterministicDeviceReduceKernel<policy_t, decltype(d_in), reduction_op_t, deterministic_accum_t, transform_t>),
-        reinterpret_cast<void*>(
-          cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
-            policy_t,
-            accumulator_t*,
-            output_it_t,
-            reduction_op_t,
-            init_t,
-            deterministic_accum_t,
-            transform_t>)};
+        reinterpret_cast<void*>(k1), reinterpret_cast<void*>(k2), reinterpret_cast<void*>(k3)};
     }
   }();
 
@@ -367,8 +367,7 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
       using deterministic_add_t   = cub::detail::rfa::deterministic_sum_t<accumulator_t>;
       using reduction_op_t        = deterministic_add_t;
       using deterministic_accum_t = deterministic_add_t::DeterministicAcc;
-      using output_it_t =
-        cuda::transform_output_iterator<cub::detail::rfa::rfa_float_transform_t<accumulator_t>, decltype(d_out.begin())>;
+      using output_it_t           = decltype(d_out.begin());
 
       using dispatch_t = cub::detail::rfa::
         dispatch_t<decltype(d_in), decltype(d_out.begin()), offset_t, init_t, transform_t, accumulator_t>;
@@ -376,28 +375,29 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
       REQUIRE(
         cudaSuccess == dispatch_t::Dispatch(nullptr, expected_bytes_allocated, d_in, d_out.begin(), num_items, init));
 
+      auto k1 = cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
+        policy_t,
+        decltype(d_in),
+        output_it_t,
+        reduction_op_t,
+        init_t,
+        deterministic_accum_t,
+        transform_t>;
+      auto k2 = cub::detail::reduce::
+        DeterministicDeviceReduceKernel<policy_t, decltype(d_in), reduction_op_t, deterministic_accum_t, transform_t>;
+      auto k3 = cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
+        policy_t,
+        deterministic_accum_t*,
+        output_it_t,
+        reduction_op_t,
+        init_t,
+        deterministic_accum_t,
+        transform_t>;
+      // TODO(bgruber): enable this when we have Catch2 3.13+
+      // UNSCOPED_CAPTURE(c2h::type_name<decltype(k1)>(), c2h::type_name<decltype(k2)>(),
+      // c2h::type_name<decltype(k3)>());
       return cuda::std::array<void*, 3>{
-        reinterpret_cast<void*>(
-          cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
-            policy_t,
-            decltype(d_in),
-            output_it_t,
-            reduction_op_t,
-            init_t,
-            deterministic_accum_t,
-            transform_t>),
-        reinterpret_cast<void*>(
-          cub::detail::reduce::
-            DeterministicDeviceReduceKernel<policy_t, decltype(d_in), reduction_op_t, deterministic_accum_t, transform_t>),
-        reinterpret_cast<void*>(
-          cub::detail::reduce::DeterministicDeviceReduceSingleTileKernel<
-            policy_t,
-            accumulator_t*,
-            output_it_t,
-            reduction_op_t,
-            init_t,
-            deterministic_accum_t,
-            transform_t>)};
+        reinterpret_cast<void*>(k1), reinterpret_cast<void*>(k2), reinterpret_cast<void*>(k3)};
     }
   }();
 

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -81,11 +81,15 @@ struct kernel_launcher_t : thrust::cuda_cub::detail::triple_chevron
   template <class K, class... Args>
   CUB_RUNTIME_FUNCTION cudaError_t doit(K kernel, Args const&... args) const
   {
-    NV_IF_TARGET(NV_IS_HOST, (auto& kernels = get_stream_registry_factory_state()->m_kernels; if (!kernels.empty()) {
-                   if (cuda::std::find(kernels.begin(), kernels.end(), reinterpret_cast<void*>(kernel))
-                       == kernels.end())
+    NV_IF_TARGET(NV_IS_HOST, ({
+                   auto& kernels = get_stream_registry_factory_state()->m_kernels;
+                   if (!kernels.empty())
                    {
-                     FAIL("Kernel is not allowed");
+                     if (cuda::std::find(kernels.begin(), kernels.end(), reinterpret_cast<void*>(kernel))
+                         == kernels.end())
+                     {
+                       FAIL("Kernel is not allowed: " << c2h::type_name<K>());
+                     }
                    }
                  }));
     return thrust::cuda_cub::detail::triple_chevron::doit(kernel, args...);


### PR DESCRIPTION
The test was wrong but always passed because the rfa dispatcher ignored `CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY` since it was hardcoded to `triple_chevron`.