### PR TITLE
Literal for `cuda::compute_capability`

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability_literals.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability_literals.pass.cpp
@@ -17,7 +17,7 @@ __host__ __device__ constexpr bool test()
   {
     using namespace cuda::literals;
 
-    auto cc = 90_cc;
+    auto cc = 9.0_cc;
     static_assert(cuda::std::is_same_v<decltype(cc), cuda::compute_capability>);
     assert(cc.get() == 90);
   }
@@ -25,7 +25,7 @@ __host__ __device__ constexpr bool test()
   {
     using namespace cuda::compute_capability_literals;
 
-    auto cc = 90_cc;
+    auto cc = 9.0_cc;
     static_assert(cuda::std::is_same_v<decltype(cc), cuda::compute_capability>);
     assert(cc.get() == 90);
   }
@@ -33,7 +33,7 @@ __host__ __device__ constexpr bool test()
   {
     using namespace cuda::literals::compute_capability_literals;
 
-    auto cc = 90_cc;
+    auto cc = 9.0_cc;
     static_assert(cuda::std::is_same_v<decltype(cc), cuda::compute_capability>);
     assert(cc.get() == 90);
   }


### PR DESCRIPTION
I'd like to add a literal for `cuda::compute_capability`, because right now, if you want to compare compute capabilities, you need to do:
```cpp
if (cc >= cuda::compute_capability{90})
{
  // ...
}
```
which is very verbose. After this change, you can just do:
```cpp
using namespace cuda::compute_capability_literals;
if (cc >= 9.0_cc)
{
  // ...
}
```

There is just one question - should this be a user defined literals (`9.0_cc`) or do we want to make it a standard literal (`9.0cc`)? I'd prefer to get rid of the `_`, but I'm not sure if compilers would like it.