### PR TITLE
Fix max atomic size for NVHPC

### DIFF
--- a/cub/cub/detail/warpspeed/look_ahead.cuh
+++ b/cub/cub/detail/warpspeed/look_ahead.cuh
@@ -36,7 +36,7 @@ CUB_NAMESPACE_BEGIN
 
 namespace detail::warpspeed
 {
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL size_t max_native_atomic_size() noexcept
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL ::cuda::std::size_t max_native_atomic_size() noexcept
 {
 #if _CCCL_CUDA_COMPILER(NVHPC)
   return 8;


### PR DESCRIPTION
We were hardcoding 16 bytes as the hard limit for the lookahead algorithm.

However, that is not correct for NVHPC which only supports 4 or 8 byte atomics

Also be safe and conditionally switch based on SM90 because that is required for 16 byte atomics

Fixes #7650
