### PR TITLE
Split CUB builds into per-launcher jobs.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -198,6 +198,122 @@
       }
     },
     {
+      "name": "cub-nolid",
+      "displayName": "CUB: No Launcher",
+      "inherits": "cub",
+      "cacheVariables": {
+        "CUB_ENABLE_LAUNCH_NO_LAUNCHER": true,
+        "CUB_ENABLE_LAUNCH_HOST_LAUNCHER": false,
+        "CUB_ENABLE_LAUNCH_DEVICE_LAUNCHER": false,
+        "CUB_ENABLE_LAUNCH_GRAPH_LAUNCHER": false
+      }
+    },
+    {
+      "name": "cub-nolid-cpp17",
+      "displayName": "CUB: No Launcher C++17",
+      "inherits": "cub-nolid",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CUDA_STANDARD": "17"
+      }
+    },
+    {
+      "name": "cub-nolid-cpp20",
+      "displayName": "CUB: No Launcher C++20",
+      "inherits": "cub-nolid",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CUDA_STANDARD": "20"
+      }
+    },
+    {
+      "name": "cub-lid0",
+      "displayName": "CUB: Host Launch",
+      "inherits": "cub",
+      "cacheVariables": {
+        "CUB_ENABLE_LAUNCH_NO_LAUNCHER": false,
+        "CUB_ENABLE_LAUNCH_HOST_LAUNCHER": true,
+        "CUB_ENABLE_LAUNCH_DEVICE_LAUNCHER": false,
+        "CUB_ENABLE_LAUNCH_GRAPH_LAUNCHER": false
+      }
+    },
+    {
+      "name": "cub-lid0-cpp17",
+      "displayName": "CUB: Host Launch C++17",
+      "inherits": "cub-lid0",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CUDA_STANDARD": "17"
+      }
+    },
+    {
+      "name": "cub-lid0-cpp20",
+      "displayName": "CUB: Host Launch C++20",
+      "inherits": "cub-lid0",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CUDA_STANDARD": "20"
+      }
+    },
+    {
+      "name": "cub-lid1",
+      "displayName": "CUB: Device Launch",
+      "inherits": "cub",
+      "cacheVariables": {
+        "CUB_ENABLE_LAUNCH_NO_LAUNCHER": false,
+        "CUB_ENABLE_LAUNCH_HOST_LAUNCHER": false,
+        "CUB_ENABLE_LAUNCH_DEVICE_LAUNCHER": true,
+        "CUB_ENABLE_LAUNCH_GRAPH_LAUNCHER": false
+      }
+    },
+    {
+      "name": "cub-lid1-cpp17",
+      "displayName": "CUB: Device Launch C++17",
+      "inherits": "cub-lid1",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CUDA_STANDARD": "17"
+      }
+    },
+    {
+      "name": "cub-lid1-cpp20",
+      "displayName": "CUB: Device Launch C++20",
+      "inherits": "cub-lid1",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CUDA_STANDARD": "20"
+      }
+    },
+    {
+      "name": "cub-lid2",
+      "displayName": "CUB: Graph Launch",
+      "inherits": "cub",
+      "cacheVariables": {
+        "CUB_ENABLE_LAUNCH_NO_LAUNCHER": false,
+        "CUB_ENABLE_LAUNCH_HOST_LAUNCHER": false,
+        "CUB_ENABLE_LAUNCH_DEVICE_LAUNCHER": false,
+        "CUB_ENABLE_LAUNCH_GRAPH_LAUNCHER": true
+      }
+    },
+    {
+      "name": "cub-lid2-cpp17",
+      "displayName": "CUB: Graph Launch C++17",
+      "inherits": "cub-lid2",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CUDA_STANDARD": "17"
+      }
+    },
+    {
+      "name": "cub-lid2-cpp20",
+      "displayName": "CUB: Graph Launch C++20",
+      "inherits": "cub-lid2",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "20",
+        "CMAKE_CUDA_STANDARD": "20"
+      }
+    },
+    {
       "name": "thrust",
       "displayName": "Thrust",
       "inherits": "base",
@@ -420,6 +536,54 @@
       "configurePreset": "cub-cpp20"
     },
     {
+      "name": "cub-nolid",
+      "configurePreset": "cub-nolid"
+    },
+    {
+      "name": "cub-nolid-cpp17",
+      "configurePreset": "cub-nolid-cpp17"
+    },
+    {
+      "name": "cub-nolid-cpp20",
+      "configurePreset": "cub-nolid-cpp20"
+    },
+    {
+      "name": "cub-lid0",
+      "configurePreset": "cub-lid0"
+    },
+    {
+      "name": "cub-lid0-cpp17",
+      "configurePreset": "cub-lid0-cpp17"
+    },
+    {
+      "name": "cub-lid0-cpp20",
+      "configurePreset": "cub-lid0-cpp20"
+    },
+    {
+      "name": "cub-lid1",
+      "configurePreset": "cub-lid1"
+    },
+    {
+      "name": "cub-lid1-cpp17",
+      "configurePreset": "cub-lid1-cpp17"
+    },
+    {
+      "name": "cub-lid1-cpp20",
+      "configurePreset": "cub-lid1-cpp20"
+    },
+    {
+      "name": "cub-lid2",
+      "configurePreset": "cub-lid2"
+    },
+    {
+      "name": "cub-lid2-cpp17",
+      "configurePreset": "cub-lid2-cpp17"
+    },
+    {
+      "name": "cub-lid2-cpp20",
+      "configurePreset": "cub-lid2-cpp20"
+    },
+    {
       "name": "thrust",
       "configurePreset": "thrust"
     },
@@ -568,6 +732,7 @@
     },
     {
       "name": "cub-nolid",
+      "configurePreset": "cub-nolid",
       "inherits": "cub",
       "filter": {
         "exclude": {
@@ -577,16 +742,17 @@
     },
     {
       "name": "cub-nolid-cpp17",
-      "configurePreset": "cub-cpp17",
+      "configurePreset": "cub-nolid-cpp17",
       "inherits": "cub-nolid"
     },
     {
       "name": "cub-nolid-cpp20",
-      "configurePreset": "cub-cpp20",
+      "configurePreset": "cub-nolid-cpp20",
       "inherits": "cub-nolid"
     },
     {
       "name": "cub-lid0",
+      "configurePreset": "cub-lid0",
       "inherits": "cub",
       "filter": {
         "include": {
@@ -596,16 +762,17 @@
     },
     {
       "name": "cub-lid0-cpp17",
-      "configurePreset": "cub-cpp17",
+      "configurePreset": "cub-lid0-cpp17",
       "inherits": "cub-lid0"
     },
     {
       "name": "cub-lid0-cpp20",
-      "configurePreset": "cub-cpp20",
+      "configurePreset": "cub-lid0-cpp20",
       "inherits": "cub-lid0"
     },
     {
       "name": "cub-lid1",
+      "configurePreset": "cub-lid1",
       "inherits": "cub",
       "filter": {
         "include": {
@@ -615,16 +782,17 @@
     },
     {
       "name": "cub-lid1-cpp17",
-      "configurePreset": "cub-cpp17",
+      "configurePreset": "cub-lid1-cpp17",
       "inherits": "cub-lid1"
     },
     {
       "name": "cub-lid1-cpp20",
-      "configurePreset": "cub-cpp20",
+      "configurePreset": "cub-lid1-cpp20",
       "inherits": "cub-lid1"
     },
     {
       "name": "cub-lid2",
+      "configurePreset": "cub-lid2",
       "inherits": "cub",
       "filter": {
         "include": {
@@ -634,12 +802,12 @@
     },
     {
       "name": "cub-lid2-cpp17",
-      "configurePreset": "cub-cpp17",
+      "configurePreset": "cub-lid2-cpp17",
       "inherits": "cub-lid2"
     },
     {
       "name": "cub-lid2-cpp20",
-      "configurePreset": "cub-cpp20",
+      "configurePreset": "cub-lid2-cpp20",
       "inherits": "cub-lid2"
     },
     {

--- a/ci/build_cub.sh
+++ b/ci/build_cub.sh
@@ -2,7 +2,56 @@
 
 set -euo pipefail
 
-source "$(dirname "${BASH_SOURCE[0]}")/build_common.sh"
+NO_LID=false
+LID0=false
+LID1=false
+LID2=false
+ARTIFACT_TAGS=()
+
+ci_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+
+new_args=$("${ci_dir}/util/extract_switches.sh" \
+  -no-lid \
+  -lid0 \
+  -lid1 \
+  -lid2 \
+  -- "$@")
+
+eval set -- ${new_args}
+while true; do
+  case "$1" in
+  -no-lid)
+    ARTIFACT_TAGS+=("no_lid")
+    NO_LID=true
+    shift
+    ;;
+  -lid0)
+    ARTIFACT_TAGS+=("lid_0")
+    LID0=true
+    shift
+    ;;
+  -lid1)
+    ARTIFACT_TAGS+=("lid_1")
+    LID1=true
+    shift
+    ;;
+  -lid2)
+    ARTIFACT_TAGS+=("lid_2")
+    LID2=true
+    shift
+    ;;
+  --)
+    shift
+    break
+    ;;
+  *)
+    echo "Unknown argument: $1"
+    exit 1
+    ;;
+  esac
+done
+
+source "${ci_dir}/build_common.sh"
 
 print_environment_details
 
@@ -27,6 +76,15 @@ if [[ "$HOST_COMPILER" == *icpc* || "$HOST_COMPILER" == *nvhpc* ]]; then
 fi
 
 PRESET="cub"
+if $NO_LID; then
+    PRESET="cub-nolid"
+elif $LID0; then
+    PRESET="cub-lid0"
+elif $LID1; then
+    PRESET="cub-lid1"
+elif $LID2; then
+    PRESET="cub-lid2"
+fi
 
 CMAKE_OPTIONS=(
     -DCMAKE_CXX_STANDARD=$CXX_STANDARD
@@ -39,7 +97,13 @@ configure_and_build_preset "CUB" "$PRESET" "${CMAKE_OPTIONS[*]}"
 
 # Create test artifacts:
 if [[ -n "${GITHUB_ACTIONS:-}" ]]; then
-    run_command "📦  Packaging test artifacts" /home/coder/cccl/ci/upload_cub_test_artifacts.sh
+    if [[ ${#ARTIFACT_TAGS[@]} -gt 0 ]]; then
+        run_command "📦  Packaging test artifacts" \
+            "${ci_dir}/upload_cub_test_artifacts.sh" \
+            "${ARTIFACT_TAGS[@]}"
+    else
+        run_command "📦  Packaging test artifacts" "${ci_dir}/upload_cub_test_artifacts.sh"
+    fi
 fi
 
 print_time_summary

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -97,10 +97,10 @@ workflows:
     - {project: 'libcudacxx', jobs: ['nvrtc'], std: 'max', gpu: 'rtx2080', sm: 'gpu'}
     - {project: 'libcudacxx', jobs: ['verify_codegen']}
     # CUB - Specialized, testing default SM
-    - {project: 'cub', jobs: ['test_nolid', 'test_lid0'], std: 'max', cxx: ['gcc', 'msvc'], gpu: 'rtxa6000', sm: 'gpu', cmake_options: '-DCUB_ENABLE_LAUNCH_VARIANTS=OFF'}
-    - {project: 'cub', jobs: ['build'], std: 'max', cxx: 'clang', cmake_options: '-DCUB_ENABLE_LAUNCH_VARIANTS=OFF'}
-    # - {project: 'cub', jobs: ['build'], std: 'max', ctk: 'nvhpc', cxx: 'nvhpc', cmake_options: '-DCUB_ENABLE_LAUNCH_VARIANTS=OFF'}
-    - {project: 'cub', jobs: ['build'], std: 'max', cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', sm: '75;80;90;100', cmake_options: '-DCUB_ENABLE_LAUNCH_VARIANTS=OFF'}
+    - {project: 'cub', jobs: ['test_nolid', 'test_lid0'], std: 'max', cxx: ['gcc', 'msvc'], gpu: 'rtxa6000', sm: 'gpu'}
+    - {project: 'cub', jobs: ['build_nolid', 'build_lid0'], std: 'max', cxx: 'clang'}
+    # - {project: 'cub', jobs: ['build_nolid', 'build_lid0'], std: 'max', ctk: 'nvhpc', cxx: 'nvhpc'}
+    - {project: 'cub', jobs: ['build_nolid', 'build_lid0'], std: 'max', cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', sm: '75;80;90;100'}
     # Thrust - Keep number of sm small. Kernel coverage is in CUB. This just tests dispatch / glue in lite mode:
     - {project: 'thrust', jobs: ['test'], std: 'max', cxx: ['gcc', 'msvc'], gpu: 'rtx4090', sm: 'gpu'}
     - {project: 'thrust', jobs: ['build'], std: 'max', cxx: 'clang', sm: '75;120'}
@@ -260,7 +260,7 @@ workflows:
     - {jobs: ['limited'], project: 'cub', std: 17, gpu: 'rtx2080'}
     # sm: all-cccl:
     - {jobs: ['build'], project: ['thrust', 'libcudacxx', 'cudax'], std: 'max', sm: 'all-cccl' }
-    - {jobs: ['build'], project: ['cub'], std: 'max', sm: 'all-cccl', cmake_options: '-DCUB_ENABLE_LAUNCH_VARIANTS=OFF'}
+    - {jobs: ['build_nolid', 'build_lid0'], project: ['cub'], std: 'max', sm: 'all-cccl'}
     # NVRTC tests don't currently support 12.0:
     - {jobs: ['nvrtc'],          project: 'libcudacxx', ctk: [        '12.X', '13.0', '13.X'], cxx: 'gcc12', std: 'all', gpu: 'rtx2080', sm: 'gpu'}
     - {jobs: ['verify_codegen'], project: 'libcudacxx'}
@@ -436,27 +436,31 @@ jobs:
   verify_codegen: { gpu: false, name: 'VerifyCodegen' }
 
   # CUB:
+  build_nolid: { name: 'BuildNoLaunch',     gpu: false, invoke: { prefix: 'build', args: '-no-lid'} }
+  build_lid0:  { name: 'BuildHostLaunch',   gpu: false, invoke: { prefix: 'build', args: '-lid0'} }
+  build_lid1:  { name: 'BuildDeviceLaunch', gpu: false, invoke: { prefix: 'build', args: '-lid1'} }
+  build_lid2:  { name: 'BuildGraphCapture', gpu: false, invoke: { prefix: 'build', args: '-lid2'} }
   # NoLid -> The string `lid_X` doesn't appear in the test name. Mostly warp/block tests, old device tests, and examples.
-  test_nolid: { name: 'TestGPU',      gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-no-lid'} }
+  test_nolid: { name: 'TestNoLaunch',      gpu: true, needs: 'build_nolid', invoke: { prefix: 'test', args: '-no-lid'} }
   # CUB uses `lid` to indicate launch strategies: whether CUB algorithms are:
   # - launched from the host (lid0):
-  test_lid0:  { name: 'HostLaunch',   gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-lid0'} }
+  test_lid0:  { name: 'HostLaunch',   gpu: true, needs: 'build_lid0', invoke: { prefix: 'test', args: '-lid0'} }
   # - launched from the device (lid1):
-  test_lid1:  { name: 'DeviceLaunch', gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-lid1'} }
+  test_lid1:  { name: 'DeviceLaunch', gpu: true, needs: 'build_lid1', invoke: { prefix: 'test', args: '-lid1'} }
   # - captured in a CUDA graph for deferred launch (lid2):
-  test_lid2:  { name: 'GraphCapture', gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-lid2'} }
+  test_lid2:  { name: 'GraphCapture', gpu: true, needs: 'build_lid2', invoke: { prefix: 'test', args: '-lid2'} }
   # Limited build reduces the number of runtime test cases, available device memory, etc, and may be used
   # to reduce test runtime in limited environments.
   limited:    { name: "SmallGMem",   gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-limited'} }
   # Compute sanitizer jobs:
-  compute_mem_nolid:  { name: 'CSMem-TestGPU',       gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-memcheck  -no-lid'} }
-  compute_mem_lid0:   { name: 'CSMem-HostLaunch',    gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-memcheck  -lid0'} }
-  compute_race_nolid: { name: 'CSRace-TestGPU',      gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-racecheck -no-lid'} }
-  compute_race_lid0:  { name: 'CSRace-HostLaunch',   gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-racecheck -lid0'} }
-  compute_init_nolid: { name: 'CSInit-TestGPU',      gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-initcheck -no-lid'} }
-  compute_init_lid0:  { name: 'CSInit-HostLaunch',   gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-initcheck -lid0'} }
-  compute_sync_nolid: { name: 'CSSync-TestGPU',      gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-synccheck -no-lid'} }
-  compute_sync_lid0:  { name: 'CSSync-HostLaunch',   gpu: true, needs: 'build', invoke: { prefix: 'test', args: '-compute-sanitizer-synccheck -lid0'} }
+  compute_mem_nolid:  { name: 'CSMem-TestGPU',       gpu: true, needs: 'build_nolid', invoke: { prefix: 'test', args: '-compute-sanitizer-memcheck  -no-lid'} }
+  compute_mem_lid0:   { name: 'CSMem-HostLaunch',    gpu: true, needs: 'build_lid0',  invoke: { prefix: 'test', args: '-compute-sanitizer-memcheck  -lid0'} }
+  compute_race_nolid: { name: 'CSRace-TestGPU',      gpu: true, needs: 'build_nolid', invoke: { prefix: 'test', args: '-compute-sanitizer-racecheck -no-lid'} }
+  compute_race_lid0:  { name: 'CSRace-HostLaunch',   gpu: true, needs: 'build_lid0',  invoke: { prefix: 'test', args: '-compute-sanitizer-racecheck -lid0'} }
+  compute_init_nolid: { name: 'CSInit-TestGPU',      gpu: true, needs: 'build_nolid', invoke: { prefix: 'test', args: '-compute-sanitizer-initcheck -no-lid'} }
+  compute_init_lid0:  { name: 'CSInit-HostLaunch',   gpu: true, needs: 'build_lid0',  invoke: { prefix: 'test', args: '-compute-sanitizer-initcheck -lid0'} }
+  compute_sync_nolid: { name: 'CSSync-TestGPU',      gpu: true, needs: 'build_nolid', invoke: { prefix: 'test', args: '-compute-sanitizer-synccheck -no-lid'} }
+  compute_sync_lid0:  { name: 'CSSync-HostLaunch',   gpu: true, needs: 'build_lid0',  invoke: { prefix: 'test', args: '-compute-sanitizer-synccheck -lid0'} }
 
   # Thrust:
   test_cpu: { name: 'TestCPU', gpu: false, needs: 'build', invoke: { prefix: 'test', args: '-cpu-only'} }
@@ -501,7 +505,8 @@ projects:
     name: 'CUB'
     stds: [17, 20]
     job_map:
-      test: ['test_nolid', 'test_lid0', 'test_lid1', 'test_lid2']
+      build: ['build_nolid', 'build_lid0', 'build_lid1', 'build_lid2']
+      test:  ['test_nolid',  'test_lid0',  'test_lid1',  'test_lid2']
       compute_sanitizer:
         - compute_mem_nolid
         - compute_mem_lid0

--- a/ci/upload_cub_test_artifacts.sh
+++ b/ci/upload_cub_test_artifacts.sh
@@ -17,24 +17,28 @@ if ! ci/util/workflow/has_consumers.sh; then
   exit 0
 fi
 
-# Figure out which artifacts need to be built:
-consumers=$(ci/util/workflow/get_consumers.sh)
-preset_variants=()
-if grep -q "TestGPU" <<< "$consumers"; then
-  preset_variants+=("no_lid")
-fi
-if grep -q "HostLaunch" <<< "$consumers"; then
-  preset_variants+=("lid_0")
-fi
-if grep -q "DeviceLaunch" <<< "$consumers"; then
-  preset_variants+=("lid_1")
-fi
-if grep -q "GraphCapture" <<< "$consumers"; then
-  preset_variants+=("lid_2")
-fi
-# Limited jobs run the entire test suite:
-if grep -q "SmallGMem" <<< "$consumers"; then
-  preset_variants+=("no_lid" "lid_0" "lid_1" "lid_2")
+if [ "$#" -gt 0 ]; then
+  preset_variants=("$@")
+else
+  # Figure out which artifacts need to be built:
+  consumers=$(ci/util/workflow/get_consumers.sh)
+  preset_variants=()
+  if grep -q "TestGPU" <<< "$consumers"; then
+    preset_variants+=("no_lid")
+  fi
+  if grep -q "HostLaunch" <<< "$consumers"; then
+    preset_variants+=("lid_0")
+  fi
+  if grep -q "DeviceLaunch" <<< "$consumers"; then
+    preset_variants+=("lid_1")
+  fi
+  if grep -q "GraphCapture" <<< "$consumers"; then
+    preset_variants+=("lid_2")
+  fi
+  # Limited jobs run the entire test suite:
+  if grep -q "SmallGMem" <<< "$consumers"; then
+    preset_variants+=("no_lid" "lid_0" "lid_1" "lid_2")
+  fi
 fi
 
 # Remove duplicates:

--- a/ci/windows/build_cub.ps1
+++ b/ci/windows/build_cub.ps1
@@ -9,7 +9,19 @@ Param(
     [string]$CUDA_ARCH = "",
     [Parameter(Mandatory = $false)]
     [Alias("cmake-options")]
-    [string]$CMAKE_OPTIONS = ""
+    [string]$CMAKE_OPTIONS = "",
+    [Parameter(Mandatory = $false)]
+    [Alias("no-lid")]
+    [switch]$NO_LID_SWITCH = $false,
+    [Parameter(Mandatory = $false)]
+    [Alias("lid0")]
+    [switch]$LID0_SWITCH = $false,
+    [Parameter(Mandatory = $false)]
+    [Alias("lid1")]
+    [switch]$LID1_SWITCH = $false,
+    [Parameter(Mandatory = $false)]
+    [Alias("lid2")]
+    [switch]$LID2_SWITCH = $false
 )
 
 $ErrorActionPreference = "Stop"
@@ -23,6 +35,21 @@ If($CURRENT_PATH -ne "ci") {
 Import-Module $PSScriptRoot/build_common.psm1 -ArgumentList @($CXX_STANDARD, $CUDA_ARCH, $CMAKE_OPTIONS)
 
 $PRESET = "cub"
+$artifactTags = @()
+
+if ($NO_LID_SWITCH) {
+    $artifactTags += "no_lid"
+    $PRESET = "cub-nolid"
+} elseif ($LID0_SWITCH) {
+    $artifactTags += "lid_0"
+    $PRESET = "cub-lid0"
+} elseif ($LID1_SWITCH) {
+    $artifactTags += "lid_1"
+    $PRESET = "cub-lid1"
+} elseif ($LID2_SWITCH) {
+    $artifactTags += "lid_2"
+    $PRESET = "cub-lid2"
+}
 $LOCAL_CMAKE_OPTIONS = "-DCMAKE_CXX_STANDARD=$CXX_STANDARD -DCMAKE_CUDA_STANDARD=$CXX_STANDARD"
 
 if ($CL_VERSION -lt [version]"19.20") {
@@ -33,7 +60,11 @@ configure_and_build_preset "CUB" $PRESET $LOCAL_CMAKE_OPTIONS
 
 if ($env:GITHUB_ACTIONS) {
     Write-Host "Packaging test artifacts..."
-    & bash "./upload_cub_test_artifacts.sh"
+    if ($artifactTags.Count -gt 0) {
+        & bash "./upload_cub_test_artifacts.sh" @artifactTags
+    } else {
+        & bash "./upload_cub_test_artifacts.sh"
+    }
 }
 
 If($CURRENT_PATH -ne "ci") {

--- a/ci/windows/test_cub.ps1
+++ b/ci/windows/test_cub.ps1
@@ -36,18 +36,23 @@ Import-Module -Name "$PSScriptRoot/build_common.psm1" -ArgumentList @($CXX_STAND
 
 $PRESET = "cub"
 $artifactTag = ""
+$variantArg = ""
 if ($NO_LID_SWITCH) {
     $artifactTag = "no_lid"
     $PRESET = "cub-nolid"
+    $variantArg = "-no-lid"
 } elseif ($LID0_SWITCH) {
     $artifactTag = "lid_0"
     $PRESET = "cub-lid0"
+    $variantArg = "-lid0"
 } elseif ($LID1_SWITCH) {
     $artifactTag = "lid_1"
     $PRESET = "cub-lid1"
+    $variantArg = "-lid1"
 } elseif ($LID2_SWITCH) {
     $artifactTag = "lid_2"
     $PRESET = "cub-lid2"
+    $variantArg = "-lid2"
 }
 
 if ($env:GITHUB_ACTIONS -and $artifactTag) {
@@ -56,7 +61,7 @@ if ($env:GITHUB_ACTIONS -and $artifactTag) {
     Write-Host "Unpacking artifact '$artifactName'"
     & bash "./util/artifacts/download_packed.sh" "$artifactName" "../"
 } else {
-    $buildCmd = "$PSScriptRoot/build_cub.ps1 -std $CXX_STANDARD -arch '$CUDA_ARCH' -cmake-options '$CMAKE_OPTIONS'"
+    $buildCmd = "$PSScriptRoot/build_cub.ps1 -std $CXX_STANDARD -arch '$CUDA_ARCH' -cmake-options '$CMAKE_OPTIONS' $variantArg"
     Write-Host "Running: $buildCmd"
     Invoke-Expression $buildCmd
 }

--- a/cub/cmake/CubCudaConfig.cmake
+++ b/cub/cmake/CubCudaConfig.cmake
@@ -12,3 +12,51 @@ option(
   "Enable separable compilation on all targets that support it."
   OFF
 )
+
+option(
+  CUB_ENABLE_LAUNCH_NO_LAUNCHER
+  "Enable tests/examples without explicit launch variants."
+  ON
+)
+option(
+  CUB_ENABLE_LAUNCH_HOST_LAUNCHER
+  "Enable host launch variants (lid_0)."
+  ON
+)
+option(
+  CUB_ENABLE_LAUNCH_DEVICE_LAUNCHER
+  "Enable device launch variants (lid_1)."
+  ON
+)
+option(
+  CUB_ENABLE_LAUNCH_GRAPH_LAUNCHER
+  "Enable graph launch variants (lid_2)."
+  ON
+)
+
+option(
+  CUB_ENABLE_LAUNCH_VARIANTS
+  "Deprecated: use CUB_ENABLE_LAUNCH_DEVICE_LAUNCHER/GRAPH_LAUNCHER to control lid_1/lid_2."
+  ON
+)
+
+if (NOT CUB_ENABLE_LAUNCH_VARIANTS)
+  message(
+    WARNING
+    "CUB_ENABLE_LAUNCH_VARIANTS is deprecated; disabling lid_1/lid_2 launch variants."
+  )
+  set(
+    CUB_ENABLE_LAUNCH_DEVICE_LAUNCHER
+    OFF
+    CACHE BOOL
+    "Enable device launch variants (lid_1)."
+    FORCE
+  )
+  set(
+    CUB_ENABLE_LAUNCH_GRAPH_LAUNCHER
+    OFF
+    CACHE BOOL
+    "Enable graph launch variants (lid_2)."
+    FORCE
+  )
+endif()

--- a/cub/cmake/CubHeaderTesting.cmake
+++ b/cub/cmake/CubHeaderTesting.cmake
@@ -4,6 +4,11 @@
 # .inl files are not globbed for, because they are not supposed to be used as public
 # entrypoints.
 
+if (NOT CUB_ENABLE_LAUNCH_NO_LAUNCHER)
+  # Header tests are treated as core-only artifacts.
+  return()
+endif()
+
 function(cub_add_header_test label definitions)
   set(headertest_target cub.headers.${label})
 

--- a/cub/examples/CMakeLists.txt
+++ b/cub/examples/CMakeLists.txt
@@ -2,6 +2,11 @@
 # depends on c2h:
 cccl_get_c2h()
 
+if (NOT CUB_ENABLE_LAUNCH_NO_LAUNCHER)
+  # Examples do not define lid variants; treat them as core-only artifacts.
+  return()
+endif()
+
 ## cub_add_example
 #
 # Add an example executable and register it with ctest.

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -1,9 +1,3 @@
-option(
-  CUB_ENABLE_LAUNCH_VARIANTS
-  "Enable CUB launch variants (lid_1 and lid_2)"
-  ON
-)
-
 if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
   if (CUB_ENABLE_RDC_TESTS)
     if ("${CMAKE_VERSION}" VERSION_LESS 3.27.5)
@@ -274,6 +268,22 @@ function(_cub_launcher_id out_var label)
   endif()
 endfunction()
 
+## _cub_launch_id_enabled
+#
+# Sets out_var to 1 if the given launcher id is enabled by the corresponding
+# CUB_ENABLE_LAUNCH_* option.
+function(_cub_launch_id_enabled out_var launcher_id)
+  if ("${launcher_id}" STREQUAL "0")
+    set(${out_var} ${CUB_ENABLE_LAUNCH_HOST_LAUNCHER} PARENT_SCOPE)
+  elseif ("${launcher_id}" STREQUAL "1")
+    set(${out_var} ${CUB_ENABLE_LAUNCH_DEVICE_LAUNCHER} PARENT_SCOPE)
+  elseif ("${launcher_id}" STREQUAL "2")
+    set(${out_var} ${CUB_ENABLE_LAUNCH_GRAPH_LAUNCHER} PARENT_SCOPE)
+  else()
+    set(${out_var} 0 PARENT_SCOPE)
+  endif()
+endfunction()
+
 foreach (test_src IN LISTS test_srcs)
   get_filename_component(test_name "${test_src}" NAME_WE)
   string(REGEX REPLACE "^catch2_test_" "" test_name "${test_name}")
@@ -349,12 +359,14 @@ foreach (test_src IN LISTS test_srcs)
 
       if (${explicit_launcher})
         set(launcher_id "${explicit_launcher_id}")
+        _cub_launch_id_enabled(launch_enabled "${launcher_id}")
       else()
         if (${CUB_FORCE_RDC})
           set(launcher_id 1)
         else()
           set(launcher_id 0)
         endif()
+        set(launch_enabled "${CUB_ENABLE_LAUNCH_NO_LAUNCHER}")
       endif()
 
       _cub_launcher_requires_rdc(cdp_val "${launcher_id}")
@@ -363,7 +375,7 @@ foreach (test_src IN LISTS test_srcs)
         continue()
       endif()
 
-      if (NOT launcher_id EQUAL 0 AND NOT CUB_ENABLE_LAUNCH_VARIANTS)
+      if (NOT launch_enabled)
         continue()
       endif()
 

--- a/cub/test/ptx-json/CMakeLists.txt
+++ b/cub/test/ptx-json/CMakeLists.txt
@@ -1,3 +1,8 @@
+if (NOT CUB_ENABLE_LAUNCH_NO_LAUNCHER)
+  message(STATUS "Skipping ptx-json tests because no-launcher is disabled.")
+  return()
+endif()
+
 if (NOT "${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
   message(STATUS "Skipping ptx-json tests on non-Linux platforms.")
   return()


### PR DESCRIPTION
Add nolid / lid_0 / lid_1 / lid_2 toggles:

    CUB_ENABLE_LAUNCH_NO_LAUNCHER
    CUB_ENABLE_LAUNCH_HOST_LAUNCHER
    CUB_ENABLE_LAUNCH_DEVICE_LAUNCHER
    CUB_ENABLE_LAUNCH_GRAPH_LAUNCHER

Updated presets and CI infra accordingly. This should fix #7670.
