### PR TITLE
Implement parallel `cuda::std::copy_if`

### DIFF
--- a/libcudacxx/benchmarks/bench/copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/copy_if/basic.cu
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/complex>
+#include <cuda/stream_ref>
+
+#include "nvbench_helper.cuh"
+
+struct is_even
+{
+  template <class T>
+  __device__ constexpr bool operator()(const T& val) const noexcept
+  {
+    return static_cast<int>(val) % 2 == 0;
+  }
+
+  __device__ constexpr bool operator()(const complex& val) const noexcept
+  {
+    return static_cast<int>(val.real()) % 2 == 0;
+  }
+};
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+  thrust::device_vector<T> out(elements, thrust::no_init);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc{};
+  auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(alloc);
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               cuda::std::copy_if(
+                 policy.with_stream(launch.get_stream().get_stream()), in.begin(), in.end(), out.begin(), is_even{});
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/libcudacxx/include/cuda/std/__pstl/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/copy_if.h
@@ -1,0 +1,90 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_COPY_IF_H
+#define _CUDA_STD___PSTL_COPY_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__algorithm/copy_if.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/integral_constant.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/copy_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _OutputIterator, class _UnaryPred)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND __has_forward_traversal<_OutputIterator> _CCCL_AND
+                 is_execution_policy_v<_Policy>)
+_CCCL_HOST_API _OutputIterator copy_if(
+  [[maybe_unused]] const _Policy& __policy,
+  _InputIterator __first,
+  _InputIterator __last,
+  _OutputIterator __result,
+  _UnaryPred __pred)
+{
+  static_assert(indirect_unary_predicate<_UnaryPred, _InputIterator>,
+                "cuda::std::copy_if: UnaryPred must satisfy indirect_unary_predicate<InputIterator>");
+
+  if (__first == __last)
+  {
+    return __result;
+  }
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__copy_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    const auto __count = ::cuda::std::distance(__first, __last);
+    return __dispatch(
+      __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__result), ::cuda::std::move(__pred));
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::copy_if requires at least one selected backend");
+    return ::cuda::std::copy_if(
+      ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__result), ::cuda::std::move(__pred));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_COPY_IF_H

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
@@ -1,0 +1,173 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_CUDA_COPY_IF_H
+#define _CUDA_STD___PSTL_CUDA_COPY_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_BACKEND_CUDA()
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
+
+#  include <cub/device/device_select.cuh>
+
+_CCCL_DIAG_POP
+
+#  include <cuda/__execution/policy.h>
+#  include <cuda/__functional/call_or.h>
+#  include <cuda/__memory_pool/device_memory_pool.h>
+#  include <cuda/__memory_resource/get_memory_resource.h>
+#  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/__stream/get_stream.h>
+#  include <cuda/__stream/stream_ref.h>
+#  include <cuda/std/__algorithm/copy_if.h>
+#  include <cuda/std/__exception/cuda_error.h>
+#  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__execution/env.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/incrementable_traits.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__iterator/next.h>
+#  include <cuda/std/__pstl/cuda/temporary_storage.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__utility/move.h>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+template <>
+struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
+{
+  template <class _Policy, class _InputIterator, class _OutputIterator, class _UnaryPredicate>
+  [[nodiscard]] _CCCL_HOST_API static _OutputIterator __par_impl(
+    const _Policy& __policy,
+    _InputIterator __first,
+    iter_difference_t<_InputIterator> __count,
+    _OutputIterator __result,
+    _UnaryPredicate __pred)
+  {
+    using _OffsetType = iter_difference_t<_InputIterator>;
+    _OffsetType __ret;
+
+    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+    auto __resource = ::cuda::__call_or(
+      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+
+    // Determine temporary device storage requirements
+    void* __temp_storage = nullptr;
+    size_t __num_bytes   = 0;
+    _CCCL_TRY_CUDA_API(
+      ::cub::DeviceSelect::If,
+      "__pstl_cuda_select_if: determination of device storage for cub::DeviceSelect::If failed",
+      __temp_storage,
+      __num_bytes,
+      __first,
+      __result,
+      static_cast<_OffsetType*>(nullptr),
+      __count,
+      __pred,
+      __stream.get());
+
+    {
+      __temporary_storage<_OffsetType, decltype(__resource)> __storage{__stream, __resource, __num_bytes};
+
+      // Run the kernel
+      _CCCL_TRY_CUDA_API(
+        ::cub::DeviceSelect::If,
+        "__pstl_cuda_select_if: kernel launch of cub::DeviceSelect::If failed",
+        __storage.__get_temp_storage(),
+        __num_bytes,
+        ::cuda::std::move(__first),
+        __result,
+        __storage.__get_result_iter(),
+        __count,
+        ::cuda::std::move(__pred),
+        __stream.get());
+
+      // Copy the result back from storage
+      _CCCL_TRY_CUDA_API(
+        ::cudaMemcpyAsync,
+        "__pstl_cuda_select_if: copy of result from device to host failed",
+        ::cuda::std::addressof(__ret),
+        __storage.__res_,
+        sizeof(_OffsetType),
+        ::cudaMemcpyDefault,
+        __stream.get());
+    }
+
+    __stream.sync();
+    return __result + static_cast<iter_difference_t<_OutputIterator>>(__ret);
+  }
+
+  _CCCL_TEMPLATE(class _Policy, class _InputIterator, class _OutputIterator, class _UnaryPredicate)
+  _CCCL_REQUIRES(__has_forward_traversal<_OutputIterator>)
+  [[nodiscard]] _CCCL_HOST_API _OutputIterator operator()(
+    [[maybe_unused]] const _Policy& __policy,
+    _InputIterator __first,
+    iter_difference_t<_InputIterator> __count,
+    _OutputIterator __result,
+    _UnaryPredicate __pred) const
+  {
+    if constexpr (::cuda::std::__has_random_access_traversal<_OutputIterator>)
+    {
+      try
+      {
+        return __par_impl(
+          __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__result), ::cuda::std::move(__pred));
+      }
+      catch (const ::cuda::cuda_error& __err)
+      {
+        if (__err.status() == ::cudaErrorMemoryAllocation)
+        {
+          _CCCL_THROW(::std::bad_alloc);
+        }
+        else
+        {
+          throw;
+        }
+      }
+    }
+    else
+    {
+      static_assert(__always_false_v<_Policy>,
+                    "__pstl_cuda_generate: CUDA backend of cuda::std::generate requires at least random access "
+                    "iterators");
+      auto __last = ::cuda::std::next(__first, __count);
+      return ::cuda::std::copy_if(
+        ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__result), ::cuda::std::move(__pred));
+    }
+  }
+};
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif /// _CCCL_HAS_BACKEND_CUDA()
+
+#endif // _CUDA_STD___PSTL_CUDA_COPY_IF_H

--- a/libcudacxx/include/cuda/std/__pstl/dispatch.h
+++ b/libcudacxx/include/cuda/std/__pstl/dispatch.h
@@ -32,6 +32,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
 
 enum class __pstl_algorithm
 {
+  __copy_if,
   __find_if,
   __for_each_n,
   __generate_n,

--- a/libcudacxx/include/cuda/std/__pstl_algorithm
+++ b/libcudacxx/include/cuda/std/__pstl_algorithm
@@ -21,6 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__pstl/copy_if.h>
 #include <cuda/std/__pstl/count.h>
 #include <cuda/std/__pstl/count_if.h>
 #include <cuda/std/__pstl/fill.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy_if.cu
@@ -1,0 +1,148 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template <class Policy, class InputIterator, class OutputIterator>
+// void copy_if(const Policy&  policy,
+//              InputIterator  first,
+//              InputIterator  last,
+//              OutoutIterator result);
+
+#include <thrust/device_vector.h>
+#include <thrust/equal.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+#include <thrust/sequence.h>
+
+#include <cuda/cmath>
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 10000;
+
+struct is_even
+{
+  __device__ constexpr bool operator()(const int& val) const noexcept
+  {
+    return (val % 2) == 0;
+  }
+};
+
+struct check_is_even
+{
+  __device__ void operator()(const cuda::std::ptrdiff_t pos, const int value) const noexcept
+  {
+    _CCCL_VERIFY(static_cast<int>(pos * 2) == value, "Invalid position");
+    _CCCL_VERIFY(is_even{}(value), "Not even");
+  }
+};
+
+template <class Policy>
+void test_copy_if(const Policy& policy, const thrust::device_vector<int>& input, thrust::device_vector<int>& output)
+{
+  { // empty should not access anything
+    const auto res = cuda::std::copy_if(
+      policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), static_cast<int*>(nullptr), is_even{});
+    CHECK(res == nullptr);
+  }
+
+  { // Same input output type
+    { // With random_access iterator
+      thrust::fill(output.begin(), output.end(), -1);
+      const auto res = cuda::std::copy_if(
+        policy, cuda::counting_iterator{0}, cuda::counting_iterator{size}, output.begin(), is_even{});
+      CHECK(thrust::equal(output.begin(), output.end(), cuda::strided_iterator{cuda::counting_iterator{0}, 2}));
+      CHECK(res == output.end());
+    }
+
+    { // With contiguous iterator
+      thrust::fill(output.begin(), output.end(), -1);
+      const auto res = cuda::std::copy_if(policy, input.begin(), input.end(), output.begin(), is_even{});
+      CHECK(thrust::equal(output.begin(), output.end(), cuda::strided_iterator{cuda::counting_iterator{0}, 2}));
+      CHECK(res == output.end());
+    }
+
+    { // With pointer
+      thrust::fill(output.begin(), output.end(), -1);
+      auto ptr       = thrust::raw_pointer_cast(input.data());
+      const auto res = cuda::std::copy_if(policy, ptr, ptr + size, output.begin(), is_even{});
+      CHECK(thrust::equal(output.begin(), output.end(), cuda::strided_iterator{cuda::counting_iterator{0}, 2}));
+      CHECK(res == output.end());
+    }
+  }
+
+  { // Different input type
+    thrust::fill(output.begin(), output.end(), -1);
+    const auto res = cuda::std::copy_if(
+      policy, cuda::counting_iterator{short{0}}, cuda::counting_iterator{short{size}}, output.begin(), is_even{});
+    CHECK(thrust::equal(output.begin(), output.end(), cuda::strided_iterator{cuda::counting_iterator{0}, 2}));
+    CHECK(res == output.end());
+  }
+
+  { // Random access output type
+    const auto res = cuda::std::copy_if(
+      policy,
+      cuda::counting_iterator{0},
+      cuda::counting_iterator{size},
+      cuda::tabulate_output_iterator{check_is_even{}, 0},
+      is_even{});
+    CHECK(res == cuda::tabulate_output_iterator{check_is_even{}, size / 2});
+  }
+
+  { // Random access output type with conversion during assignment
+    const auto res = cuda::std::copy_if(
+      policy,
+      cuda::counting_iterator{short{0}},
+      cuda::counting_iterator{short{size}},
+      cuda::tabulate_output_iterator{check_is_even{}, 0},
+      is_even{});
+    CHECK(res == cuda::tabulate_output_iterator{check_is_even{}, size / 2});
+  }
+}
+
+C2H_TEST("cuda::std::copy_if", "[parallel algorithm]")
+{
+  thrust::device_vector<int> output(size / 2, thrust::no_init);
+  thrust::device_vector<int> input(size, thrust::no_init);
+  thrust::sequence(input.begin(), input.end(), 0);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    test_copy_if(policy, input, output);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    test_copy_if(policy, input, output);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    test_copy_if(policy, input, output);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    test_copy_if(policy, input, output);
+  }
+}


### PR DESCRIPTION
This implements the copy_if algorithm for the cuda backend.

* std::copy_if see https://en.cppreference.com/w/cpp/algorithm/copy_if.html

It provides tests and benchmarks similar to Thrust and some boilerplate for libcu++

The functionality is publicly available yet and implemented in a private internal header

Fixes #7517
