### PR TITLE
Drop wrongly added tuning RANGE params

### DIFF
--- a/cub/benchmarks/bench/radix_sort/policy_selector.h
+++ b/cub/benchmarks/bench/radix_sort/policy_selector.h
@@ -3,12 +3,6 @@
 
 #include <cub/device/device_radix_sort.cuh>
 
-// %//RANGE//% TUNE_RADIX_BITS bits 8:9:1
-#define TUNE_RADIX_BITS 8
-
-// %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1
-// %RANGE% TUNE_THREADS_PER_BLOCK tpb 128:1024:32
-
 #if !TUNE_BASE
 template <typename KeyT, typename ValueT, typename OffsetT>
 struct policy_selector


### PR DESCRIPTION
Adding those to a header file have no affect