### PR TITLE
Fix caching of functions referencing numpy ufuncs (or any "dotted" functions)

### DIFF
--- a/python/cuda_cccl/cuda/compute/_caching.py
+++ b/python/cuda_cccl/cuda/compute/_caching.py
@@ -208,7 +208,14 @@ class CachableFunction:
             func.__code__.co_consts,
             tuple(contents),
             tuple(
-                _make_hashable(func.__globals__.get(name, None))
+                # if `name` is found in __globals__, try and hash
+                # the referenced object. If `name` is not found in
+                # __globals__, (e.g., `name` is part of a dotted
+                # name like `np.argmax`), for caching purposes we
+                # use the hash of the name itself. Assumes numba
+                # known how to interpret the dotted name at JIT
+                # time.
+                _make_hashable(func.__globals__.get(name, name))
                 for name in func.__code__.co_names
             ),
         )


### PR DESCRIPTION
## Description

Function that reference other functions using dotted syntax:

```python
import a

def foo(x):
    return a.b()  # a DOT b
```

End up with this in their `co_names`:

```python
In [2]: foo.__code__.co_names
Out[2]: ('a', 'b')
```

When looking at the function's `__globals__` dict, `'a'` can be resolved to the module containing the function, but `'b'` cannot be resolved to a function. Our logic for traversing the globals basically assumes that we can resolve all the things in `__globals__`. When we can't resolve something, we mistakenly use `None` in its place. This leads to bad caching, because `id(None)` or `hash(None)` is always the same.

This PR fixes our logic by using the name of the function instead of `None`. This way a function referencing `a.b` will hash differently to a function referencing `a.c`.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
