### PR TITLE
Fix operator identity and absorbing element for `char`

### DIFF
--- a/libcudacxx/include/cuda/__functional/operator_properties.h
+++ b/libcudacxx/include/cuda/__functional/operator_properties.h
@@ -411,7 +411,7 @@ template <class _Op, class _Tp>
   using _Up = ::cuda::std::remove_cv_t<_Tp>;
   if constexpr (__is_cuda_std_plus_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return _Up{};
     }
@@ -426,7 +426,8 @@ template <class _Op, class _Tp>
   }
   else if constexpr (__is_cuda_std_multiplies_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_floating_point_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_floating_point_v<_Up>
+                  || ::cuda::std::is_same_v<_Up, char>)
     {
       return _Up{1};
     }
@@ -441,7 +442,7 @@ template <class _Op, class _Tp>
   }
   else if constexpr (__is_cuda_std_bit_and_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return static_cast<_Up>(~_Up{});
     }
@@ -452,7 +453,7 @@ template <class _Op, class _Tp>
   }
   else if constexpr (__is_cuda_std_bit_or_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return _Up{};
     }
@@ -463,7 +464,7 @@ template <class _Op, class _Tp>
   }
   else if constexpr (__is_cuda_std_bit_xor_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return _Up{};
     }
@@ -496,7 +497,7 @@ template <class _Op, class _Tp>
   }
   else if constexpr (__is_cuda_minimum_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return ::cuda::std::numeric_limits<_Up>::max();
     }
@@ -511,7 +512,7 @@ template <class _Op, class _Tp>
   }
   else if constexpr (__is_cuda_maximum_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return ::cuda::std::numeric_limits<_Up>::lowest();
     }
@@ -554,7 +555,7 @@ template <class _Op, class _Tp>
   if constexpr (__is_cuda_std_multiplies_v<_Op>)
   {
     // no absorbing element for floating-point due to NaN, infinity, and -1.0 * +0.0 = -0.0 (!= +0.0)
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return _Up{};
     }
@@ -565,7 +566,7 @@ template <class _Op, class _Tp>
   }
   else if constexpr (__is_cuda_std_bit_and_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return _Up{};
     }
@@ -576,7 +577,7 @@ template <class _Op, class _Tp>
   }
   else if constexpr (__is_cuda_std_bit_or_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return static_cast<_Up>(~_Up{});
     }
@@ -609,7 +610,7 @@ template <class _Op, class _Tp>
   }
   else if constexpr (__is_cuda_minimum_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return ::cuda::std::numeric_limits<_Up>::lowest();
     }
@@ -624,7 +625,7 @@ template <class _Op, class _Tp>
   }
   else if constexpr (__is_cuda_maximum_v<_Op>)
   {
-    if constexpr (::cuda::std::__cccl_is_integer_v<_Up>)
+    if constexpr (::cuda::std::__cccl_is_integer_v<_Up> || ::cuda::std::is_same_v<_Up, char>)
     {
       return ::cuda::std::numeric_limits<_Up>::max();
     }

--- a/libcudacxx/test/libcudacxx/cuda/functional/identity_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/identity_element.pass.cpp
@@ -122,6 +122,7 @@ __host__ __device__ constexpr void test_identity_integral()
 {
   test_identity<cuda::std::logical_and, bool>(true, true);
   test_identity<cuda::std::logical_or, bool>(true, false);
+  test_identity_integral<char>();
   test_identity_integral<signed char>();
   test_identity_integral<unsigned char>();
   test_identity_integral<short>();


### PR DESCRIPTION
This PR adds the necessary checks to also provide operator properties if the element type is `char`. This fixes #6811 , which relied on `cub::detail::identity_v`.