### PR TITLE
Simplify `DeviceTransform` vectorized policy

### DIFF
--- a/cub/benchmarks/bench/transform/common.h
+++ b/cub/benchmarks/bench/transform/common.h
@@ -45,14 +45,7 @@ struct policy_selector
 #  elif TUNE_ALGORITHM == 1
     constexpr auto algorithm = cub::detail::transform::Algorithm::vectorized;
     constexpr auto policy    = cub::detail::transform::vectorized_policy{
-      TUNE_THREADS,
-      (1 << TUNE_VEC_SIZE_POW2) * TUNE_VECTORS_PER_THREAD,
-      (1 << TUNE_VEC_SIZE_POW2)
-#    ifdef TUNE_ITEMS_PER_THREAD_NO_INPUT
-        ,
-      TUNE_ITEMS_PER_THREAD_NO_INPUT
-#    endif // TUNE_ITEMS_PER_THREAD_NO_INPUT
-    };
+      TUNE_THREADS, (1 << TUNE_VEC_SIZE_POW2) * TUNE_VECTORS_PER_THREAD, (1 << TUNE_VEC_SIZE_POW2)};
     return {min_bytes_in_flight, algorithm, {}, policy, {}};
 #  elif TUNE_ALGORITHM == 2
     constexpr auto algorithm = cub::detail::transform::Algorithm::memcpy_async;

--- a/cub/cub/device/dispatch/dispatch_transform.cuh
+++ b/cub/cub/device/dispatch/dispatch_transform.cuh
@@ -386,12 +386,12 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_prefetch_or_vectorized
   if (!ipt)
   {
     // otherwise, set up the prefetch kernel
-    const auto fallback_prefetch_policy = prefetch_policy{
-      policy.vectorized.block_threads,
-      policy.vectorized.prefetch_items_per_thread_no_input,
-      policy.vectorized.prefetch_min_items_per_thread,
-      policy.vectorized.prefetch_max_items_per_thread};
-    const auto prefetch_policy = policy.algorithm == Algorithm::prefetch ? policy.prefetch : fallback_prefetch_policy;
+    auto prefetch_policy = policy.prefetch;
+    if (policy.algorithm != Algorithm::prefetch)
+    {
+      // if tuning selected the vectorized path we compiled the kernel for it, so we need to use the same block size
+      prefetch_policy.block_threads = policy.vectorized.block_threads;
+    }
 
     auto loaded_bytes_per_iter           = kernel_source.LoadedBytesPerIteration();
     const auto items_per_thread_no_input = prefetch_policy.items_per_thread_no_input;

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -118,18 +118,11 @@ struct vectorized_policy
   int block_threads;
   int items_per_thread;
   int vec_size;
-  // if we have to fall back to prefetching, use these values:
-  int prefetch_items_per_thread_no_input = 2;
-  int prefetch_min_items_per_thread      = 1;
-  int prefetch_max_items_per_thread      = 32;
 
   [[nodiscard]] _CCCL_API constexpr friend bool operator==(const vectorized_policy& lhs, const vectorized_policy& rhs)
   {
     return lhs.block_threads == rhs.block_threads && lhs.items_per_thread == rhs.items_per_thread
-        && lhs.vec_size == rhs.vec_size
-        && lhs.prefetch_items_per_thread_no_input == rhs.prefetch_items_per_thread_no_input
-        && lhs.prefetch_min_items_per_thread == rhs.prefetch_min_items_per_thread
-        && lhs.prefetch_max_items_per_thread == rhs.prefetch_max_items_per_thread;
+        && lhs.vec_size == rhs.vec_size;
   }
 
   [[nodiscard]] _CCCL_API constexpr friend bool operator!=(const vectorized_policy& lhs, const vectorized_policy& rhs)
@@ -140,12 +133,8 @@ struct vectorized_policy
 #if !_CCCL_COMPILER(NVRTC)
   friend ::std::ostream& operator<<(::std::ostream& os, const vectorized_policy& policy)
   {
-    return os
-        << "vectorized_policy { .block_threads = " << policy.block_threads
-        << ", .items_per_thread = " << policy.items_per_thread << ", .vec_size = " << policy.vec_size
-        << ", .prefetch_items_per_thread_no_input = " << policy.prefetch_items_per_thread_no_input
-        << ", .prefetch_min_items_per_thread = " << policy.prefetch_min_items_per_thread
-        << ", .prefetch_max_items_per_thread = " << policy.prefetch_max_items_per_thread << " }";
+    return os << "vectorized_policy { .block_threads = " << policy.block_threads
+              << ", .items_per_thread = " << policy.items_per_thread << ", .vec_size = " << policy.vec_size << " }";
   }
 #endif // !_CCCL_COMPILER(NVRTC)
 };


### PR DESCRIPTION
I removed the fallback values for prefetching, since we can just take the values from the neighboring prefetch policy now.

- [x] No SASS changes in `cub.bench.transform.babelstream.base` on SM `75;80;90;100`