### PR TITLE
Disable build caching for CUB compile tests

### DIFF
--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -249,6 +249,9 @@ function(
     endif()
   endif() # Not catch2 test
 
+  # Disable build caching for compile tests
+  set_tests_properties(${test_target} PROPERTIES ENVIRONMENT SCCACHE_NO_CACHE=1)
+
   # Ensure that we test with assertions enabled
   target_compile_definitions(${test_target} PRIVATE CCCL_ENABLE_ASSERTIONS)
 endfunction()


### PR DESCRIPTION
Disable build caching for the CUB tests that invoke the compiler.

Extracted from https://github.com/NVIDIA/cccl/pull/2672