### PR TITLE
Use `_CCCL[_MEOW]_API` macros in libcu++

### DIFF
--- a/libcudacxx/include/cuda/__annotated_ptr/access_property_encoding.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/access_property_encoding.h
@@ -66,7 +66,7 @@ enum class __l2_descriptor_mode_t : uint32_t
 
 #if !_CCCL_CUDA_COMPILER(NVRTC)
 
-[[nodiscard]] _CCCL_HIDE_FROM_ABI uint64_t __block_encoding_host(
+[[nodiscard]] _CCCL_HOST_API inline uint64_t __block_encoding_host(
   __l2_evict_t __primary, __l2_evict_t __secondary, const void* __ptr, uint32_t __primary_bytes, uint32_t __total_bytes)
 {
   _CCCL_ASSERT(__primary_bytes > 0, "primary_size must be greater than 0");

--- a/libcudacxx/include/cuda/__annotated_ptr/annotated_ptr_base.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/annotated_ptr_base.h
@@ -52,7 +52,7 @@ protected:
 
 #if _CCCL_CUDA_COMPILATION()
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE void* __apply_prop(void* __p) const
+  [[nodiscard]] _CCCL_DEVICE_API void* __apply_prop(void* __p) const
   {
     return ::cuda::__associate(__p, _AccessProperty{});
   }
@@ -81,7 +81,7 @@ protected:
   _CCCL_HIDE_FROM_ABI __annotated_ptr_base() noexcept = default;
 
 #if _CCCL_CUDA_COMPILATION()
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE void* __apply_prop(void* __p) const
+  [[nodiscard]] _CCCL_DEVICE_API void* __apply_prop(void* __p) const
   {
     return ::cuda::__associate_raw_descriptor(__p, __prop);
   }

--- a/libcudacxx/include/cuda/__annotated_ptr/associate_access_property.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/associate_access_property.h
@@ -57,8 +57,7 @@ inline constexpr bool __is_global_access_property_v =
 #if _CCCL_CUDA_COMPILATION()
 
 template <typename _Property>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE void*
-__associate_address_space(void* __ptr, [[maybe_unused]] _Property __prop)
+[[nodiscard]] _CCCL_DEVICE_API void* __associate_address_space(void* __ptr, [[maybe_unused]] _Property __prop)
 {
   if constexpr (::cuda::std::is_same_v<_Property, access_property::shared>)
   {
@@ -79,14 +78,14 @@ __associate_address_space(void* __ptr, [[maybe_unused]] _Property __prop)
   return __ptr;
 }
 
-_CCCL_HIDE_FROM_ABI _CCCL_DEVICE void* __associate_raw_descriptor(void* __ptr, [[maybe_unused]] uint64_t __prop)
+_CCCL_DEVICE_API inline void* __associate_raw_descriptor(void* __ptr, [[maybe_unused]] uint64_t __prop)
 {
   NV_IF_TARGET(NV_PROVIDES_SM_80, (return ::__nv_associate_access_property(__ptr, __prop);))
   return __ptr;
 }
 
 template <typename _Property>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE void* __associate_descriptor(void* __ptr, _Property __prop)
+[[nodiscard]] _CCCL_DEVICE_API void* __associate_descriptor(void* __ptr, _Property __prop)
 {
   static_assert(__is_access_property_v<_Property>, "invalid cuda::access_property");
   if constexpr (!::cuda::std::is_same_v<_Property, access_property::shared>)

--- a/libcudacxx/include/cuda/__annotated_ptr/createpolicy.h
+++ b/libcudacxx/include/cuda/__annotated_ptr/createpolicy.h
@@ -44,7 +44,7 @@ enum class __l2_evict_t : uint32_t
 #if _CCCL_CUDA_COMPILATION()
 
 template <typename = void>
-[[nodiscard]] _CCCL_CONST _CCCL_HIDE_FROM_ABI _CCCL_DEVICE uint64_t __createpolicy_range_ptx(
+[[nodiscard]] _CCCL_CONST _CCCL_DEVICE_API uint64_t __createpolicy_range_ptx(
   __l2_evict_t __primary, __l2_evict_t __secondary, size_t __gmem_ptr, uint32_t __primary_size, uint32_t __total_size)
 {
   uint64_t __policy;
@@ -114,7 +114,7 @@ template <typename = void>
 }
 
 template <typename = void>
-[[nodiscard]] _CCCL_CONST _CCCL_HIDE_FROM_ABI _CCCL_DEVICE uint64_t
+[[nodiscard]] _CCCL_CONST _CCCL_DEVICE_API uint64_t
 __createpolicy_fraction_ptx(__l2_evict_t __primary, __l2_evict_t __secondary, float __fraction)
 {
   uint64_t __policy;
@@ -174,7 +174,7 @@ __createpolicy_fraction_ptx(__l2_evict_t __primary, __l2_evict_t __secondary, fl
 extern "C" _CCCL_DEVICE void __createpolicy_is_not_supported_before_SM_80();
 
 template <typename T = void>
-[[nodiscard]] _CCCL_CONST _CCCL_HIDE_FROM_ABI _CCCL_DEVICE uint64_t __createpolicy_range(
+[[nodiscard]] _CCCL_CONST _CCCL_DEVICE_API uint64_t __createpolicy_range(
   __l2_evict_t __primary, __l2_evict_t __secondary, const void* __ptr, uint32_t __primary_size, uint32_t __total_size)
 {
   _CCCL_ASSERT(::cuda::device::is_address_from(__ptr, ::cuda::device::address_space::global), "ptr must be global");
@@ -190,7 +190,7 @@ template <typename T = void>
 }
 
 template <typename T = void>
-[[nodiscard]] _CCCL_CONST _CCCL_HIDE_FROM_ABI _CCCL_DEVICE uint64_t
+[[nodiscard]] _CCCL_CONST _CCCL_DEVICE_API uint64_t
 __createpolicy_fraction(__l2_evict_t __primary, __l2_evict_t __secondary, float __fraction = 1.0f)
 {
   _CCCL_ASSERT(__fraction > 0.0f && __fraction <= 1.0f, "fraction must be between 0.0f and 1.0f");

--- a/libcudacxx/include/cuda/__atomic/atomic.h
+++ b/libcudacxx/include/cuda/__atomic/atomic.h
@@ -110,7 +110,7 @@ struct atomic_ref : public ::cuda::std::__atomic_ref_impl<_Tp, _Sco>
   }
 };
 
-inline _CCCL_HOST_DEVICE void
+_CCCL_API inline void
 atomic_thread_fence(memory_order __m, [[maybe_unused]] thread_scope _Scope = thread_scope::thread_scope_system)
 {
   NV_DISPATCH_TARGET(
@@ -133,7 +133,7 @@ atomic_thread_fence(memory_order __m, [[maybe_unused]] thread_scope _Scope = thr
     (::cuda::std::atomic_thread_fence(__m);))
 }
 
-inline _CCCL_HOST_DEVICE void atomic_signal_fence(memory_order __m)
+_CCCL_API inline void atomic_signal_fence(memory_order __m)
 {
   ::cuda::std::atomic_signal_fence(__m);
 }

--- a/libcudacxx/include/cuda/__barrier/barrier_arrive_tx.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_arrive_tx.h
@@ -38,7 +38,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 
 extern "C" _CCCL_DEVICE void __cuda_ptx_barrier_arrive_tx_is_not_supported_before_SM_90__();
-[[nodiscard]] _CCCL_DEVICE inline barrier<thread_scope_block>::arrival_token barrier_arrive_tx(
+[[nodiscard]] _CCCL_DEVICE_API inline barrier<thread_scope_block>::arrival_token barrier_arrive_tx(
   barrier<thread_scope_block>& __b,
   ::cuda::std::ptrdiff_t __arrive_count_update,
   ::cuda::std::ptrdiff_t __transaction_count_update)

--- a/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_block_scope.h
@@ -56,7 +56,7 @@
 #include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
-[[nodiscard]] _CCCL_DEVICE ::cuda::std::uint64_t* barrier_native_handle(barrier<thread_scope_block>& __b);
+[[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint64_t* barrier_native_handle(barrier<thread_scope_block>& __b);
 _CCCL_END_NAMESPACE_CUDA_DEVICE
 
 _CCCL_BEGIN_NAMESPACE_CUDA
@@ -71,10 +71,10 @@ class barrier<thread_scope_block, ::cuda::std::__empty_completion> : public __bl
   using __barrier_base = ::cuda::std::__barrier_base<::cuda::std::__empty_completion, thread_scope_block>;
   __barrier_base __barrier;
 
-  _CCCL_DEVICE friend ::cuda::std::uint64_t* ::cuda::device::_LIBCUDACXX_ABI_NAMESPACE::barrier_native_handle(
+  _CCCL_DEVICE_API friend ::cuda::std::uint64_t* ::cuda::device::_LIBCUDACXX_ABI_NAMESPACE::barrier_native_handle(
     barrier<thread_scope_block>& __b);
 
-  [[nodiscard]] _CCCL_DEVICE ::cuda::std::uint64_t* __native_handle() const
+  [[nodiscard]] _CCCL_DEVICE_API ::cuda::std::uint64_t* __native_handle() const
   {
     return ::cuda::device::barrier_native_handle(const_cast<barrier&>(*this));
   }
@@ -527,7 +527,7 @@ _CCCL_END_NAMESPACE_CUDA
 
 _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 
-[[nodiscard]] _CCCL_DEVICE inline ::cuda::std::uint64_t* barrier_native_handle(barrier<thread_scope_block>& __b)
+[[nodiscard]] _CCCL_DEVICE_API inline ::cuda::std::uint64_t* barrier_native_handle(barrier<thread_scope_block>& __b)
 {
   return reinterpret_cast<::cuda::std::uint64_t*>(&__b.__barrier);
 }

--- a/libcudacxx/include/cuda/__barrier/barrier_expect_tx.h
+++ b/libcudacxx/include/cuda/__barrier/barrier_expect_tx.h
@@ -37,7 +37,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 
 extern "C" _CCCL_DEVICE void __cuda_ptx_barrier_expect_tx_is_not_supported_before_SM_90__();
-_CCCL_DEVICE inline void
+_CCCL_DEVICE_API inline void
 barrier_expect_tx(barrier<thread_scope_block>& __b, ::cuda::std::ptrdiff_t __transaction_count_update)
 {
   _CCCL_ASSERT(

--- a/libcudacxx/include/cuda/__bit/bit_reverse.h
+++ b/libcudacxx/include/cuda/__bit/bit_reverse.h
@@ -90,7 +90,7 @@ template <typename _Tp>
 #if _CCCL_CUDA_COMPILATION()
 
 template <typename _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE constexpr _Tp __bit_reverse_device(_Tp __value) noexcept
+[[nodiscard]] _CCCL_DEVICE_API constexpr _Tp __bit_reverse_device(_Tp __value) noexcept
 {
 #  if _CCCL_HAS_INT128()
   if constexpr (sizeof(_Tp) == sizeof(__uint128_t))

--- a/libcudacxx/include/cuda/__bit/bitfield.h
+++ b/libcudacxx/include/cuda/__bit/bitfield.h
@@ -34,28 +34,28 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 
 #if __cccl_ptx_isa >= 200
 
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE uint32_t
+[[nodiscard]] _CCCL_DEVICE_API inline uint32_t
 __bfi(uint32_t __dest, uint32_t __source, int __start, int __width) noexcept
 {
   asm("bfi.b32 %0, %1, %2, %3, %4;" : "=r"(__dest) : "r"(__source), "r"(__dest), "r"(__start), "r"(__width));
   return __dest;
 }
 
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE uint64_t
+[[nodiscard]] _CCCL_DEVICE_API inline uint64_t
 __bfi(uint64_t __dest, uint64_t __source, int __start, int __width) noexcept
 {
   asm("bfi.b64 %0, %1, %2, %3, %4;" : "=l"(__dest) : "l"(__source), "l"(__dest), "r"(__start), "r"(__width));
   return __dest;
 }
 
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE uint32_t __bfe(uint32_t __value, int __start, int __width) noexcept
+[[nodiscard]] _CCCL_DEVICE_API inline uint32_t __bfe(uint32_t __value, int __start, int __width) noexcept
 {
   uint32_t __ret;
   asm("bfe.u32 %0, %1, %2, %3;" : "=r"(__ret) : "r"(__value), "r"(__start), "r"(__width));
   return __ret;
 }
 
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE uint64_t __bfe(uint64_t __value, int __start, int __width) noexcept
+[[nodiscard]] _CCCL_DEVICE_API inline uint64_t __bfe(uint64_t __value, int __start, int __width) noexcept
 {
   uint64_t __ret;
   asm("bfe.u64 %0, %1, %2, %3;" : "=l"(__ret) : "l"(__value), "r"(__start), "r"(__width));

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -147,7 +147,7 @@ private:
   //! memory pointed to by \p __first and
   //! \p __last lives long enough
   template <class _Iter>
-  _CCCL_HIDE_FROM_ABI void __copy_cross(_Iter __first, [[maybe_unused]] _Iter __last, pointer __dest, size_type __count)
+  _CCCL_HOST_API void __copy_cross(_Iter __first, [[maybe_unused]] _Iter __last, pointer __dest, size_type __count)
   {
     if (__count == 0)
     {
@@ -164,7 +164,7 @@ private:
 public:
   //! @brief Copy-constructs from a buffer
   //! @param __other The other buffer.
-  _CCCL_HIDE_FROM_ABI explicit buffer(const buffer& __other)
+  _CCCL_HOST_API explicit buffer(const buffer& __other)
       : __buf_(__other.memory_resource(), __other.stream(), __other.size())
   {
     this->__copy_cross<const_pointer>(
@@ -174,7 +174,7 @@ public:
   //! @brief Move-constructs from a buffer
   //! @param __other The other buffer. After move construction, the other buffer
   //! can only be assigned to or destroyed.
-  _CCCL_HIDE_FROM_ABI buffer(buffer&& __other) noexcept
+  _CCCL_HOST_API buffer(buffer&& __other) noexcept
       : __buf_(::cuda::std::move(__other.__buf_))
   {}
 
@@ -182,7 +182,7 @@ public:
   //! @param __other The other buffer.
   _CCCL_TEMPLATE(class... _OtherProperties)
   _CCCL_REQUIRES(__properties_match<_OtherProperties...>)
-  _CCCL_HIDE_FROM_ABI explicit buffer(const buffer<_Tp, _OtherProperties...>& __other)
+  _CCCL_HOST_API explicit buffer(const buffer<_Tp, _OtherProperties...>& __other)
       : __buf_(__other.memory_resource(), __other.stream(), __other.size())
   {
     this->__copy_cross<const_pointer>(
@@ -204,8 +204,7 @@ public:
   _CCCL_TEMPLATE(class _Resource, class _Env = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES(
     ::cuda::mr::synchronous_resource<::cuda::std::decay_t<_Resource>> _CCCL_AND __buffer_compatible_env<_Env>)
-  _CCCL_HIDE_FROM_ABI
-  buffer(::cuda::stream_ref __stream, _Resource&& __resource, [[maybe_unused]] const _Env& __env = {})
+  _CCCL_HOST_API buffer(::cuda::stream_ref __stream, _Resource&& __resource, [[maybe_unused]] const _Env& __env = {})
       : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)), __stream, 0)
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
@@ -225,7 +224,7 @@ public:
   _CCCL_TEMPLATE(class _Resource, class _Env = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES(
     ::cuda::mr::synchronous_resource<::cuda::std::decay_t<_Resource>> _CCCL_AND __buffer_compatible_env<_Env>)
-  _CCCL_HIDE_FROM_ABI explicit buffer(
+  _CCCL_HOST_API explicit buffer(
     ::cuda::stream_ref __stream,
     _Resource&& __resource,
     const size_type __size,
@@ -248,7 +247,7 @@ public:
   _CCCL_TEMPLATE(class _Iter, class _Resource, class _Env = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES(::cuda::mr::synchronous_resource<::cuda::std::decay_t<_Resource>>
                    _CCCL_AND ::cuda::std::__has_forward_traversal<_Iter>)
-  _CCCL_HIDE_FROM_ABI
+  _CCCL_HOST_API
   buffer(::cuda::stream_ref __stream,
          _Resource&& __resource,
          _Iter __first,
@@ -272,11 +271,10 @@ public:
   _CCCL_TEMPLATE(class _Resource, class _Env = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES(
     ::cuda::mr::synchronous_resource<::cuda::std::decay_t<_Resource>> _CCCL_AND __buffer_compatible_env<_Env>)
-  _CCCL_HIDE_FROM_ABI
-  buffer(::cuda::stream_ref __stream,
-         _Resource&& __resource,
-         ::cuda::std::initializer_list<_Tp> __ilist,
-         [[maybe_unused]] const _Env& __env = {})
+  _CCCL_HOST_API buffer(::cuda::stream_ref __stream,
+                        _Resource&& __resource,
+                        ::cuda::std::initializer_list<_Tp> __ilist,
+                        [[maybe_unused]] const _Env& __env = {})
       : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)), __stream, __ilist.size())
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
@@ -293,7 +291,7 @@ public:
   _CCCL_REQUIRES(
     ::cuda::mr::synchronous_resource<::cuda::std::decay_t<_Resource>> _CCCL_AND __compatible_range<_Range>
       _CCCL_AND ::cuda::std::ranges::forward_range<_Range> _CCCL_AND ::cuda::std::ranges::sized_range<_Range>)
-  _CCCL_HIDE_FROM_ABI
+  _CCCL_HOST_API
   buffer(::cuda::stream_ref __stream, _Resource&& __resource, _Range&& __range, [[maybe_unused]] const _Env& __env = {})
       : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
                __stream,
@@ -315,7 +313,7 @@ public:
   _CCCL_REQUIRES(
     ::cuda::mr::synchronous_resource<::cuda::std::decay_t<_Resource>> _CCCL_AND __compatible_range<_Range>
       _CCCL_AND ::cuda::std::ranges::forward_range<_Range> _CCCL_AND(!::cuda::std::ranges::sized_range<_Range>))
-  _CCCL_HIDE_FROM_ABI
+  _CCCL_HOST_API
   buffer(::cuda::stream_ref __stream, _Resource&& __resource, _Range&& __range, [[maybe_unused]] const _Env& __env = {})
       : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
                __stream,
@@ -337,21 +335,21 @@ public:
 
   //! @brief Returns an iterator to the first element of the buffer. If the
   //! buffer is empty, the returned iterator will be equal to end().
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI iterator begin() noexcept
+  [[nodiscard]] _CCCL_HOST_API iterator begin() noexcept
   {
     return iterator{__buf_.data()};
   }
 
   //! @brief Returns an immutable iterator to the first element of the buffer.
   //! If the buffer is empty, the returned iterator will be equal to end().
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_iterator begin() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_iterator begin() const noexcept
   {
     return const_iterator{__buf_.data()};
   }
 
   //! @brief Returns an immutable iterator to the first element of the buffer.
   //! If the buffer is empty, the returned iterator will be equal to end().
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_iterator cbegin() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_iterator cbegin() const noexcept
   {
     return const_iterator{__buf_.data()};
   }
@@ -359,7 +357,7 @@ public:
   //! @brief Returns an iterator to the element following the last element of
   //! the buffer. This element acts as a placeholder; attempting to access it
   //! results in undefined behavior.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI iterator end() noexcept
+  [[nodiscard]] _CCCL_HOST_API iterator end() noexcept
   {
     return iterator{__buf_.data() + __buf_.size()};
   }
@@ -367,7 +365,7 @@ public:
   //! @brief Returns an immutable iterator to the element following the last
   //! element of the buffer. This element acts as a placeholder; attempting to
   //! access it results in undefined behavior.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_iterator end() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_iterator end() const noexcept
   {
     return const_iterator{__buf_.data() + __buf_.size()};
   }
@@ -375,7 +373,7 @@ public:
   //! @brief Returns an immutable iterator to the element following the last
   //! element of the buffer. This element acts as a placeholder; attempting to
   //! access it results in undefined behavior.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_iterator cend() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_iterator cend() const noexcept
   {
     return const_iterator{__buf_.data() + __buf_.size()};
   }
@@ -383,7 +381,7 @@ public:
   //! @brief Returns a reverse iterator to the first element of the reversed
   //! buffer. It corresponds to the last element of the non-reversed buffer. If
   //! the buffer is empty, the returned iterator is equal to rend().
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI reverse_iterator rbegin() noexcept
+  [[nodiscard]] _CCCL_HOST_API reverse_iterator rbegin() noexcept
   {
     return reverse_iterator{end()};
   }
@@ -391,7 +389,7 @@ public:
   //! @brief Returns an immutable reverse iterator to the first element of the
   //! reversed buffer. It corresponds to the last element of the non-reversed
   //! buffer. If the buffer is empty, the returned iterator is equal to rend().
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_reverse_iterator rbegin() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_reverse_iterator rbegin() const noexcept
   {
     return const_reverse_iterator{end()};
   }
@@ -399,7 +397,7 @@ public:
   //! @brief Returns an immutable reverse iterator to the first element of the
   //! reversed buffer. It corresponds to the last element of the non-reversed
   //! buffer. If the buffer is empty, the returned iterator is equal to rend().
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_reverse_iterator crbegin() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_reverse_iterator crbegin() const noexcept
   {
     return const_reverse_iterator{end()};
   }
@@ -408,7 +406,7 @@ public:
   //! element of the reversed buffer. It corresponds to the element preceding
   //! the first element of the non-reversed buffer. This element acts as a
   //! placeholder, attempting to access it results in undefined behavior.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI reverse_iterator rend() noexcept
+  [[nodiscard]] _CCCL_HOST_API reverse_iterator rend() noexcept
   {
     return reverse_iterator{begin()};
   }
@@ -417,7 +415,7 @@ public:
   //! last element of the reversed buffer. It corresponds to the element
   //! preceding the first element of the non-reversed buffer. This element acts
   //! as a placeholder, attempting to access it results in undefined behavior.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_reverse_iterator rend() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_reverse_iterator rend() const noexcept
   {
     return const_reverse_iterator{begin()};
   }
@@ -426,21 +424,21 @@ public:
   //! last element of the reversed buffer. It corresponds to the element
   //! preceding the first element of the non-reversed buffer. This element acts
   //! as a placeholder, attempting to access it results in undefined behavior.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_reverse_iterator crend() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_reverse_iterator crend() const noexcept
   {
     return const_reverse_iterator{begin()};
   }
 
   //! @brief Returns a pointer to the first element of the buffer. If the buffer
   //! has not allocated memory the pointer will be null.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI pointer data() noexcept
+  [[nodiscard]] _CCCL_HOST_API pointer data() noexcept
   {
     return __buf_.data();
   }
 
   //! @brief Returns a pointer to the first element of the buffer. If the buffer
   //! has not allocated memory the pointer will be null.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_pointer data() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_pointer data() const noexcept
   {
     return __buf_.data();
   }
@@ -448,14 +446,14 @@ public:
 #  ifndef _CCCL_DOXYGEN_INVOKED
   //! @brief Returns a pointer to the first element of the buffer. If the buffer
   //! is empty, the returned pointer will be null.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI pointer __unwrapped_begin() noexcept
+  [[nodiscard]] _CCCL_HOST_API pointer __unwrapped_begin() noexcept
   {
     return __buf_.data();
   }
 
   //! @brief Returns a const pointer to the first element of the buffer. If the
   //! buffer is empty, the returned pointer will be null.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_pointer __unwrapped_begin() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_pointer __unwrapped_begin() const noexcept
   {
     return __buf_.data();
   }
@@ -463,7 +461,7 @@ public:
   //! @brief Returns a pointer to the element following the last element of the
   //! buffer. This element acts as a placeholder; attempting to access it
   //! results in undefined behavior.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI pointer __unwrapped_end() noexcept
+  [[nodiscard]] _CCCL_HOST_API pointer __unwrapped_end() noexcept
   {
     return __buf_.data() + __buf_.size();
   }
@@ -471,7 +469,7 @@ public:
   //! @brief Returns a const pointer to the element following the last element
   //! of the buffer. This element acts as a placeholder; attempting to access it
   //! results in undefined behavior.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_pointer __unwrapped_end() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_pointer __unwrapped_end() const noexcept
   {
     return __buf_.data() + __buf_.size();
   }
@@ -482,7 +480,7 @@ public:
   //! @brief Returns a reference to the \p __n 'th element of the async_vector
   //! @param __n The index of the element we want to access
   //! @note Does not synchronize with the stored stream
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI reference get_unsynchronized(const size_type __n) noexcept
+  [[nodiscard]] _CCCL_HOST_API reference get_unsynchronized(const size_type __n) noexcept
   {
     _CCCL_ASSERT(__n < __buf_.size(), "cuda::buffer::get_unsynchronized out of range!");
     return __unwrapped_begin()[__n];
@@ -491,20 +489,20 @@ public:
   //! @brief Returns a reference to the \p __n 'th element of the async_vector
   //! @param __n The index of the element we want to access
   //! @note Does not synchronize with the stored stream
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const_reference get_unsynchronized(const size_type __n) const noexcept
+  [[nodiscard]] _CCCL_HOST_API const_reference get_unsynchronized(const size_type __n) const noexcept
   {
     _CCCL_ASSERT(__n < __buf_.size(), "cuda::buffer::get_unsynchronized out of range!");
     return __unwrapped_begin()[__n];
   }
 
   //! @brief Returns the current number of elements stored in the buffer.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI size_type size() const noexcept
+  [[nodiscard]] _CCCL_HOST_API size_type size() const noexcept
   {
     return __buf_.size();
   }
 
   //! @brief Returns true if the buffer is empty.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI bool empty() const noexcept
+  [[nodiscard]] _CCCL_HOST_API bool empty() const noexcept
   {
     return __buf_.size() == 0;
   }
@@ -513,7 +511,7 @@ public:
   //! Returns a \c const reference to the :ref:`any_resource <libcudacxx-memory-resource-any-resource>` that holds the
   //! memory resource used to allocate the buffer
   //! @endrst
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const __resource_t& memory_resource() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const __resource_t& memory_resource() const noexcept
   {
     return __buf_.memory_resource();
   }
@@ -521,7 +519,7 @@ public:
   //! @brief Returns the stored stream
   //! @note Stream used to allocate the buffer is initially stored in the
   //! buffer, but can be changed with `set_stream`
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr stream_ref stream() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr stream_ref stream() const noexcept
   {
     return __buf_.stream();
   }
@@ -529,7 +527,7 @@ public:
   //! @brief Replaces the stored stream
   //! @param __new_stream the new stream
   //! @note Always synchronizes with the old stream
-  _CCCL_HIDE_FROM_ABI constexpr void set_stream(stream_ref __new_stream)
+  _CCCL_HOST_API constexpr void set_stream(stream_ref __new_stream)
   {
     __buf_.set_stream_unsynchronized(__new_stream);
   }
@@ -537,14 +535,14 @@ public:
   //! @brief Move assignment operator
   //! @param __other The other buffer. After move assignment, the other buffer
   //! can only be assigned to or destroyed.
-  _CCCL_HIDE_FROM_ABI void operator=(buffer&& __other)
+  _CCCL_HOST_API void operator=(buffer&& __other)
   {
     __buf_ = ::cuda::std::move(__other.__buf_);
   }
 
   //! @brief Swaps the contents of a buffer with those of \p __other
   //! @param __other The other buffer.
-  _CCCL_HIDE_FROM_ABI void swap(buffer& __other) noexcept
+  _CCCL_HOST_API void swap(buffer& __other) noexcept
   {
     ::cuda::std::swap(__buf_, __other.__buf_);
   }
@@ -552,7 +550,7 @@ public:
   //! @brief Swaps the contents of two buffers
   //! @param __lhs One buffer.
   //! @param __rhs The other buffer.
-  _CCCL_HIDE_FROM_ABI friend void swap(buffer& __lhs, buffer& __rhs) noexcept
+  _CCCL_HOST_API friend void swap(buffer& __lhs, buffer& __rhs) noexcept
   {
     __lhs.swap(__rhs);
   }
@@ -562,7 +560,7 @@ public:
   //! @param __stream The stream to deallocate the buffer on.
   //! @warning After this explicit destroy call, the buffer can only be assigned
   //! to or destroyed.
-  _CCCL_HIDE_FROM_ABI void destroy(::cuda::stream_ref __stream)
+  _CCCL_HOST_API void destroy(::cuda::stream_ref __stream)
   {
     __buf_.destroy(__stream);
   }
@@ -573,7 +571,7 @@ public:
   //! calling buffer.destroy(buffer.stream())
   //! @warning After this explicit destroy call, the buffer can only be assigned
   //! to or destroyed.
-  _CCCL_HIDE_FROM_ABI void destroy()
+  _CCCL_HOST_API void destroy()
   {
     __buf_.destroy();
   }
@@ -582,7 +580,7 @@ public:
   //! cuda::launch.
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   template <class _DeviceAccessible = ::cuda::mr::device_accessible>
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto transform_launch_argument(::cuda::stream_ref, buffer& __self) noexcept
+  [[nodiscard]] _CCCL_HOST_API friend auto transform_launch_argument(::cuda::stream_ref, buffer& __self) noexcept
     _CCCL_TRAILING_REQUIRES(::cuda::std::span<_Tp>)(::cuda::std::__is_included_in_v<_DeviceAccessible, _Properties...>)
   {
     return {__self.__unwrapped_begin(), __self.size()};
@@ -592,9 +590,9 @@ public:
   //! cuda::launch
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   template <class _DeviceAccessible = ::cuda::mr::device_accessible>
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto
-  transform_launch_argument(::cuda::stream_ref, const buffer& __self) noexcept _CCCL_TRAILING_REQUIRES(
-    ::cuda::std::span<const _Tp>)(::cuda::std::__is_included_in_v<_DeviceAccessible, _Properties...>)
+  [[nodiscard]] _CCCL_HOST_API friend auto transform_launch_argument(::cuda::stream_ref, const buffer& __self) noexcept
+    _CCCL_TRAILING_REQUIRES(::cuda::std::span<const _Tp>)(
+      ::cuda::std::__is_included_in_v<_DeviceAccessible, _Properties...>)
   {
     return {__self.__unwrapped_begin(), __self.size()};
   }
@@ -602,7 +600,7 @@ public:
   //! @brief Forwards the passed properties
   _CCCL_TEMPLATE(class _Property)
   _CCCL_REQUIRES((!property_with_value<_Property>) _CCCL_AND ::cuda::std::__is_included_in_v<_Property, _Properties...>)
-  _CCCL_HIDE_FROM_ABI friend void get_property(const buffer&, _Property) noexcept {}
+  _CCCL_HOST_API friend void get_property(const buffer&, _Property) noexcept {}
 };
 
 template <class _Tp>
@@ -631,8 +629,7 @@ _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 //! @param __first Pointer to the first element to be initialized.
 //! @param __count The number of elements to be initialized.
 template <typename _Tp, mr::__memory_accessability _Accessability>
-_CCCL_HIDE_FROM_ABI void
-__fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::std::size_t __count, const _Tp& __value)
+_CCCL_HOST_API void __fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::std::size_t __count, const _Tp& __value)
 {
   if (__count == 0)
   {

--- a/libcudacxx/include/cuda/__container/heterogeneous_iterator.h
+++ b/libcudacxx/include/cuda/__container/heterogeneous_iterator.h
@@ -83,14 +83,14 @@ public:
 
   //! @brief Dereference a \c heterogeneous_iterator
   //! @return A reference to the element the iterator points to
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST constexpr reference operator*() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr reference operator*() const noexcept
   {
     return *__ptr_;
   }
 
   //! @brief Operator arrow on a \c heterogeneous_iterator
   //! @return A pointer to the element the iterator points to
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST constexpr pointer operator->() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr pointer operator->() const noexcept
   {
     return __ptr_;
   }
@@ -98,8 +98,7 @@ public:
   //! @brief Dereference a \c heterogeneous_iterator
   //! @param __count The offset at which we want to dereference
   //! @return A reference of the \p __count th element after the one the iterator points to
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST constexpr reference
-  operator[](const difference_type __count) const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr reference operator[](const difference_type __count) const noexcept
   {
     return *(__ptr_ + __count);
   }
@@ -130,14 +129,14 @@ public:
 
   //! @brief Dereference a \c heterogeneous_iterator
   //! @return A reference to the element the iterator points to
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE constexpr reference operator*() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reference operator*() const noexcept
   {
     return *__ptr_;
   }
 
   //! @brief Operator arrow on a \c heterogeneous_iterator
   //! @return A pointer to the element the iterator points to
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE constexpr pointer operator->() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr pointer operator->() const noexcept
   {
     return __ptr_;
   }
@@ -145,8 +144,7 @@ public:
   //! @brief Dereference a \c heterogeneous_iterator
   //! @param __count The offset at which we want to dereference
   //! @return A reference of the \p __count th element after the one the iterator points to
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE constexpr reference
-  operator[](const difference_type __count) const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr reference operator[](const difference_type __count) const noexcept
   {
     return *(__ptr_ + __count);
   }
@@ -171,20 +169,20 @@ public:
 
   _CCCL_HIDE_FROM_ABI __heterogeneous_iterator_access() = default;
 
-  _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE explicit constexpr __heterogeneous_iterator_access(pointer __ptr) noexcept
+  _CCCL_API explicit constexpr __heterogeneous_iterator_access(pointer __ptr) noexcept
       : __ptr_(__ptr)
   {}
 
   //! @brief Dereference a \c heterogeneous_iterator
   //! @return A reference to the element the iterator points to
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr reference operator*() const noexcept
+  [[nodiscard]] _CCCL_API constexpr reference operator*() const noexcept
   {
     return *__ptr_;
   }
 
   //! @brief Operator arrow on a \c heterogeneous_iterator
   //! @return A pointer to the element the iterator points to
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr pointer operator->() const noexcept
+  [[nodiscard]] _CCCL_API constexpr pointer operator->() const noexcept
   {
     return __ptr_;
   }
@@ -192,8 +190,7 @@ public:
   //! @brief Dereference a \c heterogeneous_iterator
   //! @param __count The offset at which we want to dereference
   //! @return A reference to the `__count` element after the one the iterator points to
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr reference
-  operator[](const difference_type __count) const noexcept
+  [[nodiscard]] _CCCL_API constexpr reference operator[](const difference_type __count) const noexcept
   {
     return *(__ptr_ + __count);
   }

--- a/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
+++ b/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
@@ -99,7 +99,7 @@ private:
     && ::cuda::std::__type_set_contains_v<::cuda::std::__make_type_set<_OtherProperties...>, _Properties...>;
 
   //! @brief Determines the allocation size given the alignment and size of `T`
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI static constexpr size_t __get_allocation_size(const size_t __count) noexcept
+  [[nodiscard]] _CCCL_HOST_API static constexpr size_t __get_allocation_size(const size_t __count) noexcept
   {
     constexpr size_t __alignment = alignof(_Tp);
     return (__count * sizeof(_Tp) + (__alignment - 1)) & ~(__alignment - 1);
@@ -107,7 +107,7 @@ private:
 
   //! @brief Determines the properly aligned start of the buffer given the
   //! alignment and size of `T`
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _Tp* __get_data() const noexcept
+  [[nodiscard]] _CCCL_HOST_API _Tp* __get_data() const noexcept
   {
     constexpr size_t __alignment = alignof(_Tp);
     size_t __space               = __get_allocation_size(__count_);
@@ -120,7 +120,7 @@ private:
   //! cuda::launch.
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   template <class _Tp2 = _Tp>
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto
+  [[nodiscard]] _CCCL_HOST_API friend auto
   transform_launch_argument(::cuda::stream_ref, __uninitialized_async_buffer& __self) noexcept
     _CCCL_TRAILING_REQUIRES(::cuda::std::span<_Tp>)(
       ::cuda::std::same_as<_Tp, _Tp2>&& ::cuda::std::__is_included_in_v<::cuda::mr::device_accessible, _Properties...>)
@@ -132,7 +132,7 @@ private:
   //! cuda::launch
   //! @pre The buffer must have the cuda::mr::device_accessible property.
   template <class _Tp2 = _Tp>
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI friend auto
+  [[nodiscard]] _CCCL_HOST_API friend auto
   transform_launch_argument(::cuda::stream_ref, const __uninitialized_async_buffer& __self) noexcept
     _CCCL_TRAILING_REQUIRES(::cuda::std::span<const _Tp>)(
       ::cuda::std::same_as<_Tp, _Tp2>&& ::cuda::std::__is_included_in_v<::cuda::mr::device_accessible, _Properties...>)
@@ -179,7 +179,7 @@ private:
     //! @brief Forwards the passed properties
     _CCCL_TEMPLATE(class _Property)
     _CCCL_REQUIRES(::cuda::std::__is_included_in_v<_Property, _Properties...>)
-    _CCCL_HIDE_FROM_ABI friend constexpr void get_property(const __fake_resource_ref&, _Property) noexcept {}
+    _CCCL_HOST_API friend constexpr void get_property(const __fake_resource_ref&, _Property) noexcept {}
   };
 #  endif // _CCCL_DOXYGEN_INVOKED
 
@@ -200,7 +200,7 @@ public:
   //! @note Depending on the alignment requirements of `T` the size of the
   //! underlying allocation might be larger than `count * sizeof(T)`. Only
   //! allocates memory when \p __count > 0
-  _CCCL_HIDE_FROM_ABI
+  _CCCL_HOST_API
   __uninitialized_async_buffer(__async_resource __mr, const ::cuda::stream_ref __stream, const size_t __count)
       : __mr_(::cuda::std::move(__mr))
       , __stream_(__stream)
@@ -208,13 +208,13 @@ public:
       , __buf_(__count_ == 0 ? nullptr : __mr_.allocate(__stream_, __get_allocation_size(__count_), alignof(_Tp)))
   {}
 
-  _CCCL_HIDE_FROM_ABI __uninitialized_async_buffer(const __uninitialized_async_buffer&)            = delete;
-  _CCCL_HIDE_FROM_ABI __uninitialized_async_buffer& operator=(const __uninitialized_async_buffer&) = delete;
+  __uninitialized_async_buffer(const __uninitialized_async_buffer&)            = delete;
+  __uninitialized_async_buffer& operator=(const __uninitialized_async_buffer&) = delete;
 
   //! @brief Move-constructs a \c __uninitialized_async_buffer from \p __other
   //! @param __other Another \c __uninitialized_async_buffer
   //! Takes ownership of the allocation in \p __other and resets it
-  _CCCL_HIDE_FROM_ABI __uninitialized_async_buffer(__uninitialized_async_buffer&& __other) noexcept
+  _CCCL_HOST_API __uninitialized_async_buffer(__uninitialized_async_buffer&& __other) noexcept
       : __mr_(::cuda::std::move(__other.__mr_))
       , __stream_(::cuda::std::exchange(__other.__stream_, ::cuda::stream_ref{::cudaStream_t{}}))
       , __count_(::cuda::std::exchange(__other.__count_, 0))
@@ -226,8 +226,7 @@ public:
   //! properties Takes ownership of the allocation in \p __other and resets it
   _CCCL_TEMPLATE(class... _OtherProperties)
   _CCCL_REQUIRES(__properties_match<_OtherProperties...>)
-  _CCCL_HIDE_FROM_ABI
-  __uninitialized_async_buffer(__uninitialized_async_buffer<_Tp, _OtherProperties...>&& __other) noexcept
+  _CCCL_HOST_API __uninitialized_async_buffer(__uninitialized_async_buffer<_Tp, _OtherProperties...>&& __other) noexcept
       : __mr_(::cuda::std::move(__other.__mr_))
       , __stream_(::cuda::std::exchange(__other.__stream_, ::cuda::stream_ref{::cudaStream_t{}}))
       , __count_(::cuda::std::exchange(__other.__count_, 0))
@@ -238,7 +237,7 @@ public:
   //! @param __other Another \c __uninitialized_async_buffer
   //! Deallocates the current allocation and then takes ownership of the
   //! allocation in \p __other and resets it
-  _CCCL_HIDE_FROM_ABI __uninitialized_async_buffer& operator=(__uninitialized_async_buffer&& __other) noexcept
+  _CCCL_HOST_API __uninitialized_async_buffer& operator=(__uninitialized_async_buffer&& __other) noexcept
   {
     if (this == ::cuda::std::addressof(__other))
     {
@@ -263,7 +262,7 @@ public:
   //! @warning destroy does not destroy any objects that may or may not reside
   //! within the buffer. It is the user's responsibility to ensure that all
   //! objects within the buffer have been properly destroyed.
-  _CCCL_HIDE_FROM_ABI void destroy(::cuda::stream_ref __stream)
+  _CCCL_HOST_API void destroy(::cuda::stream_ref __stream)
   {
     if (__buf_)
     {
@@ -283,7 +282,7 @@ public:
   //! @warning destroy does not destroy any objects that may or may not reside
   //! within the buffer. It is the user's responsibility to ensure that all
   //! objects within the buffer have been properly destroyed.
-  _CCCL_HIDE_FROM_ABI void destroy()
+  _CCCL_HOST_API void destroy()
   {
     destroy(__stream_);
   }
@@ -293,19 +292,19 @@ public:
   //! @warning The destructor does not destroy any objects that may or may not
   //! reside within the buffer. It is the user's responsibility to ensure that
   //! all objects within the buffer have been properly destroyed.
-  _CCCL_HIDE_FROM_ABI ~__uninitialized_async_buffer()
+  _CCCL_HOST_API ~__uninitialized_async_buffer()
   {
     destroy();
   }
 
   //! @brief Returns an aligned pointer to the first element in the buffer
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr pointer begin() noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr pointer begin() noexcept
   {
     return __get_data();
   }
 
   //! @overload
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr const_pointer begin() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr const_pointer begin() const noexcept
   {
     return __get_data();
   }
@@ -313,37 +312,37 @@ public:
   //! @brief Returns an aligned pointer to the element following the last
   //! element of the buffer. This element acts as a placeholder; attempting to
   //! access it results in undefined behavior.
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr pointer end() noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr pointer end() noexcept
   {
     return __get_data() + __count_;
   }
 
   //! @overload
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr const_pointer end() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr const_pointer end() const noexcept
   {
     return __get_data() + __count_;
   }
 
   //! @brief Returns an aligned pointer to the first element in the buffer
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr pointer data() noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr pointer data() noexcept
   {
     return __get_data();
   }
 
   //! @overload
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr const_pointer data() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr const_pointer data() const noexcept
   {
     return __get_data();
   }
 
   //! @brief Returns the size of the buffer
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr size_type size() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr size_type size() const noexcept
   {
     return __count_;
   }
 
   //! @brief Returns the size of the buffer in bytes
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr size_type size_bytes() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr size_type size_bytes() const noexcept
   {
     return __count_ * sizeof(_Tp);
   }
@@ -353,7 +352,7 @@ public:
   //! <cuda-memory-resource-any-async-resource>` that holds the memory resource
   //! used to allocate the buffer
   //! @endrst
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI const __async_resource& memory_resource() const noexcept
+  [[nodiscard]] _CCCL_HOST_API const __async_resource& memory_resource() const noexcept
   {
     return __mr_;
   }
@@ -361,7 +360,7 @@ public:
   //! @brief Returns the stored stream
   //! @note Stream used to allocate the buffer is initially stored in the
   //! buffer, but can be changed with `set_stream`
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr ::cuda::stream_ref stream() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr ::cuda::stream_ref stream() const noexcept
   {
     return __stream_;
   }
@@ -369,7 +368,7 @@ public:
   //! @brief Replaces the stored stream
   //! @param __new_stream the new stream
   //! @note Always synchronizes with the old stream
-  _CCCL_HIDE_FROM_ABI constexpr void set_stream(::cuda::stream_ref __new_stream)
+  _CCCL_HOST_API constexpr void set_stream(::cuda::stream_ref __new_stream)
   {
     if (__new_stream != __stream_)
     {
@@ -383,7 +382,7 @@ public:
   //! @warning This does not synchronize between \p __new_stream and the current
   //! stream. It is the user's responsibility to ensure proper stream order
   //! going forward
-  _CCCL_HIDE_FROM_ABI constexpr void set_stream_unsynchronized(::cuda::stream_ref __new_stream) noexcept
+  _CCCL_HOST_API constexpr void set_stream_unsynchronized(::cuda::stream_ref __new_stream) noexcept
   {
     __stream_ = __new_stream;
   }
@@ -391,14 +390,14 @@ public:
   //! @brief Forwards the passed properties
   _CCCL_TEMPLATE(class _Property)
   _CCCL_REQUIRES((!property_with_value<_Property>) _CCCL_AND ::cuda::std::__is_included_in_v<_Property, _Properties...>)
-  _CCCL_HIDE_FROM_ABI friend constexpr void get_property(const __uninitialized_async_buffer&, _Property) noexcept {}
+  _CCCL_HOST_API friend constexpr void get_property(const __uninitialized_async_buffer&, _Property) noexcept {}
 
   //! @brief Internal method to grow the allocation to a new size \p __count.
   //! @param __count The new size of the allocation.
   //! @return An \c __uninitialized_async_buffer that holds the previous
   //! allocation
   //! @warning This buffer must outlive the returned buffer
-  _CCCL_HIDE_FROM_ABI __uninitialized_async_buffer __replace_allocation(const size_t __count)
+  _CCCL_HOST_API __uninitialized_async_buffer __replace_allocation(const size_t __count)
   {
     // Create a new buffer with a reference to the stored memory resource and
     // swap allocation information

--- a/libcudacxx/include/cuda/__hierarchy/get_launch_dimensions.h
+++ b/libcudacxx/include/cuda/__hierarchy/get_launch_dimensions.h
@@ -69,7 +69,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA
  *  Hierarchy that the launch dimensions are requested for
  */
 template <class _BottomLevel, class... _LevelDescs>
-constexpr auto _CCCL_HOST get_launch_dimensions(const hierarchy<_BottomLevel, _LevelDescs...>& __hierarchy)
+[[nodiscard]] _CCCL_HOST_API constexpr auto
+get_launch_dimensions(const hierarchy<_BottomLevel, _LevelDescs...>& __hierarchy)
 {
   if constexpr (hierarchy<_BottomLevel, _LevelDescs...>::has_level(cluster))
   {

--- a/libcudacxx/include/cuda/__launch/configuration.h
+++ b/libcudacxx/include/cuda/__launch/configuration.h
@@ -67,7 +67,7 @@ template <__detail::launch_option_kind Kind>
 struct find_option_in_tuple_impl
 {
   template <typename Option, typename... Options>
-  _CCCL_DEVICE auto& operator()(const Option& opt, const Options&... rest)
+  _CCCL_DEVICE_API auto& operator()(const Option& opt, const Options&... rest)
   {
     if constexpr (Option::kind == Kind)
     {
@@ -79,14 +79,14 @@ struct find_option_in_tuple_impl
     }
   }
 
-  _CCCL_DEVICE auto operator()()
+  _CCCL_DEVICE_API auto operator()()
   {
     return option_not_found();
   }
 };
 
 template <__detail::launch_option_kind Kind, typename... Options>
-_CCCL_DEVICE auto& find_option_in_tuple(const ::cuda::std::tuple<Options...>& tuple)
+_CCCL_DEVICE_API auto& find_option_in_tuple(const ::cuda::std::tuple<Options...>& tuple)
 {
   return ::cuda::std::apply(find_option_in_tuple_impl<Kind>(), tuple);
 }

--- a/libcudacxx/include/cuda/__memcpy_async/cp_async_bulk_shared_global.h
+++ b/libcudacxx/include/cuda/__memcpy_async/cp_async_bulk_shared_global.h
@@ -41,7 +41,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 
 extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_bulk_shared_global_is_not_supported_before_SM_90__();
 template <typename _Group>
-inline _CCCL_DEVICE void __cp_async_bulk_shared_global_and_expect_tx(
+_CCCL_DEVICE_API inline void __cp_async_bulk_shared_global_and_expect_tx(
   const _Group& __g, char* __dest, const char* __src, ::cuda::std::size_t __size, ::cuda::std::uint64_t* __bar_handle)
 {
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk

--- a/libcudacxx/include/cuda/__memcpy_async/cp_async_fallback.h
+++ b/libcudacxx/include/cuda/__memcpy_async/cp_async_fallback.h
@@ -37,8 +37,7 @@ struct __copy_chunk
 };
 
 template <::cuda::std::size_t _Alignment, typename _Group>
-inline _CCCL_HOST_DEVICE void
-__cp_async_fallback_mechanism(_Group __g, char* __dest, const char* __src, ::cuda::std::size_t __size)
+_CCCL_API void __cp_async_fallback_mechanism(_Group __g, char* __dest, const char* __src, ::cuda::std::size_t __size)
 {
   // Maximal copy size is 16 bytes
   constexpr ::cuda::std::size_t __copy_size = (_Alignment > 16) ? 16 : _Alignment;

--- a/libcudacxx/include/cuda/__memcpy_async/cp_async_shared_global.h
+++ b/libcudacxx/include/cuda/__memcpy_async/cp_async_shared_global.h
@@ -38,7 +38,7 @@ extern "C" _CCCL_DEVICE void __cuda_ptx_cp_async_shared_global_is_not_supported_
 
 #  if _CCCL_CUDA_COMPILER(NVCC, <, 12, 1) // WAR for compiler state space issues
 template <size_t _Copy_size>
-inline _CCCL_DEVICE void __cp_async_shared_global(char* __dest, const char* __src)
+_CCCL_DEVICE_API void __cp_async_shared_global(char* __dest, const char* __src)
 {
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async
 
@@ -65,7 +65,7 @@ inline _CCCL_DEVICE void __cp_async_shared_global(char* __dest, const char* __sr
     (::cuda::__cuda_ptx_cp_async_shared_global_is_not_supported_before_SM_80__();));
 }
 template <>
-inline _CCCL_DEVICE void __cp_async_shared_global<16>(char* __dest, const char* __src)
+_CCCL_DEVICE_API inline void __cp_async_shared_global<16>(char* __dest, const char* __src)
 {
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async
   // When copying 16 bytes, it is possible to skip L1 cache (.cg).
@@ -86,7 +86,7 @@ inline _CCCL_DEVICE void __cp_async_shared_global<16>(char* __dest, const char* 
 }
 #  else // ^^^^ NVCC 12.0 / !NVCC 12.0 vvvvv WAR for compiler state space issues
 template <size_t _Copy_size>
-inline _CCCL_DEVICE void __cp_async_shared_global(char* __dest, const char* __src)
+_CCCL_DEVICE_API void __cp_async_shared_global(char* __dest, const char* __src)
 {
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async
 
@@ -104,7 +104,7 @@ inline _CCCL_DEVICE void __cp_async_shared_global(char* __dest, const char* __sr
     (::cuda::__cuda_ptx_cp_async_shared_global_is_not_supported_before_SM_80__();));
 }
 template <>
-inline _CCCL_DEVICE void __cp_async_shared_global<16>(char* __dest, const char* __src)
+_CCCL_DEVICE_API inline void __cp_async_shared_global<16>(char* __dest, const char* __src)
 {
   // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async
   // When copying 16 bytes, it is possible to skip L1 cache (.cg).
@@ -119,7 +119,7 @@ inline _CCCL_DEVICE void __cp_async_shared_global<16>(char* __dest, const char* 
 #  endif // _CCCL_CUDA_COMPILER(NVCC, >=, 12, 1)
 
 template <size_t _Alignment, typename _Group>
-inline _CCCL_DEVICE void
+_CCCL_DEVICE_API void
 __cp_async_shared_global_mechanism(_Group __g, char* __dest, const char* __src, ::cuda::std::size_t __size)
 {
   // If `if constexpr` is not available, this function gets instantiated even

--- a/libcudacxx/include/cuda/__memcpy_async/dispatch_memcpy_async.h
+++ b/libcudacxx/include/cuda/__memcpy_async/dispatch_memcpy_async.h
@@ -50,7 +50,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA
  ***********************************************************************/
 
 template <::cuda::std::size_t _Align, typename _Group>
-[[nodiscard]] _CCCL_DEVICE inline __completion_mechanism __dispatch_memcpy_async_any_to_any(
+[[nodiscard]] _CCCL_DEVICE_API __completion_mechanism __dispatch_memcpy_async_any_to_any(
   _Group const& __group,
   char* __dest_char,
   char const* __src_char,
@@ -63,7 +63,7 @@ template <::cuda::std::size_t _Align, typename _Group>
 }
 
 template <::cuda::std::size_t _Align, typename _Group>
-[[nodiscard]] _CCCL_DEVICE inline __completion_mechanism __dispatch_memcpy_async_global_to_shared(
+[[nodiscard]] _CCCL_DEVICE_API __completion_mechanism __dispatch_memcpy_async_global_to_shared(
   _Group const& __group,
   char* __dest_char,
   char const* __src_char,
@@ -109,7 +109,7 @@ template <::cuda::std::size_t _Align, typename _Group>
 
 // __dispatch_memcpy_async is the internal entry point for dispatching to the correct memcpy_async implementation.
 template <::cuda::std::size_t _Align, typename _Group>
-[[nodiscard]] _CCCL_API inline __completion_mechanism __dispatch_memcpy_async(
+[[nodiscard]] _CCCL_API __completion_mechanism __dispatch_memcpy_async(
   _Group const& __group,
   char* __dest_char,
   char const* __src_char,
@@ -145,7 +145,7 @@ template <::cuda::std::size_t _Align, typename _Group>
 }
 
 template <::cuda::std::size_t _Align, typename _Group>
-[[nodiscard]] _CCCL_API inline __completion_mechanism __dispatch_memcpy_async(
+[[nodiscard]] _CCCL_API __completion_mechanism __dispatch_memcpy_async(
   _Group const& __group,
   char* __dest_char,
   char const* __src_char,

--- a/libcudacxx/include/cuda/__memcpy_async/memcpy_async_tx.h
+++ b/libcudacxx/include/cuda/__memcpy_async/memcpy_async_tx.h
@@ -44,7 +44,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 
 extern "C" _CCCL_DEVICE void __cuda_ptx_memcpy_async_tx_is_not_supported_before_SM_90__();
 template <typename _Tp, ::cuda::std::size_t _Alignment>
-_CCCL_DEVICE inline async_contract_fulfillment memcpy_async_tx(
+_CCCL_DEVICE_API async_contract_fulfillment memcpy_async_tx(
   _Tp* __dest,
   const _Tp* __src,
   ::cuda::aligned_size_t<_Alignment> __size,

--- a/libcudacxx/include/cuda/__ptx/ptx_helper_functions.h
+++ b/libcudacxx/include/cuda/__ptx/ptx_helper_functions.h
@@ -87,26 +87,26 @@ using ::ulonglong4_32a;
  * Conversion from generic pointer -> state space "pointer"
  *
  **************************************************************/
-inline _CCCL_DEVICE ::cuda::std::uint32_t __as_ptr_smem(const void* __ptr)
+_CCCL_DEVICE_API inline ::cuda::std::uint32_t __as_ptr_smem(const void* __ptr)
 {
   // Consider adding debug asserts here.
   return static_cast<::cuda::std::uint32_t>(::__cvta_generic_to_shared(__ptr));
 }
 
-inline _CCCL_DEVICE ::cuda::std::uint32_t __as_ptr_dsmem(const void* __ptr)
+_CCCL_DEVICE_API inline ::cuda::std::uint32_t __as_ptr_dsmem(const void* __ptr)
 {
   // No difference in implementation to __as_ptr_smem.
   return __as_ptr_smem(__ptr);
 }
 
-inline _CCCL_DEVICE ::cuda::std::uint32_t __as_ptr_remote_dsmem(const void* __ptr)
+_CCCL_DEVICE_API inline ::cuda::std::uint32_t __as_ptr_remote_dsmem(const void* __ptr)
 {
   // No difference in implementation to __as_ptr_smem.
   // Consider adding debug asserts here.
   return __as_ptr_smem(__ptr);
 }
 
-inline _CCCL_DEVICE ::cuda::std::uint64_t __as_ptr_gmem(const void* __ptr)
+_CCCL_DEVICE_API inline ::cuda::std::uint64_t __as_ptr_gmem(const void* __ptr)
 {
   // Consider adding debug asserts here.
   return static_cast<::cuda::std::uint64_t>(::__cvta_generic_to_global(__ptr));
@@ -118,28 +118,28 @@ inline _CCCL_DEVICE ::cuda::std::uint64_t __as_ptr_gmem(const void* __ptr)
  *
  **************************************************************/
 template <typename _Tp>
-inline _CCCL_DEVICE _Tp* __from_ptr_smem(::cuda::std::size_t __ptr)
+_CCCL_DEVICE_API _Tp* __from_ptr_smem(::cuda::std::size_t __ptr)
 {
   // Consider adding debug asserts here.
   return reinterpret_cast<_Tp*>(::__cvta_shared_to_generic(__ptr));
 }
 
 template <typename _Tp>
-inline _CCCL_DEVICE _Tp* __from_ptr_dsmem(::cuda::std::size_t __ptr)
+_CCCL_DEVICE_API _Tp* __from_ptr_dsmem(::cuda::std::size_t __ptr)
 {
   // Consider adding debug asserts here.
   return __from_ptr_smem<_Tp>(__ptr);
 }
 
 template <typename _Tp>
-inline _CCCL_DEVICE _Tp* __from_ptr_remote_dsmem(::cuda::std::size_t __ptr)
+_CCCL_DEVICE_API _Tp* __from_ptr_remote_dsmem(::cuda::std::size_t __ptr)
 {
   // Consider adding debug asserts here.
   return __from_ptr_smem<_Tp>(__ptr);
 }
 
 template <typename _Tp>
-inline _CCCL_DEVICE _Tp* __from_ptr_gmem(::cuda::std::size_t __ptr)
+_CCCL_DEVICE_API _Tp* __from_ptr_gmem(::cuda::std::size_t __ptr)
 {
   // Consider adding debug asserts here.
   return reinterpret_cast<_Tp*>(::__cvta_global_to_generic(__ptr));
@@ -152,7 +152,7 @@ inline _CCCL_DEVICE _Tp* __from_ptr_gmem(::cuda::std::size_t __ptr)
  **************************************************************/
 
 template <typename _B8>
-inline _CCCL_DEVICE uint32_t __b8_as_u32(_B8 __val)
+_CCCL_DEVICE_API uint32_t __b8_as_u32(_B8 __val)
 {
   static_assert(sizeof(_B8) == 1);
   ::cuda::std::uint32_t __u32 = 0;
@@ -161,7 +161,7 @@ inline _CCCL_DEVICE uint32_t __b8_as_u32(_B8 __val)
 }
 
 template <typename _B8>
-inline _CCCL_DEVICE _B8 __u32_as_b8(uint32_t __u32)
+_CCCL_DEVICE_API _B8 __u32_as_b8(uint32_t __u32)
 {
   static_assert(sizeof(_B8) == 1);
   _B8 b8;

--- a/libcudacxx/include/cuda/__warp/lane_mask.h
+++ b/libcudacxx/include/cuda/__warp/lane_mask.h
@@ -41,14 +41,14 @@ public:
   //! @param __v The value to initialize the lane mask with. Defaults to 0.
   //!
   //! @post `value() == __v`
-  _CCCL_DEVICE _CCCL_HIDE_FROM_ABI explicit constexpr lane_mask(::cuda::std::uint32_t __v = 0) noexcept
+  _CCCL_DEVICE_API explicit constexpr lane_mask(::cuda::std::uint32_t __v = 0) noexcept
       : __value_{__v}
   {}
 
   //! @brief Returns the value of the lane mask as a 32-bit unsigned integer.
   //!
   //! @return The value of the lane mask.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI constexpr ::cuda::std::uint32_t value() const noexcept
+  [[nodiscard]] _CCCL_DEVICE_API constexpr ::cuda::std::uint32_t value() const noexcept
   {
     return __value_;
   }
@@ -58,7 +58,7 @@ public:
   //! This operator allows explicit conversion of the lane mask to a 32-bit unsigned integer.
   //!
   //! @return The value of the lane mask as a 32-bit unsigned integer.
-  _CCCL_DEVICE _CCCL_HIDE_FROM_ABI explicit constexpr operator ::cuda::std::uint32_t() const noexcept
+  _CCCL_DEVICE_API explicit constexpr operator ::cuda::std::uint32_t() const noexcept
   {
     return __value_;
   }
@@ -66,7 +66,7 @@ public:
   //! @brief Returns a lane mask object with no lane bits set.
   //!
   //! @return A lane mask with no lane bits set.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI static constexpr lane_mask none() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr lane_mask none() noexcept
   {
     return lane_mask{};
   }
@@ -76,7 +76,7 @@ public:
   //! @return A lane mask with all lane bits set.
   //!
   //! @note This function may return a mask with 1s set even on inactive lane bits,
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI static constexpr lane_mask all() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr lane_mask all() noexcept
   {
     return lane_mask{0xffffffff};
   }
@@ -86,7 +86,7 @@ public:
   //! This function returns a lane_mask object equivalent to calling `lane_mask{::__activemask()}`.
   //!
   //! @return A lane mask with all active lane bits set.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI static lane_mask all_active() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static lane_mask all_active() noexcept
   {
     return lane_mask{::__activemask()};
   }
@@ -96,7 +96,7 @@ public:
   //! This function is equivalent to constructing a lane_mask object with value of %%lanemask_eq PTX special register.
   //!
   //! @return A lane mask with the current lane bit set.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI static lane_mask this_lane() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static lane_mask this_lane() noexcept
   {
     return lane_mask{::cuda::ptx::get_sreg_lanemask_eq()};
   }
@@ -108,7 +108,7 @@ public:
   //! @return A lane mask with all lanes less than the current lane set.
   //!
   //! @note This function may return a mask with 1s set even on inactive lane bits,
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI static lane_mask all_less() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static lane_mask all_less() noexcept
   {
     return lane_mask{::cuda::ptx::get_sreg_lanemask_lt()};
   }
@@ -120,7 +120,7 @@ public:
   //! @return A lane mask with all lanes equal to or less than the current lane set.
   //!
   //! @note This function may return a mask with 1s set even on inactive lane bits,
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI static lane_mask all_less_equal() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static lane_mask all_less_equal() noexcept
   {
     return lane_mask{::cuda::ptx::get_sreg_lanemask_le()};
   }
@@ -132,7 +132,7 @@ public:
   //! @return A lane mask with all lanes greater than the current lane set.
   //!
   //! @note This function may return a mask with 1s set even on inactive lane bits,
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI static lane_mask all_greater() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static lane_mask all_greater() noexcept
   {
     return lane_mask{::cuda::ptx::get_sreg_lanemask_gt()};
   }
@@ -144,7 +144,7 @@ public:
   //! @return A lane mask with all lanes greater than or equal to the current lane set.
   //!
   //! @note This function may return a mask with 1s set even on inactive lane bits,
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI static lane_mask all_greater_equal() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static lane_mask all_greater_equal() noexcept
   {
     return lane_mask{::cuda::ptx::get_sreg_lanemask_ge()};
   }
@@ -157,7 +157,7 @@ public:
   //! @return A lane mask with all lanes not equal to the current lane set.
   //!
   //! @note This function may return a mask with 1s set even on inactive lane bits.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI static lane_mask all_not_equal() noexcept
+  [[nodiscard]] _CCCL_DEVICE_API static lane_mask all_not_equal() noexcept
   {
     return lane_mask{~::cuda::ptx::get_sreg_lanemask_eq()};
   }
@@ -168,8 +168,7 @@ public:
   //! @param __rhs The right-hand side lane_mask.
   //!
   //! @return A new lane_mask object representing the bitwise AND of the two lane_masks.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI friend constexpr lane_mask
-  operator&(lane_mask __lhs, lane_mask __rhs) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API friend constexpr lane_mask operator&(lane_mask __lhs, lane_mask __rhs) noexcept
   {
     return lane_mask{__lhs.__value_ & __rhs.__value_};
   }
@@ -179,7 +178,7 @@ public:
   //! @param __v The lane_mask to AND with the current lane_mask.
   //!
   //! @return A reference to the current lane_mask after the AND operation.
-  _CCCL_DEVICE _CCCL_HIDE_FROM_ABI constexpr lane_mask& operator&=(lane_mask __v) noexcept
+  _CCCL_DEVICE_API constexpr lane_mask& operator&=(lane_mask __v) noexcept
   {
     return *this = *this & __v;
   }
@@ -190,8 +189,7 @@ public:
   //! @param __rhs The right-hand side lane_mask.
   //!
   //! @return A new lane_mask object representing the bitwise OR of the two lane_masks.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI friend constexpr lane_mask
-  operator|(lane_mask __lhs, lane_mask __rhs) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API friend constexpr lane_mask operator|(lane_mask __lhs, lane_mask __rhs) noexcept
   {
     return lane_mask{__lhs.__value_ | __rhs.__value_};
   }
@@ -201,7 +199,7 @@ public:
   //! @param __v The lane_mask to OR with the current lane_mask.
   //!
   //! @return A reference to the current lane_mask after the OR operation.
-  _CCCL_DEVICE _CCCL_HIDE_FROM_ABI constexpr lane_mask& operator|=(lane_mask __v) noexcept
+  _CCCL_DEVICE_API constexpr lane_mask& operator|=(lane_mask __v) noexcept
   {
     return *this = *this | __v;
   }
@@ -212,8 +210,7 @@ public:
   //! @param __rhs The right-hand side lane_mask.
   //!
   //! @return A new lane_mask object representing the bitwise XOR of the two lane_masks.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI friend constexpr lane_mask
-  operator^(lane_mask __lhs, lane_mask __rhs) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API friend constexpr lane_mask operator^(lane_mask __lhs, lane_mask __rhs) noexcept
   {
     return lane_mask{__lhs.__value_ ^ __rhs.__value_};
   }
@@ -223,7 +220,7 @@ public:
   //! @param __v The lane_mask to XOR with the current lane_mask.
   //!
   //! @return A reference to the current lane_mask after the XOR operation.
-  _CCCL_DEVICE _CCCL_HIDE_FROM_ABI constexpr lane_mask& operator^=(lane_mask __v) noexcept
+  _CCCL_DEVICE_API constexpr lane_mask& operator^=(lane_mask __v) noexcept
   {
     return *this = *this ^ __v;
   }
@@ -236,8 +233,7 @@ public:
   //! @return A new lane_mask object representing the left-shifted lane_mask.
   //!
   //! @pre `__shift` must be in the range [0, 32).
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI friend constexpr lane_mask
-  operator<<(lane_mask __mask, int __shift) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API friend constexpr lane_mask operator<<(lane_mask __mask, int __shift) noexcept
   {
     _CCCL_ASSERT(__shift >= 0 && __shift < 32, "shift must be in range [0, 32)");
     return lane_mask{__mask.__value_ << __shift};
@@ -250,7 +246,7 @@ public:
   //! @return A reference to the current lane_mask after the left shift operation.
   //!
   //! @pre `__shift` must be in the range [0, 32).
-  _CCCL_DEVICE _CCCL_HIDE_FROM_ABI constexpr lane_mask& operator<<=(int __shift) noexcept
+  _CCCL_DEVICE_API constexpr lane_mask& operator<<=(int __shift) noexcept
   {
     _CCCL_ASSERT(__shift >= 0 && __shift < 32, "shift must be in range [0, 32)");
     return *this = *this << __shift;
@@ -262,8 +258,7 @@ public:
   //! @param __shift The number of bits to shift right.
   //!
   //! @return A new lane_mask object representing the right-shifted lane_mask.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI friend constexpr lane_mask
-  operator>>(lane_mask __mask, int __shift) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API friend constexpr lane_mask operator>>(lane_mask __mask, int __shift) noexcept
   {
     _CCCL_ASSERT(__shift >= 0 && __shift < 32, "shift must be in range [0, 32)");
     return lane_mask{__mask.__value_ >> __shift};
@@ -276,7 +271,7 @@ public:
   //! @return A reference to the current lane_mask after the right shift operation.
   //!
   //! @pre `__shift` must be in the range [0, 32).
-  _CCCL_DEVICE _CCCL_HIDE_FROM_ABI constexpr lane_mask& operator>>=(int __shift) noexcept
+  _CCCL_DEVICE_API constexpr lane_mask& operator>>=(int __shift) noexcept
   {
     _CCCL_ASSERT(__shift >= 0 && __shift < 32, "shift must be in range [0, 32)");
     return *this = *this >> __shift;
@@ -287,7 +282,7 @@ public:
   //! @param __mask The lane_mask to negate.
   //!
   //! @return A new lane_mask object representing the negated lane_mask.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI friend constexpr lane_mask operator~(lane_mask __mask) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API friend constexpr lane_mask operator~(lane_mask __mask) noexcept
   {
     return lane_mask{~__mask.__value_};
   }
@@ -298,8 +293,7 @@ public:
   //! @param __rhs The right-hand side lane_mask.
   //!
   //! @return `true` if the two lane_masks are equal, `false` otherwise.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI friend constexpr bool
-  operator==(lane_mask __lhs, lane_mask __rhs) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API friend constexpr bool operator==(lane_mask __lhs, lane_mask __rhs) noexcept
   {
     return __lhs.__value_ == __rhs.__value_;
   }
@@ -310,8 +304,7 @@ public:
   //! @param __rhs The right-hand side lane_mask.
   //!
   //! @return `true` if the two lane_masks are not equal, `false` otherwise.
-  [[nodiscard]] _CCCL_DEVICE _CCCL_HIDE_FROM_ABI friend constexpr bool
-  operator!=(lane_mask __lhs, lane_mask __rhs) noexcept
+  [[nodiscard]] _CCCL_DEVICE_API friend constexpr bool operator!=(lane_mask __lhs, lane_mask __rhs) noexcept
   {
     return !(__lhs == __rhs);
   }

--- a/libcudacxx/include/cuda/__warp/warp_match_all.h
+++ b/libcudacxx/include/cuda/__warp/warp_match_all.h
@@ -37,8 +37,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 extern "C" _CCCL_DEVICE void __cuda__match_all_sync_is_not_supported_before_SM_70__();
 
 template <typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE bool
-warp_match_all(const _Tp& __data, lane_mask __lane_mask = lane_mask::all())
+[[nodiscard]] _CCCL_DEVICE_API bool warp_match_all(const _Tp& __data, lane_mask __lane_mask = lane_mask::all())
 {
   _CCCL_ASSERT(__lane_mask != lane_mask::none(), "lane_mask must be non-zero");
   constexpr int __ratio = ::cuda::ceil_div(sizeof(_Up), sizeof(uint32_t));

--- a/libcudacxx/include/cuda/__warp/warp_shuffle.h
+++ b/libcudacxx/include/cuda/__warp/warp_shuffle.h
@@ -48,15 +48,14 @@ struct warp_shuffle_result
   bool pred;
 
   template <typename _Up = _Tp>
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE
-  operator ::cuda::std::enable_if_t<!::cuda::std::is_array_v<_Up>, _Up>() const
+  [[nodiscard]] _CCCL_DEVICE_API operator ::cuda::std::enable_if_t<!::cuda::std::is_array_v<_Up>, _Up>() const
   {
     return data;
   }
 };
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Up> warp_shuffle_idx(
+[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up> warp_shuffle_idx(
   const _Tp& __data, int __src_lane, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
@@ -92,14 +91,14 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 }
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Up>
+[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up>
 warp_shuffle_idx(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
 {
   return ::cuda::device::warp_shuffle_idx(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Tp> warp_shuffle_up(
+[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Tp> warp_shuffle_up(
   const _Tp& __data, int __delta, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
@@ -140,14 +139,14 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 }
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Up>
+[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up>
 warp_shuffle_up(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
 {
   return ::cuda::device::warp_shuffle_up(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Up> warp_shuffle_down(
+[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up> warp_shuffle_down(
   const _Tp& __data, int __delta, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
@@ -188,14 +187,14 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 }
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Tp>
+[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Tp>
 warp_shuffle_down(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
 {
   return ::cuda::device::warp_shuffle_down(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Up> warp_shuffle_xor(
+[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up> warp_shuffle_xor(
   const _Tp& __data, int __xor_mask, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
@@ -236,7 +235,7 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 }
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE warp_shuffle_result<_Up>
+[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up>
 warp_shuffle_xor(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
 {
   return ::cuda::device::warp_shuffle_xor(__data, __src_lane, 0xFFFFFFFF, __width);

--- a/libcudacxx/include/cuda/barrier
+++ b/libcudacxx/include/cuda/barrier
@@ -70,7 +70,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE_EXPERIMENTAL
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk instead") inline _CCCL_DEVICE void cp_async_bulk_global_to_shared(
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk instead") _CCCL_DEVICE_API inline void
+cp_async_bulk_global_to_shared(
   void* __dest, const void* __src, ::cuda::std::uint32_t __size, ::cuda::barrier<::cuda::thread_scope_block>& __bar)
 {
   _CCCL_ASSERT(__size % 16 == 0, "Size must be multiple of 16.");
@@ -90,7 +91,7 @@ CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk instead") inline _CCCL_DEV
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_shared_to_global(void* __dest, const void* __src, ::cuda::std::uint32_t __size)
 {
   _CCCL_ASSERT(__size % 16 == 0, "Size must be multiple of 16.");
@@ -104,7 +105,7 @@ cp_async_bulk_shared_to_global(void* __dest, const void* __src, ::cuda::std::uin
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_tensor_1d_global_to_shared(
   void* __dest, const CUtensorMap* __tensor_map, int __c0, ::cuda::barrier<::cuda::thread_scope_block>& __bar)
 {
@@ -121,7 +122,7 @@ cp_async_bulk_tensor_1d_global_to_shared(
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_tensor_2d_global_to_shared(
   void* __dest, const CUtensorMap* __tensor_map, int __c0, int __c1, ::cuda::barrier<::cuda::thread_scope_block>& __bar)
 {
@@ -138,7 +139,7 @@ cp_async_bulk_tensor_2d_global_to_shared(
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_tensor_3d_global_to_shared(
   void* __dest,
   const CUtensorMap* __tensor_map,
@@ -160,7 +161,7 @@ cp_async_bulk_tensor_3d_global_to_shared(
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_tensor_4d_global_to_shared(
   void* __dest,
   const CUtensorMap* __tensor_map,
@@ -183,7 +184,7 @@ cp_async_bulk_tensor_4d_global_to_shared(
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_tensor_5d_global_to_shared(
   void* __dest,
   const CUtensorMap* __tensor_map,
@@ -207,7 +208,7 @@ cp_async_bulk_tensor_5d_global_to_shared(
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_tensor_1d_shared_to_global(const CUtensorMap* __tensor_map, int __c0, const void* __src)
 {
   const ::cuda::std::int32_t __coords[]{__c0};
@@ -217,7 +218,7 @@ cp_async_bulk_tensor_1d_shared_to_global(const CUtensorMap* __tensor_map, int __
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_tensor_2d_shared_to_global(const CUtensorMap* __tensor_map, int __c0, int __c1, const void* __src)
 {
   const ::cuda::std::int32_t __coords[]{__c0, __c1};
@@ -227,7 +228,7 @@ cp_async_bulk_tensor_2d_shared_to_global(const CUtensorMap* __tensor_map, int __
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_tensor_3d_shared_to_global(
   const CUtensorMap* __tensor_map, int __c0, int __c1, int __c2, const void* __src)
 {
@@ -238,7 +239,7 @@ cp_async_bulk_tensor_3d_shared_to_global(
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_tensor_4d_shared_to_global(
   const CUtensorMap* __tensor_map, int __c0, int __c1, int __c2, int __c3, const void* __src)
 {
@@ -249,7 +250,7 @@ cp_async_bulk_tensor_4d_shared_to_global(
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-tensor
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_tensor instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_tensor_5d_shared_to_global(
   const CUtensorMap* __tensor_map, int __c0, int __c1, int __c2, int __c3, int __c4, const void* __src)
 {
@@ -260,7 +261,7 @@ cp_async_bulk_tensor_5d_shared_to_global(
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-membar
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::fence_proxy_async instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::fence_proxy_async instead") _CCCL_DEVICE_API inline void
 fence_proxy_async_shared_cta()
 {
   ::cuda::ptx::fence_proxy_async(::cuda::ptx::space_shared);
@@ -268,7 +269,7 @@ fence_proxy_async_shared_cta()
 
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-commit-group
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_commit_group instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_commit_group instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_commit_group()
 {
   ::cuda::ptx::cp_async_bulk_commit_group();
@@ -277,7 +278,7 @@ cp_async_bulk_commit_group()
 //! Deprecated [Since 3.2]
 // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#data-movement-and-conversion-instructions-cp-async-bulk-wait-group
 template <int __n_prior>
-CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_wait_group_read instead") inline _CCCL_DEVICE void
+CCCL_DEPRECATED_BECAUSE("Use cuda::ptx::cp_async_bulk_wait_group_read instead") _CCCL_DEVICE_API inline void
 cp_async_bulk_wait_group_read()
 {
   static_assert(__n_prior <= 63, "cp_async_bulk_wait_group_read: waiting for more than 63 groups is not supported.");

--- a/libcudacxx/include/cuda/pipeline
+++ b/libcudacxx/include/cuda/pipeline
@@ -338,9 +338,9 @@ _CCCL_END_NAMESPACE_CUDA
 _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 
 template <uint8_t _Prior>
-_CCCL_DEVICE void __pipeline_consumer_wait(pipeline<thread_scope_thread>& __pipeline);
+_CCCL_DEVICE_API void __pipeline_consumer_wait(pipeline<thread_scope_thread>& __pipeline);
 
-_CCCL_DEVICE inline void __pipeline_consumer_wait(pipeline<thread_scope_thread>& __pipeline, uint8_t __prior);
+_CCCL_DEVICE_API inline void __pipeline_consumer_wait(pipeline<thread_scope_thread>& __pipeline, uint8_t __prior);
 
 _CCCL_END_NAMESPACE_CUDA_DEVICE
 
@@ -422,14 +422,14 @@ _CCCL_END_NAMESPACE_CUDA
 _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 
 template <uint8_t _Prior>
-_CCCL_DEVICE void __pipeline_consumer_wait([[maybe_unused]] pipeline<thread_scope_thread>& __pipeline)
+_CCCL_DEVICE_API void __pipeline_consumer_wait([[maybe_unused]] pipeline<thread_scope_thread>& __pipeline)
 {
   NV_IF_TARGET(NV_PROVIDES_SM_80, constexpr uint8_t __max_prior = 8;
 
                asm volatile("cp.async.wait_group %0;" : : "n"(_Prior < __max_prior ? _Prior : __max_prior));)
 }
 
-_CCCL_DEVICE inline void __pipeline_consumer_wait(pipeline<thread_scope_thread>& __pipeline, uint8_t __prior)
+_CCCL_DEVICE_API inline void __pipeline_consumer_wait(pipeline<thread_scope_thread>& __pipeline, uint8_t __prior)
 {
   switch (__prior)
   {

--- a/libcudacxx/include/cuda/std/__atomic/api/common.h
+++ b/libcudacxx/include/cuda/std/__atomic/api/common.h
@@ -24,169 +24,167 @@
 #include <cuda/std/__atomic/types/base.h>
 
 // API definitions for the base atomic implementation
-#define _LIBCUDACXX_ATOMIC_COMMON_IMPL(_CONST, _VOLATILE)                                                           \
-  _CCCL_HOST_DEVICE inline bool is_lock_free() const _VOLATILE noexcept                                             \
-  {                                                                                                                 \
-    return _LIBCUDACXX_ATOMIC_IS_LOCK_FREE(sizeof(_Tp));                                                            \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline void store(_Tp __d, memory_order __m = memory_order_seq_cst)                             \
-    _CONST _VOLATILE noexcept _LIBCUDACXX_CHECK_STORE_MEMORY_ORDER(__m)                                             \
-  {                                                                                                                 \
-    __atomic_store_dispatch(&__a, __d, __m, _Sco{});                                                                \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline _Tp load(memory_order __m = memory_order_seq_cst)                                        \
-    const _VOLATILE noexcept _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)                                               \
-  {                                                                                                                 \
-    return __atomic_load_dispatch(&__a, __m, _Sco{});                                                               \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline operator _Tp() const _VOLATILE noexcept                                                  \
-  {                                                                                                                 \
-    return load();                                                                                                  \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
-  {                                                                                                                 \
-    return __atomic_exchange_dispatch(&__a, __d, __m, _Sco{});                                                      \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline bool compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __s, memory_order __f)        \
-    _CONST _VOLATILE noexcept _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)                                     \
-  {                                                                                                                 \
-    return __atomic_compare_exchange_weak_dispatch(&__a, &__e, __d, __s, __f, _Sco{});                              \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline bool compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __s, memory_order __f)      \
-    _CONST _VOLATILE noexcept _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)                                     \
-  {                                                                                                                 \
-    return __atomic_compare_exchange_strong_dispatch(&__a, &__e, __d, __s, __f, _Sco{});                            \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline bool compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst)   \
-    _CONST _VOLATILE noexcept                                                                                       \
-  {                                                                                                                 \
-    if (memory_order_acq_rel == __m)                                                                                \
-      return __atomic_compare_exchange_weak_dispatch(&__a, &__e, __d, __m, memory_order_acquire, _Sco{});           \
-    else if (memory_order_release == __m)                                                                           \
-      return __atomic_compare_exchange_weak_dispatch(&__a, &__e, __d, __m, memory_order_relaxed, _Sco{});           \
-    else                                                                                                            \
-      return __atomic_compare_exchange_weak_dispatch(&__a, &__e, __d, __m, __m, _Sco{});                            \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline bool compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst) \
-    _CONST _VOLATILE noexcept                                                                                       \
-  {                                                                                                                 \
-    if (memory_order_acq_rel == __m)                                                                                \
-      return __atomic_compare_exchange_strong_dispatch(&__a, &__e, __d, __m, memory_order_acquire, _Sco{});         \
-    else if (memory_order_release == __m)                                                                           \
-      return __atomic_compare_exchange_strong_dispatch(&__a, &__e, __d, __m, memory_order_relaxed, _Sco{});         \
-    else                                                                                                            \
-      return __atomic_compare_exchange_strong_dispatch(&__a, &__e, __d, __m, __m, _Sco{});                          \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const _VOLATILE noexcept     \
-  {                                                                                                                 \
-    __atomic_wait(&__a, __v, __m, _Sco{});                                                                          \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline void notify_one() _CONST _VOLATILE noexcept                                              \
-  {                                                                                                                 \
-    __atomic_notify_one(&__a, _Sco{});                                                                              \
-  }                                                                                                                 \
-  _CCCL_HOST_DEVICE inline void notify_all() _CONST _VOLATILE noexcept                                              \
-  {                                                                                                                 \
-    __atomic_notify_all(&__a, _Sco{});                                                                              \
+#define _LIBCUDACXX_ATOMIC_COMMON_IMPL(_CONST, _VOLATILE)                                                   \
+  _CCCL_API inline bool is_lock_free() const _VOLATILE noexcept                                             \
+  {                                                                                                         \
+    return _LIBCUDACXX_ATOMIC_IS_LOCK_FREE(sizeof(_Tp));                                                    \
+  }                                                                                                         \
+  _CCCL_API inline void store(_Tp __d, memory_order __m = memory_order_seq_cst)                             \
+    _CONST _VOLATILE noexcept _LIBCUDACXX_CHECK_STORE_MEMORY_ORDER(__m)                                     \
+  {                                                                                                         \
+    __atomic_store_dispatch(&__a, __d, __m, _Sco{});                                                        \
+  }                                                                                                         \
+  _CCCL_API inline _Tp load(memory_order __m = memory_order_seq_cst)                                        \
+    const _VOLATILE noexcept _LIBCUDACXX_CHECK_LOAD_MEMORY_ORDER(__m)                                       \
+  {                                                                                                         \
+    return __atomic_load_dispatch(&__a, __m, _Sco{});                                                       \
+  }                                                                                                         \
+  _CCCL_API inline operator _Tp() const _VOLATILE noexcept                                                  \
+  {                                                                                                         \
+    return load();                                                                                          \
+  }                                                                                                         \
+  _CCCL_API inline _Tp exchange(_Tp __d, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
+  {                                                                                                         \
+    return __atomic_exchange_dispatch(&__a, __d, __m, _Sco{});                                              \
+  }                                                                                                         \
+  _CCCL_API inline bool compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __s, memory_order __f)        \
+    _CONST _VOLATILE noexcept _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)                             \
+  {                                                                                                         \
+    return __atomic_compare_exchange_weak_dispatch(&__a, &__e, __d, __s, __f, _Sco{});                      \
+  }                                                                                                         \
+  _CCCL_API inline bool compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __s, memory_order __f)      \
+    _CONST _VOLATILE noexcept _LIBCUDACXX_CHECK_EXCHANGE_MEMORY_ORDER(__s, __f)                             \
+  {                                                                                                         \
+    return __atomic_compare_exchange_strong_dispatch(&__a, &__e, __d, __s, __f, _Sco{});                    \
+  }                                                                                                         \
+  _CCCL_API inline bool compare_exchange_weak(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst)   \
+    _CONST _VOLATILE noexcept                                                                               \
+  {                                                                                                         \
+    if (memory_order_acq_rel == __m)                                                                        \
+      return __atomic_compare_exchange_weak_dispatch(&__a, &__e, __d, __m, memory_order_acquire, _Sco{});   \
+    else if (memory_order_release == __m)                                                                   \
+      return __atomic_compare_exchange_weak_dispatch(&__a, &__e, __d, __m, memory_order_relaxed, _Sco{});   \
+    else                                                                                                    \
+      return __atomic_compare_exchange_weak_dispatch(&__a, &__e, __d, __m, __m, _Sco{});                    \
+  }                                                                                                         \
+  _CCCL_API inline bool compare_exchange_strong(_Tp& __e, _Tp __d, memory_order __m = memory_order_seq_cst) \
+    _CONST _VOLATILE noexcept                                                                               \
+  {                                                                                                         \
+    if (memory_order_acq_rel == __m)                                                                        \
+      return __atomic_compare_exchange_strong_dispatch(&__a, &__e, __d, __m, memory_order_acquire, _Sco{}); \
+    else if (memory_order_release == __m)                                                                   \
+      return __atomic_compare_exchange_strong_dispatch(&__a, &__e, __d, __m, memory_order_relaxed, _Sco{}); \
+    else                                                                                                    \
+      return __atomic_compare_exchange_strong_dispatch(&__a, &__e, __d, __m, __m, _Sco{});                  \
+  }                                                                                                         \
+  _CCCL_API inline void wait(_Tp __v, memory_order __m = memory_order_seq_cst) const _VOLATILE noexcept     \
+  {                                                                                                         \
+    __atomic_wait(&__a, __v, __m, _Sco{});                                                                  \
+  }                                                                                                         \
+  _CCCL_API inline void notify_one() _CONST _VOLATILE noexcept                                              \
+  {                                                                                                         \
+    __atomic_notify_one(&__a, _Sco{});                                                                      \
+  }                                                                                                         \
+  _CCCL_API inline void notify_all() _CONST _VOLATILE noexcept                                              \
+  {                                                                                                         \
+    __atomic_notify_all(&__a, _Sco{});                                                                      \
   }
 
 // API definitions for arithmetic atomics
-#define _LIBCUDACXX_ATOMIC_ARITHMETIC_IMPL(_CONST, _VOLATILE)                                                         \
-  _CCCL_HOST_DEVICE inline _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
-  {                                                                                                                   \
-    return __atomic_fetch_add_dispatch(&__a, __op, __m, _Sco{});                                                      \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
-  {                                                                                                                   \
-    return __atomic_fetch_sub_dispatch(&__a, __op, __m, _Sco{});                                                      \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp operator++(int) _CONST _VOLATILE noexcept                                              \
-  {                                                                                                                   \
-    return fetch_add(_Tp(1));                                                                                         \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp operator--(int) _CONST _VOLATILE noexcept                                              \
-  {                                                                                                                   \
-    return fetch_sub(_Tp(1));                                                                                         \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp operator++() _CONST _VOLATILE noexcept                                                 \
-  {                                                                                                                   \
-    return fetch_add(_Tp(1)) + _Tp(1);                                                                                \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp operator--() _CONST _VOLATILE noexcept                                                 \
-  {                                                                                                                   \
-    return fetch_sub(_Tp(1)) - _Tp(1);                                                                                \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp operator+=(_Tp __op) _CONST _VOLATILE noexcept                                         \
-  {                                                                                                                   \
-    return fetch_add(__op) + __op;                                                                                    \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp operator-=(_Tp __op) _CONST _VOLATILE noexcept                                         \
-  {                                                                                                                   \
-    return fetch_sub(__op) - __op;                                                                                    \
+#define _LIBCUDACXX_ATOMIC_ARITHMETIC_IMPL(_CONST, _VOLATILE)                                                 \
+  _CCCL_API inline _Tp fetch_add(_Tp __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
+  {                                                                                                           \
+    return __atomic_fetch_add_dispatch(&__a, __op, __m, _Sco{});                                              \
+  }                                                                                                           \
+  _CCCL_API inline _Tp fetch_sub(_Tp __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
+  {                                                                                                           \
+    return __atomic_fetch_sub_dispatch(&__a, __op, __m, _Sco{});                                              \
+  }                                                                                                           \
+  _CCCL_API inline _Tp operator++(int) _CONST _VOLATILE noexcept                                              \
+  {                                                                                                           \
+    return fetch_add(_Tp(1));                                                                                 \
+  }                                                                                                           \
+  _CCCL_API inline _Tp operator--(int) _CONST _VOLATILE noexcept                                              \
+  {                                                                                                           \
+    return fetch_sub(_Tp(1));                                                                                 \
+  }                                                                                                           \
+  _CCCL_API inline _Tp operator++() _CONST _VOLATILE noexcept                                                 \
+  {                                                                                                           \
+    return fetch_add(_Tp(1)) + _Tp(1);                                                                        \
+  }                                                                                                           \
+  _CCCL_API inline _Tp operator--() _CONST _VOLATILE noexcept                                                 \
+  {                                                                                                           \
+    return fetch_sub(_Tp(1)) - _Tp(1);                                                                        \
+  }                                                                                                           \
+  _CCCL_API inline _Tp operator+=(_Tp __op) _CONST _VOLATILE noexcept                                         \
+  {                                                                                                           \
+    return fetch_add(__op) + __op;                                                                            \
+  }                                                                                                           \
+  _CCCL_API inline _Tp operator-=(_Tp __op) _CONST _VOLATILE noexcept                                         \
+  {                                                                                                           \
+    return fetch_sub(__op) - __op;                                                                            \
   }
 
 // API definitions for bitwise atomics
-#define _LIBCUDACXX_ATOMIC_BITWISE_IMPL(_CONST, _VOLATILE)                                                            \
-  _CCCL_HOST_DEVICE inline _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
-  {                                                                                                                   \
-    return __atomic_fetch_and_dispatch(&__a, __op, __m, _Sco{});                                                      \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept  \
-  {                                                                                                                   \
-    return __atomic_fetch_or_dispatch(&__a, __op, __m, _Sco{});                                                       \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
-  {                                                                                                                   \
-    return __atomic_fetch_xor_dispatch(&__a, __op, __m, _Sco{});                                                      \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp operator&=(_Tp __op) _CONST _VOLATILE noexcept                                         \
-  {                                                                                                                   \
-    return fetch_and(__op) & __op;                                                                                    \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp operator|=(_Tp __op) _CONST _VOLATILE noexcept                                         \
-  {                                                                                                                   \
-    return fetch_or(__op) | __op;                                                                                     \
-  }                                                                                                                   \
-  _CCCL_HOST_DEVICE inline _Tp operator^=(_Tp __op) _CONST _VOLATILE noexcept                                         \
-  {                                                                                                                   \
-    return fetch_xor(__op) ^ __op;                                                                                    \
+#define _LIBCUDACXX_ATOMIC_BITWISE_IMPL(_CONST, _VOLATILE)                                                    \
+  _CCCL_API inline _Tp fetch_and(_Tp __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
+  {                                                                                                           \
+    return __atomic_fetch_and_dispatch(&__a, __op, __m, _Sco{});                                              \
+  }                                                                                                           \
+  _CCCL_API inline _Tp fetch_or(_Tp __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept  \
+  {                                                                                                           \
+    return __atomic_fetch_or_dispatch(&__a, __op, __m, _Sco{});                                               \
+  }                                                                                                           \
+  _CCCL_API inline _Tp fetch_xor(_Tp __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
+  {                                                                                                           \
+    return __atomic_fetch_xor_dispatch(&__a, __op, __m, _Sco{});                                              \
+  }                                                                                                           \
+  _CCCL_API inline _Tp operator&=(_Tp __op) _CONST _VOLATILE noexcept                                         \
+  {                                                                                                           \
+    return fetch_and(__op) & __op;                                                                            \
+  }                                                                                                           \
+  _CCCL_API inline _Tp operator|=(_Tp __op) _CONST _VOLATILE noexcept                                         \
+  {                                                                                                           \
+    return fetch_or(__op) | __op;                                                                             \
+  }                                                                                                           \
+  _CCCL_API inline _Tp operator^=(_Tp __op) _CONST _VOLATILE noexcept                                         \
+  {                                                                                                           \
+    return fetch_xor(__op) ^ __op;                                                                            \
   }
 
 // API definitions for atomics with pointers
-#define _LIBCUDACXX_ATOMIC_POINTER_IMPL(_CONST, _VOLATILE)                                        \
-  _CCCL_HOST_DEVICE inline _Tp fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) \
-    _CONST _VOLATILE noexcept                                                                     \
-  {                                                                                               \
-    return __atomic_fetch_add_dispatch(&__a, __op, __m, __thread_scope_system_tag{});             \
-  }                                                                                               \
-  _CCCL_HOST_DEVICE inline _Tp fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) \
-    _CONST _VOLATILE noexcept                                                                     \
-  {                                                                                               \
-    return __atomic_fetch_sub_dispatch(&__a, __op, __m, __thread_scope_system_tag{});             \
-  }                                                                                               \
-  _CCCL_HOST_DEVICE inline _Tp operator++(int) _CONST _VOLATILE noexcept                          \
-  {                                                                                               \
-    return fetch_add(1);                                                                          \
-  }                                                                                               \
-  _CCCL_HOST_DEVICE inline _Tp operator--(int) _CONST _VOLATILE noexcept                          \
-  {                                                                                               \
-    return fetch_sub(1);                                                                          \
-  }                                                                                               \
-  _CCCL_HOST_DEVICE inline _Tp operator++() _CONST _VOLATILE noexcept                             \
-  {                                                                                               \
-    return fetch_add(1) + 1;                                                                      \
-  }                                                                                               \
-  _CCCL_HOST_DEVICE inline _Tp operator--() _CONST _VOLATILE noexcept                             \
-  {                                                                                               \
-    return fetch_sub(1) - 1;                                                                      \
-  }                                                                                               \
-  _CCCL_HOST_DEVICE inline _Tp operator+=(ptrdiff_t __op) _CONST _VOLATILE noexcept               \
-  {                                                                                               \
-    return fetch_add(__op) + __op;                                                                \
-  }                                                                                               \
-  _CCCL_HOST_DEVICE inline _Tp operator-=(ptrdiff_t __op) _CONST _VOLATILE noexcept               \
-  {                                                                                               \
-    return fetch_sub(__op) - __op;                                                                \
+#define _LIBCUDACXX_ATOMIC_POINTER_IMPL(_CONST, _VOLATILE)                                                          \
+  _CCCL_API inline _Tp fetch_add(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
+  {                                                                                                                 \
+    return __atomic_fetch_add_dispatch(&__a, __op, __m, __thread_scope_system_tag{});                               \
+  }                                                                                                                 \
+  _CCCL_API inline _Tp fetch_sub(ptrdiff_t __op, memory_order __m = memory_order_seq_cst) _CONST _VOLATILE noexcept \
+  {                                                                                                                 \
+    return __atomic_fetch_sub_dispatch(&__a, __op, __m, __thread_scope_system_tag{});                               \
+  }                                                                                                                 \
+  _CCCL_API inline _Tp operator++(int) _CONST _VOLATILE noexcept                                                    \
+  {                                                                                                                 \
+    return fetch_add(1);                                                                                            \
+  }                                                                                                                 \
+  _CCCL_API inline _Tp operator--(int) _CONST _VOLATILE noexcept                                                    \
+  {                                                                                                                 \
+    return fetch_sub(1);                                                                                            \
+  }                                                                                                                 \
+  _CCCL_API inline _Tp operator++() _CONST _VOLATILE noexcept                                                       \
+  {                                                                                                                 \
+    return fetch_add(1) + 1;                                                                                        \
+  }                                                                                                                 \
+  _CCCL_API inline _Tp operator--() _CONST _VOLATILE noexcept                                                       \
+  {                                                                                                                 \
+    return fetch_sub(1) - 1;                                                                                        \
+  }                                                                                                                 \
+  _CCCL_API inline _Tp operator+=(ptrdiff_t __op) _CONST _VOLATILE noexcept                                         \
+  {                                                                                                                 \
+    return fetch_add(__op) + __op;                                                                                  \
+  }                                                                                                                 \
+  _CCCL_API inline _Tp operator-=(ptrdiff_t __op) _CONST _VOLATILE noexcept                                         \
+  {                                                                                                                 \
+    return fetch_sub(__op) - __op;                                                                                  \
   }
 
 #endif // __CUDA_STD___ATOMIC_API_COMMON_H

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_local.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_local.h
@@ -39,7 +39,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if _CCCL_CUDA_COMPILATION()
 
-_CCCL_DEVICE inline bool __cuda_is_local(const volatile void* __ptr)
+_CCCL_DEVICE_API inline bool __cuda_is_local(const volatile void* __ptr)
 {
 #  if defined(_CCCL_ATOMIC_UNSAFE_AUTOMATIC_STORAGE) && !defined(_LIBCUDACXX_FORCE_PTX_AUTOMATIC_STORAGE_PATH)
   return false;
@@ -52,42 +52,42 @@ _CCCL_DEVICE inline bool __cuda_is_local(const volatile void* __ptr)
 }
 
 template <class _Type>
-_CCCL_DEVICE void __cuda_fetch_local_bop_and(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_fetch_local_bop_and(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom & __v;
 }
 template <class _Type>
-_CCCL_DEVICE void __cuda_fetch_local_bop_or(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_fetch_local_bop_or(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom | __v;
 }
 template <class _Type>
-_CCCL_DEVICE void __cuda_fetch_local_bop_xor(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_fetch_local_bop_xor(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom ^ __v;
 }
 template <class _Type>
-_CCCL_DEVICE void __cuda_fetch_local_bop_add(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_fetch_local_bop_add(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom + __v;
 }
 template <class _Type>
-_CCCL_DEVICE void __cuda_fetch_local_bop_sub(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_fetch_local_bop_sub(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom - __v;
 }
 template <class _Type>
-_CCCL_DEVICE void __cuda_fetch_local_bop_max(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_fetch_local_bop_max(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __atom < __v ? __v : __atom;
 }
 template <class _Type>
-_CCCL_DEVICE void __cuda_fetch_local_bop_min(volatile _Type& __atom, _Type const& __v)
+_CCCL_DEVICE_API void __cuda_fetch_local_bop_min(volatile _Type& __atom, _Type const& __v)
 {
   __atom = __v < __atom ? __v : __atom;
 }
 
-_CCCL_DEVICE inline bool __cuda_load_weak_if_local(const volatile void* __ptr, void* __ret, size_t __size)
+_CCCL_DEVICE_API inline bool __cuda_load_weak_if_local(const volatile void* __ptr, void* __ret, size_t __size)
 {
   if (!__cuda_is_local(__ptr))
   {
@@ -99,7 +99,7 @@ _CCCL_DEVICE inline bool __cuda_load_weak_if_local(const volatile void* __ptr, v
   return true;
 }
 
-_CCCL_DEVICE inline bool __cuda_store_weak_if_local(volatile void* __ptr, const void* __val, size_t __size)
+_CCCL_DEVICE_API inline bool __cuda_store_weak_if_local(volatile void* __ptr, const void* __val, size_t __size)
 {
   if (!__cuda_is_local(__ptr))
   {
@@ -110,7 +110,7 @@ _CCCL_DEVICE inline bool __cuda_store_weak_if_local(volatile void* __ptr, const 
 }
 
 template <class _Type>
-_CCCL_DEVICE bool
+_CCCL_DEVICE_API bool
 __cuda_compare_exchange_weak_if_local(volatile _Type* __ptr, _Type* __expected, const _Type* __desired, bool* __success)
 {
   if (!__cuda_is_local(__ptr))
@@ -132,7 +132,7 @@ __cuda_compare_exchange_weak_if_local(volatile _Type* __ptr, _Type* __expected, 
 }
 
 template <class _Type>
-_CCCL_DEVICE bool __cuda_exchange_weak_if_local(volatile _Type* __ptr, _Type* __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_exchange_weak_if_local(volatile _Type* __ptr, _Type* __val, _Type* __ret)
 {
   if (!__cuda_is_local(__ptr))
   {
@@ -145,7 +145,7 @@ _CCCL_DEVICE bool __cuda_exchange_weak_if_local(volatile _Type* __ptr, _Type* __
 }
 
 template <class _Type, class _BOp>
-_CCCL_DEVICE bool __cuda_fetch_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret, _BOp&& __bop)
+_CCCL_DEVICE_API bool __cuda_fetch_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret, _BOp&& __bop)
 {
   if (!__cuda_is_local(__ptr))
   {
@@ -158,43 +158,43 @@ _CCCL_DEVICE bool __cuda_fetch_weak_if_local(volatile _Type* __ptr, _Type __val,
 }
 
 template <class _Type>
-_CCCL_DEVICE bool __cuda_fetch_and_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_fetch_and_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
   return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_and<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE bool __cuda_fetch_or_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_fetch_or_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
   return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_or<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE bool __cuda_fetch_xor_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_fetch_xor_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
   return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_xor<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE bool __cuda_fetch_add_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_fetch_add_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
   return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_add<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE bool __cuda_fetch_sub_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_fetch_sub_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
   return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_sub<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE bool __cuda_fetch_max_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_fetch_max_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
   return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_max<_Type>);
 }
 
 template <class _Type>
-_CCCL_DEVICE bool __cuda_fetch_min_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
+_CCCL_DEVICE_API bool __cuda_fetch_min_weak_if_local(volatile _Type* __ptr, _Type __val, _Type* __ret)
 {
   return __cuda_fetch_weak_if_local(__ptr, __val, __ret, __cuda_fetch_local_bop_min<_Type>);
 }

--- a/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_derived.h
+++ b/libcudacxx/include/cuda/std/__atomic/functions/cuda_ptx_derived.h
@@ -51,7 +51,7 @@ template <class _Operand>
 using __cuda_atomic_enable_native_ld_st = enable_if_t<_Operand::__size >= 16, bool>;
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_ld_st<_Operand> = 0>
-static inline _CCCL_DEVICE void
+_CCCL_DEVICE_API void
 __cuda_atomic_load(const _Type* __ptr, _Type& __dst, _Order, _Operand, _Sco, __atomic_cuda_mmio_disable)
 {
   constexpr uint64_t __alignmask = (sizeof(uint16_t) - 1);
@@ -65,7 +65,7 @@ __cuda_atomic_load(const _Type* __ptr, _Type& __dst, _Order, _Operand, _Sco, __a
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-static inline _CCCL_DEVICE bool
+_CCCL_DEVICE_API bool
 __cuda_atomic_compare_exchange(_Type* __ptr, _Type& __dst, _Type __cmp, _Type __op, _Order, _Operand, _Sco)
 {
   constexpr uint64_t __alignmask = (sizeof(uint32_t) - 1);
@@ -111,7 +111,7 @@ template <class _Type,
           class _Operand,
           class _Sco,
           __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-_CCCL_DEVICE _Type __cuda_atomic_fetch_update(_Type* __ptr, const _Fn& __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API _Type __cuda_atomic_fetch_update(_Type* __ptr, const _Fn& __op, _Order, _Operand, _Sco)
 {
   constexpr uint64_t __alignmask = (sizeof(uint32_t) - 1);
   constexpr uint32_t __sizemask  = (1 << (sizeof(_Type) * 8)) - 1;
@@ -153,7 +153,7 @@ struct __cuda_atomic_op_bind
 {
   _Type __val;
 
-  [[nodiscard]] _CCCL_DEVICE _Type operator()(_Type __old) const
+  [[nodiscard]] _CCCL_DEVICE_API _Type operator()(_Type __old) const
   {
     return _Op<_Type>{}(__val, __old);
   }
@@ -163,7 +163,7 @@ template <class _Type>
 struct __cuda_atomic_op_store
 {
   // Just return first value
-  [[nodiscard]] _CCCL_DEVICE _Type operator()(_Type __val, _Type) const
+  [[nodiscard]] _CCCL_DEVICE_API _Type operator()(_Type __val, _Type) const
   {
     return __val;
   }
@@ -172,7 +172,7 @@ struct __cuda_atomic_op_store
 template <class _Type>
 struct __cuda_atomic_op_fetch_min
 {
-  [[nodiscard]] _CCCL_DEVICE _Type operator()(_Type __op, _Type __old) const
+  [[nodiscard]] _CCCL_DEVICE_API _Type operator()(_Type __op, _Type __old) const
   {
     return __op < __old ? __op : __old;
   }
@@ -181,7 +181,7 @@ struct __cuda_atomic_op_fetch_min
 template <class _Type>
 struct __cuda_atomic_op_fetch_max
 {
-  [[nodiscard]] _CCCL_DEVICE _Type operator()(_Type __op, _Type __old) const
+  [[nodiscard]] _CCCL_DEVICE_API _Type operator()(_Type __op, _Type __old) const
   {
     return __old < __op ? __op : __old;
   }
@@ -194,7 +194,7 @@ template <class _Type,
           class _Operand,
           class _Sco,
           __cuda_atomic_enable_native_bitwise<_Operand> = 0>
-_CCCL_DEVICE _Type __cuda_atomic_fetch_update(_Type* __ptr, const _Fn& __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API _Type __cuda_atomic_fetch_update(_Type* __ptr, const _Fn& __op, _Order, _Operand, _Sco)
 {
   _Type __expected = 0;
   NV_IF_TARGET(
@@ -213,8 +213,7 @@ _CCCL_DEVICE _Type __cuda_atomic_fetch_update(_Type* __ptr, const _Fn& __op, _Or
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_ld_st<_Operand> = 0>
-static inline _CCCL_DEVICE void
-__cuda_atomic_store(_Type* __ptr, _Type __val, _Order, _Operand, _Sco, __atomic_cuda_mmio_disable)
+_CCCL_DEVICE_API void __cuda_atomic_store(_Type* __ptr, _Type __val, _Order, _Operand, _Sco, __atomic_cuda_mmio_disable)
 {
   // Store requires cas on 8/16b types
   __cuda_atomic_fetch_update(
@@ -226,7 +225,7 @@ __cuda_atomic_store(_Type* __ptr, _Type __val, _Order, _Operand, _Sco, __atomic_
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_arithmetic<_Operand> = 0>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_add(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -237,7 +236,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_add(_Type* __ptr, _Type& __d
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_and(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -248,7 +247,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_and(_Type* __ptr, _Type& __d
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_xor(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -259,7 +258,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_xor(_Type* __ptr, _Type& __d
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_or(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -270,7 +269,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_or(_Type* __ptr, _Type& __ds
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_arithmetic<_Operand> = 0>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_min(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -281,7 +280,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_min(_Type* __ptr, _Type& __d
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_arithmetic<_Operand> = 0>
-static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_fetch_max(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -292,7 +291,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_fetch_max(_Type* __ptr, _Type& __d
 }
 
 template <class _Type, class _Order, class _Operand, class _Sco, __cuda_atomic_enable_non_native_bitwise<_Operand> = 0>
-static inline _CCCL_DEVICE void __cuda_atomic_exchange(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
+_CCCL_DEVICE_API void __cuda_atomic_exchange(_Type* __ptr, _Type& __dst, _Type __op, _Order, _Operand, _Sco)
 {
   __dst = __cuda_atomic_fetch_update(
     __ptr,
@@ -303,8 +302,7 @@ static inline _CCCL_DEVICE void __cuda_atomic_exchange(_Type* __ptr, _Type& __ds
 }
 
 template <typename _Tp, typename _Fn, typename _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp
-__atomic_fetch_update_cuda(_Tp* __ptr, const _Fn& __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_update_cuda(_Tp* __ptr, const _Fn& __op, int __memorder, _Sco)
 {
   _Tp __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, _Sco{});
   _Tp __desired  = __op(__expected);
@@ -315,8 +313,7 @@ __atomic_fetch_update_cuda(_Tp* __ptr, const _Fn& __op, int __memorder, _Sco)
   return __expected;
 }
 template <typename _Tp, typename _Fn, typename _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp
-__atomic_fetch_update_cuda(_Tp volatile* __ptr, const _Fn& __op, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_update_cuda(_Tp volatile* __ptr, const _Fn& __op, int __memorder, _Sco)
 {
   _Tp __expected = __atomic_load_n_cuda(__ptr, __ATOMIC_RELAXED, _Sco{});
   _Tp __desired  = __op(__expected);
@@ -328,14 +325,14 @@ __atomic_fetch_update_cuda(_Tp volatile* __ptr, const _Fn& __op, int __memorder,
 }
 
 template <typename _Tp, typename _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp __atomic_load_n_cuda(const _Tp* __ptr, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_load_n_cuda(const _Tp* __ptr, int __memorder, _Sco)
 {
   _Tp __ret;
   __atomic_load_cuda(__ptr, __ret, __memorder, _Sco{});
   return __ret;
 }
 template <typename _Tp, typename _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp __atomic_load_n_cuda(const _Tp volatile* __ptr, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_load_n_cuda(const _Tp volatile* __ptr, int __memorder, _Sco)
 {
   _Tp __ret;
   __atomic_load_cuda(__ptr, __ret, __memorder, _Sco{});
@@ -343,26 +340,25 @@ template <typename _Tp, typename _Sco>
 }
 
 template <typename _Tp, typename _Sco>
-_CCCL_DEVICE void __atomic_store_n_cuda(_Tp* __ptr, _Tp __val, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_store_n_cuda(_Tp* __ptr, _Tp __val, int __memorder, _Sco)
 {
   __atomic_store_cuda(__ptr, __val, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Sco>
-_CCCL_DEVICE void __atomic_store_n_cuda(_Tp volatile* __ptr, _Tp __val, int __memorder, _Sco)
+_CCCL_DEVICE_API void __atomic_store_n_cuda(_Tp volatile* __ptr, _Tp __val, int __memorder, _Sco)
 {
   __atomic_store_cuda(__ptr, __val, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp __atomic_exchange_n_cuda(_Tp* __ptr, _Tp __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_exchange_n_cuda(_Tp* __ptr, _Tp __val, int __memorder, _Sco)
 {
   _Tp __ret;
   __atomic_exchange_cuda(__ptr, __ret, __val, __memorder, _Sco{});
   return __ret;
 }
 template <typename _Tp, typename _Sco>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp
-__atomic_exchange_n_cuda(_Tp volatile* __ptr, _Tp __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_exchange_n_cuda(_Tp volatile* __ptr, _Tp __val, int __memorder, _Sco)
 {
   _Tp __ret;
   __atomic_exchange_cuda(__ptr, __ret, __val, __memorder, _Sco{});
@@ -370,81 +366,76 @@ __atomic_exchange_n_cuda(_Tp volatile* __ptr, _Tp __val, int __memorder, _Sco)
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_arithmetic<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp __atomic_fetch_add_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_add_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::plus>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_arithmetic<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp
-__atomic_fetch_add_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_add_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::plus>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp __atomic_fetch_and_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_and_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_and>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp
-__atomic_fetch_and_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_and_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_and>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp __atomic_fetch_or_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_or_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_or>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp __atomic_fetch_or_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_or_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_or>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp __atomic_fetch_xor_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_xor_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_xor>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_bitwise<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp
-__atomic_fetch_xor_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_xor_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(__ptr, __cuda_atomic_op_bind<_Tp, ::cuda::std::bit_xor>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp __atomic_fetch_min_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_min_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_min>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp
-__atomic_fetch_min_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_min_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_min>{__val}, __memorder, _Sco{});
 }
 
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp __atomic_fetch_max_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_max_cuda(_Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_max>{__val}, __memorder, _Sco{});
 }
 template <typename _Tp, typename _Up, typename _Sco, __atomic_enable_if_not_native_minmax<_Tp> = 0>
-[[nodiscard]] static inline _CCCL_DEVICE _Tp
-__atomic_fetch_max_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
+[[nodiscard]] _CCCL_DEVICE_API _Tp __atomic_fetch_max_cuda(volatile _Tp* __ptr, _Up __val, int __memorder, _Sco)
 {
   return __atomic_fetch_update_cuda(
     __ptr, __cuda_atomic_op_bind<_Tp, __cuda_atomic_op_fetch_max>{__val}, __memorder, _Sco{});
 }
 
-_CCCL_DEVICE static inline void __atomic_signal_fence_cuda(int)
+_CCCL_DEVICE_API inline void __atomic_signal_fence_cuda(int)
 {
   asm volatile("" ::: "memory");
 }

--- a/libcudacxx/include/cuda/std/__atomic/order.h
+++ b/libcudacxx/include/cuda/std/__atomic/order.h
@@ -96,7 +96,7 @@ using memory_order = enum memory_order {
 
 #endif // _CCCL_STD_VER >= 2020
 
-_CCCL_HOST_DEVICE inline int __stronger_order_cuda(int __a, int __b)
+_CCCL_API inline int __stronger_order_cuda(int __a, int __b)
 {
   int const __max = __a > __b ? __a : __b;
   if (__max != __ATOMIC_RELEASE)
@@ -107,7 +107,7 @@ _CCCL_HOST_DEVICE inline int __stronger_order_cuda(int __a, int __b)
   return __xform[__a < __b ? __a : __b];
 }
 
-_CCCL_HOST_DEVICE inline constexpr int __atomic_order_to_int(memory_order __order)
+_CCCL_API constexpr int __atomic_order_to_int(memory_order __order)
 {
   // Avoid switch statement to make this a constexpr.
   return __order == memory_order_relaxed
@@ -121,7 +121,7 @@ _CCCL_HOST_DEVICE inline constexpr int __atomic_order_to_int(memory_order __orde
                         : (__order == memory_order_acq_rel ? __ATOMIC_ACQ_REL : __ATOMIC_CONSUME))));
 }
 
-_CCCL_HOST_DEVICE inline constexpr int __atomic_failure_order_to_int(memory_order __order)
+_CCCL_API constexpr int __atomic_failure_order_to_int(memory_order __order)
 {
   // Avoid switch statement to make this a constexpr.
   return __order == memory_order_relaxed

--- a/libcudacxx/include/cuda/std/__atomic/types/base.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/base.h
@@ -43,29 +43,29 @@ struct __atomic_storage
 
   _CCCL_HIDE_FROM_ABI explicit constexpr __atomic_storage() noexcept = default;
 
-  _CCCL_HOST_DEVICE constexpr explicit inline __atomic_storage(_Tp value) noexcept
+  _CCCL_API constexpr explicit __atomic_storage(_Tp value) noexcept
       : __a_value(value)
   {}
 
-  _CCCL_HOST_DEVICE inline auto get() noexcept -> __underlying_t*
+  _CCCL_API auto get() noexcept -> __underlying_t*
   {
     return &__a_value;
   }
-  _CCCL_HOST_DEVICE inline auto get() const noexcept -> const __underlying_t*
+  _CCCL_API auto get() const noexcept -> const __underlying_t*
   {
     return &__a_value;
   }
-  _CCCL_HOST_DEVICE inline auto get() volatile noexcept -> volatile __underlying_t*
+  _CCCL_API auto get() volatile noexcept -> volatile __underlying_t*
   {
     return &__a_value;
   }
-  _CCCL_HOST_DEVICE inline auto get() const volatile noexcept -> const volatile __underlying_t*
+  _CCCL_API auto get() const volatile noexcept -> const volatile __underlying_t*
   {
     return &__a_value;
   }
 };
 
-_CCCL_HOST_DEVICE inline void __atomic_thread_fence_dispatch(memory_order __order)
+_CCCL_API inline void __atomic_thread_fence_dispatch(memory_order __order)
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
@@ -74,7 +74,7 @@ _CCCL_HOST_DEVICE inline void __atomic_thread_fence_dispatch(memory_order __orde
     (__atomic_thread_fence_host(__order);))
 }
 
-_CCCL_HOST_DEVICE inline void __atomic_signal_fence_dispatch(memory_order __order)
+_CCCL_API inline void __atomic_signal_fence_dispatch(memory_order __order)
 {
   NV_DISPATCH_TARGET(NV_IS_DEVICE,
                      (__atomic_signal_fence_cuda(static_cast<__memory_order_underlying_t>(__order));),
@@ -83,13 +83,13 @@ _CCCL_HOST_DEVICE inline void __atomic_signal_fence_dispatch(memory_order __orde
 }
 
 template <typename _Sto, typename _Up, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline void __atomic_init_dispatch(_Sto* __a, _Up __val)
+_CCCL_API void __atomic_init_dispatch(_Sto* __a, _Up __val)
 {
   __atomic_assign_volatile(__a->get(), __val);
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline void __atomic_store_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
+_CCCL_API void __atomic_store_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
@@ -99,8 +99,7 @@ _CCCL_HOST_DEVICE inline void __atomic_store_dispatch(_Sto* __a, _Up __val, memo
 }
 
 template <typename _Sto, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_load_dispatch(const _Sto* __a, memory_order __order, _Sco = {})
-  -> __atomic_underlying_t<_Sto>
+_CCCL_API auto __atomic_load_dispatch(const _Sto* __a, memory_order __order, _Sco = {}) -> __atomic_underlying_t<_Sto>
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,
@@ -110,7 +109,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_load_dispatch(const _Sto* __a, memory_ord
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_exchange_dispatch(_Sto* __a, _Up __value, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_exchange_dispatch(_Sto* __a, _Up __value, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   NV_DISPATCH_TARGET(
@@ -121,7 +120,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_exchange_dispatch(_Sto* __a, _Up __value,
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline bool __atomic_compare_exchange_strong_dispatch(
+_CCCL_API bool __atomic_compare_exchange_strong_dispatch(
   _Sto* __a, _Up* __expected, _Up __val, memory_order __success, memory_order __failure, _Sco = {})
 {
   bool __result = false;
@@ -141,7 +140,7 @@ _CCCL_HOST_DEVICE inline bool __atomic_compare_exchange_strong_dispatch(
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline bool __atomic_compare_exchange_weak_dispatch(
+_CCCL_API bool __atomic_compare_exchange_weak_dispatch(
   _Sto* __a, _Up* __expected, _Up __val, memory_order __success, memory_order __failure, _Sco = {})
 {
   bool __result = false;
@@ -161,7 +160,7 @@ _CCCL_HOST_DEVICE inline bool __atomic_compare_exchange_weak_dispatch(
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   NV_DISPATCH_TARGET(
@@ -172,7 +171,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   NV_DISPATCH_TARGET(
@@ -183,7 +182,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   NV_DISPATCH_TARGET(
@@ -194,7 +193,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __patte
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   NV_DISPATCH_TARGET(
@@ -205,7 +204,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __patter
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_xor_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_xor_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   NV_DISPATCH_TARGET(
@@ -216,7 +215,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_xor_dispatch(_Sto* __a, _Up __patte
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_max_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_max_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   NV_IF_TARGET(
@@ -226,7 +225,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_max_dispatch(_Sto* __a, _Up __val, 
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_base<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_min_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_min_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   NV_IF_TARGET(

--- a/libcudacxx/include/cuda/std/__atomic/types/common.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/common.h
@@ -55,13 +55,13 @@ using __atomic_underlying_remove_cv_t = remove_cv_t<typename _Tp::__underlying_t
 // the default operator= in an object is not volatile, a byte-by-byte copy
 // is required.
 template <typename _Tp, typename _Tv>
-_CCCL_HOST_DEVICE enable_if_t<is_assignable_v<_Tp&, _Tv>> __atomic_assign_volatile(_Tp* __a_value, _Tv const& __val)
+_CCCL_API enable_if_t<is_assignable_v<_Tp&, _Tv>> __atomic_assign_volatile(_Tp* __a_value, _Tv const& __val)
 {
   *__a_value = __val;
 }
 
 template <typename _Tp, typename _Tv>
-_CCCL_HOST_DEVICE enable_if_t<is_assignable_v<_Tp&, _Tv>>
+_CCCL_API enable_if_t<is_assignable_v<_Tp&, _Tv>>
 __atomic_assign_volatile(_Tp volatile* __a_value, _Tv volatile const& __val)
 {
   volatile char* __to         = reinterpret_cast<volatile char*>(__a_value);
@@ -73,7 +73,7 @@ __atomic_assign_volatile(_Tp volatile* __a_value, _Tv volatile const& __val)
   }
 }
 
-_CCCL_HOST_DEVICE inline int __atomic_memcmp(void const* __lhs, void const* __rhs, size_t __count)
+_CCCL_API inline int __atomic_memcmp(void const* __lhs, void const* __rhs, size_t __count)
 {
   NV_DISPATCH_TARGET(
     NV_IS_DEVICE,

--- a/libcudacxx/include/cuda/std/__atomic/types/locked.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/locked.h
@@ -43,43 +43,43 @@ struct __atomic_locked_storage
 
   _CCCL_HIDE_FROM_ABI explicit constexpr __atomic_locked_storage() noexcept = default;
 
-  _CCCL_HOST_DEVICE constexpr explicit inline __atomic_locked_storage(_Tp value) noexcept
+  _CCCL_API constexpr explicit __atomic_locked_storage(_Tp value) noexcept
       : __a_value(value)
       , __a_lock{}
   {}
 
   template <typename _Sco>
-  _CCCL_HOST_DEVICE inline void __lock(_Sco) const volatile noexcept
+  _CCCL_API void __lock(_Sco) const volatile noexcept
   {
     while (1 == __atomic_exchange_dispatch(&__a_lock, _CCCL_ATOMIC_FLAG_TYPE(true), memory_order_acquire, _Sco{}))
       /*spin*/;
   }
   template <typename _Sco>
-  _CCCL_HOST_DEVICE inline void __lock(_Sco) const noexcept
+  _CCCL_API void __lock(_Sco) const noexcept
   {
     while (1 == __atomic_exchange_dispatch(&__a_lock, _CCCL_ATOMIC_FLAG_TYPE(true), memory_order_acquire, _Sco{}))
       /*spin*/;
   }
   template <typename _Sco>
-  _CCCL_HOST_DEVICE inline void __unlock(_Sco) const volatile noexcept
+  _CCCL_API void __unlock(_Sco) const volatile noexcept
   {
     __atomic_store_dispatch(&__a_lock, _CCCL_ATOMIC_FLAG_TYPE(false), memory_order_release, _Sco{});
   }
   template <typename _Sco>
-  _CCCL_HOST_DEVICE inline void __unlock(_Sco) const noexcept
+  _CCCL_API void __unlock(_Sco) const noexcept
   {
     __atomic_store_dispatch(&__a_lock, _CCCL_ATOMIC_FLAG_TYPE(false), memory_order_release, _Sco{});
   }
 };
 
 template <typename _Sto, typename _Up, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline void __atomic_init_dispatch(_Sto* __a, _Up __val)
+_CCCL_API void __atomic_init_dispatch(_Sto* __a, _Up __val)
 {
   __atomic_assign_volatile(&__a->__a_value, __val);
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline void __atomic_store_dispatch(_Sto* __a, _Up __val, memory_order, _Sco = {})
+_CCCL_API void __atomic_store_dispatch(_Sto* __a, _Up __val, memory_order, _Sco = {})
 {
   __a->__lock(_Sco{});
   __atomic_assign_volatile(&__a->__a_value, __val);
@@ -87,8 +87,7 @@ _CCCL_HOST_DEVICE inline void __atomic_store_dispatch(_Sto* __a, _Up __val, memo
 }
 
 template <typename _Sto, typename _Sco, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_load_dispatch(const _Sto* __a, memory_order, _Sco = {})
-  -> __atomic_underlying_t<_Sto>
+_CCCL_API auto __atomic_load_dispatch(const _Sto* __a, memory_order, _Sco = {}) -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
   _Tp __old;
@@ -99,7 +98,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_load_dispatch(const _Sto* __a, memory_ord
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_exchange_dispatch(_Sto* __a, _Up __value, memory_order, _Sco = {})
+_CCCL_API auto __atomic_exchange_dispatch(_Sto* __a, _Up __value, memory_order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -112,7 +111,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_exchange_dispatch(_Sto* __a, _Up __value,
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline bool __atomic_compare_exchange_strong_dispatch(
+_CCCL_API bool __atomic_compare_exchange_strong_dispatch(
   _Sto* __a, _Up* __expected, _Up __value, memory_order, memory_order, _Sco = {})
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -133,7 +132,7 @@ _CCCL_HOST_DEVICE inline bool __atomic_compare_exchange_strong_dispatch(
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline bool
+_CCCL_API bool
 __atomic_compare_exchange_weak_dispatch(_Sto* __a, _Up* __expected, _Up __value, memory_order, memory_order, _Sco = {})
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -154,7 +153,7 @@ __atomic_compare_exchange_weak_dispatch(_Sto* __a, _Up* __expected, _Up __value,
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta, memory_order, _Sco = {})
+_CCCL_API auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta, memory_order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -167,7 +166,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta, memory_order, _Sco = {})
+_CCCL_API auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta, memory_order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -180,7 +179,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __pattern, memory_order, _Sco = {})
+_CCCL_API auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __pattern, memory_order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -193,7 +192,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __patte
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __pattern, memory_order, _Sco = {})
+_CCCL_API auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __pattern, memory_order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -206,7 +205,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __patter
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_locked<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_xor_dispatch(_Sto* __a, _Up __pattern, memory_order, _Sco = {})
+_CCCL_API auto __atomic_fetch_xor_dispatch(_Sto* __a, _Up __pattern, memory_order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;

--- a/libcudacxx/include/cuda/std/__atomic/types/reference.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/reference.h
@@ -43,23 +43,23 @@ struct __atomic_ref_storage
 
   __atomic_ref_storage() = delete;
 
-  _CCCL_HOST_DEVICE constexpr explicit inline __atomic_ref_storage(_Tp* value) noexcept
+  _CCCL_API constexpr explicit __atomic_ref_storage(_Tp* value) noexcept
       : __a_value(value)
   {}
 
-  _CCCL_HOST_DEVICE inline auto get() noexcept -> __underlying_t*
+  _CCCL_API auto get() noexcept -> __underlying_t*
   {
     return __a_value;
   }
-  _CCCL_HOST_DEVICE inline auto get() const noexcept -> __underlying_t*
+  _CCCL_API auto get() const noexcept -> __underlying_t*
   {
     return __a_value;
   }
-  _CCCL_HOST_DEVICE inline auto get() volatile noexcept -> volatile __underlying_t*
+  _CCCL_API auto get() volatile noexcept -> volatile __underlying_t*
   {
     return __a_value;
   }
-  _CCCL_HOST_DEVICE inline auto get() const volatile noexcept -> volatile __underlying_t*
+  _CCCL_API auto get() const volatile noexcept -> volatile __underlying_t*
   {
     return __a_value;
   }

--- a/libcudacxx/include/cuda/std/__atomic/types/small.h
+++ b/libcudacxx/include/cuda/std/__atomic/types/small.h
@@ -40,20 +40,20 @@ using __atomic_small_proxy_t = _If<is_signed_v<_Tp>, int32_t, uint32_t>;
 
 // Arithmetic conversions to/from proxy types
 template <class _Tp, enable_if_t<is_arithmetic_v<_Tp>, int> = 0>
-_CCCL_HOST_DEVICE constexpr __atomic_small_proxy_t<_Tp> __atomic_small_to_32(_Tp __val)
+_CCCL_API constexpr __atomic_small_proxy_t<_Tp> __atomic_small_to_32(_Tp __val)
 {
   return static_cast<__atomic_small_proxy_t<_Tp>>(__val);
 }
 
 template <class _Tp, enable_if_t<is_arithmetic_v<_Tp>, int> = 0>
-_CCCL_HOST_DEVICE constexpr _Tp __atomic_small_from_32(__atomic_small_proxy_t<_Tp> __val)
+_CCCL_API constexpr _Tp __atomic_small_from_32(__atomic_small_proxy_t<_Tp> __val)
 {
   return static_cast<_Tp>(__val);
 }
 
 // Non-arithmetic conversion to/from proxy types
 template <class _Tp, enable_if_t<!is_arithmetic_v<_Tp>, int> = 0>
-_CCCL_HOST_DEVICE inline __atomic_small_proxy_t<_Tp> __atomic_small_to_32(_Tp __val)
+_CCCL_API __atomic_small_proxy_t<_Tp> __atomic_small_to_32(_Tp __val)
 {
   __atomic_small_proxy_t<_Tp> __temp{};
   ::cuda::std::memcpy(&__temp, &__val, sizeof(_Tp));
@@ -66,7 +66,7 @@ _CCCL_DIAG_SUPPRESS_GCC("-Wclass-memaccess")
 #endif
 
 template <class _Tp, enable_if_t<!is_arithmetic_v<_Tp>, int> = 0>
-_CCCL_HOST_DEVICE inline _Tp __atomic_small_from_32(__atomic_small_proxy_t<_Tp> __val)
+_CCCL_API _Tp __atomic_small_from_32(__atomic_small_proxy_t<_Tp> __val)
 {
   // GCC starting with GCC8 warns about our extended floating point types having protected data members
   _Tp __temp{};
@@ -83,11 +83,11 @@ struct __atomic_small_storage
   using __proxy_t                     = __atomic_small_proxy_t<_Tp>;
   static constexpr __atomic_tag __tag = __atomic_tag::__atomic_small_tag;
 
-  _CCCL_HOST_DEVICE constexpr explicit __atomic_small_storage() noexcept
+  _CCCL_API constexpr explicit __atomic_small_storage() noexcept
       : __a_value{__proxy_t{}}
   {}
 
-  _CCCL_HOST_DEVICE constexpr explicit __atomic_small_storage(_Tp __value) noexcept
+  _CCCL_API constexpr explicit __atomic_small_storage(_Tp __value) noexcept
       : __a_value{__atomic_small_to_32(__value)}
   {}
 
@@ -95,27 +95,26 @@ struct __atomic_small_storage
 };
 
 template <typename _Sto, typename _Up, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline void __atomic_init_dispatch(_Sto* __a, _Up __val)
+_CCCL_API void __atomic_init_dispatch(_Sto* __a, _Up __val)
 {
   __atomic_init_dispatch(&__a->__a_value, __atomic_small_to_32(__val));
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline void __atomic_store_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
+_CCCL_API void __atomic_store_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
 {
   __atomic_store_dispatch(&__a->__a_value, __atomic_small_to_32(__val), __order, _Sco{});
 }
 
 template <typename _Sto, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_load_dispatch(const _Sto* __a, memory_order __order, _Sco = {})
-  -> __atomic_underlying_t<_Sto>
+_CCCL_API auto __atomic_load_dispatch(const _Sto* __a, memory_order __order, _Sco = {}) -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
   return __atomic_small_from_32<_Tp>(__atomic_load_dispatch(&__a->__a_value, __order, _Sco{}));
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_exchange_dispatch(_Sto* __a, _Up __value, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_exchange_dispatch(_Sto* __a, _Up __value, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -124,7 +123,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_exchange_dispatch(_Sto* __a, _Up __value,
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline bool __atomic_compare_exchange_weak_dispatch(
+_CCCL_API bool __atomic_compare_exchange_weak_dispatch(
   _Sto* __a, _Up* __expected, _Up __value, memory_order __success, memory_order __failure, _Sco = {})
 {
   using _Tp            = __atomic_underlying_t<_Sto>;
@@ -148,7 +147,7 @@ _CCCL_HOST_DEVICE inline bool __atomic_compare_exchange_weak_dispatch(
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline bool __atomic_compare_exchange_strong_dispatch(
+_CCCL_API bool __atomic_compare_exchange_strong_dispatch(
   _Sto* __a, _Up* __expected, _Up __value, memory_order __success, memory_order __failure, _Sco = {})
 {
   using _Tp        = __atomic_underlying_t<_Sto>;
@@ -167,7 +166,7 @@ _CCCL_HOST_DEVICE inline bool __atomic_compare_exchange_strong_dispatch(
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -176,7 +175,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_add_dispatch(_Sto* __a, _Up __delta
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -185,7 +184,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_sub_dispatch(_Sto* __a, _Up __delta
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -194,7 +193,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_and_dispatch(_Sto* __a, _Up __patte
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -203,7 +202,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_or_dispatch(_Sto* __a, _Up __patter
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_xor_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_xor_dispatch(_Sto* __a, _Up __pattern, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   using _Tp = __atomic_underlying_t<_Sto>;
@@ -212,7 +211,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_xor_dispatch(_Sto* __a, _Up __patte
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_max_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_max_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   static_assert(is_floating_point_v<__atomic_underlying_t<_Sto>> || is_integral_v<__atomic_underlying_t<_Sto>>, "");
@@ -222,7 +221,7 @@ _CCCL_HOST_DEVICE inline auto __atomic_fetch_max_dispatch(_Sto* __a, _Up __val, 
 }
 
 template <typename _Sto, typename _Up, typename _Sco, __atomic_storage_is_small<_Sto> = 0>
-_CCCL_HOST_DEVICE inline auto __atomic_fetch_min_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
+_CCCL_API auto __atomic_fetch_min_dispatch(_Sto* __a, _Up __val, memory_order __order, _Sco = {})
   -> __atomic_underlying_t<_Sto>
 {
   static_assert(is_floating_point_v<__atomic_underlying_t<_Sto>> || is_integral_v<__atomic_underlying_t<_Sto>>, "");

--- a/libcudacxx/include/cuda/std/__atomic/wait/polling.h
+++ b/libcudacxx/include/cuda/std/__atomic/wait/polling.h
@@ -39,20 +39,20 @@ struct __atomic_poll_tester
   __underlying_t __val;
   memory_order __order;
 
-  _CCCL_HOST_DEVICE __atomic_poll_tester(_Tp const volatile* __a, __underlying_t __v, memory_order __o)
+  _CCCL_API __atomic_poll_tester(_Tp const volatile* __a, __underlying_t __v, memory_order __o)
       : __atom(__a)
       , __val(__v)
       , __order(__o)
   {}
 
-  _CCCL_HOST_DEVICE bool operator()() const
+  _CCCL_API bool operator()() const
   {
     return !(__atomic_load_dispatch(__atom, __order, _Sco{}) == __val);
   }
 };
 
 template <typename _Tp, typename _Sco>
-_CCCL_HOST_DEVICE void __atomic_try_wait_slow_fallback(
+_CCCL_API void __atomic_try_wait_slow_fallback(
   _Tp const volatile* __a, __atomic_underlying_remove_cv_t<_Tp> __val, memory_order __order, _Sco)
 {
   ::cuda::std::__cccl_thread_poll_with_backoff(__atomic_poll_tester<_Tp, _Sco>(__a, __val, __order));

--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -83,7 +83,7 @@ template <class _Full>
 #if _CCCL_CUDA_COMPILATION()
 
 template <class _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE _Tp __byteswap_impl_device(_Tp __val) noexcept
+[[nodiscard]] _CCCL_DEVICE_API _Tp __byteswap_impl_device(_Tp __val) noexcept
 {
   if constexpr (sizeof(_Tp) == sizeof(uint16_t))
   {

--- a/libcudacxx/include/cuda/std/__bit/countl.h
+++ b/libcudacxx/include/cuda/std/__bit/countl.h
@@ -96,7 +96,7 @@ template <typename _Tp>
 
 #  if !_CCCL_COMPILER(NVRTC)
 template <typename _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST int __cccl_countl_zero_impl_host(_Tp __v) noexcept
+[[nodiscard]] _CCCL_HOST_API int __cccl_countl_zero_impl_host(_Tp __v) noexcept
 {
 #    if _CCCL_COMPILER(MSVC)
   constexpr auto __digits = numeric_limits<_Tp>::digits;
@@ -113,7 +113,7 @@ template <typename _Tp>
 
 #  if _CCCL_CUDA_COMPILATION()
 template <typename _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE int __cccl_countl_zero_impl_device(_Tp __v) noexcept
+[[nodiscard]] _CCCL_DEVICE_API int __cccl_countl_zero_impl_device(_Tp __v) noexcept
 {
   if constexpr (sizeof(_Tp) == sizeof(uint32_t))
   {

--- a/libcudacxx/include/cuda/std/__bit/countr.h
+++ b/libcudacxx/include/cuda/std/__bit/countr.h
@@ -93,7 +93,7 @@ template <typename _Tp>
 
 #  if !_CCCL_COMPILER(NVRTC)
 template <typename _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST int __cccl_countr_zero_impl_host(_Tp __v) noexcept
+[[nodiscard]] _CCCL_HOST_API int __cccl_countr_zero_impl_host(_Tp __v) noexcept
 {
   // nvcc does not support __builtin_ctz, so we use it only for host code
 #    if defined(_CCCL_BUILTIN_CTZ)
@@ -125,7 +125,7 @@ template <typename _Tp>
 
 #  if _CCCL_CUDA_COMPILATION()
 template <typename _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE int __cccl_countr_zero_impl_device(_Tp __v) noexcept
+[[nodiscard]] _CCCL_DEVICE_API int __cccl_countr_zero_impl_device(_Tp __v) noexcept
 {
   if constexpr (sizeof(_Tp) == sizeof(uint32_t))
   {

--- a/libcudacxx/include/cuda/std/__bit/popcount.h
+++ b/libcudacxx/include/cuda/std/__bit/popcount.h
@@ -78,7 +78,7 @@ template <typename _Tp>
 
 #  if !_CCCL_COMPILER(NVRTC)
 template <typename _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST int __cccl_popcount_impl_host(_Tp __v) noexcept
+[[nodiscard]] _CCCL_HOST_API int __cccl_popcount_impl_host(_Tp __v) noexcept
 {
 #    if _CCCL_COMPILER(MSVC) && _CCCL_ARCH(X86_64)
   if constexpr (sizeof(_Tp) == sizeof(uint32_t))
@@ -107,7 +107,7 @@ template <typename _Tp>
 
 #  if _CCCL_CUDA_COMPILATION()
 template <typename _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE int __cccl_popcount_impl_device(_Tp __v) noexcept
+[[nodiscard]] _CCCL_DEVICE_API int __cccl_popcount_impl_device(_Tp __v) noexcept
 {
   if constexpr (sizeof(_Tp) == sizeof(uint32_t))
   {

--- a/libcudacxx/include/cuda/std/__cccl/sequence_access.h
+++ b/libcudacxx/include/cuda/std/__cccl/sequence_access.h
@@ -24,64 +24,60 @@
 
 // We need to define hidden friends for {cr,r,}{begin,end} of our containers as we will otherwise encounter ambigouities
 #define _CCCL_SYNTHESIZE_SEQUENCE_ACCESS(_ClassName, _ConstIter)                                                       \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend iterator begin(_ClassName& __sequence) noexcept(noexcept(__sequence.begin())) \
+  [[nodiscard]] _CCCL_API friend iterator begin(_ClassName& __sequence) noexcept(noexcept(__sequence.begin()))         \
   {                                                                                                                    \
     return __sequence.begin();                                                                                         \
   }                                                                                                                    \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend _ConstIter begin(const _ClassName& __sequence) noexcept(                      \
+  [[nodiscard]] _CCCL_API friend _ConstIter begin(const _ClassName& __sequence) noexcept(noexcept(__sequence.begin())) \
+  {                                                                                                                    \
+    return __sequence.begin();                                                                                         \
+  }                                                                                                                    \
+  [[nodiscard]] _CCCL_API friend iterator end(_ClassName& __sequence) noexcept(noexcept(__sequence.end()))             \
+  {                                                                                                                    \
+    return __sequence.end();                                                                                           \
+  }                                                                                                                    \
+  [[nodiscard]] _CCCL_API friend _ConstIter end(const _ClassName& __sequence) noexcept(noexcept(__sequence.end()))     \
+  {                                                                                                                    \
+    return __sequence.end();                                                                                           \
+  }                                                                                                                    \
+  [[nodiscard]] _CCCL_API friend _ConstIter cbegin(const _ClassName& __sequence) noexcept(                             \
     noexcept(__sequence.begin()))                                                                                      \
   {                                                                                                                    \
     return __sequence.begin();                                                                                         \
   }                                                                                                                    \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend iterator end(_ClassName& __sequence) noexcept(noexcept(__sequence.end()))     \
-  {                                                                                                                    \
-    return __sequence.end();                                                                                           \
-  }                                                                                                                    \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend _ConstIter end(const _ClassName& __sequence) noexcept(                        \
-    noexcept(__sequence.end()))                                                                                        \
-  {                                                                                                                    \
-    return __sequence.end();                                                                                           \
-  }                                                                                                                    \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend _ConstIter cbegin(const _ClassName& __sequence) noexcept(                     \
-    noexcept(__sequence.begin()))                                                                                      \
-  {                                                                                                                    \
-    return __sequence.begin();                                                                                         \
-  }                                                                                                                    \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend _ConstIter cend(const _ClassName& __sequence) noexcept(                       \
-    noexcept(__sequence.end()))                                                                                        \
+  [[nodiscard]] _CCCL_API friend _ConstIter cend(const _ClassName& __sequence) noexcept(noexcept(__sequence.end()))    \
   {                                                                                                                    \
     return __sequence.end();                                                                                           \
   }
-#define _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(_ClassName, _ConstRevIter)                            \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend reverse_iterator rbegin(_ClassName& __sequence) noexcept(     \
-    noexcept(__sequence.rbegin()))                                                                     \
-  {                                                                                                    \
-    return __sequence.rbegin();                                                                        \
-  }                                                                                                    \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend _ConstRevIter rbegin(const _ClassName& __sequence) noexcept(  \
-    noexcept(__sequence.rbegin()))                                                                     \
-  {                                                                                                    \
-    return __sequence.rbegin();                                                                        \
-  }                                                                                                    \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend reverse_iterator rend(_ClassName& __sequence) noexcept(       \
-    noexcept(__sequence.rend()))                                                                       \
-  {                                                                                                    \
-    return __sequence.rend();                                                                          \
-  }                                                                                                    \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend _ConstRevIter rend(const _ClassName& __sequence) noexcept(    \
-    noexcept(__sequence.rend()))                                                                       \
-  {                                                                                                    \
-    return __sequence.rend();                                                                          \
-  }                                                                                                    \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend _ConstRevIter crbegin(const _ClassName& __sequence) noexcept( \
-    noexcept(__sequence.rbegin()))                                                                     \
-  {                                                                                                    \
-    return __sequence.rbegin();                                                                        \
-  }                                                                                                    \
-  [[nodiscard]] _CCCL_HOST_DEVICE friend _ConstRevIter crend(const _ClassName& __sequence) noexcept(   \
-    noexcept(__sequence.rend()))                                                                       \
-  {                                                                                                    \
-    return __sequence.rend();                                                                          \
+#define _CCCL_SYNTHESIZE_SEQUENCE_REVERSE_ACCESS(_ClassName, _ConstRevIter)                                          \
+  [[nodiscard]] _CCCL_API friend reverse_iterator rbegin(_ClassName& __sequence) noexcept(                           \
+    noexcept(__sequence.rbegin()))                                                                                   \
+  {                                                                                                                  \
+    return __sequence.rbegin();                                                                                      \
+  }                                                                                                                  \
+  [[nodiscard]] _CCCL_API friend _ConstRevIter rbegin(const _ClassName& __sequence) noexcept(                        \
+    noexcept(__sequence.rbegin()))                                                                                   \
+  {                                                                                                                  \
+    return __sequence.rbegin();                                                                                      \
+  }                                                                                                                  \
+  [[nodiscard]] _CCCL_API friend reverse_iterator rend(_ClassName& __sequence) noexcept(noexcept(__sequence.rend())) \
+  {                                                                                                                  \
+    return __sequence.rend();                                                                                        \
+  }                                                                                                                  \
+  [[nodiscard]] _CCCL_API friend _ConstRevIter rend(const _ClassName& __sequence) noexcept(                          \
+    noexcept(__sequence.rend()))                                                                                     \
+  {                                                                                                                  \
+    return __sequence.rend();                                                                                        \
+  }                                                                                                                  \
+  [[nodiscard]] _CCCL_API friend _ConstRevIter crbegin(const _ClassName& __sequence) noexcept(                       \
+    noexcept(__sequence.rbegin()))                                                                                   \
+  {                                                                                                                  \
+    return __sequence.rbegin();                                                                                      \
+  }                                                                                                                  \
+  [[nodiscard]] _CCCL_API friend _ConstRevIter crend(const _ClassName& __sequence) noexcept(                         \
+    noexcept(__sequence.rend()))                                                                                     \
+  {                                                                                                                  \
+    return __sequence.rend();                                                                                        \
   }
 
 #endif // __CCCL_SEQUENCE_ACCESS_H

--- a/libcudacxx/include/cuda/std/__complex/complex.h
+++ b/libcudacxx/include/cuda/std/__complex/complex.h
@@ -125,7 +125,7 @@ public:
     return *this;
   }
 
-  _CCCL_HOST constexpr operator ::std::complex<_Tp>() const
+  _CCCL_HOST_API constexpr operator ::std::complex<_Tp>() const
   {
     return {__re_, __im_};
   }

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -159,7 +159,7 @@ public:
     return *this;
   }
 
-  _CCCL_HOST operator ::std::complex<value_type>() const
+  _CCCL_HOST_API operator ::std::complex<value_type>() const
   {
     return {__repr_.x, __repr_.y};
   }

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -159,7 +159,7 @@ public:
     return *this;
   }
 
-  _CCCL_HOST operator ::std::complex<value_type>() const
+  _CCCL_HOST_API operator ::std::complex<value_type>() const
   {
     return {__repr_.x, __repr_.y};
   }

--- a/libcudacxx/include/cuda/std/__cstdlib/aligned_alloc.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/aligned_alloc.h
@@ -40,7 +40,7 @@ extern "C" _CCCL_DEVICE void* __cuda_syscall_aligned_malloc(size_t, size_t);
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 #if !_CCCL_COMPILER(NVRTC)
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST void*
+[[nodiscard]] _CCCL_HOST_API inline void*
 __aligned_alloc_host([[maybe_unused]] size_t __nbytes, [[maybe_unused]] size_t __align) noexcept
 {
 #  if _CCCL_OS(WINDOWS)

--- a/libcudacxx/include/cuda/std/__cstdlib/malloc.h
+++ b/libcudacxx/include/cuda/std/__cstdlib/malloc.h
@@ -39,7 +39,7 @@ using ::free;
 using ::malloc;
 
 #if _CCCL_CUDA_COMPILATION()
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_DEVICE void* __calloc_device(size_t __n, size_t __size) noexcept
+[[nodiscard]] _CCCL_DEVICE_API inline void* __calloc_device(size_t __n, size_t __size) noexcept
 {
   void* __ptr{};
   // check for overflow through a hypothetical larger integer

--- a/libcudacxx/include/cuda/std/__exception/exception_macros.h
+++ b/libcudacxx/include/cuda/std/__exception/exception_macros.h
@@ -34,7 +34,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 struct __cccl_catch_any_lvalue
 {
   template <class _Tp>
-  _CCCL_HOST_DEVICE operator _Tp&() const noexcept;
+  _CCCL_API operator _Tp&() const noexcept;
 };
 
 _CCCL_END_NAMESPACE_CUDA_STD

--- a/libcudacxx/include/cuda/std/__iterator/iter_move.h
+++ b/libcudacxx/include/cuda/std/__iterator/iter_move.h
@@ -40,7 +40,7 @@ _CCCL_DIAG_SUPPRESS_CLANG("-Wvoid-ptr-dereference")
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_RANGES
 _CCCL_BEGIN_NAMESPACE_CPO(__iter_move)
 
-_CCCL_HOST_DEVICE void iter_move();
+_CCCL_API void iter_move();
 
 #if _CCCL_HAS_CONCEPTS()
 template <class _Tp>

--- a/libcudacxx/include/cuda/std/__ranges/range_adaptor.h
+++ b/libcudacxx/include/cuda/std/__ranges/range_adaptor.h
@@ -63,7 +63,7 @@ struct __pipeable
 _CCCL_CTAD_SUPPORTED_FOR_TYPE(__pipeable);
 
 template <class _Tp>
-_CCCL_HOST_DEVICE _Tp __derived_from_range_adaptor_closure(__range_adaptor_closure<_Tp>*);
+_CCCL_API _Tp __derived_from_range_adaptor_closure(__range_adaptor_closure<_Tp>*);
 
 template <class _Tp>
 _CCCL_CONCEPT __is_range_adaptor_closure = _CCCL_REQUIRES_EXPR(

--- a/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
+++ b/libcudacxx/include/cuda/std/__string/constexpr_c_functions.h
@@ -49,8 +49,7 @@ __cccl_strcpy_impl_constexpr(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_R
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-_CCCL_HIDE_FROM_ABI _CCCL_HOST _CharT*
-__cccl_strcpy_impl_host(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src) noexcept
+_CCCL_HOST_API _CharT* __cccl_strcpy_impl_host(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
@@ -96,7 +95,7 @@ __cccl_strncpy_impl_constexpr(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-_CCCL_HIDE_FROM_ABI _CCCL_HOST _CharT*
+_CCCL_HOST_API _CharT*
 __cccl_strncpy_impl_host(_CharT* _CCCL_RESTRICT __dst, const _CharT* _CCCL_RESTRICT __src, size_t __n) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
@@ -137,7 +136,7 @@ template <class _CharT>
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST size_t __cccl_strlen_impl_host(const _CharT* __ptr) noexcept
+[[nodiscard]] _CCCL_HOST_API size_t __cccl_strlen_impl_host(const _CharT* __ptr) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
@@ -182,8 +181,7 @@ template <class _CharT>
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST int
-__cccl_strcmp_impl_host(const _CharT* __lhs, const _CharT* __rhs) noexcept
+[[nodiscard]] _CCCL_HOST_API int __cccl_strcmp_impl_host(const _CharT* __lhs, const _CharT* __rhs) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
@@ -234,8 +232,7 @@ __cccl_strncmp_impl_constexpr(const _CharT* __lhs, const _CharT* __rhs, size_t _
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST int
-__cccl_strncmp_impl_host(const _CharT* __lhs, const _CharT* __rhs, size_t __n) noexcept
+[[nodiscard]] _CCCL_HOST_API int __cccl_strncmp_impl_host(const _CharT* __lhs, const _CharT* __rhs, size_t __n) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
@@ -276,7 +273,7 @@ template <class _CharT>
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _CharT* __cccl_strchr_impl_host(_CharT* __ptr, _CharT __c) noexcept
+[[nodiscard]] _CCCL_HOST_API _CharT* __cccl_strchr_impl_host(_CharT* __ptr, _CharT __c) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
@@ -325,7 +322,7 @@ template <class _CharT>
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _CharT>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _CharT* __cccl_strrchr_impl_host(_CharT* __ptr, _CharT __c) noexcept
+[[nodiscard]] _CCCL_HOST_API _CharT* __cccl_strrchr_impl_host(_CharT* __ptr, _CharT __c) noexcept
 {
   if constexpr (sizeof(_CharT) == 1)
   {
@@ -368,7 +365,7 @@ template <class _Tp>
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _Tp* __cccl_memchr_impl_host(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+[[nodiscard]] _CCCL_HOST_API _Tp* __cccl_memchr_impl_host(_Tp* __ptr, _Tp __c, size_t __n) noexcept
 {
   if constexpr (sizeof(_Tp) == 1)
   {
@@ -421,8 +418,7 @@ template <class _Tp>
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _Tp*
-__cccl_memmove_impl_host(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
+[[nodiscard]] _CCCL_HOST_API _Tp* __cccl_memmove_impl_host(_Tp* __dst, const _Tp* __src, size_t __n) noexcept
 {
   return reinterpret_cast<_Tp*>(::memmove(__dst, __src, __n * sizeof(_Tp)));
 }
@@ -464,8 +460,7 @@ __cccl_memcmp_impl_constexpr(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noe
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST int
-__cccl_memcmp_impl_host(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noexcept
+[[nodiscard]] _CCCL_HOST_API int __cccl_memcmp_impl_host(const _Tp* __lhs, const _Tp* __rhs, size_t __n) noexcept
 {
   if constexpr (sizeof(_Tp) == 1)
   {
@@ -509,7 +504,7 @@ __cccl_memcpy_impl_constexpr(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRIC
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _Tp*
+[[nodiscard]] _CCCL_HOST_API _Tp*
 __cccl_memcpy_impl_host(_Tp* _CCCL_RESTRICT __dst, const _Tp* _CCCL_RESTRICT __src, size_t __n) noexcept
 {
   return reinterpret_cast<_Tp*>(::memcpy(__dst, __src, __n * sizeof(_Tp)));
@@ -546,7 +541,7 @@ template <class _Tp>
 
 #if !_CCCL_COMPILER(NVRTC)
 template <class _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST _Tp* __cccl_memset_impl_host(_Tp* __ptr, _Tp __c, size_t __n) noexcept
+[[nodiscard]] _CCCL_HOST_API _Tp* __cccl_memset_impl_host(_Tp* __ptr, _Tp __c, size_t __n) noexcept
 {
   if constexpr (sizeof(_Tp) == 1)
   {

--- a/libcudacxx/include/cuda/std/__type_traits/aligned_storage.h
+++ b/libcudacxx/include/cuda/std/__type_traits/aligned_storage.h
@@ -82,12 +82,12 @@ struct __find_pod
     : public __type_front<__type_find_if<__type_push_back<_TL, __fallback_overaligned<_Align>>, __has_align<_Align>>>
 {};
 
-_CCCL_HOST_DEVICE constexpr size_t __select_align_fn_2_(size_t __len, size_t __min, size_t __max)
+_CCCL_API constexpr size_t __select_align_fn_2_(size_t __len, size_t __min, size_t __max)
 {
   return __len < __max ? __min : __max;
 }
 
-_CCCL_HOST_DEVICE constexpr size_t __select_align_fn_(size_t __len, size_t __a1, size_t __a2)
+_CCCL_API constexpr size_t __select_align_fn_(size_t __len, size_t __a1, size_t __a2)
 {
   return __select_align_fn_2_(__len, __a2 < __a1 ? __a2 : __a1, __a1 < __a2 ? __a2 : __a1);
 }

--- a/libcudacxx/include/cuda/std/__utility/pair.h
+++ b/libcudacxx/include/cuda/std/__utility/pair.h
@@ -335,7 +335,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _U2,
             class _Constraints                                       = __pair_constructible<const _U1&, const _U2&>,
             enable_if_t<_Constraints::__explicit_constructible, int> = 0>
-  _CCCL_HOST _CCCL_API explicit constexpr pair(const ::std::pair<_U1, _U2>& __p) noexcept(
+  _CCCL_HOST_API explicit constexpr pair(const ::std::pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
   {}
@@ -344,7 +344,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _U2,
             class _Constraints                                       = __pair_constructible<const _U1&, const _U2&>,
             enable_if_t<_Constraints::__implicit_constructible, int> = 0>
-  _CCCL_HOST _CCCL_API constexpr pair(const ::std::pair<_U1, _U2>& __p) noexcept(
+  _CCCL_HOST_API constexpr pair(const ::std::pair<_U1, _U2>& __p) noexcept(
     is_nothrow_constructible_v<_T1, const _U1&> && is_nothrow_constructible_v<_T2, const _U2&>)
       : __base(__p.first, __p.second)
   {}
@@ -353,7 +353,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _U2,
             class _Constraints                                       = __pair_constructible<_U1, _U2>,
             enable_if_t<_Constraints::__explicit_constructible, int> = 0>
-  _CCCL_HOST _CCCL_API explicit constexpr pair(::std::pair<_U1, _U2>&& __p) noexcept(
+  _CCCL_HOST_API explicit constexpr pair(::std::pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::forward<_U1>(__p.first), ::cuda::std::forward<_U2>(__p.second))
   {}
@@ -362,7 +362,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
             class _U2,
             class _Constraints                                       = __pair_constructible<_U1, _U2>,
             enable_if_t<_Constraints::__implicit_constructible, int> = 0>
-  _CCCL_HOST _CCCL_API constexpr pair(::std::pair<_U1, _U2>&& __p) noexcept(
+  _CCCL_HOST_API constexpr pair(::std::pair<_U1, _U2>&& __p) noexcept(
     is_nothrow_constructible_v<_T1, _U1> && is_nothrow_constructible_v<_T2, _U2>)
       : __base(::cuda::std::forward<_U1>(__p.first), ::cuda::std::forward<_U2>(__p.second))
   {}
@@ -399,7 +399,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   // std assignments
 #if !_CCCL_COMPILER(NVRTC)
   template <class _UT1 = _T1, enable_if_t<is_copy_assignable_v<_UT1> && is_copy_assignable_v<_T2>, int> = 0>
-  _CCCL_HOST constexpr pair& operator=(::std::pair<_T1, _T2> const& __p) noexcept(
+  _CCCL_HOST_API constexpr pair& operator=(::std::pair<_T1, _T2> const& __p) noexcept(
     is_nothrow_copy_assignable_v<_T1> && is_nothrow_copy_assignable_v<_T2>)
   {
     this->first  = __p.first;
@@ -408,7 +408,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   }
 
   template <class _UT1 = _T1, enable_if_t<is_move_assignable_v<_UT1> && is_move_assignable_v<_T2>, int> = 0>
-  _CCCL_HOST constexpr pair& operator=(::std::pair<_T1, _T2>&& __p) noexcept(
+  _CCCL_HOST_API constexpr pair& operator=(::std::pair<_T1, _T2>&& __p) noexcept(
     is_nothrow_copy_assignable_v<_T1> && is_nothrow_copy_assignable_v<_T2>)
   {
     this->first  = ::cuda::std::forward<_T1>(__p.first);
@@ -428,7 +428,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   }
 
 #  if !_CCCL_COMPILER(NVRTC)
-  _CCCL_API inline _CCCL_HOST constexpr const pair& operator=(::std::pair<_T1, _T2> const& __p) const
+  _CCCL_HOST_API inline constexpr const pair& operator=(::std::pair<_T1, _T2> const& __p) const
     noexcept(is_nothrow_copy_assignable_v<const _T1> && is_nothrow_copy_assignable_v<const _T2>)
     requires(is_copy_assignable_v<const _T1> && is_copy_assignable_v<const _T2>)
   {
@@ -448,7 +448,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
   }
 
 #  if !_CCCL_COMPILER(NVRTC)
-  _CCCL_API inline _CCCL_HOST constexpr const pair& operator=(::std::pair<_T1, _T2>&& __p) const
+  _CCCL_HOST_API inline constexpr const pair& operator=(::std::pair<_T1, _T2>&& __p) const
     noexcept(is_nothrow_assignable_v<const _T1&, _T1> && is_nothrow_assignable_v<const _T2&, _T2>)
     requires(is_assignable_v<const _T1&, _T1> && is_assignable_v<const _T2&, _T2>)
   {
@@ -469,7 +469,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
 #  if !_CCCL_COMPILER(NVRTC)
   template <class _U1, class _U2>
-  _CCCL_API inline _CCCL_HOST constexpr const pair& operator=(const ::std::pair<_U1, _U2>& __p) const
+  _CCCL_HOST_API inline constexpr const pair& operator=(const ::std::pair<_U1, _U2>& __p) const
     requires(is_assignable_v<const _T1&, const _U1&> && is_assignable_v<const _T2&, const _U2&>)
   {
     this->first  = __p.first;
@@ -489,7 +489,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 
 #  if !_CCCL_COMPILER(NVRTC)
   template <class _U1, class _U2>
-  _CCCL_API inline _CCCL_HOST constexpr const pair& operator=(::std::pair<_U1, _U2>&& __p) const
+  _CCCL_HOST_API inline constexpr const pair& operator=(::std::pair<_U1, _U2>&& __p) const
     requires(is_assignable_v<const _T1&, _U1> && is_assignable_v<const _T2&, _U2>)
   {
     this->first  = ::cuda::std::forward<_U1>(__p.first);
@@ -518,7 +518,7 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT pair : public __pair_base<_T1, _T2>
 #endif // _CCCL_STD_VER >= 2023
 
 #if !_CCCL_COMPILER(NVRTC)
-  _CCCL_HOST constexpr operator ::std::pair<_T1, _T2>() const
+  _CCCL_HOST_API constexpr operator ::std::pair<_T1, _T2>() const
   {
     return {this->first, this->second};
   }

--- a/libcudacxx/include/cuda/std/__utility/typeid.h
+++ b/libcudacxx/include/cuda/std/__utility/typeid.h
@@ -112,15 +112,14 @@ template <class _Tp, size_t _Np>
 struct __static_nameof;
 
 template <size_t _Np, size_t _Mp, size_t... _Is>
-_CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __sstring<_Np>
-__make_pretty_name_impl(char const (&__s)[_Mp], index_sequence<_Is...>) noexcept
+_CCCL_API constexpr __sstring<_Np> __make_pretty_name_impl(char const (&__s)[_Mp], index_sequence<_Is...>) noexcept
 {
   static_assert(_Mp <= _Np, "Type name too long for __pretty_nameof");
   return __sstring<_Np>{{(_Is < _Mp ? __s[_Is] : '\0')...}, _Mp - 1};
 }
 
 template <class _Tp, size_t _Np>
-_CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr auto __make_pretty_name(integral_constant<size_t, _Np>) noexcept //
+_CCCL_API constexpr auto __make_pretty_name(integral_constant<size_t, _Np>) noexcept //
   -> enable_if_t<_Np == size_t(-1), __string_view>
 {
   using _TpName = __static_nameof<_Tp, sizeof(_CCCL_BUILTIN_PRETTY_FUNCTION())>;
@@ -128,7 +127,7 @@ _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr auto __make_pretty_name(integral
 }
 
 template <class _Tp, size_t _Np>
-_CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr auto __make_pretty_name(integral_constant<size_t, _Np>) noexcept //
+_CCCL_API constexpr auto __make_pretty_name(integral_constant<size_t, _Np>) noexcept //
   -> enable_if_t<_Np != size_t(-1), __sstring<_Np>>
 {
   return ::cuda::std::__make_pretty_name_impl<_Np>(_CCCL_BUILTIN_PRETTY_FUNCTION(), make_index_sequence<_Np>{});
@@ -154,15 +153,13 @@ struct __pretty_name_begin
 };
 
 // If a position is -1, it is an invalid position. Return it unchanged.
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr ptrdiff_t
-__add_string_view_position(ptrdiff_t __pos, ptrdiff_t __diff) noexcept
+[[nodiscard]] _CCCL_API constexpr ptrdiff_t __add_string_view_position(ptrdiff_t __pos, ptrdiff_t __diff) noexcept
 {
   return __pos == -1 ? -1 : __pos + __diff;
 }
 
 // Get the type name from the pretty name by trimming the front and back.
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __string_view
-__find_pretty_name(__string_view __sv) noexcept
+[[nodiscard]] _CCCL_API constexpr __string_view __find_pretty_name(__string_view __sv) noexcept
 {
   return __sv.substr(::cuda::std::__add_string_view_position(
                        __sv.find("__pretty_name_begin<"), ptrdiff_t(sizeof("__pretty_name_begin<")) - 1),
@@ -170,7 +167,7 @@ __find_pretty_name(__string_view __sv) noexcept
 }
 
 template <class _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __string_view __pretty_nameof_helper() noexcept
+[[nodiscard]] _CCCL_API constexpr __string_view __pretty_nameof_helper() noexcept
 {
 #if _CCCL_COMPILER(GCC, <, 9) && !defined(__CUDA_ARCH__)
   return ::cuda::std::__find_pretty_name(::cuda::std::__make_pretty_name<_Tp>(integral_constant<size_t, size_t(-1)>{}));
@@ -180,7 +177,7 @@ template <class _Tp>
 }
 
 template <class _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __string_view __pretty_nameof() noexcept
+[[nodiscard]] _CCCL_API constexpr __string_view __pretty_nameof() noexcept
 {
   return ::cuda::std::__pretty_nameof_helper<typename __pretty_name_begin<_Tp>::__pretty_name_end>();
 }
@@ -214,11 +211,11 @@ struct __type_info_ptr_
 {
   _CCCL_HIDE_FROM_ABI constexpr __type_info_ptr_() noexcept = default;
 
-  _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __type_info_ptr_(__type_info_impl (*__pfn_)() noexcept) noexcept
+  _CCCL_API constexpr __type_info_ptr_(__type_info_impl (*__pfn_)() noexcept) noexcept
       : __pfn_(__pfn_)
   {}
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __type_info_ref_ operator*() const noexcept;
+  [[nodiscard]] _CCCL_API constexpr __type_info_ref_ operator*() const noexcept;
 
   [[nodiscard]] _CCCL_API friend constexpr bool operator==(__type_info_ptr_ __a, __type_info_ptr_ __b) noexcept
   {
@@ -239,38 +236,38 @@ struct __type_info
 {
   __type_info() = delete;
 
-  _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE explicit constexpr __type_info(__type_info_impl (*__pfn)() noexcept) noexcept
+  _CCCL_API explicit constexpr __type_info(__type_info_impl (*__pfn)() noexcept) noexcept
       : __pfn_(__pfn)
   {}
 
   template <class _Tp>
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE static constexpr __type_info_impl __get_ti_for() noexcept
+  [[nodiscard]] _CCCL_API static constexpr __type_info_impl __get_ti_for() noexcept
   {
     return __type_info_impl{::cuda::std::__pretty_nameof<_Tp>()};
   }
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr char const* name() const noexcept
+  [[nodiscard]] _CCCL_API constexpr char const* name() const noexcept
   {
     return __pfn_().__name_.begin();
   }
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __string_view __name_view() const noexcept
+  [[nodiscard]] _CCCL_API constexpr __string_view __name_view() const noexcept
   {
     return __pfn_().__name_;
   }
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr bool before(__type_info const& __other) const noexcept
+  [[nodiscard]] _CCCL_API constexpr bool before(__type_info const& __other) const noexcept
   {
     return __pfn_().__name_ < __other.__pfn_().__name_;
   }
 
   // Not yet implemented:
-  // [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr size_t hash_code() const noexcept
+  // [[nodiscard]] _CCCL_API constexpr size_t hash_code() const noexcept
   // {
   //   return ;
   // }
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __type_info_ptr_ operator&() const noexcept
+  [[nodiscard]] _CCCL_API constexpr __type_info_ptr_ operator&() const noexcept
   {
     return __type_info_ptr_{__pfn_};
   }
@@ -297,21 +294,20 @@ private:
 
 struct __type_info_ref_ : __type_info
 {
-  _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __type_info_ref_(__type_info_impl (*__pfn)() noexcept) noexcept
+  _CCCL_API constexpr __type_info_ref_(__type_info_impl (*__pfn)() noexcept) noexcept
       : __type_info(__pfn)
   {}
 
-  _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __type_info_ref_(__type_info const& __other) noexcept
+  _CCCL_API constexpr __type_info_ref_(__type_info const& __other) noexcept
       : __type_info(__other)
   {}
 
-  _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __type_info_ref_(__type_info_ref_ const& __other) noexcept
+  _CCCL_API constexpr __type_info_ref_(__type_info_ref_ const& __other) noexcept
       : __type_info(__other)
   {}
 };
 
-[[nodiscard]] _CCCL_HIDE_FROM_ABI _CCCL_HOST_DEVICE constexpr __type_info_ref_
-__type_info_ptr_::operator*() const noexcept
+[[nodiscard]] _CCCL_API constexpr __type_info_ref_ __type_info_ptr_::operator*() const noexcept
 {
   return __type_info_ref_(__pfn_);
 }
@@ -345,39 +341,39 @@ struct __type_info
   __type_info(__type_info const&)            = delete;
   __type_info& operator=(__type_info const&) = delete;
 
-  _CCCL_HIDE_FROM_ABI constexpr __type_info(__string_view __name) noexcept
+  _CCCL_HOST_API constexpr __type_info(__string_view __name) noexcept
       : __name_(__name)
   {}
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr char const* name() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr char const* name() const noexcept
   {
     return __name_.begin();
   }
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr __string_view __name_view() const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr __string_view __name_view() const noexcept
   {
     return __name_;
   }
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr bool before(const __type_info& __other) const noexcept
+  [[nodiscard]] _CCCL_HOST_API constexpr bool before(const __type_info& __other) const noexcept
   {
     return __name_ < __other.__name_;
   }
 
   // Not yet implemented:
-  // [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr size_t hash_code() const noexcept
+  // [[nodiscard]] _CCCL_HOST_API constexpr size_t hash_code() const noexcept
   // {
   //   return ;
   // }
 
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_API friend constexpr bool
   operator==(const __type_info& __lhs, const __type_info& __rhs) noexcept
   {
     return &__lhs == &__rhs || __lhs.__name_ == __rhs.__name_;
   }
 
 #  if _CCCL_STD_VER <= 2017
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI friend constexpr bool
+  [[nodiscard]] _CCCL_HOST_API friend constexpr bool
   operator!=(const __type_info& __lhs, const __type_info& __rhs) noexcept
   {
     return !(__lhs == __rhs);
@@ -400,7 +396,7 @@ _CCCL_GLOBAL_CONSTANT __type_info __typeid_v{::cuda::std::__pretty_nameof<_Tp>()
 // When inline variables are available, this indirection through an inline function
 // is not necessary, but it doesn't hurt either.
 template <class _Tp>
-[[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr __type_info const& __typeid() noexcept
+[[nodiscard]] _CCCL_HOST_API constexpr __type_info const& __typeid() noexcept
 {
   return __typeid_v<_Tp>;
 }

--- a/libcudacxx/include/cuda/std/bitset
+++ b/libcudacxx/include/cuda/std/bitset
@@ -62,25 +62,25 @@ struct __avoid_promotions
   _CCCL_HIDE_FROM_ABI constexpr __avoid_promotions() = default;
 
   template <class _Tp, typename = enable_if_t<is_integral_v<_Tp>>>
-  _CCCL_HOST_DEVICE constexpr __avoid_promotions(_Tp __i)
+  _CCCL_API constexpr __avoid_promotions(_Tp __i)
       : __data(static_cast<_Int>(__i))
   {}
 
-  _CCCL_HOST_DEVICE constexpr explicit operator bool() const
+  _CCCL_API constexpr explicit operator bool() const
   {
     return static_cast<bool>(__data);
   }
 
   // helper for fill_n
-  _CCCL_HOST_DEVICE constexpr friend _Int __convert_to_integral(__avoid_promotions __self)
+  _CCCL_API constexpr friend _Int __convert_to_integral(__avoid_promotions __self)
   {
     return __self.__data;
   }
 
-#define _DEFINE_UNARY(__op)                                                                         \
-  _CCCL_HOST_DEVICE constexpr friend __avoid_promotions operator __op(__avoid_promotions __operand) \
-  {                                                                                                 \
-    return __avoid_promotions(static_cast<_Int>(__op static_cast<__base>(__operand.__data)));       \
+#define _DEFINE_UNARY(__op)                                                                   \
+  _CCCL_API constexpr friend __avoid_promotions operator __op(__avoid_promotions __operand)   \
+  {                                                                                           \
+    return __avoid_promotions(static_cast<_Int>(__op static_cast<__base>(__operand.__data))); \
   }
 
   _DEFINE_UNARY(~)
@@ -89,12 +89,12 @@ struct __avoid_promotions
 
 #define _DEFINE_SHIFT(__op)                                                                                            \
   template <class _Tp>                                                                                                 \
-  _CCCL_HOST_DEVICE constexpr friend __avoid_promotions operator __op(__avoid_promotions __operand, _Tp __n)           \
+  _CCCL_API constexpr friend __avoid_promotions operator __op(__avoid_promotions __operand, _Tp __n)                   \
   {                                                                                                                    \
     return __avoid_promotions(static_cast<_Int>(static_cast<__base>(__operand.__data) __op static_cast<__base>(__n))); \
   }                                                                                                                    \
   template <class _Tp>                                                                                                 \
-  _CCCL_HOST_DEVICE constexpr friend __avoid_promotions operator __op(                                                 \
+  _CCCL_API constexpr friend __avoid_promotions operator __op(                                                         \
     __avoid_promotions __operand, __avoid_promotions<_Tp> __n)                                                         \
   {                                                                                                                    \
     return __avoid_promotions(                                                                                         \
@@ -107,7 +107,7 @@ struct __avoid_promotions
 
 #define _DEFINE_SHIFT_ASSIGNMENT(__op)                                                       \
   template <class _Tp>                                                                       \
-  _CCCL_HOST_DEVICE constexpr __avoid_promotions& operator __op##=(_Tp __n)                  \
+  _CCCL_API constexpr __avoid_promotions& operator __op##=(_Tp __n)                          \
   {                                                                                          \
     if (__n >= sizeof(_Int) * CHAR_BIT)                                                      \
     {                                                                                        \
@@ -124,12 +124,11 @@ struct __avoid_promotions
   _DEFINE_SHIFT_ASSIGNMENT(>>)
 #undef _DEFINE_SHIFT_ASSIGNMENT
 
-#define _DEFINE_BINARY(__op)                                                                        \
-  _CCCL_HOST_DEVICE constexpr friend __avoid_promotions operator __op(                              \
-    __avoid_promotions __lhs, __avoid_promotions __rhs)                                             \
-  {                                                                                                 \
-    return __avoid_promotions(                                                                      \
-      static_cast<_Int>(static_cast<__base>(__lhs.__data) __op static_cast<__base>(__rhs.__data))); \
+#define _DEFINE_BINARY(__op)                                                                                      \
+  _CCCL_API constexpr friend __avoid_promotions operator __op(__avoid_promotions __lhs, __avoid_promotions __rhs) \
+  {                                                                                                               \
+    return __avoid_promotions(                                                                                    \
+      static_cast<_Int>(static_cast<__base>(__lhs.__data) __op static_cast<__base>(__rhs.__data)));               \
   }
 
   _DEFINE_BINARY(+)
@@ -143,7 +142,7 @@ struct __avoid_promotions
 #undef _DEFINE_BINARY
 
 #define _DEFINE_ASSIGNMENT(__op)                                                                    \
-  _CCCL_HOST_DEVICE constexpr __avoid_promotions& operator __op##=(__avoid_promotions __rhs)        \
+  _CCCL_API constexpr __avoid_promotions& operator __op##=(__avoid_promotions __rhs)                \
   {                                                                                                 \
     __data = static_cast<_Int>(static_cast<__base>(__data) __op static_cast<__base>(__rhs.__data)); \
     return *this;                                                                                   \
@@ -159,10 +158,10 @@ struct __avoid_promotions
   _DEFINE_ASSIGNMENT(^)
 #undef _DEFINE_ASSIGNMENT
 
-#define _DEFINE_COMPARISON(__op)                                                                            \
-  _CCCL_HOST_DEVICE constexpr friend bool operator __op(__avoid_promotions __lhs, __avoid_promotions __rhs) \
-  {                                                                                                         \
-    return static_cast<_Int>(static_cast<__base>(__lhs.__data) __op static_cast<__base>(__rhs.__data));     \
+#define _DEFINE_COMPARISON(__op)                                                                        \
+  _CCCL_API constexpr friend bool operator __op(__avoid_promotions __lhs, __avoid_promotions __rhs)     \
+  {                                                                                                     \
+    return static_cast<_Int>(static_cast<__base>(__lhs.__data) __op static_cast<__base>(__rhs.__data)); \
   }
 
   _DEFINE_COMPARISON(<)


### PR DESCRIPTION
In some places, we still use `_CCCL_HIDE_FROM_ABI` + `(_CCCL_HOST|_CCCL_DEVICE|_CCCL_HOST_DEVICE)` combination. This PR replaces these by the `_CCCL[_MEOW]_API` macros