### PR TITLE
[cudax] Make `hierarchy_group` a concept

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/concepts.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/concepts.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL_HIERARCHY
-#define _CUDA_EXPERIMENTAL_HIERARCHY
+#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_CONCEPTS_CUH
+#define _CUDA_EXPERIMENTAL___HIERARCHY_CONCEPTS_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -21,9 +21,22 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/experimental/__hierarchy/concepts.cuh>
-#include <cuda/experimental/__hierarchy/fwd.cuh>
-#include <cuda/experimental/__hierarchy/grid_sync.cuh>
-#include <cuda/experimental/__hierarchy/this_group.cuh>
+#include <cuda/std/__concepts/concept_macros.h>
 
-#endif // _CUDA_EXPERIMENTAL_HIERARCHY
+#include <cuda/std/__cccl/prologue.h>
+
+namespace cuda::experimental
+{
+// todo:
+//   - add check that level_type is actually a valid level type
+//   - check that at least level_type{}.count(__g) and level_type{}.rank(__g) are valid?
+template <class _Tp>
+_CCCL_CONCEPT hierarchy_group = _CCCL_REQUIRES_EXPR((_Tp), _Tp& __g)(
+  typename(typename _Tp::level_type), //
+  __g.sync() //
+);
+} // namespace cuda::experimental
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_EXPERIMENTAL___HIERARCHY_CONCEPTS_CUH

--- a/cudax/include/cuda/experimental/__hierarchy/fwd.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/fwd.cuh
@@ -25,45 +25,19 @@
 
 namespace cuda::experimental
 {
-// hierarchy group kinds
-
-class __this_hierarchy_group_kind
-{};
-
-// hierarchy group base
-
-template <class _Level, class _Hierarchy, class _Kind>
-class __hierarchy_group_base;
 template <class _Level, class _Hierarchy>
-using __this_hierarchy_group_base = __hierarchy_group_base<_Level, _Hierarchy, __this_hierarchy_group_kind>;
+class __this_group_base;
 
-// hierarchy groups
-
-template <class _Hierarchy, class _Kind>
-class thread_group;
-template <class _Hierarchy, class _Kind>
-class warp_group;
-template <class _Hierarchy, class _Kind>
-class block_group;
-template <class _Hierarchy, class _Kind>
-class cluster_group;
-template <class _Hierarchy, class _Kind>
-class grid_group;
-
-// traits
-
-template <class _Tp>
-inline constexpr bool __is_this_hierarchy_group_v = false;
 template <class _Hierarchy>
-inline constexpr bool __is_this_hierarchy_group_v<thread_group<_Hierarchy, __this_hierarchy_group_kind>> = true;
+class this_thread;
 template <class _Hierarchy>
-inline constexpr bool __is_this_hierarchy_group_v<warp_group<_Hierarchy, __this_hierarchy_group_kind>> = true;
+class this_warp;
 template <class _Hierarchy>
-inline constexpr bool __is_this_hierarchy_group_v<block_group<_Hierarchy, __this_hierarchy_group_kind>> = true;
+class this_block;
 template <class _Hierarchy>
-inline constexpr bool __is_this_hierarchy_group_v<cluster_group<_Hierarchy, __this_hierarchy_group_kind>> = true;
+class this_cluster;
 template <class _Hierarchy>
-inline constexpr bool __is_this_hierarchy_group_v<grid_group<_Hierarchy, __this_hierarchy_group_kind>> = true;
+class this_grid;
 } // namespace cuda::experimental
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/cudax/include/cuda/experimental/__hierarchy/this_group.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/this_group.cuh
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_GROUP_CUH
-#define _CUDA_EXPERIMENTAL___HIERARCHY_GROUP_CUH
+#ifndef _CUDA_EXPERIMENTAL___HIERARCHY_THIS_GROUP_CUH
+#define _CUDA_EXPERIMENTAL___HIERARCHY_THIS_GROUP_CUH
 
 #include <cuda/std/detail/__config>
 
@@ -39,7 +39,7 @@ using __hierarchy_type_of =
 
 // todo: use __hier_ in queries
 template <class _Level, class _Hierarchy>
-class __hierarchy_group_base<_Level, _Hierarchy, __this_hierarchy_group_kind>
+class __this_group_base
 {
   static_assert(__is_hierarchy_level_v<_Level>);
   static_assert(__is_hierarchy_v<_Hierarchy>);
@@ -49,9 +49,13 @@ class __hierarchy_group_base<_Level, _Hierarchy, __this_hierarchy_group_kind>
 public:
   using hierarchy_type = _Hierarchy;
 
+  // todo: do we want to allow construction without hierarchy? Or some `cuda::no_hierarchy` tag? Or construction from
+  //       {level_type}_desc type? The reason is that it would be nice not to force the users to use the hierarchy type.
+  //       Maybe even storing the reference to hierarchy is an overkill and we would be fine with the level description.
+
   _CCCL_TEMPLATE(class _HierarchyLike)
   _CCCL_REQUIRES(::cuda::std::is_same_v<_Hierarchy, __hierarchy_type_of<_HierarchyLike>>)
-  _CCCL_DEVICE_API __hierarchy_group_base(const _HierarchyLike& __hier_like) noexcept
+  _CCCL_DEVICE_API __this_group_base(const _HierarchyLike& __hier_like) noexcept
       : __hier_{::cuda::__unpack_hierarchy_if_needed(__hier_like)}
   {}
 
@@ -94,9 +98,9 @@ public:
 };
 
 template <class _Hierarchy>
-class thread_group<_Hierarchy, __this_hierarchy_group_kind> : __this_hierarchy_group_base<thread_level, _Hierarchy>
+class this_thread : __this_group_base<thread_level, _Hierarchy>
 {
-  using __base_type = __this_hierarchy_group_base<thread_level, _Hierarchy>;
+  using __base_type = __this_group_base<thread_level, _Hierarchy>;
 
 public:
   using level_type = thread_level;
@@ -115,13 +119,12 @@ public:
 
 _CCCL_TEMPLATE(class _Hierarchy)
 _CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
-_CCCL_HOST_DEVICE thread_group(const _Hierarchy&)
-  -> thread_group<__hierarchy_type_of<_Hierarchy>, __this_hierarchy_group_kind>;
+_CCCL_HOST_DEVICE this_thread(const _Hierarchy&) -> this_thread<__hierarchy_type_of<_Hierarchy>>;
 
 template <class _Hierarchy>
-class warp_group<_Hierarchy, __this_hierarchy_group_kind> : __this_hierarchy_group_base<warp_level, _Hierarchy>
+class this_warp : __this_group_base<warp_level, _Hierarchy>
 {
-  using __base_type = __this_hierarchy_group_base<warp_level, _Hierarchy>;
+  using __base_type = __this_group_base<warp_level, _Hierarchy>;
 
 public:
   using level_type = warp_level;
@@ -143,13 +146,12 @@ public:
 
 _CCCL_TEMPLATE(class _Hierarchy)
 _CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
-_CCCL_HOST_DEVICE warp_group(const _Hierarchy&)
-  -> warp_group<__hierarchy_type_of<_Hierarchy>, __this_hierarchy_group_kind>;
+_CCCL_HOST_DEVICE this_warp(const _Hierarchy&) -> this_warp<__hierarchy_type_of<_Hierarchy>>;
 
 template <class _Hierarchy>
-class block_group<_Hierarchy, __this_hierarchy_group_kind> : __this_hierarchy_group_base<block_level, _Hierarchy>
+class this_block : __this_group_base<block_level, _Hierarchy>
 {
-  using __base_type = __this_hierarchy_group_base<block_level, _Hierarchy>;
+  using __base_type = __this_group_base<block_level, _Hierarchy>;
 
 public:
   using level_type = block_level;
@@ -172,13 +174,12 @@ public:
 
 _CCCL_TEMPLATE(class _Hierarchy)
 _CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
-_CCCL_HOST_DEVICE block_group(const _Hierarchy&)
-  -> block_group<__hierarchy_type_of<_Hierarchy>, __this_hierarchy_group_kind>;
+_CCCL_HOST_DEVICE this_block(const _Hierarchy&) -> this_block<__hierarchy_type_of<_Hierarchy>>;
 
 template <class _Hierarchy>
-class cluster_group<_Hierarchy, __this_hierarchy_group_kind> : __this_hierarchy_group_base<cluster_level, _Hierarchy>
+class this_cluster : __this_group_base<cluster_level, _Hierarchy>
 {
-  using __base_type = __this_hierarchy_group_base<cluster_level, _Hierarchy>;
+  using __base_type = __this_group_base<cluster_level, _Hierarchy>;
 
 public:
   using level_type = cluster_level;
@@ -206,13 +207,12 @@ public:
 
 _CCCL_TEMPLATE(class _Hierarchy)
 _CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
-_CCCL_HOST_DEVICE cluster_group(const _Hierarchy&)
-  -> cluster_group<__hierarchy_type_of<_Hierarchy>, __this_hierarchy_group_kind>;
+_CCCL_HOST_DEVICE this_cluster(const _Hierarchy&) -> this_cluster<__hierarchy_type_of<_Hierarchy>>;
 
 template <class _Hierarchy>
-class grid_group<_Hierarchy, __this_hierarchy_group_kind> : __this_hierarchy_group_base<grid_level, _Hierarchy>
+class this_grid : __this_group_base<grid_level, _Hierarchy>
 {
-  using __base_type = __this_hierarchy_group_base<grid_level, _Hierarchy>;
+  using __base_type = __this_group_base<grid_level, _Hierarchy>;
 
 public:
   using level_type = grid_level;
@@ -230,45 +230,9 @@ public:
 
 _CCCL_TEMPLATE(class _Hierarchy)
 _CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_Hierarchy>)
-_CCCL_HOST_DEVICE grid_group(const _Hierarchy&)
-  -> grid_group<__hierarchy_type_of<_Hierarchy>, __this_hierarchy_group_kind>;
-
-_CCCL_TEMPLATE(class _HierarchyLike)
-_CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_HierarchyLike>)
-[[nodiscard]] _CCCL_DEVICE_API auto this_thread(const _HierarchyLike& __hier_like) noexcept
-{
-  return thread_group{__hier_like};
-}
-
-_CCCL_TEMPLATE(class _HierarchyLike)
-_CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_HierarchyLike>)
-[[nodiscard]] _CCCL_DEVICE_API auto this_warp(const _HierarchyLike& __hier_like) noexcept
-{
-  return warp_group{__hier_like};
-}
-
-_CCCL_TEMPLATE(class _HierarchyLike)
-_CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_HierarchyLike>)
-[[nodiscard]] _CCCL_DEVICE_API auto this_block(const _HierarchyLike& __hier_like) noexcept
-{
-  return block_group{__hier_like};
-}
-
-_CCCL_TEMPLATE(class _HierarchyLike)
-_CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_HierarchyLike>)
-[[nodiscard]] _CCCL_DEVICE_API auto this_cluster(const _HierarchyLike& __hier_like) noexcept
-{
-  return cluster_group{__hier_like};
-}
-
-_CCCL_TEMPLATE(class _HierarchyLike)
-_CCCL_REQUIRES(__is_or_has_hierarchy_member_v<_HierarchyLike>)
-[[nodiscard]] _CCCL_DEVICE_API auto this_grid(const _HierarchyLike& __hier_like) noexcept
-{
-  return grid_group{__hier_like};
-}
+_CCCL_HOST_DEVICE this_grid(const _Hierarchy&) -> this_grid<__hierarchy_type_of<_Hierarchy>>;
 } // namespace cuda::experimental
 
 #include <cuda/std/__cccl/epilogue.h>
 
-#endif // _CUDA_EXPERIMENTAL___HIERARCHY_GROUP_CUH
+#endif // _CUDA_EXPERIMENTAL___HIERARCHY_THIS_GROUP_CUH

--- a/cudax/test/hierarchy/group.cu
+++ b/cudax/test/hierarchy/group.cu
@@ -23,14 +23,18 @@
 
 #include "testing.cuh"
 
-template <class... GArgs, class T, cuda::std::size_t N>
-[[nodiscard]] __device__ T sum(cudax::thread_group<GArgs...> group, T (&array)[N])
+template <class Group,
+          class T,
+          cuda::std::size_t N,
+          cuda::std::enable_if_t<cudax::hierarchy_group<Group>, int>                                        = 0,
+          cuda::std::enable_if_t<cuda::std::is_same_v<typename Group::level_type, cuda::thread_level>, int> = 0>
+[[nodiscard]] __device__ T sum(Group group, T (&array)[N])
 {
   return cub::ThreadReduce(array, cuda::std::plus<T>{});
 }
 
-template <class... GArgs, class T, cuda::std::size_t N>
-[[nodiscard]] __device__ T sum(cudax::warp_group<GArgs...> group, T (&array)[N])
+template <class Hierarchy, class T, cuda::std::size_t N>
+[[nodiscard]] __device__ T sum(cudax::this_warp<Hierarchy> group, T (&array)[N])
 {
   using WarpReduce = cub::WarpReduce<T>;
 
@@ -40,8 +44,8 @@ template <class... GArgs, class T, cuda::std::size_t N>
   return WarpReduce{temp_storage}.Sum(partial);
 }
 
-template <class... GArgs, class T, cuda::std::size_t N>
-[[nodiscard]] __device__ T sum(cudax::block_group<GArgs...> group, T (&array)[N])
+template <class Hierarchy, class T, cuda::std::size_t N>
+[[nodiscard]] __device__ T sum(cudax::this_block<Hierarchy> group, T (&array)[N])
 {
   // todo: Replace 32 with value from group.
   using BlockReduce = cub::BlockReduce<T, 32>;
@@ -58,101 +62,108 @@ struct TestKernel
     {
       unsigned array[]{1, 2, 3};
 
-      auto this_thread = cudax::this_thread(config);
+      cudax::this_thread thread{config};
+      static_assert(cudax::hierarchy_group<decltype(thread)>);
 
-      this_thread.sync();
+      thread.sync();
 
-      const auto result = sum(this_thread, array);
+      const auto result = sum(thread, array);
       CUDAX_REQUIRE(result == 6);
 
-      CUDAX_REQUIRE(cuda::gpu_thread.count(this_thread) == 1);
-      CUDAX_REQUIRE(cuda::gpu_thread.rank(this_thread) == 0);
-      CUDAX_REQUIRE(this_thread.count(cuda::warp) == cuda::gpu_thread.count(cuda::warp));
-      CUDAX_REQUIRE(this_thread.rank(cuda::warp) == cuda::gpu_thread.rank(cuda::warp));
-      CUDAX_REQUIRE(this_thread.count(cuda::block) == cuda::gpu_thread.count(cuda::block));
-      CUDAX_REQUIRE(this_thread.rank(cuda::block) == cuda::gpu_thread.rank(cuda::block));
-      CUDAX_REQUIRE(this_thread.count(cuda::cluster) == cuda::gpu_thread.count(cuda::cluster));
-      CUDAX_REQUIRE(this_thread.rank(cuda::cluster) == cuda::gpu_thread.rank(cuda::cluster));
-      CUDAX_REQUIRE(this_thread.count(cuda::grid) == cuda::gpu_thread.count(cuda::grid));
-      CUDAX_REQUIRE(this_thread.rank(cuda::grid) == cuda::gpu_thread.rank(cuda::grid));
+      CUDAX_REQUIRE(cuda::gpu_thread.count(thread) == 1);
+      CUDAX_REQUIRE(cuda::gpu_thread.rank(thread) == 0);
+      CUDAX_REQUIRE(thread.count(cuda::warp) == cuda::gpu_thread.count(cuda::warp));
+      CUDAX_REQUIRE(thread.rank(cuda::warp) == cuda::gpu_thread.rank(cuda::warp));
+      CUDAX_REQUIRE(thread.count(cuda::block) == cuda::gpu_thread.count(cuda::block));
+      CUDAX_REQUIRE(thread.rank(cuda::block) == cuda::gpu_thread.rank(cuda::block));
+      CUDAX_REQUIRE(thread.count(cuda::cluster) == cuda::gpu_thread.count(cuda::cluster));
+      CUDAX_REQUIRE(thread.rank(cuda::cluster) == cuda::gpu_thread.rank(cuda::cluster));
+      CUDAX_REQUIRE(thread.count(cuda::grid) == cuda::gpu_thread.count(cuda::grid));
+      CUDAX_REQUIRE(thread.rank(cuda::grid) == cuda::gpu_thread.rank(cuda::grid));
     }
     {
       unsigned array[]{1, 2, 3};
 
-      auto this_warp = cudax::this_warp(config);
-      this_warp.sync();
+      cudax::this_warp warp{config};
+      static_assert(cudax::hierarchy_group<decltype(warp)>);
 
-      const auto result = sum(this_warp, array);
+      warp.sync();
+
+      const auto result = sum(warp, array);
       if (cuda::gpu_thread.rank(cuda::warp) == 0)
       {
         CUDAX_REQUIRE(result == 6 * cuda::gpu_thread.count(cuda::warp));
       }
 
-      CUDAX_REQUIRE(cuda::gpu_thread.count(this_warp) == cuda::gpu_thread.count(cuda::warp));
-      CUDAX_REQUIRE(cuda::gpu_thread.rank(this_warp) == cuda::gpu_thread.rank(cuda::warp));
-      CUDAX_REQUIRE(cuda::warp.count(this_warp) == 1);
-      CUDAX_REQUIRE(cuda::warp.rank(this_warp) == 0);
-      CUDAX_REQUIRE(this_warp.count(cuda::block) == cuda::warp.count(cuda::block));
-      CUDAX_REQUIRE(this_warp.rank(cuda::block) == cuda::warp.rank(cuda::block));
-      CUDAX_REQUIRE(this_warp.count(cuda::cluster) == cuda::warp.count(cuda::cluster));
-      CUDAX_REQUIRE(this_warp.rank(cuda::cluster) == cuda::warp.rank(cuda::cluster));
-      CUDAX_REQUIRE(this_warp.count(cuda::grid) == cuda::warp.count(cuda::grid));
-      CUDAX_REQUIRE(this_warp.rank(cuda::grid) == cuda::warp.rank(cuda::grid));
+      CUDAX_REQUIRE(cuda::gpu_thread.count(warp) == cuda::gpu_thread.count(cuda::warp));
+      CUDAX_REQUIRE(cuda::gpu_thread.rank(warp) == cuda::gpu_thread.rank(cuda::warp));
+      CUDAX_REQUIRE(cuda::warp.count(warp) == 1);
+      CUDAX_REQUIRE(cuda::warp.rank(warp) == 0);
+      CUDAX_REQUIRE(warp.count(cuda::block) == cuda::warp.count(cuda::block));
+      CUDAX_REQUIRE(warp.rank(cuda::block) == cuda::warp.rank(cuda::block));
+      CUDAX_REQUIRE(warp.count(cuda::cluster) == cuda::warp.count(cuda::cluster));
+      CUDAX_REQUIRE(warp.rank(cuda::cluster) == cuda::warp.rank(cuda::cluster));
+      CUDAX_REQUIRE(warp.count(cuda::grid) == cuda::warp.count(cuda::grid));
+      CUDAX_REQUIRE(warp.rank(cuda::grid) == cuda::warp.rank(cuda::grid));
     }
     {
       unsigned array[]{1, 2, 3};
 
-      auto this_block = cudax::this_block(config);
-      this_block.sync();
+      cudax::this_block block{config};
+      static_assert(cudax::hierarchy_group<decltype(block)>);
 
-      const auto result = sum(this_block, array);
+      block.sync();
+
+      const auto result = sum(block, array);
       if (cuda::gpu_thread.rank(cuda::block) == 0)
       {
         CUDAX_REQUIRE(result == 6 * cuda::gpu_thread.count(cuda::block));
       }
 
-      CUDAX_REQUIRE(cuda::gpu_thread.count(this_block) == cuda::gpu_thread.count(cuda::block));
-      CUDAX_REQUIRE(cuda::gpu_thread.rank(this_block) == cuda::gpu_thread.rank(cuda::block));
-      CUDAX_REQUIRE(cuda::warp.count(this_block) == cuda::warp.count(cuda::block));
-      CUDAX_REQUIRE(cuda::warp.rank(this_block) == cuda::warp.rank(cuda::block));
-      CUDAX_REQUIRE(cuda::block.count(this_block) == 1);
-      CUDAX_REQUIRE(cuda::block.rank(this_block) == 0);
-      CUDAX_REQUIRE(this_block.count(cuda::cluster) == cuda::block.count(cuda::cluster));
-      CUDAX_REQUIRE(this_block.rank(cuda::cluster) == cuda::block.rank(cuda::cluster));
-      CUDAX_REQUIRE(this_block.count(cuda::grid) == cuda::block.count(cuda::grid));
-      CUDAX_REQUIRE(this_block.rank(cuda::grid) == cuda::block.rank(cuda::grid));
+      CUDAX_REQUIRE(cuda::gpu_thread.count(block) == cuda::gpu_thread.count(cuda::block));
+      CUDAX_REQUIRE(cuda::gpu_thread.rank(block) == cuda::gpu_thread.rank(cuda::block));
+      CUDAX_REQUIRE(cuda::warp.count(block) == cuda::warp.count(cuda::block));
+      CUDAX_REQUIRE(cuda::warp.rank(block) == cuda::warp.rank(cuda::block));
+      CUDAX_REQUIRE(cuda::block.count(block) == 1);
+      CUDAX_REQUIRE(cuda::block.rank(block) == 0);
+      CUDAX_REQUIRE(block.count(cuda::cluster) == cuda::block.count(cuda::cluster));
+      CUDAX_REQUIRE(block.rank(cuda::cluster) == cuda::block.rank(cuda::cluster));
+      CUDAX_REQUIRE(block.count(cuda::grid) == cuda::block.count(cuda::grid));
+      CUDAX_REQUIRE(block.rank(cuda::grid) == cuda::block.rank(cuda::grid));
     }
     {
-      auto this_cluster = cudax::this_cluster(config);
-      CUDAX_REQUIRE(this_cluster.count(cuda::grid) == cuda::cluster.count(cuda::grid));
-      CUDAX_REQUIRE(this_cluster.rank(cuda::grid) == cuda::cluster.rank(cuda::grid));
-      this_cluster.sync();
+      cudax::this_cluster cluster{config};
+      static_assert(cudax::hierarchy_group<decltype(cluster)>);
 
-      CUDAX_REQUIRE(cuda::gpu_thread.count(this_cluster) == cuda::gpu_thread.count(cuda::cluster));
-      CUDAX_REQUIRE(cuda::gpu_thread.rank(this_cluster) == cuda::gpu_thread.rank(cuda::cluster));
-      CUDAX_REQUIRE(cuda::warp.count(this_cluster) == cuda::warp.count(cuda::cluster));
-      CUDAX_REQUIRE(cuda::warp.rank(this_cluster) == cuda::warp.rank(cuda::cluster));
-      CUDAX_REQUIRE(cuda::block.count(this_cluster) == cuda::block.count(cuda::cluster));
-      CUDAX_REQUIRE(cuda::block.rank(this_cluster) == cuda::block.rank(cuda::cluster));
-      CUDAX_REQUIRE(cuda::cluster.count(this_cluster) == 1);
-      CUDAX_REQUIRE(cuda::cluster.rank(this_cluster) == 0);
-      CUDAX_REQUIRE(this_cluster.count(cuda::grid) == cuda::cluster.count(cuda::grid));
-      CUDAX_REQUIRE(this_cluster.rank(cuda::grid) == cuda::cluster.rank(cuda::grid));
+      cluster.sync();
+
+      CUDAX_REQUIRE(cuda::gpu_thread.count(cluster) == cuda::gpu_thread.count(cuda::cluster));
+      CUDAX_REQUIRE(cuda::gpu_thread.rank(cluster) == cuda::gpu_thread.rank(cuda::cluster));
+      CUDAX_REQUIRE(cuda::warp.count(cluster) == cuda::warp.count(cuda::cluster));
+      CUDAX_REQUIRE(cuda::warp.rank(cluster) == cuda::warp.rank(cuda::cluster));
+      CUDAX_REQUIRE(cuda::block.count(cluster) == cuda::block.count(cuda::cluster));
+      CUDAX_REQUIRE(cuda::block.rank(cluster) == cuda::block.rank(cuda::cluster));
+      CUDAX_REQUIRE(cuda::cluster.count(cluster) == 1);
+      CUDAX_REQUIRE(cuda::cluster.rank(cluster) == 0);
+      CUDAX_REQUIRE(cluster.count(cuda::grid) == cuda::cluster.count(cuda::grid));
+      CUDAX_REQUIRE(cluster.rank(cuda::grid) == cuda::cluster.rank(cuda::grid));
     }
     {
-      auto this_grid = cudax::this_grid(config);
-      this_grid.sync();
+      cudax::this_grid grid{config};
+      static_assert(cudax::hierarchy_group<decltype(grid)>);
 
-      CUDAX_REQUIRE(cuda::gpu_thread.count(this_grid) == cuda::gpu_thread.count(cuda::grid));
-      CUDAX_REQUIRE(cuda::gpu_thread.rank(this_grid) == cuda::gpu_thread.rank(cuda::grid));
-      CUDAX_REQUIRE(cuda::warp.count(this_grid) == cuda::warp.count(cuda::grid));
-      CUDAX_REQUIRE(cuda::warp.rank(this_grid) == cuda::warp.rank(cuda::grid));
-      CUDAX_REQUIRE(cuda::block.count(this_grid) == cuda::block.count(cuda::grid));
-      CUDAX_REQUIRE(cuda::block.rank(this_grid) == cuda::block.rank(cuda::grid));
-      CUDAX_REQUIRE(cuda::cluster.count(this_grid) == cuda::cluster.count(cuda::grid));
-      CUDAX_REQUIRE(cuda::cluster.rank(this_grid) == cuda::cluster.rank(cuda::grid));
-      CUDAX_REQUIRE(cuda::grid.count(this_grid) == 1);
-      CUDAX_REQUIRE(cuda::grid.rank(this_grid) == 0);
+      grid.sync();
+
+      CUDAX_REQUIRE(cuda::gpu_thread.count(grid) == cuda::gpu_thread.count(cuda::grid));
+      CUDAX_REQUIRE(cuda::gpu_thread.rank(grid) == cuda::gpu_thread.rank(cuda::grid));
+      CUDAX_REQUIRE(cuda::warp.count(grid) == cuda::warp.count(cuda::grid));
+      CUDAX_REQUIRE(cuda::warp.rank(grid) == cuda::warp.rank(cuda::grid));
+      CUDAX_REQUIRE(cuda::block.count(grid) == cuda::block.count(cuda::grid));
+      CUDAX_REQUIRE(cuda::block.rank(grid) == cuda::block.rank(cuda::grid));
+      CUDAX_REQUIRE(cuda::cluster.count(grid) == cuda::cluster.count(cuda::grid));
+      CUDAX_REQUIRE(cuda::cluster.rank(grid) == cuda::cluster.rank(cuda::grid));
+      CUDAX_REQUIRE(cuda::grid.count(grid) == 1);
+      CUDAX_REQUIRE(cuda::grid.rank(grid) == 0);
     }
   }
 };
@@ -169,3 +180,30 @@ C2H_TEST("Hierarchy groups", "[hierarchy]")
 
   stream.sync();
 }
+
+// missing level_type and sync()
+struct InvalidGroup1
+{};
+
+// missing sync()
+struct InvalidGroup2
+{
+  using level_type = cuda::thread_level;
+};
+
+// missing level_type
+struct InvalidGroup3
+{
+  __device__ void sync();
+};
+
+struct ValidGroup
+{
+  using level_type = cuda::thread_level;
+  __device__ void sync();
+};
+
+static_assert(!cudax::hierarchy_group<InvalidGroup1>);
+static_assert(!cudax::hierarchy_group<InvalidGroup2>);
+static_assert(!cudax::hierarchy_group<InvalidGroup3>);
+static_assert(cudax::hierarchy_group<ValidGroup>);

--- a/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -36,6 +36,7 @@
 #  include <cuda/std/array>
 
 #  if defined(_CUDAX_HIERARCHY)
+#    include <cuda/experimental/__hierarchy/concepts.cuh>
 #    include <cuda/experimental/__hierarchy/fwd.cuh>
 #  endif // _CUDAX_HIERARCHY
 
@@ -320,8 +321,7 @@ struct hierarchy_level_base
 
 #  if defined(_CUDAX_HIERARCHY)
   _CCCL_TEMPLATE(class _Tp, class _Group)
-  _CCCL_REQUIRES(
-    ::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND ::cuda::experimental::__is_this_hierarchy_group_v<_Group>)
+  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND ::cuda::experimental::hierarchy_group<_Group>)
   [[nodiscard]] _CCCL_API static constexpr _Tp count_as(const _Group& __group) noexcept
   {
     if constexpr (::cuda::std::is_same_v<_Level, typename _Group::level_type>)
@@ -336,7 +336,7 @@ struct hierarchy_level_base
   }
 
   _CCCL_TEMPLATE(class _Group)
-  _CCCL_REQUIRES(::cuda::experimental::__is_this_hierarchy_group_v<_Group>)
+  _CCCL_REQUIRES(::cuda::experimental::hierarchy_group<_Group>)
   [[nodiscard]] _CCCL_API static constexpr ::cuda::std::size_t count(const _Group& __group) noexcept
   {
     if constexpr (::cuda::std::is_same_v<_Level, typename _Group::level_type>)
@@ -352,8 +352,7 @@ struct hierarchy_level_base
 
 #    if _CCCL_CUDA_COMPILATION()
   _CCCL_TEMPLATE(class _Tp, class _Group)
-  _CCCL_REQUIRES(
-    ::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND ::cuda::experimental::__is_this_hierarchy_group_v<_Group>)
+  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND ::cuda::experimental::hierarchy_group<_Group>)
   [[nodiscard]] _CCCL_API static constexpr _Tp rank_as(const _Group& __group) noexcept
   {
     if constexpr (::cuda::std::is_same_v<_Level, typename _Group::level_type>)
@@ -368,7 +367,7 @@ struct hierarchy_level_base
   }
 
   _CCCL_TEMPLATE(class _Group)
-  _CCCL_REQUIRES(::cuda::experimental::__is_this_hierarchy_group_v<_Group>)
+  _CCCL_REQUIRES(::cuda::experimental::hierarchy_group<_Group>)
   [[nodiscard]] _CCCL_API static constexpr ::cuda::std::size_t rank(const _Group& __group) noexcept
   {
     if constexpr (::cuda::std::is_same_v<_Level, typename _Group::level_type>)


### PR DESCRIPTION
At first, I thought it would be better to make the hierarchy groups specializations of a single class, but that design quite ugly and complicated.

After @fbusato's review on #7699, I think it would be better to make hiearachy group a concept. That way we can get rid of a lot of the metaprogramming and specializations and make it easier to implement new group kinds.

Currently the only requirements are specifying at what hierarchy level are the units grouped and the ability to synchronize the group. There may be more in the future as we move forward in the design