### PR TITLE
Pass `PARALLEL_LEVEL` to cmake --build in `ci/build_stdpar.sh`

### DIFF
--- a/ci/build_stdpar.sh
+++ b/ci/build_stdpar.sh
@@ -24,8 +24,10 @@ cd "${workdir}"
 
 # Configure and build
 rm -rf build
-mkdir build
-cd build
-# Explicitly compile for hopper since the CI machine does not have a gpu:
-cmake -G Ninja .. -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" -DCMAKE_CXX_FLAGS="-gpu=cc90"
-cmake --build .
+
+cmake -B build -S . -G Ninja \
+  -DCMAKE_CXX_STANDARD="${CXX_STANDARD}" \
+  `# Explicitly compile for hopper since the CI machine does not have a gpu:` \
+  -DCMAKE_CXX_FLAGS="-gpu=cc90"
+
+cmake --build build -j ${PARALLEL_LEVEL:-}


### PR DESCRIPTION
Do `cmake --build build -j ${PARALLEL_LEVEL:-}` in `ci/build_stdpar.sh`.

Extracted from https://github.com/NVIDIA/cccl/pull/2672