### PR TITLE
Pass `PARALLEL_LEVEL` to cmake --build in `ci/build_matx.sh`

### DIFF
--- a/ci/matx/build_matx.sh
+++ b/ci/matx/build_matx.sh
@@ -92,9 +92,9 @@ cat $version_override_file
 
 # Configure and build
 rm -rf build
-mkdir build
-cd build
-cmake -G Ninja ../MatX \
+
+cmake \
+  -B build -S MatX -G Ninja \
   "-DCMAKE_CUDA_ARCHITECTURES=75;120" \
   "-DRAPIDS_CMAKE_CPM_OVERRIDE_VERSION_FILE=${version_override_file}" \
   -DMATX_BUILD_TESTS=ON \
@@ -102,4 +102,4 @@ cmake -G Ninja ../MatX \
   -DMATX_BUILD_BENCHMARKS=ON \
   -DMATX_EN_CUTENSOR=ON
 
-cmake --build .
+cmake --build build -j ${PARALLEL_LEVEL:-}


### PR DESCRIPTION
Do `cmake --build build -j ${PARALLEL_LEVEL:-}` in `ci/build_matx.sh`.

Extracted from https://github.com/NVIDIA/cccl/pull/2672