### PR TITLE
Replace `find_package(CUDAToolkit)` with `cccl_get_cudatoolkit()`

### DIFF
--- a/c2h/CMakeLists.txt
+++ b/c2h/CMakeLists.txt
@@ -2,24 +2,31 @@ cmake_minimum_required(VERSION 3.21)
 
 project(C2H LANGUAGES CXX CUDA)
 
-cccl_get_catch2()
-
 # when CCCL is used from the CTK, C2H does not need to be rebuilt when making local changes to CCCL (faster iteration)
 option(C2H_USE_CCCL_FROM_CTK "Use CCCL from the CTK in c2h." OFF)
 
-if (C2H_USE_CCCL_FROM_CTK)
-  find_package(CUDAToolkit REQUIRED)
-else()
+# Get dependencies.
+cccl_get_catch2()
+if (NOT C2H_USE_CCCL_FROM_CTK)
   cccl_get_cccl()
-  find_package(CUDAToolkit)
+endif()
+cccl_get_cudatoolkit()
+
+set(has_curand OFF)
+if (TARGET CUDA::curand)
+  set(has_curand ON)
 endif()
 
-set(curand_default OFF)
-if (CUDA_curand_LIBRARY)
-  set(curand_default ON)
-endif()
+option(C2H_ENABLE_CURAND "Use CUDA CURAND library in c2h." ${has_curand})
 
-option(C2H_ENABLE_CURAND "Use CUDA CURAND library in c2h." ${curand_default})
+# Disable C2H_ENABLE_CURAND if cuRAND is unavailable.
+if (C2H_ENABLE_CURAND AND NOT has_curand)
+  message(
+    WARNING
+    "C2H_ENABLE_CURAND is requested, but CUDA::curand is unavailable. Disabling."
+  )
+  set(C2H_ENABLE_CURAND OFF)
+endif()
 
 add_library(
   cccl.c2h

--- a/cmake/CCCLCheckCudaArchitectures.cmake
+++ b/cmake/CCCLCheckCudaArchitectures.cmake
@@ -53,6 +53,7 @@ endfunction()
 
 # Query nvcc --help to determine which architectures are supported.
 function(_cccl_detect_nvcc_arch_support arches_var)
+  # cccl_get_cudatoolkit() is intentionally not used here.
   find_package(CUDAToolkit)
   if (NOT CUDAToolkit_FOUND)
     message(

--- a/libcudacxx/cmake/LibcudacxxInternalHeaderTesting.cmake
+++ b/libcudacxx/cmake/LibcudacxxInternalHeaderTesting.cmake
@@ -4,14 +4,10 @@
 # .inl files are not globbed for, because they are not supposed to be used as public
 # entrypoints.
 
+cccl_get_cudatoolkit()
+
 # Meta target for all configs' header builds:
 add_custom_target(libcudacxx.test.internal_headers)
-
-if ("NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-  find_package(NVHPC)
-else()
-  cccl_get_cudatoolkit()
-endif()
 
 # We need to handle atomic headers differently as they do not compile on architectures below sm70
 set(architectures_at_least_sm70)
@@ -43,12 +39,6 @@ list(FILTER internal_headers EXCLUDE REGEX "__cuda/*")
 # generated cuda::ptx headers are not standalone
 list(FILTER internal_headers EXCLUDE REGEX "__ptx/instructions/generated")
 
-if ("NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-  set(cudart_name NVHPC::CUDART)
-else()
-  set(cudart_name CUDA::cudart)
-endif()
-
 function(libcudacxx_create_internal_header_test header_name headertest_src)
   # Create the default target for that file
   add_library(internal_headertest_${header_name} SHARED "${headertest_src}.cu")
@@ -61,7 +51,7 @@ function(libcudacxx_create_internal_header_test header_name headertest_src)
     internal_headertest_${header_name}
     PUBLIC #
       libcudacxx.compiler_interface
-      ${cudart_name}
+      CUDA::cudart
   )
 
   # Ensure that if this is an atomic header, we only include the right architectures

--- a/libcudacxx/cmake/LibcudacxxPublicHeaderTestingHost.cmake
+++ b/libcudacxx/cmake/LibcudacxxPublicHeaderTestingHost.cmake
@@ -4,6 +4,8 @@
 # .inl files are not globbed for, because they are not supposed to be used as public
 # entrypoints.
 
+cccl_get_cudatoolkit()
+
 # Meta target for all configs' header builds:
 add_custom_target(libcudacxx.test.public_headers_host_only)
 add_custom_target(libcudacxx.test.public_headers_host_only_with_ctk)


### PR DESCRIPTION
We have the `cccl_get_cudatoolkit()` macro that I believe should always be used instead of `find_package(CUDAToolkit)`.