### PR TITLE
Implement parallel `cuda::std::remove_copy_{_if}`

### DIFF
--- a/libcudacxx/benchmarks/bench/remove_copy/basic.cu
+++ b/libcudacxx/benchmarks/bench/remove_copy/basic.cu
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/complex>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+  thrust::device_vector<T> out(elements, thrust::no_init);
+  const auto count = cuda::std::count(cuda::execution::__cub_par_unseq, in.begin(), in.end(), T{42});
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements - count);
+
+  caching_allocator_t alloc{};
+
+  state.exec(
+    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      do_not_optimize(cuda::std::remove_copy(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), T{42}));
+    });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/libcudacxx/benchmarks/bench/remove_copy_if/basic.cu
+++ b/libcudacxx/benchmarks/bench/remove_copy_if/basic.cu
@@ -1,0 +1,58 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/complex>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+struct is_even
+{
+  template <class T>
+  __device__ constexpr bool operator()(const T& val) const noexcept
+  {
+    return static_cast<int>(val) % 2 == 0;
+  }
+
+  __device__ constexpr bool operator()(const complex& val) const noexcept
+  {
+    return static_cast<int>(val.real()) % 2 == 0;
+  }
+};
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+  thrust::device_vector<T> out(elements, thrust::no_init);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements / 2);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(
+                 cuda::std::remove_copy_if(cuda_policy(alloc, launch), in.begin(), in.end(), out.begin(), is_even{}));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/libcudacxx/include/cuda/std/__pstl/remove_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/remove_copy.h
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_REMOVE_COPY_H
+#define _CUDA_STD___PSTL_REMOVE_COPY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__algorithm/remove_copy.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/integral_constant.h>
+#  include <cuda/std/__type_traits/is_comparable.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/copy_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+template <class _Tp>
+struct __remove_compare_not_eq
+{
+  _Tp __val_;
+
+  _CCCL_API constexpr __remove_compare_not_eq(const _Tp& __val) noexcept(is_nothrow_copy_constructible_v<_Tp>)
+      : __val_(__val)
+  {}
+
+  template <class _Up>
+  [[nodiscard]] _CCCL_API _CCCL_FORCEINLINE constexpr bool operator()(const _Up& __rhs) const
+    noexcept(__is_cpp17_nothrow_equality_comparable_v<_Tp, _Up>)
+  {
+    return !static_cast<bool>(__val_ == __rhs);
+  }
+};
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _OutputIterator, class _Tp)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND __has_forward_traversal<_OutputIterator> _CCCL_AND
+                 is_execution_policy_v<_Policy>)
+_CCCL_HOST_API _OutputIterator remove_copy(
+  [[maybe_unused]] const _Policy& __policy,
+  _InputIterator __first,
+  _InputIterator __last,
+  _OutputIterator __result,
+  const _Tp& __value)
+{
+  if (__first == __last)
+  {
+    return __result;
+  }
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__copy_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    const auto __count = ::cuda::std::distance(__first, __last);
+    return __dispatch(
+      __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__result), __remove_compare_not_eq{__value});
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::remove_copy requires at least one selected backend");
+    return ::cuda::std::remove_copy(
+      ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__result), __value);
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_REMOVE_COPY_H

--- a/libcudacxx/include/cuda/std/__pstl/remove_copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/remove_copy_if.h
@@ -1,0 +1,96 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_REMOVE_COPY_IF_H
+#define _CUDA_STD___PSTL_REMOVE_COPY_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/std/__algorithm/remove_copy_if.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/not_fn.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/integral_constant.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/copy_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _OutputIterator, class _UnaryPred)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND __has_forward_traversal<_OutputIterator> _CCCL_AND
+                 is_execution_policy_v<_Policy>)
+_CCCL_HOST_API _OutputIterator remove_copy_if(
+  [[maybe_unused]] const _Policy& __policy,
+  _InputIterator __first,
+  _InputIterator __last,
+  _OutputIterator __result,
+  _UnaryPred __pred)
+{
+  static_assert(indirect_unary_predicate<_UnaryPred, _InputIterator>,
+                "cuda::std::remove_copy_if: UnaryPred must satisfy indirect_unary_predicate<InputIterator>");
+
+  if (__first == __last)
+  {
+    return __result;
+  }
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__copy_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    const auto __count = ::cuda::std::distance(__first, __last);
+    return __dispatch(
+      __policy,
+      ::cuda::std::move(__first),
+      __count,
+      ::cuda::std::move(__result),
+      ::cuda::std::not_fn(::cuda::std::move(__pred)));
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>,
+                  "Parallel cuda::std::remove_copy_if requires at least one selected backend");
+    return ::cuda::std::remove_copy_if(
+      ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__result), ::cuda::std::move(__pred));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_REMOVE_COPY_IF_H

--- a/libcudacxx/include/cuda/std/__pstl_algorithm
+++ b/libcudacxx/include/cuda/std/__pstl_algorithm
@@ -34,6 +34,8 @@
 #include <cuda/std/__pstl/generate.h>
 #include <cuda/std/__pstl/generate_n.h>
 #include <cuda/std/__pstl/reduce.h>
+#include <cuda/std/__pstl/remove_copy.h>
+#include <cuda/std/__pstl/remove_copy_if.h>
 #include <cuda/std/__pstl/replace.h>
 #include <cuda/std/__pstl/replace_copy.h>
 #include <cuda/std/__pstl/replace_copy_if.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy.cu
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template <class Policy, class InputIterator, class OutputIterator, class T>
+// OutputIterator remove_copy(const Policy&  policy,
+//                            InputIterator  first,
+//                            InputIterator  last,
+//                            OutputIterator result,
+//                            const T&       value);
+
+#include <thrust/device_vector.h>
+#include <thrust/equal.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+
+#include <cuda/cmath>
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 10000;
+
+template <class Policy>
+void test_remove_copy(const Policy& policy, thrust::device_vector<int>& output)
+{
+  { // empty should not access anything
+    const auto res = cuda::std::remove_copy(
+      policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), static_cast<int*>(nullptr), 42);
+    CHECK(res == nullptr);
+  }
+
+  { // With matching value
+    thrust::fill(output.begin(), output.end(), 0);
+    const auto res =
+      cuda::std::remove_copy(policy, cuda::counting_iterator{0}, cuda::counting_iterator{size}, output.begin(), 42);
+    CHECK(cuda::std::distance(output.begin(), res) == size - 1);
+
+    const auto mid = cuda::std::next(output.begin(), 42);
+    CHECK(thrust::equal(output.begin(), mid, cuda::counting_iterator{0}));
+    CHECK(thrust::equal(mid, res, cuda::counting_iterator{43}));
+  }
+
+  { // With conversion for value type
+    thrust::fill(output.begin(), output.end(), 0);
+    const auto res = cuda::std::remove_copy(
+      policy, cuda::counting_iterator{0}, cuda::counting_iterator{size}, output.begin(), short{42});
+    CHECK(cuda::std::distance(output.begin(), res) == size - 1);
+
+    const auto mid = cuda::std::next(output.begin(), 42);
+    CHECK(thrust::equal(output.begin(), mid, cuda::counting_iterator{0}));
+    CHECK(thrust::equal(mid, res, cuda::counting_iterator{43}));
+  }
+}
+
+C2H_TEST("cuda::std::remove_copy", "[parallel algorithm]")
+{
+  thrust::device_vector<int> output(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    test_remove_copy(policy, output);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    test_remove_copy(policy, output);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    test_remove_copy(policy, output);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    test_remove_copy(policy, output);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy_if.cu
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template <class Policy, class InputIterator, class OutputIterator, class UnaryPredicate>
+// OutputIterator remove_copy_if(const Policy&  policy,
+//                               InputIterator  first,
+//                               InputIterator  last,
+//                               OutputIterator result,
+//                               UnaryPredicate pred);
+
+#include <thrust/device_vector.h>
+#include <thrust/equal.h>
+#include <thrust/execution_policy.h>
+#include <thrust/fill.h>
+
+#include <cuda/cmath>
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 10000;
+
+template <class T = int>
+struct is_even
+{
+  __device__ constexpr bool operator()(const T& val) const noexcept
+  {
+    return (val % 2) == 0;
+  }
+};
+
+template <class Policy>
+void test_remove_copy_if(const Policy& policy, thrust::device_vector<int>& output)
+{
+  { // empty should not access anything
+    const auto res = cuda::std::remove_copy_if(
+      policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), static_cast<int*>(nullptr), is_even{});
+    CHECK(res == nullptr);
+  }
+
+  { // With matching predicate (copy odd elements)
+    thrust::fill(output.begin(), output.end(), 0);
+    const auto res = cuda::std::remove_copy_if(
+      policy, cuda::counting_iterator{0}, cuda::counting_iterator{size}, output.begin(), is_even{});
+    CHECK(thrust::equal(output.begin(), res, cuda::strided_iterator{cuda::counting_iterator{1}, 2}));
+    CHECK(cuda::std::distance(output.begin(), res) == size / 2);
+  }
+
+  { // With conversion for predicate
+    thrust::fill(output.begin(), output.end(), 0);
+    const auto res = cuda::std::remove_copy_if(
+      policy,
+      cuda::counting_iterator{0},
+      cuda::counting_iterator{size},
+      output.begin(),
+      is_even<cuda::std::ptrdiff_t>{});
+    CHECK(thrust::equal(output.begin(), res, cuda::strided_iterator{cuda::counting_iterator{1}, 2}));
+    CHECK(cuda::std::distance(output.begin(), res) == size / 2);
+  }
+}
+
+C2H_TEST("cuda::std::remove_copy_if", "[parallel algorithm]")
+{
+  thrust::device_vector<int> output(size / 2, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    test_remove_copy_if(policy, output);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    test_remove_copy_if(policy, output);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    test_remove_copy_if(policy, output);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    test_remove_copy_if(policy, output);
+  }
+}

--- a/thrust/benchmarks/bench/remove_copy/basic.cu
+++ b/thrust/benchmarks/bench/remove_copy/basic.cu
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <thrust/count.h>
+#include <thrust/device_vector.h>
+#include <thrust/remove.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/complex>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+  thrust::device_vector<T> out(elements, thrust::no_init);
+  const auto count = thrust::count(thrust::device, in.begin(), in.end(), T{42});
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements - count);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(thrust::remove_copy(policy(alloc, launch), in.begin(), in.end(), out.begin(), T{42}));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/thrust/benchmarks/bench/remove_copy_if/basic.cu
+++ b/thrust/benchmarks/bench/remove_copy_if/basic.cu
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <thrust/device_vector.h>
+#include <thrust/remove.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/complex>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+struct is_even
+{
+  template <class T>
+  __device__ constexpr bool operator()(const T& val) const noexcept
+  {
+    return static_cast<int>(val) % 2 == 0;
+  }
+
+  __device__ constexpr bool operator()(const complex& val) const noexcept
+  {
+    return static_cast<int>(val.real()) % 2 == 0;
+  }
+};
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+  thrust::device_vector<T> out(elements, thrust::no_init);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements / 2);
+
+  caching_allocator_t alloc{};
+
+  state.exec(
+    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      do_not_optimize(thrust::remove_copy_if(policy(alloc, launch), in.begin(), in.end(), out.begin(), is_even{}));
+    });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));


### PR DESCRIPTION
This implements the remove algorithm for the cuda backend.

* `std::remove_copy` see https://en.cppreference.com/w/cpp/algorithm/remove_copy.html
* `std::remove_copy_if` see https://en.cppreference.com/w/cpp/algorithm/remove_copy.html

It provides tests and benchmarks similar to Thrust and some boilerplate for libcu++

The functionality is publicly available yet and implemented in a private internal header

Fixes #7694

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
