### PR TITLE
Clarify Docker install step for WSL in .devcontainer README

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -79,8 +79,8 @@ Apart from the initial setup of WSL, the process for using CCCL's Dev Containers
 - Windows OS that supports WSL 2 (Windows 11 or newer)
 - [Windows Subsystem for Linux v2 (WSL 2)](https://learn.microsoft.com/en-us/windows/wsl/install)
 - [Visual Studio Code](https://code.visualstudio.com/) (installed on Windows host)
-- [Docker](https://docs.docker.com/engine/install/)
-    - Required for VSCode / Dev Container integration
+- [Docker](https://docs.docker.com/desktop/setup/install/windows-install/)
+    - Required for [VSCode / Dev Container integration](https://code.visualstudio.com/docs/devcontainers/containers#_installation)
 - [VSCode Remote Development Extension Pack](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.vscode-remote-extensionpack) (installed on Windows host)
     - Includes [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) and [WSL](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) extensions
 


### PR DESCRIPTION
## Description

Addresses https://github.com/NVIDIA/cccl/issues/7508.

For WSL users, the .devcontainers' README is written in a way where it sounds like installing the VSCode Remote Development Extension Pack will automatically handle the Docker step, when in fact it will only handle automatically finding an already-installed Docker.

This PR clarifies the wording of the README so it explicitly states that Docker needs to be installed before installing the VSCode Remote Development Extension Pack.

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
