### PR TITLE
Incorrect scoped_range_in placement

### DIFF
--- a/libcudacxx/include/cuda/__nvtx/nvtx.h
+++ b/libcudacxx/include/cuda/__nvtx/nvtx.h
@@ -101,9 +101,9 @@ _CCCL_END_NAMESPACE_CUDA
 // into a dispatch region running only on the host, while preserving the semantic scope where the range is declared.
 #    define _CCCL_NVTX_RANGE_SCOPE_IF(condition, name)                                                                 \
       _CCCL_BEFORE_NVTX_RANGE_SCOPE(name)                                                                              \
-      ::cuda::std::optional<::nvtx3::v1::scoped_range_in<::cuda::detail::NVTXCCCLDomain>> __cuda_nvtx3_range;          \
       NV_IF_TARGET(                                                                                                    \
         NV_IS_HOST, ({                                                                                                 \
+          ::cuda::std::optional<::nvtx3::v1::scoped_range_in<::cuda::detail::NVTXCCCLDomain>> __cuda_nvtx3_range;      \
           static const ::nvtx3::v1::registered_string_in<::cuda::detail::NVTXCCCLDomain> __cuda_nvtx3_func_name{name}; \
           static const ::nvtx3::v1::event_attributes __cuda_nvtx3_func_attr{__cuda_nvtx3_func_name};                   \
           if (condition)                                                                                               \


### PR DESCRIPTION
The `optional<scoped_range_in<NVTXCCCLDomain>>` has to be inside the `NV_IS_HOST` macro. `~scoped_range_in` calls `domain::get<>`, which is defined like this:

```cpp
  template <typename D = global,
    typename std::enable_if<
      detail::is_c_string<decltype(D::name)>::value
    , int>::type = 0>
  NVTX3_NO_DISCARD static domain const& get() noexcept
  {
    static domain const d(D::name);
    return d;
  }
```

It initializes an object `d` with static storage duration. The problem is that the initializer is a call to a non-constexpr constructor:

```cpp
explicit domain(char const* name) noexcept : _domain{nvtxDomainCreateA(name)} {}
```

What we have is a dynamic initializer in a device module. That's not currently possible, so the build breaks. Moving the scoped_range_in object inside `NV_IS_HOST` stops this device module contamination.
