### PR TITLE
Improve documentation of `zip_iterator` 

### DIFF
--- a/libcudacxx/include/cuda/__iterator/zip_function.h
+++ b/libcudacxx/include/cuda/__iterator/zip_function.h
@@ -107,6 +107,16 @@ public:
   }
 };
 
+//! @brief Creates a @c zip_function from a function
+//! @tparam _Fn The functor to wrap
+//! @relates zip_iterator
+//! @relates zip_function
+template <class _Fn>
+_CCCL_API constexpr zip_function<::cuda::std::decay_t<_Fn>> make_zip_function(_Fn&& __fun)
+{
+  return zip_function<::cuda::std::decay_t<_Fn>>{::cuda::std::forward<_Fn>(__fun)};
+}
+
 //! @}
 
 _CCCL_END_NAMESPACE_CUDA

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -524,6 +524,7 @@ _CCCL_HOST_DEVICE zip_iterator(_Iterators...) -> zip_iterator<_Iterators...>;
 
 //! @brief Creates a @c zip_iterator from a tuple of iterators.
 //! @param __t The tuple of iterators to wrap
+//! @relates zip_iterator
 template <typename... Iterators>
 _CCCL_API constexpr zip_iterator<Iterators...> make_zip_iterator(::cuda::std::tuple<Iterators...> __t)
 {
@@ -532,6 +533,7 @@ _CCCL_API constexpr zip_iterator<Iterators...> make_zip_iterator(::cuda::std::tu
 
 //! @brief Creates a @c zip_iterator from a variadic number of iterators.
 //! @param __iters The iterators to wrap
+//! @relates zip_iterator
 template <typename... Iterators>
 _CCCL_API constexpr zip_iterator<Iterators...> make_zip_iterator(Iterators... __iters)
 {

--- a/libcudacxx/include/cuda/__iterator/zip_transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_transform_iterator.h
@@ -552,7 +552,9 @@ template <class _Fn, class... _Iterators>
 _CCCL_HOST_DEVICE zip_transform_iterator(_Fn, _Iterators...) -> zip_transform_iterator<_Fn, _Iterators...>;
 
 //! @brief Creates a @c zip_transform_iterator from a tuple of iterators.
+//! @param __fun The functor used to transform the input ranges
 //! @param __t The tuple of iterators to wrap
+//! @relates zip_transform_iterator
 template <class _Fn, class... _Iterators>
 [[nodiscard]] _CCCL_API constexpr auto
 make_zip_transform_iterator(_Fn __fun, ::cuda::std::tuple<_Iterators...> __t) noexcept(
@@ -563,7 +565,9 @@ make_zip_transform_iterator(_Fn __fun, ::cuda::std::tuple<_Iterators...> __t) no
 }
 
 //! @brief Creates a @c zip_transform_iterator from a variadic number of iterators.
+//! @param __fun The functor used to transform the input ranges
 //! @param __iters The iterators to wrap
+//! @relates zip_transform_iterator
 template <class _Fn, class... _Iterators>
 [[nodiscard]] _CCCL_API constexpr auto make_zip_transform_iterator(_Fn __fun, _Iterators... __iters) noexcept(
   ::cuda::std::is_nothrow_move_constructible_v<_Fn>


### PR DESCRIPTION
The `make_zip_{transform}_iterator` functions were not properly linked to the `zip_{transform}_iterator` class so they would not appear in the docs

Thanks to @wence- for finding this

I also added `make_zip_function` Its not useful but thrust has it so it simplifies transition