### PR TITLE
Vectorize reduction also for trivially relocatable types

### DIFF
--- a/cub/cub/agent/agent_reduce.cuh
+++ b/cub/cub/agent/agent_reduce.cuh
@@ -215,7 +215,7 @@ struct AgentReduceImpl
     (VECTOR_LOAD_LENGTH > 1) && (ITEMS_PER_THREAD % VECTOR_LOAD_LENGTH == 0)
     && (::cuda::std::is_pointer_v<InputIteratorT>)
     // TODO(bgruber): remove the check for is_primitive<ValueT> in CCCL 4.0
-    &&(is_primitive<InputT>::value || thrust::is_trivially_relocatable_v<InputT>);
+    &&(is_primitive<InputT>::value || THRUST_NS_QUALIFIER::is_trivially_relocatable_v<InputT>);
 
   static constexpr CacheLoadModifier LOAD_MODIFIER = AgentReducePolicy::LOAD_MODIFIER;
 


### PR DESCRIPTION
I want to reduce our use of `cub::is_primitive`, but switching to `cuda::std::trivially_copyable` is a breaking change for any user that specializes `cub::Traits` for any non-trivially copyable type. So let's use both and drop `cub::is_primitive` in CCCL 4.0.