### PR TITLE
cuda.compute: Faster TransformIterator construction

### DIFF
--- a/python/cuda_cccl/cuda/compute/_jit.py
+++ b/python/cuda_cccl/cuda/compute/_jit.py
@@ -11,7 +11,6 @@ import inspect
 import operator
 import struct
 import textwrap
-import uuid
 from types import new_class
 from typing import TYPE_CHECKING, Callable, Hashable, List, Tuple
 
@@ -434,6 +433,7 @@ def _numba_type_to_type_descriptor(numba_type):
     return cccl_types.from_numpy_dtype(dtype)
 
 
+@cache_with_registered_key_functions
 def _infer_return_type(py_func, input_types):
     # Ensure any gpu_struct classes referenced in the function are registered
     _ensure_function_structs_registered(py_func)
@@ -449,22 +449,6 @@ def _infer_return_type(py_func, input_types):
         py_func, input_numba_types, abi_info={"abi_name": abi_name}
     )
     return _numba_type_to_type_descriptor(return_type)
-
-
-# -----------------------------------------------------------------------------
-# Iterator compilation
-# -----------------------------------------------------------------------------
-
-
-@functools.lru_cache(maxsize=256)
-def _cached_compile(func, sig, abi_name=None, **kwargs):
-    """Cached wrapper around numba.cuda.compile."""
-    return numba.cuda.compile(func, sig, abi_info={"abi_name": abi_name}, **kwargs)
-
-
-def _get_abi_suffix():
-    """Generate a unique ABI suffix."""
-    return uuid.uuid4().hex
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Description

When constructing `TransformIterator`, we use numba type inference to figure the output type of the operator. This can be relatively expensive, and is relatively easily cached.

```python
# before:
In [4]: %timeit TransformIterator(arr, lambda x: x ** 2)
7.18 ms ± 10.6 μs per loop (mean ± std. dev. of 7 runs, 100 loops each)

# after
In [6]: %timeit TransformIterator(arr, lambda x: x ** 2)
15.3 μs ± 14.3 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
