### PR TITLE
Deprecate `<`, `<=`, `>` and `>=` operators for `cuda::arch_id`

### DIFF
--- a/libcudacxx/include/cuda/__device/arch_id.h
+++ b/libcudacxx/include/cuda/__device/arch_id.h
@@ -45,6 +45,34 @@ enum class arch_id : int
 #undef _CCCL_DEFINE_ARCH_SPECIFIC_ID
 };
 
+// todo: = delete these in 4.0.
+#define _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(_OP)                                                                   \
+  CCCL_DEPRECATED_BECAUSE("Comparing cuda::arch_id using operator" _CCCL_TO_STRING(                                 \
+    _OP) " is deprecated and will be deleted in the next major release. Compare cuda::compute_capabilities of the " \
+         "given "                                                                                                   \
+         "cuda::arch_id instead.")
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(<) _CCCL_API constexpr bool
+operator<(arch_id __lhs, arch_id __rhs) noexcept
+{
+  return ::cuda::std::to_underlying(__lhs) < ::cuda::std::to_underlying(__rhs);
+}
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(<=) _CCCL_API constexpr bool
+operator<=(arch_id __lhs, arch_id __rhs) noexcept
+{
+  return ::cuda::std::to_underlying(__lhs) <= ::cuda::std::to_underlying(__rhs);
+}
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(>) _CCCL_API constexpr bool
+operator>(arch_id __lhs, arch_id __rhs) noexcept
+{
+  return ::cuda::std::to_underlying(__lhs) > ::cuda::std::to_underlying(__rhs);
+}
+[[nodiscard]] _CCCL_DEPRECATED_ARCH_ID_COMPARISONS(>=) _CCCL_API constexpr bool
+operator>=(arch_id __lhs, arch_id __rhs) noexcept
+{
+  return ::cuda::std::to_underlying(__lhs) >= ::cuda::std::to_underlying(__rhs);
+}
+#undef _CCCL_DEPRECATED_ARCH_ID_COMPARISONS
+
 [[nodiscard]] _CCCL_API constexpr auto __all_arch_ids() noexcept
 {
   return ::cuda::std::array{


### PR DESCRIPTION
We don't want users to do:
```cpp
if (cuda::arch_id::sm_120 > cuda::arch_id::sm_120a) { /* ... */ }
```
They should get `compute_capability` of the `arch_id` and compare that instead.

We need to finish #7654 first, before merging this one.