### PR TITLE
Use modern __syncthreads_or primitive

### DIFF
--- a/cub/cub/agent/agent_find.cuh
+++ b/cub/cub/agent/agent_find.cuh
@@ -193,7 +193,7 @@ struct agent_t
           ? ConsumeTile(tile_offset, ::cuda::std::bool_constant<attempt_vectorization>{})
           : ConsumeTile(tile_offset, ::cuda::std::false_type{});
 
-      const bool found_block = syncthreads_or(found_thread);
+      const bool found_block = __syncthreads_or(found_thread);
       if (found_block)
       {
         // our block found it, update global position and exit


### PR DESCRIPTION
Somehow this slipped through and I used an old version (sm20 dated) of `__syncthreads_or()`. 

It's coming from an internal CUDA header that looks like this.

https://github.com/zspace/system.cuda-12.6/blob/b3d92c837713411301ae5df45b0c7758df7d931e/include/sm_20_intrinsics.hpp#L90-L93

Anyways, this PR uses [the proper modern ](https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html?highlight=__syncthreads_or#synchronization-functions)`syncthreads_or`