### PR TITLE
Don't use `inline` with glibcxx namespaces

### DIFF
--- a/libcudacxx/include/cuda/std/__fwd/string.h
+++ b/libcudacxx/include/cuda/std/__fwd/string.h
@@ -33,11 +33,11 @@ _CCCL_BEGIN_NAMESPACE_STD
 
 // libstdc++ puts basic_string to inline cxx11 namespace
 #  if _GLIBCXX_USE_CXX11_ABI
-_GLIBCXX_BEGIN_NAMESPACE_CXX11
+inline _GLIBCXX_BEGIN_NAMESPACE_CXX11
 #  endif // _GLIBCXX_USE_CXX11_ABI
 
-template <class _CharT, class _Traits, class _Alloc>
-class basic_string;
+  template <class _CharT, class _Traits, class _Alloc>
+  class basic_string;
 
 #  if _GLIBCXX_USE_CXX11_ABI
 _GLIBCXX_END_NAMESPACE_CXX11


### PR DESCRIPTION
The glibcxx namespace macros can expand to nothing, so it leaves plain `inline` somewhere in our code. We can remove it, because glibcxx defines the namespace as `inline` if needed inside the `c++config`