### PR TITLE
Remove use of `_CCCL_IF_CONSTEVAL` macros from libcu++ tests

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/functional/absorbing_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/absorbing_element.pass.cpp
@@ -11,16 +11,9 @@
 #include <cuda/functional>
 #include <cuda/std/cassert>
 #include <cuda/std/limits>
+#include <cuda/std/type_traits>
 
 #include "test_macros.h"
-
-#if _CCCL_COMPILER(GCC, >=, 12)
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(3215) // "if consteval" and "if not consteval" are not standard in this mode
-_CCCL_DIAG_SUPPRESS_GCC("-Wc++23-extensions")
-#endif // _CCCL_COMPILER(GCC, >=, 12)
-#if _CCCL_CUDA_COMPILER(CLANG, >=, 13)
-_CCCL_DIAG_SUPPRESS_CLANG("-Wc++23-extensions")
-#endif // _CCCL_CUDA_COMPILER(CLANG, >=, 13)
 
 /***********************************************************************************************************************
  * Helper
@@ -82,7 +75,7 @@ __host__ __device__ constexpr void test_absorbing_impl(bool has_absorbing, [[may
     else
     {
       assert((absorbing == cuda::absorbing_element<Op, T>()));
-      _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+      if (!cuda::std::__cccl_default_is_constant_evaluated())
       {
         test_absorbing_impl2<Op, T>();
         test_absorbing_impl2<Op, const T>();

--- a/libcudacxx/test/libcudacxx/cuda/functional/identity_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/functional/identity_element.pass.cpp
@@ -12,16 +12,9 @@
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>
 #include <cuda/std/limits>
+#include <cuda/std/type_traits>
 
 #include "test_macros.h"
-
-#if _CCCL_COMPILER(GCC, >=, 12)
-_CCCL_BEGIN_NV_DIAG_SUPPRESS(3215) // "if consteval" and "if not consteval" are not standard in this mode
-_CCCL_DIAG_SUPPRESS_GCC("-Wc++23-extensions")
-#endif // _CCCL_COMPILER(GCC, >=, 12)
-#if _CCCL_CUDA_COMPILER(CLANG, >=, 13)
-_CCCL_DIAG_SUPPRESS_CLANG("-Wc++23-extensions")
-#endif // _CCCL_CUDA_COMPILER(CLANG, >=, 13)
 
 /***********************************************************************************************************************
  * Helper
@@ -88,7 +81,7 @@ __host__ __device__ constexpr void test_identity_impl(bool has_identity, [[maybe
 #if _CCCL_CTK_AT_LEAST(12, 2) || _CCCL_DEVICE_COMPILATION()
     else
     {
-      _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+      if (!cuda::std::__cccl_default_is_constant_evaluated())
       {
         assert((identity == cuda::identity_element<Op, T>()));
         test_identity_impl2<Op, T>();


### PR DESCRIPTION
They shouldn't be used in tests. This PR replaces them with
```cpp
if (!cuda::std::__cccl_default_is_constant_evaluated()) { ... }
```