### PR TITLE
Improve reduce implementation

### DIFF
--- a/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
@@ -41,14 +41,18 @@ _CCCL_DIAG_POP
 #  include <cuda/std/__exception/cuda_error.h>
 #  include <cuda/std/__execution/env.h>
 #  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/invoke.h>
 #  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__iterator/next.h>
 #  include <cuda/std/__memory/addressof.h>
 #  include <cuda/std/__memory/construct_at.h>
 #  include <cuda/std/__new/bad_alloc.h>
 #  include <cuda/std/__numeric/reduce.h>
 #  include <cuda/std/__pstl/dispatch.h>
 #  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_nothrow_constructible.h>
+#  include <cuda/std/__utility/forward.h>
 #  include <cuda/std/__utility/move.h>
 
 #  include <cuda_runtime.h>
@@ -76,7 +80,8 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
       {}
 
       template <class _Index, class _Up>
-      _CCCL_DEVICE_API void operator()(_Index, _Up&& __value)
+      _CCCL_DEVICE_API _CCCL_FORCEINLINE void
+      operator()(_Index, _Up&& __value) noexcept(is_nothrow_constructible_v<_Tp, _Up>)
       {
         ::cuda::std::__construct_at(__ptr_, ::cuda::std::forward<_Up>(__value));
       }
@@ -97,57 +102,66 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
     _CCCL_HOST_API ~__allocation_guard()
     {
       __resource_.deallocate(__stream_, __ptr_, __num_bytes_, alignof(_Tp));
-      __stream_.sync();
     }
 
-    [[nodiscard]] _CCCL_HOST_API auto __get_result_iter()
+    [[nodiscard]] _CCCL_HOST_API auto __get_result_iter() noexcept
     {
       if constexpr (::cuda::std::__detail::__can_optimize_construct_at<_Tp, _AccumT>)
       {
-        return reinterpret_cast<_Tp*>(__ptr_);
+        return __ptr_;
       }
       else
       {
-        return ::cuda::tabulate_output_iterator{__construct_result{reinterpret_cast<_Tp*>(__ptr_)}};
+        return ::cuda::tabulate_output_iterator{__construct_result{__ptr_}};
       }
     }
 
-    [[nodiscard]] _CCCL_HOST_API void* __get_temp_storage()
+    [[nodiscard]] _CCCL_HOST_API void* __get_temp_storage() noexcept
     {
-      return static_cast<void*>(reinterpret_cast<unsigned char*>(__ptr_) + sizeof(_Tp));
+      return static_cast<void*>(__ptr_ + 1);
     }
   };
 
-  template <class _Policy, class _Iter, class _Tp, class _BinaryOp>
+  template <class _Policy, class _Iter, class _Size, class _Tp, class _BinaryOp>
   [[nodiscard]] _CCCL_HOST_API static _Tp
-  __par_impl([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _Tp __init, _BinaryOp __func)
+  __par_impl([[maybe_unused]] const _Policy& __policy, _Iter __first, _Size __count, _Tp __init, _BinaryOp __func)
   {
     _Tp __ret;
 
+    // We need to know the accumulator type to determine whether we need construct_at for the return value
+    using _AccumT = __accumulator_t<_BinaryOp, iter_reference_t<_Iter>, _Tp>;
+
+    // Determine temporary device storage requirements for reduce
+    void* __temp_storage = nullptr;
+    size_t __num_bytes   = 0;
+    _CCCL_TRY_CUDA_API(
+      ::cub::DeviceReduce::Reduce,
+      "__pstl_cuda_reduce: determination of device storage for cub::DeviceReduce::Reduce failed",
+      __temp_storage,
+      __num_bytes,
+      __first,
+      static_cast<_Tp*>(nullptr),
+      __count,
+      __func,
+      __init);
+
+    // Allocate memory for result
+    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __resource = ::cuda::__call_or(
+      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+
     {
-      // We need to know the accumulator type to determine whether we need construct_at for the return value
-      using _AccumT = __accumulator_t<_BinaryOp, iter_reference_t<_Iter>, _Tp>;
-
-      //!    // Determine temporary device storage requirements for reduce
-      void* __temp_storage   = nullptr;
-      size_t __num_bytes     = 0;
-      const auto __num_items = ::cuda::std::distance(__first, __last);
-      ::cub::DeviceReduce::Reduce(
-        __temp_storage, __num_bytes, __first, static_cast<_Tp*>(nullptr), __num_items, __func, __init);
-
-      // Allocate memory for result
-      auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-      auto __resource = ::cuda::__call_or(
-        ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
       __allocation_guard<_Tp, _AccumT, decltype(__resource)> __guard{__stream, __resource, __num_bytes};
 
       // Run the reduction
-      ::cub::DeviceReduce::Reduce(
+      _CCCL_TRY_CUDA_API(
+        ::cub::DeviceReduce::Reduce,
+        "__pstl_cuda_reduce: kernel launch of cub::DeviceReduce::Reduce failed",
         __guard.__get_temp_storage(),
         __num_bytes,
         ::cuda::std::move(__first),
         __guard.__get_result_iter(),
-        __num_items,
+        __count,
         ::cuda::std::move(__func),
         ::cuda::std::move(__init),
         __stream.get());
@@ -163,23 +177,20 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
         __stream.get());
     }
 
+    __stream.sync();
     return __ret;
   }
 
-  template <class _Policy, class _Iter, class _Tp, class _BinaryOp>
+  template <class _Policy, class _Iter, class _Size, class _Tp, class _BinaryOp>
   [[nodiscard]] _CCCL_HOST_API _Tp
-  operator()([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _Tp __init, _BinaryOp __func) const
+  operator()([[maybe_unused]] const _Policy& __policy, _Iter __first, _Size __count, _Tp __init, _BinaryOp __func) const
   {
     if constexpr (::cuda::std::__has_random_access_traversal<_Iter>)
     {
       try
       {
         return __par_impl(
-          __policy,
-          ::cuda::std::move(__first),
-          ::cuda::std::move(__last),
-          ::cuda::std::move(__init),
-          ::cuda::std::move(__func));
+          __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__init), ::cuda::std::move(__func));
       }
       catch (const ::cuda::cuda_error& __err)
       {
@@ -198,8 +209,16 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
       static_assert(__always_false_v<_Policy>,
                     "__pstl_dispatch: CUDA backend of cuda::std::reduce requires at least random access iterators");
       return ::cuda::std::reduce(
-        ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__init), ::cuda::std::move(__func));
+        __first, ::cuda::std::next(__first, __count), ::cuda::std::move(__init), ::cuda::std::move(__func));
     }
+  }
+
+  template <class _Policy, class _Iter, class _Tp, class _BinaryOp>
+  [[nodiscard]] _CCCL_HOST_API _Tp
+  operator()([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _Tp __init, _BinaryOp __func) const
+  {
+    const auto __count = ::cuda::std::distance(__first, __last);
+    return (*this)(__policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__init), ::cuda::std::move(__func));
   }
 };
 

--- a/libcudacxx/include/cuda/std/__pstl/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/reduce.h
@@ -86,7 +86,11 @@ _CCCL_REQUIRES(__has_forward_traversal<_Iter> _CCCL_AND is_execution_policy_v<_P
 [[nodiscard]] _CCCL_HOST_API _Tp reduce(const _Policy& __policy, _Iter __first, _Iter __last, _Tp __init)
 {
   return ::cuda::std::reduce(
-    __policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__init), ::cuda::std::plus<>{});
+    __policy,
+    ::cuda::std::move(__first),
+    ::cuda::std::move(__last),
+    ::cuda::std::move(__init),
+    ::cuda::std::plus<_Tp>{});
 }
 
 _CCCL_TEMPLATE(class _Policy, class _Iter)
@@ -94,7 +98,11 @@ _CCCL_REQUIRES(__has_forward_traversal<_Iter> _CCCL_AND is_execution_policy_v<_P
 [[nodiscard]] _CCCL_HOST_API iter_value_t<_Iter> reduce(const _Policy& __policy, _Iter __first, _Iter __last)
 {
   return ::cuda::std::reduce(
-    __policy, ::cuda::std::move(__first), ::cuda::std::move(__last), iter_value_t<_Iter>{}, ::cuda::std::plus<>{});
+    __policy,
+    ::cuda::std::move(__first),
+    ::cuda::std::move(__last),
+    iter_value_t<_Iter>{},
+    ::cuda::std::plus<iter_value_t<_Iter>>{});
 }
 
 _CCCL_END_NAMESPACE_ARCH_DEPENDENT


### PR DESCRIPTION
We weren properly checking for errors of the CUB calls.

Also make it so that the allocation guard does not sync in the destructor because we want to explicitly do that in code to ensure we do not forget it

Pulled out of #7382