### PR TITLE
Remove recursion from __internal_is_address_from

### DIFF
--- a/libcudacxx/include/cuda/__memory/address_space.h
+++ b/libcudacxx/include/cuda/__memory/address_space.h
@@ -169,7 +169,7 @@ enum class address_space
                       "  selp.u32 %0, 1, 0, p;\n\t"
                       "}\n\t" : "=r"(__ret) : "l"(__ptr));
          return static_cast<bool>(__ret);),
-        (/* Fall through to `case shared:` */;))
+        ([[fallthrough]]; /* to `case shared:` */))
 #  else // ^^^ _CCCL_CUDA_COMPILER(NVCC, <, 12, 3) || _CCCL_CUDA_COMPILER(NVRTC, <, 12, 3) ^^^ /
         // vvv !_CCCL_CUDA_COMPILER(NVCC, <, 12, 3) && !_CCCL_CUDA_COMPILER(NVRTC, <, 12, 3) vvv
       NV_IF_ELSE_TARGET(


### PR DESCRIPTION
## Description

When running on pre-Hopper GPUs, a call to `__internal_is_address_from(ptr, cluster_shared)` would simply make a recursive call to `__internal_is_address_from(ptr, shared)`.  The recursion would stop there; there was no infinite recursion or large stack sizes.  But when compiling the GPU code with debug information and no optimization (`nvcc -G`), the recursive call would remain in the PTX and that would cause either ptxas or nvlink to be unable to calculate the correct stack size for the kernel.  That could result in a failed kernel if the default stack size is too small.

Avoid this problem by removing the recursive call in `__internal_is_address_from`.  Instead move the `case address_space::shared:` code to just after `case address_space::cluster_shared:` and have `case address_space::cluster_shared:` `[[fallthrough]]` to `case address_space::shared:` on pre-Hopper GPUs.

This fixes some stdpar tests when compiled with `nvc++ -g -stdpar` on pre-Hopper GPUs.  It fixes some CUDA applications compiled with `nvcc -G`, though I don't have any real-world examples.

Also fixes NVBug: 5880331

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
