### PR TITLE
Implement the new tuning API for `detail::for_each::dispatch_t`

### DIFF
--- a/c/parallel/src/for.cu
+++ b/c/parallel/src/for.cu
@@ -73,7 +73,8 @@ static std::string get_device_for_kernel_name()
   check(cccl_type_name_from_nvrtc<for_each_wrapper>(&function_op_t));
   check(cccl_type_name_from_nvrtc<OffsetT>(&offset_t));
 
-  return std::format("cub::detail::for_each::static_kernel<device_for_policy, {0}, {1}>", offset_t, function_op_t);
+  return std::format(
+    "cub::detail::for_each::static_kernel<device_for_policy_selector, {0}, {1}>", offset_t, function_op_t);
 }
 
 CUresult cccl_device_for_build_ex(

--- a/c/parallel/src/for/for_op_helper.cpp
+++ b/c/parallel/src/for/for_op_helper.cpp
@@ -130,6 +130,7 @@ std::string get_for_kernel(cccl_op_t user_op, cccl_iterator_t iter)
 #include <cuda/std/iterator>
 #include <cub/agent/agent_for.cuh>
 #include <cub/device/dispatch/kernels/kernel_for_each.cuh>
+#include <cub/device/dispatch/tuning/tuning_for.cuh>
 
 struct __align__({2}) storage_t {{
   char data[{3}];
@@ -152,15 +153,7 @@ struct for_each_wrapper
   }}
 }};
 
-using policy_dim_t = cub::detail::for_each::policy_t<256, 2>;
-
-struct device_for_policy
-{{
-  struct ActivePolicy
-  {{
-    using for_policy_t = policy_dim_t;
-  }};
-}};
+using device_for_policy_selector = cub::detail::for_each::policy_selector;
 )XXX",
     get_for_kernel_iterator(iter), // 0 - Iterator definition
     get_for_kernel_user_op(user_op, iter), // 1 - User op wrapper definition,

--- a/cub/cub/device/device_for.cuh
+++ b/cub/cub/device/device_for.cuh
@@ -114,7 +114,7 @@ private:
       { // Vectorize loads
         const OffsetT num_vec_items = ::cuda::ceil_div(num_items, wrapped_op_t::vec_size);
 
-        return detail::for_each::dispatch_t<OffsetT, wrapped_op_t>::dispatch(
+        return detail::for_each::dispatch<OffsetT, wrapped_op_t>(
           num_vec_items,
           wrapped_op_t{
             unwrapped_first, op, num_items % wrapped_op_t::vec_size ? num_vec_items - 1 : num_vec_items, num_items},
@@ -127,7 +127,7 @@ private:
     else
     {
       using wrapped_op_t = detail::for_each::op_wrapper_t<OffsetT, OpT, RandomAccessOrContiguousIteratorT>;
-      return detail::for_each::dispatch_t<OffsetT, wrapped_op_t>::dispatch(num_items, wrapped_op_t{first, op}, stream);
+      return detail::for_each::dispatch<OffsetT, wrapped_op_t>(num_items, wrapped_op_t{first, op}, stream);
     }
   }
 
@@ -563,7 +563,7 @@ public:
       return cudaSuccess;
     }
     using offset_t = ShapeT;
-    return detail::for_each::dispatch_t<offset_t, OpT>::dispatch(static_cast<offset_t>(shape), op, stream);
+    return detail::for_each::dispatch<offset_t, OpT>(static_cast<offset_t>(shape), op, stream);
   }
 
 private:

--- a/cub/cub/device/dispatch/dispatch_for.cuh
+++ b/cub/cub/device/dispatch/dispatch_for.cuh
@@ -14,6 +14,7 @@
 #endif // no system header
 
 #include <cub/agent/agent_for.cuh>
+#include <cub/detail/arch_dispatch.cuh>
 #include <cub/device/dispatch/kernels/kernel_for_each.cuh>
 #include <cub/device/dispatch/tuning/tuning_for.cuh>
 #include <cub/thread/thread_load.cuh>
@@ -30,131 +31,110 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::for_each
 {
-// The dispatch layer is in the detail namespace until we figure out tuning API
-template <class OffsetT, class OpT, class PolicyHubT = policy_hub_t>
-struct dispatch_t
+template <typename PolicySelector, typename OffsetT, typename OpT>
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t
+invoke_dynamic_block_size(OffsetT num_items, OpT op, cudaStream_t stream, for_policy active_policy)
 {
-  OffsetT num_items;
-  OpT op;
-  cudaStream_t stream;
+  int block_threads = 256;
+  auto kernel       = detail::for_each::dynamic_kernel<PolicySelector, OffsetT, OpT>;
+  NV_IF_TARGET(NV_IS_HOST,
+               (int _{}; //
+                if (const auto error = CubDebug(cudaOccupancyMaxPotentialBlockSize(&_, &block_threads, kernel))) {
+                  return error;
+                }));
 
-  CUB_RUNTIME_FUNCTION dispatch_t(OffsetT num_items, OpT op, cudaStream_t stream)
-      : num_items(num_items)
-      , op(op)
-      , stream(stream)
-  {}
-
-  template <typename ActivePolicyT>
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_dynamic_block_size()
-  {
-    if (num_items == 0)
-    {
-      return cudaSuccess;
-    }
-
-    int block_threads = 256;
-    auto kernel       = detail::for_each::dynamic_kernel<typename PolicyHubT::MaxPolicy, OffsetT, OpT>;
-    NV_IF_TARGET(NV_IS_HOST,
-                 (int _{}; //
-                  if (const auto error = CubDebug(cudaOccupancyMaxPotentialBlockSize(&_, &block_threads, kernel))) {
-                    return error;
-                  }));
-
-    constexpr int items_per_thread = ActivePolicyT::for_policy_t::items_per_thread;
-
-    const auto tile_size = static_cast<OffsetT>(block_threads * items_per_thread);
-    const auto num_tiles = ::cuda::ceil_div(num_items, tile_size);
+  const auto tile_size = static_cast<OffsetT>(block_threads * active_policy.items_per_thread);
+  const auto num_tiles = ::cuda::ceil_div(num_items, tile_size);
 
 #ifdef CUB_DEBUG_LOG
-    _CubLog("Invoking detail::for_each::dynamic_kernel<<<%d, %d, 0, %lld>>>(), "
-            "%d items per thread\n",
-            static_cast<int>(num_tiles),
-            static_cast<int>(block_threads),
-            reinterpret_cast<long long>(stream),
-            static_cast<int>(items_per_thread));
+  _CubLog("Invoking detail::for_each::dynamic_kernel<<<%d, %d, 0, %lld>>>(), "
+          "%d items per thread\n",
+          static_cast<int>(num_tiles),
+          static_cast<int>(block_threads),
+          reinterpret_cast<long long>(stream),
+          static_cast<int>(active_policy.items_per_thread));
 #endif
 
-    if (const auto error = CubDebug(
-          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
-            static_cast<unsigned int>(num_tiles), static_cast<unsigned int>(block_threads), 0, stream)
-            .doit(kernel, num_items, op)))
-    {
-      return error;
-    }
+  if (const auto error = CubDebug(
+        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
+          static_cast<unsigned int>(num_tiles), static_cast<unsigned int>(block_threads), 0, stream)
+          .doit(kernel, num_items, op)))
+  {
+    return error;
+  }
 
-    if (auto error = CubDebug(detail::DebugSyncStream(stream)))
-    {
-      CubDebug(error = SyncStream(stream)); // TODO(bgruber): this does not make sense to me
-      return error;
-    }
+  if (auto error = CubDebug(detail::DebugSyncStream(stream)))
+  {
+    CubDebug(error = SyncStream(stream)); // TODO(bgruber): this does not make sense to me
+    return error;
+  }
 
+  return cudaSuccess;
+}
+
+template <class PolicySelector, class OffsetT, class OpT>
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t
+invoke_static_block_size(OffsetT num_items, OpT op, cudaStream_t stream, for_policy active_policy)
+{
+  const int block_threads    = active_policy.block_threads;
+  const int items_per_thread = active_policy.items_per_thread;
+  const auto tile_size       = static_cast<OffsetT>(block_threads * items_per_thread);
+  const auto num_tiles       = ::cuda::ceil_div(num_items, tile_size);
+
+#ifdef CUB_DEBUG_LOG
+  _CubLog("Invoking detail::for_each::static_kernel<<<%d, %d, 0, %lld>>>(), "
+          "%d items per thread\n",
+          static_cast<int>(num_tiles),
+          static_cast<int>(block_threads),
+          reinterpret_cast<long long>(stream),
+          static_cast<int>(items_per_thread));
+#endif
+
+  if (const auto error = CubDebug(
+        THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
+          static_cast<unsigned int>(num_tiles), static_cast<unsigned int>(block_threads), 0, stream)
+          .doit(detail::for_each::static_kernel<PolicySelector, OffsetT, OpT>, num_items, op)))
+  {
+    return error;
+  }
+
+  if (auto error = CubDebug(detail::DebugSyncStream(stream)))
+  {
+    CubDebug(error = SyncStream(stream)); // TODO(bgruber): this does not make sense to me
+    return error;
+  }
+
+  return cudaSuccess;
+}
+
+// The dispatch layer is in the detail namespace until we figure out tuning API
+template <class OffsetT, class OpT, class PolicySelector = policy_selector>
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t
+dispatch(OffsetT num_items, OpT op, cudaStream_t stream, PolicySelector policy_selector = {})
+{
+  if (num_items == 0)
+  {
     return cudaSuccess;
   }
 
-  template <typename ActivePolicyT>
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t invoke_static_block_size()
+  ::cuda::arch_id arch_id{};
+  if (const auto error = CubDebug(ptx_arch_id(arch_id)))
   {
-    if (num_items == 0)
-    {
-      return cudaSuccess;
-    }
-
-    constexpr int block_threads     = ActivePolicyT::for_policy_t::block_threads;
-    constexpr int items_per_thread1 = ActivePolicyT::for_policy_t::items_per_thread;
-    constexpr auto tile_size        = static_cast<OffsetT>(block_threads * items_per_thread1);
-    const auto num_tiles            = ::cuda::ceil_div(num_items, tile_size);
-
-#ifdef CUB_DEBUG_LOG
-    _CubLog("Invoking detail::for_each::static_kernel<<<%d, %d, 0, %lld>>>(), "
-            "%d items per thread\n",
-            static_cast<int>(num_tiles),
-            static_cast<int>(block_threads),
-            reinterpret_cast<long long>(stream),
-            static_cast<int>(items_per_thread1));
-#endif
-
-    if (const auto error = CubDebug(
-          THRUST_NS_QUALIFIER::cuda_cub::detail::triple_chevron(
-            static_cast<unsigned int>(num_tiles), static_cast<unsigned int>(block_threads), 0, stream)
-            .doit(detail::for_each::static_kernel<typename PolicyHubT::MaxPolicy, OffsetT, OpT>, num_items, op)))
-    {
-      return error;
-    }
-
-    if (auto error = CubDebug(detail::DebugSyncStream(stream)))
-    {
-      CubDebug(error = SyncStream(stream)); // TODO(bgruber): this does not make sense to me
-      return error;
-    }
-
-    return cudaSuccess;
+    return error;
   }
 
-  template <typename ActivePolicyT>
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t Invoke()
-  {
-    if constexpr (ActivePolicyT::for_policy_t::block_threads > 0)
+  return CubDebug(dispatch_arch(policy_selector, arch_id, [&](auto policy_getter) {
+    constexpr for_policy active_policy = policy_getter();
+    if constexpr (active_policy.block_threads > 0)
     {
-      return invoke_static_block_size<ActivePolicyT>();
+      return invoke_static_block_size<PolicySelector>(num_items, op, stream, active_policy);
     }
     else
     {
-      return invoke_dynamic_block_size<ActivePolicyT>();
+      return invoke_dynamic_block_size<PolicySelector>(num_items, op, stream, active_policy);
     }
-  }
-
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t dispatch(OffsetT num_items, OpT op, cudaStream_t stream)
-  {
-    int ptx_version = 0;
-    if (const auto error = CubDebug(PtxVersion(ptx_version)))
-    {
-      return error;
-    }
-
-    dispatch_t dispatch(num_items, op, stream);
-    return CubDebug(PolicyHubT::MaxPolicy::Invoke(ptx_version, dispatch));
-  }
-};
+  }));
+}
 } // namespace detail::for_each
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/dispatch/kernels/kernel_for_each.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_for_each.cuh
@@ -16,6 +16,7 @@
 #include <cub/agent/agent_for.cuh>
 #include <cub/detail/mdspan_utils.cuh> // is_sub_size_static
 #include <cub/detail/type_traits.cuh> // implicit_prom_t
+#include <cub/device/dispatch/tuning/tuning_for.cuh>
 
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>
@@ -85,14 +86,18 @@ using can_regain_copy_freedom =
 // clang-format on
 
 // This kernel is used when the block size is not known at compile time
-template <class ChainedPolicyT, class OffsetT, class OpT>
+template <class PolicySelector, class OffsetT, class OpT>
+#if _CCCL_HAS_CONCEPTS()
+  requires for_policy_selector<PolicySelector>
+#endif // _CCCL_HAS_CONCEPTS()
 CUB_DETAIL_KERNEL_ATTRIBUTES void dynamic_kernel(OffsetT num_items, OpT op)
 {
-  using active_policy_t = typename ChainedPolicyT::ActivePolicy::for_policy_t;
-  using agent_t         = agent_block_striped_t<active_policy_t, OffsetT, OpT>;
+  static constexpr for_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  using agent_policy_t               = policy_t<policy.block_threads, policy.items_per_thread>;
+  using agent_t                      = agent_block_striped_t<agent_policy_t, OffsetT, OpT>;
 
   const auto block_threads  = static_cast<OffsetT>(blockDim.x);
-  const auto items_per_tile = active_policy_t::items_per_thread * block_threads;
+  const auto items_per_tile = policy.items_per_thread * block_threads;
   const auto tile_base      = static_cast<OffsetT>(blockIdx.x) * items_per_tile;
   const auto num_remaining  = num_items - tile_base;
   const auto items_in_tile  = static_cast<OffsetT>(num_remaining < items_per_tile ? num_remaining : items_per_tile);
@@ -108,16 +113,19 @@ CUB_DETAIL_KERNEL_ATTRIBUTES void dynamic_kernel(OffsetT num_items, OpT op)
 }
 
 // This kernel is used when the block size is known at compile time
-template <class ChainedPolicyT, class OffsetT, class OpT>
+template <class PolicySelector, class OffsetT, class OpT>
+#if _CCCL_HAS_CONCEPTS()
+  requires for_policy_selector<PolicySelector>
+#endif // _CCCL_HAS_CONCEPTS()
 CUB_DETAIL_KERNEL_ATTRIBUTES //
-__launch_bounds__(ChainedPolicyT::ActivePolicy::for_policy_t::block_threads) //
+__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads)) //
   void static_kernel(OffsetT num_items, OpT op)
 {
-  using active_policy_t = typename ChainedPolicyT::ActivePolicy::for_policy_t;
-  using agent_t         = agent_block_striped_t<active_policy_t, OffsetT, OpT>;
+  static constexpr for_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  using agent_policy_t               = policy_t<policy.block_threads, policy.items_per_thread>;
+  using agent_t                      = agent_block_striped_t<agent_policy_t, OffsetT, OpT>;
 
-  constexpr auto block_threads  = active_policy_t::block_threads;
-  constexpr auto items_per_tile = active_policy_t::items_per_thread * block_threads;
+  constexpr auto items_per_tile = policy.items_per_thread * policy.block_threads;
 
   const auto tile_base     = static_cast<OffsetT>(blockIdx.x) * items_per_tile;
   const auto num_remaining = num_items - tile_base;
@@ -125,11 +133,11 @@ __launch_bounds__(ChainedPolicyT::ActivePolicy::for_policy_t::block_threads) //
 
   if (items_in_tile == items_per_tile)
   {
-    agent_t{tile_base, op}.template consume_tile<true>(items_per_tile, block_threads);
+    agent_t{tile_base, op}.template consume_tile<true>(items_per_tile, policy.block_threads);
   }
   else
   {
-    agent_t{tile_base, op}.template consume_tile<false>(items_in_tile, block_threads);
+    agent_t{tile_base, op}.template consume_tile<false>(items_in_tile, policy.block_threads);
   }
 }
 

--- a/cub/cub/device/dispatch/tuning/tuning_for.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_for.cuh
@@ -16,10 +16,52 @@
 #include <cub/agent/agent_for.cuh>
 #include <cub/util_device.cuh>
 
+#if !_CCCL_COMPILER(NVRTC)
+#  include <ostream>
+#endif
+
 CUB_NAMESPACE_BEGIN
 
 namespace detail::for_each
 {
+struct for_policy
+{
+  int block_threads;
+  int items_per_thread;
+
+  _CCCL_API constexpr friend bool operator==(const for_policy& lhs, const for_policy& rhs)
+  {
+    return lhs.block_threads == rhs.block_threads && lhs.items_per_thread == rhs.items_per_thread;
+  }
+
+  _CCCL_API constexpr friend bool operator!=(const for_policy& lhs, const for_policy& rhs)
+  {
+    return !(lhs == rhs);
+  }
+
+#if !_CCCL_COMPILER(NVRTC)
+  friend ::std::ostream& operator<<(::std::ostream& os, const for_policy& policy)
+  {
+    return os << "for_policy { .block_threads = " << policy.block_threads
+              << ", .items_per_thread = " << policy.items_per_thread << " }";
+  }
+#endif // !_CCCL_COMPILER(NVRTC)
+};
+
+#if _CCCL_HAS_CONCEPTS()
+template <typename T>
+concept for_policy_selector = policy_selector<T, for_policy>;
+#endif // _CCCL_HAS_CONCEPTS()
+
+struct policy_selector
+{
+  [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::arch_id /*arch*/) const -> for_policy
+  {
+    return for_policy{256, 2};
+  }
+};
+
+// TODO(bgruber): remove once we publish the tuning API
 struct policy_hub_t
 {
   struct policy_500_t : ChainedPolicy<500, policy_500_t, policy_500_t>


### PR DESCRIPTION
- [x] No SASS diff for `cub.bench.for_each.base.base`.

Fixes: #7525
