### PR TITLE
Fix identity_element tests

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/functional/identity_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/identity_element.pass.cpp
@@ -249,7 +249,10 @@ __host__ __device__ bool test_extended_floating_point()
 int main(int, char**)
 {
   assert(test());
+#if _CCCL_HAS_CONSTEXPR_BIT_CAST()
   static_assert(test());
+#endif // _CCCL_HAS_CONSTEXPR_BIT_CAST
+
   assert(test_extended_floating_point()); // run-time only
   return 0;
 }


### PR DESCRIPTION
We need constexpr bit_cast for the tests, which is not always available
