### PR TITLE
Rename the docs header for the C++ libraries from "CUDA C++ Core Libraries" to "CCCL C++ Libraries"

### DIFF
--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -1,7 +1,7 @@
 .. _cccl-cpp-libraries:
 
-CUDA C++ Core Libraries
-=======================
+CCCL C++ Libraries
+==================
 
 .. toctree::
    :hidden:
@@ -19,7 +19,7 @@ CUDA C++ Core Libraries
 
 Welcome to the CUDA Core Compute Libraries (CCCL) libraries for C++.
 
-The concept for the  CCCL C++ librarires grew organically out of the Thrust,
+The concept for the CCCL C++ librarires grew organically out of the Thrust,
 CUB, and libcudacxx projects that were developed independently over the years
 with a similar goal: to provide high-quality, high-performance, and
 easy-to-use C++ abstractions for CUDA developers. Naturally, there was a lot

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,4 +13,4 @@ make CUDA C++ and Python more delightful.
 
 - :ref:`cccl-cpp-libraries`
 
-- :doc:`Python Libraries <python/index>`
+- :doc:`CCCL Python Libraries <python/index>`


### PR DESCRIPTION
Here's what the docs landing page looks like right now:

- Title: "CUDA Core Compute Libraries (CCCL)".
- Section: "CUDA C++ Core Libraries".
- Section: "CCCL Python Libraries".

This is inconsistent and makes it unclear what CCCL stands for. I mean, okay, the ambiguity *WAS* the reason I chose the name, but now it just means CUDA Core Compute Libraries.