### PR TITLE
Add env-based cub::RadixSort::SortKeys* 

### DIFF
--- a/cub/cub/device/device_radix_sort.cuh
+++ b/cub/cub/device/device_radix_sort.cuh
@@ -2477,8 +2477,8 @@ public:
   //! @rst
   //! Sorts keys into ascending order using :math:`\approx 2N` auxiliary storage.
   //!
-  //! .. versionadded:: 3.2.0
-  //!    First appears in CUDA Toolkit 13.2.
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
   //!
   //! This is an environment-based API that allows customization of:
   //!
@@ -2542,18 +2542,23 @@ public:
             typename NumItemsT,
             typename EnvT = ::cuda::std::execution::env<>,
             typename ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
-  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  SortKeys(const KeyT* d_keys_in, KeyT* d_keys_out, NumItemsT num_items, int begin_bit, int end_bit, EnvT env = {})
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortKeys(
+    const KeyT* d_keys_in,
+    KeyT* d_keys_out,
+    NumItemsT num_items,
+    int begin_bit = 0,
+    int end_bit   = sizeof(KeyT) * 8,
+    EnvT env      = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
     using offset_t = detail::choose_offset_t<NumItemsT>;
 
     // Dispatch with environment - handles all boilerplate
+    DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
+    DoubleBuffer<NullType> d_values;
+
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      using tuning_t = decltype(tuning);
-      DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
-      DoubleBuffer<NullType> d_values;
       return detail::radix_sort::dispatch<SortOrder::Ascending>(
         storage, bytes, d_keys, d_values, static_cast<offset_t>(num_items), begin_bit, end_bit, false, stream);
     });
@@ -2964,8 +2969,8 @@ public:
   //! @rst
   //! Sorts keys into ascending order using :math:`\approx N` auxiliary storage.
   //!
-  //! .. versionadded:: 3.2.0
-  //!    First appears in CUDA Toolkit 13.2.
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
   //!
   //! This is an environment-based API that allows customization of:
   //!
@@ -3033,16 +3038,16 @@ public:
             typename NumItemsT,
             typename EnvT = ::cuda::std::execution::env<>,
             typename ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
-  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  SortKeys(DoubleBuffer<KeyT>& d_keys, NumItemsT num_items, int begin_bit, int end_bit, EnvT env = {})
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortKeys(
+    DoubleBuffer<KeyT>& d_keys, NumItemsT num_items, int begin_bit = 0, int end_bit = sizeof(KeyT) * 8, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
     using offset_t = detail::choose_offset_t<NumItemsT>;
 
+    DoubleBuffer<NullType> d_values;
+
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      using tuning_t = decltype(tuning);
-      DoubleBuffer<NullType> d_values;
       return detail::radix_sort::dispatch<SortOrder::Ascending>(
         storage, bytes, d_keys, d_values, static_cast<offset_t>(num_items), begin_bit, end_bit, true, stream);
     });
@@ -3444,8 +3449,8 @@ public:
   //! @rst
   //! Sorts keys into descending order using :math:`\approx 2N` auxiliary storage.
   //!
-  //! .. versionadded:: 3.2.0
-  //!    First appears in CUDA Toolkit 13.2.
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
   //!
   //! This is an environment-based API that allows customization of:
   //!
@@ -3510,17 +3515,22 @@ public:
             typename EnvT = ::cuda::std::execution::env<>,
             typename ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortKeysDescending(
-    const KeyT* d_keys_in, KeyT* d_keys_out, NumItemsT num_items, int begin_bit, int end_bit, EnvT env = {})
+    const KeyT* d_keys_in,
+    KeyT* d_keys_out,
+    NumItemsT num_items,
+    int begin_bit = 0,
+    int end_bit   = sizeof(KeyT) * 8,
+    EnvT env      = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
     using offset_t = detail::choose_offset_t<NumItemsT>;
 
     // Dispatch with environment - handles all boilerplate
+    DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
+    DoubleBuffer<NullType> d_values;
+
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      using tuning_t = decltype(tuning);
-      DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
-      DoubleBuffer<NullType> d_values;
       return detail::radix_sort::dispatch<SortOrder::Descending>(
         storage, bytes, d_keys, d_values, static_cast<offset_t>(num_items), begin_bit, end_bit, false, stream);
     });
@@ -3929,8 +3939,8 @@ public:
   //! @rst
   //! Sorts keys into descending order using :math:`\approx N` auxiliary storage.
   //!
-  //! .. versionadded:: 3.2.0
-  //!    First appears in CUDA Toolkit 13.2.
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
   //!
   //! This is an environment-based API that allows customization of:
   //!
@@ -3998,16 +4008,16 @@ public:
             typename NumItemsT,
             typename EnvT = ::cuda::std::execution::env<>,
             typename ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
-  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t
-  SortKeysDescending(DoubleBuffer<KeyT>& d_keys, NumItemsT num_items, int begin_bit, int end_bit, EnvT env = {})
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortKeysDescending(
+    DoubleBuffer<KeyT>& d_keys, NumItemsT num_items, int begin_bit = 0, int end_bit = sizeof(KeyT) * 8, EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE(GetName());
 
     using offset_t = detail::choose_offset_t<NumItemsT>;
 
+    DoubleBuffer<NullType> d_values;
+
     return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
-      using tuning_t = decltype(tuning);
-      DoubleBuffer<NullType> d_values;
       return detail::radix_sort::dispatch<SortOrder::Descending>(
         storage, bytes, d_keys, d_values, static_cast<offset_t>(num_items), begin_bit, end_bit, true, stream);
     });

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -95,11 +95,7 @@ TEST_CASE("Device radix sort keys descending works with default environment", "[
 
   REQUIRE(cudaSuccess
           == cub::DeviceRadixSort::SortKeysDescending(
-            keys_in.data().get(),
-            keys_out.data().get(),
-            static_cast<int>(keys_in.size()),
-            0,
-            static_cast<int>(static_cast<int>(sizeof(int) * 8))));
+            keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
   c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
 
@@ -194,13 +190,7 @@ C2H_TEST("Device radix sort keys uses environment", "[radix_sort][device]")
   REQUIRE(
     cudaSuccess
     == cub::DeviceRadixSort::SortKeys(
-      nullptr,
-      expected_bytes_allocated,
-      keys_in.data().get(),
-      keys_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      0,
-      static_cast<int>(static_cast<int>(sizeof(int) * 8))));
+      nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
   auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
 
@@ -351,13 +341,7 @@ TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]")
   REQUIRE(
     cudaSuccess
     == cub::DeviceRadixSort::SortKeys(
-      nullptr,
-      expected_bytes_allocated,
-      keys_in.data().get(),
-      keys_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      0,
-      static_cast<int>(static_cast<int>(sizeof(int) * 8))));
+      nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
@@ -388,13 +372,7 @@ TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_sort][
   REQUIRE(
     cudaSuccess
     == cub::DeviceRadixSort::SortKeysDescending(
-      nullptr,
-      expected_bytes_allocated,
-      keys_in.data().get(),
-      keys_out.data().get(),
-      static_cast<int>(keys_in.size()),
-      0,
-      static_cast<int>(static_cast<int>(sizeof(int) * 8))));
+      nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
   auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
   auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};

--- a/cub/test/catch2_test_device_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_radix_sort_env_api.cu
@@ -32,11 +32,6 @@ C2H_TEST("cub::DeviceRadixSort::SortPairs env-based API", "[radix_sort][env]")
     std::cerr << "cub::DeviceRadixSort::SortPairs failed with status: " << error << std::endl;
   }
 
-  if (error != cudaSuccess)
-  {
-    std::cerr << "cub::DeviceRadixSort::SortPairs failed with status: " << error << std::endl;
-  }
-
   thrust::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   thrust::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
   // example-end radix-sort-pairs-env
@@ -60,11 +55,6 @@ C2H_TEST("cub::DeviceRadixSort::SortPairsDescending env-based API", "[radix_sort
     values_in.data().get(),
     values_out.data().get(),
     static_cast<int>(keys_in.size()));
-
-  if (error != cudaSuccess)
-  {
-    std::cerr << "cub::DeviceRadixSort::SortPairsDescending failed with status: " << error << std::endl;
-  }
 
   if (error != cudaSuccess)
   {
@@ -120,9 +110,8 @@ C2H_TEST("cub::DeviceRadixSort::SortKeys DoubleBuffer env-based API", "[radix_so
   // example-end radix-sort-keys-db-env
 
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<int> result(keys_buf0.size());
-  cudaMemcpy(result.data().get(), d_keys.Current(), sizeof(int) * keys_buf0.size(), cudaMemcpyDeviceToDevice);
-  REQUIRE(result == expected_keys);
+  auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
+  REQUIRE(keys == expected_keys);
 }
 
 C2H_TEST("cub::DeviceRadixSort::SortKeysDescending env-based API", "[radix_sort][env]")
@@ -165,7 +154,6 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DoubleBuffer env-based API", 
   // example-end radix-sort-keys-descending-db-env
 
   REQUIRE(error == cudaSuccess);
-  thrust::device_vector<int> result(keys_buf0.size());
-  cudaMemcpy(result.data().get(), d_keys.Current(), sizeof(int) * keys_buf0.size(), cudaMemcpyDeviceToDevice);
-  REQUIRE(result == expected_keys);
+  auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
+  REQUIRE(keys == expected_keys);
 }


### PR DESCRIPTION
Adds env based:

- `RadixSort::SortKeys`
- `RadixSort::SortKeysDescending`


and closes #7545.

- [x] It is based off and will remain draft until https://github.com/NVIDIA/cccl/pull/7461 is merged.

Adds env overloads for default API and `DoubleBuffer` API. Env overloads for the `decomposer` APIs will be added in subsequent PR.

**No determinsm requirements are imposed or queried for `RadixSort`. Any non-deterministic solution should be wrong**
