### PR TITLE
Check for `_GLIBCXX_USE_CXX11_ABI` only when compiling with libstdc++

### DIFF
--- a/libcudacxx/include/cuda/std/__fwd/string.h
+++ b/libcudacxx/include/cuda/std/__fwd/string.h
@@ -32,16 +32,16 @@
 _CCCL_BEGIN_NAMESPACE_STD
 
 // libstdc++ puts basic_string to inline cxx11 namespace
-#  if _GLIBCXX_USE_CXX11_ABI
+#  if _CCCL_HOST_STD_LIB(LIBSTDCXX) && _GLIBCXX_USE_CXX11_ABI
 inline _GLIBCXX_BEGIN_NAMESPACE_CXX11
-#  endif // _GLIBCXX_USE_CXX11_ABI
+#  endif // _CCCL_HOST_STD_LIB(LIBSTDCXX) && _GLIBCXX_USE_CXX11_ABI
 
   template <class _CharT, class _Traits, class _Alloc>
   class basic_string;
 
-#  if _GLIBCXX_USE_CXX11_ABI
+#  if _CCCL_HOST_STD_LIB(LIBSTDCXX) && _GLIBCXX_USE_CXX11_ABI
 _GLIBCXX_END_NAMESPACE_CXX11
-#  endif // _GLIBCXX_USE_CXX11_ABI
+#  endif // _CCCL_HOST_STD_LIB(LIBSTDCXX) && _GLIBCXX_USE_CXX11_ABI
 
 _CCCL_END_NAMESPACE_STD
 #endif // _CCCL_HAS_HOST_STD_LIB()


### PR DESCRIPTION
Guys from TensorRT team had problem compiling libcu++ when using libc++ as the host standard library and defining `_GLIBCXX_USE_CXX11_ABI` at the same time. This PR fixes that