### PR TITLE
Overload standard iterator functions for `cuda` iterators

### DIFF
--- a/libcudacxx/include/cuda/__iterator/transform_input_output_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_input_output_iterator.h
@@ -28,7 +28,9 @@
 #include <cuda/std/__concepts/equality_comparable.h>
 #include <cuda/std/__concepts/invocable.h>
 #include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__iterator/advance.h>
 #include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/distance.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__ranges/compressed_movable_box.h>
 #include <cuda/std/__ranges/concepts.h>
@@ -506,12 +508,12 @@ public:
 #endif // !_LIBCUDACXX_HAS_NO_SPACESHIP_OPERATOR
 };
 
-//! @brief make_transform_output_iterator creates a @c transform_output_iterator from an iterator, an input functor
-//! and an output functor
-//! @param __iter The iterator pointing to the input range of the newly created @c transform_output_iterator.
+//! @brief make_transform_output_iterator creates a @c transform_input_output_iterator from an iterator, an input
+//! functor and an output functor
+//! @param __iter The iterator pointing to the input range of the newly created @c transform_input_output_iterator.
 //! @param __input_fun The input functor used to transform the range when read
 //! @param __output_fun The output functor used to transform the range when written
-//! @relates transform_output_iterator
+//! @relates transform_input_output_iterator
 template <class _InputFn, class _OutputFn, class _Iter>
 [[nodiscard]] _CCCL_API constexpr auto
 make_transform_input_output_iterator(_Iter __iter, _InputFn __input_fun, _OutputFn __output_fun)
@@ -522,6 +524,52 @@ make_transform_input_output_iterator(_Iter __iter, _InputFn __input_fun, _Output
 //! @}
 
 _CCCL_END_NAMESPACE_CUDA
+
+#ifndef _CCCL_DOXYGEN_INVOKED
+#  if _CCCL_HAS_HOST_STD_LIB()
+_CCCL_BEGIN_NAMESPACE_STD
+
+//! transform_input_output_iterator is a C++20 iterator, so it does not play well with legacy STL features like
+//! std::distance. To work around that specialize those functions for transform_input_output_iterator
+template <class _Diff, class _InputFn, class _OutputFn, class _Iter>
+_CCCL_HOST_API constexpr void
+advance(::cuda::transform_input_output_iterator<_InputFn, _OutputFn, _Iter>& __iter, _Diff __diff)
+{
+  ::cuda::std::advance(__iter, ::cuda::std::move(__diff));
+}
+
+template <class _InputFn, class _OutputFn, class _Iter>
+[[nodiscard]] _CCCL_HOST_API constexpr ::cuda::std::iter_difference_t<_Iter>
+distance(::cuda::transform_input_output_iterator<_InputFn, _OutputFn, _Iter> __first,
+         ::cuda::transform_input_output_iterator<_InputFn, _OutputFn, _Iter> __last)
+{
+  return ::cuda::std::distance(::cuda::std::move(__first), ::cuda::std::move(__last));
+}
+
+template <class _InputFn, class _OutputFn, class _Iter>
+[[nodiscard]] _CCCL_HOST_API constexpr ::cuda::transform_input_output_iterator<_InputFn, _OutputFn, _Iter>
+next(::cuda::transform_input_output_iterator<_InputFn, _OutputFn, _Iter> __iter,
+     ::cuda::std::iter_difference_t<_Iter> __n = 1)
+{
+  _CCCL_ASSERT(__n >= 0 || ::cuda::std::__has_bidirectional_traversal<_Iter>,
+               "Attempt to std::next(it, n) with negative n on a non-bidirectional iterator");
+  ::cuda::std::advance(__iter, __n);
+  return __iter;
+}
+
+template <class _InputFn, class _OutputFn, class _Iter>
+[[nodiscard]] _CCCL_HOST_API constexpr ::cuda::transform_input_output_iterator<_InputFn, _OutputFn, _Iter>
+prev(::cuda::transform_input_output_iterator<_InputFn, _OutputFn, _Iter> __iter,
+     ::cuda::std::iter_difference_t<_Iter> __n = 1)
+{
+  _CCCL_ASSERT(__n <= 0 || ::cuda::std::__has_bidirectional_traversal<_Iter>,
+               "Attempt to std::prev(it, +n) on a non-bidi iterator");
+  ::cuda::std::advance(__iter, -__n);
+  return __iter;
+}
+_CCCL_END_NAMESPACE_STD
+#  endif // _CCCL_HAS_HOST_STD_LIB()
+#endif // _CCCL_DOXYGEN_INVOKED
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__iterator/transform_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/transform_iterator.h
@@ -29,7 +29,9 @@
 #include <cuda/std/__concepts/equality_comparable.h>
 #include <cuda/std/__concepts/invocable.h>
 #include <cuda/std/__functional/invoke.h>
+#include <cuda/std/__iterator/advance.h>
 #include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/distance.h>
 #include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/__ranges/compressed_movable_box.h>
 #include <cuda/std/__ranges/concepts.h>
@@ -531,6 +533,48 @@ template <class _Fn, class _Iter>
 //! @}
 
 _CCCL_END_NAMESPACE_CUDA
+
+#ifndef _CCCL_DOXYGEN_INVOKED
+#  if _CCCL_HAS_HOST_STD_LIB()
+_CCCL_BEGIN_NAMESPACE_STD
+
+//! transform_iterator is a C++20 iterator, so it does not play well with legacy STL features like std::distance
+//! To work around that specialize those functions for transform_iterator
+template <class _Diff, class _Fn, class _Iter>
+_CCCL_HOST_API constexpr void advance(::cuda::transform_iterator<_Fn, _Iter>& __iter, _Diff __diff)
+{
+  ::cuda::std::advance(__iter, ::cuda::std::move(__diff));
+}
+
+template <class _Fn, class _Iter>
+[[nodiscard]] _CCCL_HOST_API constexpr ::cuda::std::iter_difference_t<_Iter>
+distance(::cuda::transform_iterator<_Fn, _Iter> __first, ::cuda::transform_iterator<_Fn, _Iter> __last)
+{
+  return ::cuda::std::distance(::cuda::std::move(__first), ::cuda::std::move(__last));
+}
+
+template <class _Fn, class _Iter>
+[[nodiscard]] _CCCL_HOST_API constexpr ::cuda::transform_iterator<_Fn, _Iter>
+next(::cuda::transform_iterator<_Fn, _Iter> __iter, ::cuda::std::iter_difference_t<_Iter> __n = 1)
+{
+  _CCCL_ASSERT(__n >= 0 || ::cuda::std::__has_bidirectional_traversal<_Iter>,
+               "Attempt to std::next(it, n) with negative n on a non-bidirectional iterator");
+  ::cuda::std::advance(__iter, __n);
+  return __iter;
+}
+
+template <class _Fn, class _Iter>
+[[nodiscard]] _CCCL_HOST_API constexpr ::cuda::transform_iterator<_Fn, _Iter>
+prev(::cuda::transform_iterator<_Fn, _Iter> __iter, ::cuda::std::iter_difference_t<_Iter> __n = 1)
+{
+  _CCCL_ASSERT(__n <= 0 || ::cuda::std::__has_bidirectional_traversal<_Iter>,
+               "Attempt to std::prev(it, +n) on a non-bidi iterator");
+  ::cuda::std::advance(__iter, -__n);
+  return __iter;
+}
+_CCCL_END_NAMESPACE_STD
+#  endif // _CCCL_HAS_HOST_STD_LIB()
+#endif // _CCCL_DOXYGEN_INVOKED
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__iterator/zip_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/zip_iterator.h
@@ -30,7 +30,9 @@
 #include <cuda/std/__concepts/equality_comparable.h>
 #include <cuda/std/__functional/invoke.h>
 #include <cuda/std/__functional/operations.h>
+#include <cuda/std/__iterator/advance.h>
 #include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/distance.h>
 #include <cuda/std/__iterator/incrementable_traits.h>
 #include <cuda/std/__iterator/iter_move.h>
 #include <cuda/std/__iterator/iter_swap.h>
@@ -550,6 +552,50 @@ template <class... _Iterators>
 inline constexpr bool __is_fancy_pointer<::cuda::zip_iterator<_Iterators...>> = false;
 _CCCL_END_NAMESPACE_CUDA_STD
 #endif // _CCCL_COMPILER(MSVC) && _CCCL_STD_VER <= 2017
+
+#ifndef _CCCL_DOXYGEN_INVOKED
+#  if _CCCL_HAS_HOST_STD_LIB()
+_CCCL_BEGIN_NAMESPACE_STD
+
+//! zip_iterator is a C++20 iterator, so it does not play well with legacy STL features like std::distance
+//! To work around that specialize those functions for zip_iterator
+template <class _Diff, class... _Iterators>
+_CCCL_HOST_API constexpr void advance(::cuda::zip_iterator<_Iterators...>& __iter, _Diff __diff)
+{
+  ::cuda::std::advance(__iter, ::cuda::std::move(__diff));
+}
+
+template <class... _Iterators>
+[[nodiscard]] _CCCL_HOST_API constexpr ::cuda::std::common_type_t<::cuda::std::iter_difference_t<_Iterators>...>
+distance(::cuda::zip_iterator<_Iterators...> __first, ::cuda::zip_iterator<_Iterators...> __last)
+{
+  return ::cuda::std::distance(::cuda::std::move(__first), ::cuda::std::move(__last));
+}
+
+template <class... _Iterators>
+[[nodiscard]] _CCCL_HOST_API constexpr ::cuda::zip_iterator<_Iterators...>
+next(::cuda::zip_iterator<_Iterators...> __iter,
+     ::cuda::std::common_type_t<::cuda::std::iter_difference_t<_Iterators>...> __n = 1)
+{
+  _CCCL_ASSERT(__n >= 0 || ::cuda::__zip_iter_constraints<_Iterators...>::__all_bidirectional,
+               "Attempt to std::next(it, n) with negative n on a non-bidirectional iterator");
+  ::cuda::std::advance(__iter, __n);
+  return __iter;
+}
+
+template <class... _Iterators>
+[[nodiscard]] _CCCL_HOST_API constexpr ::cuda::zip_iterator<_Iterators...>
+prev(::cuda::zip_iterator<_Iterators...> __iter,
+     ::cuda::std::common_type_t<::cuda::std::iter_difference_t<_Iterators>...> __n = 1)
+{
+  _CCCL_ASSERT(__n <= 0 || ::cuda::__zip_iter_constraints<_Iterators...>::__all_bidirectional,
+               "Attempt to std::prev(it, +n) on a non-bidi iterator");
+  ::cuda::std::advance(__iter, -__n);
+  return __iter;
+}
+_CCCL_END_NAMESPACE_STD
+#  endif // _CCCL_HAS_HOST_STD_LIB()
+#endif // _CCCL_DOXYGEN_INVOKED
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/counting_iterator/host_stl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/counting_iterator/host_stl.pass.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <iterator>
+
+#include "test_macros.h"
+
+constexpr bool test()
+{
+  cuda::counting_iterator<int> iter1{42};
+  cuda::counting_iterator<int> iter2{1337};
+  const int dist = 1337 - 42;
+
+  {
+    auto diff = ::std::distance(iter1, iter2);
+    static_assert(cuda::std::is_same_v<decltype(diff), cuda::std::iter_difference_t<cuda::counting_iterator<int>>>);
+    static_assert(noexcept(::std::distance(iter1, iter2)));
+    assert(diff == dist);
+  }
+
+  {
+    auto iter = ::std::next(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::counting_iterator<int>>);
+    static_assert(noexcept(::std::next(iter1, dist)));
+    assert(iter == iter2);
+  }
+
+  {
+    auto iter = ::std::prev(iter2, dist);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::counting_iterator<int>>);
+    static_assert(noexcept(::std::prev(iter2, dist)));
+    assert(iter == iter1);
+  }
+
+  {
+    ::std::advance(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(::std::advance(iter1, dist)), void>);
+    static_assert(noexcept(::std::advance(iter1, dist)));
+    assert(iter1 == iter2);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 test();
+                 static_assert(test());
+               }))
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/host_stl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_input_output_iterator/host_stl.pass.cpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+constexpr bool test()
+{
+  int data[100] = {};
+  cuda::transform_input_output_iterator<PlusOne, PlusOne, advance_only_iterator> iter1{
+    advance_only_iterator{data}, PlusOne{}, PlusOne{}};
+  cuda::transform_input_output_iterator<PlusOne, PlusOne, advance_only_iterator> iter2{
+    advance_only_iterator{data + 42}, PlusOne{}, PlusOne{}};
+  const int dist = 42;
+
+  {
+    auto diff = ::std::distance(iter1, iter2);
+    static_assert(
+      cuda::std::is_same_v<
+        decltype(diff),
+        cuda::std::iter_difference_t<cuda::transform_input_output_iterator<PlusOne, PlusOne, advance_only_iterator>>>);
+    assert(diff == dist);
+  }
+
+  {
+    auto iter = ::std::next(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(iter),
+                                       cuda::transform_input_output_iterator<PlusOne, PlusOne, advance_only_iterator>>);
+    assert(iter == iter2);
+  }
+
+  {
+    auto iter = ::std::prev(iter2, dist);
+    static_assert(cuda::std::is_same_v<decltype(iter),
+                                       cuda::transform_input_output_iterator<PlusOne, PlusOne, advance_only_iterator>>);
+    assert(iter == iter1);
+  }
+
+  {
+    ::std::advance(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(::std::advance(iter1, dist)), void>);
+    assert(iter1 == iter2);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 test();
+                 static_assert(test());
+               }))
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/host_stl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_iterator/host_stl.pass.cpp
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+constexpr bool test()
+{
+  int data[100] = {};
+  cuda::transform_iterator<PlusOne, advance_only_iterator> iter1{advance_only_iterator{data}, PlusOne{}};
+  cuda::transform_iterator<PlusOne, advance_only_iterator> iter2{advance_only_iterator{data + 42}, PlusOne{}};
+  const int dist = 42;
+
+  {
+    auto diff = ::std::distance(iter1, iter2);
+    static_assert(
+      cuda::std::is_same_v<decltype(diff),
+                           cuda::std::iter_difference_t<cuda::transform_iterator<PlusOne, advance_only_iterator>>>);
+    assert(diff == dist);
+  }
+
+  {
+    auto iter = ::std::next(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_iterator<PlusOne, advance_only_iterator>>);
+    assert(iter == iter2);
+  }
+
+  {
+    auto iter = ::std::prev(iter2, dist);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::transform_iterator<PlusOne, advance_only_iterator>>);
+    assert(iter == iter1);
+  }
+
+  {
+    ::std::advance(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(::std::advance(iter1, dist)), void>);
+    assert(iter1 == iter2);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 test();
+                 static_assert(test());
+               }))
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_stl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/transform_output_iterator/host_stl.pass.cpp
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+#include "types.h"
+
+constexpr bool test()
+{
+  int data[100] = {};
+  cuda::transform_output_iterator<PlusOne, advance_only_iterator> iter1{advance_only_iterator{data}, PlusOne{}};
+  cuda::transform_output_iterator<PlusOne, advance_only_iterator> iter2{advance_only_iterator{data + 42}, PlusOne{}};
+  const int dist = 42;
+
+  {
+    auto diff = ::std::distance(iter1, iter2);
+    static_assert(cuda::std::is_same_v<
+                  decltype(diff),
+                  cuda::std::iter_difference_t<cuda::transform_output_iterator<PlusOne, advance_only_iterator>>>);
+    assert(diff == dist);
+  }
+
+  {
+    auto iter = ::std::next(iter1, dist);
+    static_assert(
+      cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<PlusOne, advance_only_iterator>>);
+    assert(iter == iter2);
+  }
+
+  {
+    auto iter = ::std::prev(iter2, dist);
+    static_assert(
+      cuda::std::is_same_v<decltype(iter), cuda::transform_output_iterator<PlusOne, advance_only_iterator>>);
+    assert(iter == iter1);
+  }
+
+  {
+    ::std::advance(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(::std::advance(iter1, dist)), void>);
+    assert(iter1 == iter2);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 test();
+                 static_assert(test());
+               }))
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/host_stl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_iterator/host_stl.pass.cpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+
+constexpr bool test()
+{
+  int data[100] = {};
+  cuda::zip_iterator<advance_only_iterator> iter1{advance_only_iterator{data}};
+  cuda::zip_iterator<advance_only_iterator> iter2{advance_only_iterator{data + 42}};
+  const int dist = 42;
+
+  {
+    auto diff = ::std::distance(iter1, iter2);
+    static_assert(
+      cuda::std::is_same_v<decltype(diff), cuda::std::iter_difference_t<cuda::zip_iterator<advance_only_iterator>>>);
+    assert(diff == dist);
+  }
+
+  {
+    auto iter = ::std::next(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_iterator<advance_only_iterator>>);
+    assert(iter == iter2);
+  }
+
+  {
+    auto iter = ::std::prev(iter2, dist);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_iterator<advance_only_iterator>>);
+    assert(iter == iter1);
+  }
+
+  {
+    ::std::advance(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(::std::advance(iter1, dist)), void>);
+    assert(iter1 == iter2);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 test();
+                 static_assert(test());
+               }))
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/host_stl.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/zip_transform_iterator/host_stl.pass.cpp
@@ -1,0 +1,73 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// UNSUPPORTED: nvrtc
+
+#include <cuda/iterator>
+#include <cuda/std/cassert>
+
+#include <iterator>
+
+#include "test_iterators.h"
+#include "test_macros.h"
+
+struct plus_1337
+{
+  constexpr int operator()(const int& value) const noexcept
+  {
+    return value + 42;
+  }
+};
+
+constexpr bool test()
+{
+  int data[100] = {};
+  cuda::zip_transform_iterator<plus_1337, advance_only_iterator> iter1{plus_1337{}, advance_only_iterator{data}};
+  cuda::zip_transform_iterator<plus_1337, advance_only_iterator> iter2{plus_1337{}, advance_only_iterator{data + 42}};
+  const int dist = 42;
+
+  {
+    auto diff = ::std::distance(iter1, iter2);
+    static_assert(
+      cuda::std::is_same_v<decltype(diff),
+                           cuda::std::iter_difference_t<cuda::zip_transform_iterator<plus_1337, advance_only_iterator>>>);
+    assert(diff == dist);
+  }
+
+  {
+    auto iter = ::std::next(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_transform_iterator<plus_1337, advance_only_iterator>>);
+    assert(iter == iter2);
+  }
+
+  {
+    auto iter = ::std::prev(iter2, dist);
+    static_assert(cuda::std::is_same_v<decltype(iter), cuda::zip_transform_iterator<plus_1337, advance_only_iterator>>);
+    assert(iter == iter1);
+  }
+
+  {
+    ::std::advance(iter1, dist);
+    static_assert(cuda::std::is_same_v<decltype(::std::advance(iter1, dist)), void>);
+    assert(iter1 == iter2);
+  }
+
+  return true;
+}
+
+int main(int, char**)
+{
+  NV_IF_TARGET(NV_IS_HOST, ({
+                 test();
+                 static_assert(test());
+               }))
+
+  return 0;
+}

--- a/libcudacxx/test/support/test_iterators.h
+++ b/libcudacxx/test/support/test_iterators.h
@@ -2068,4 +2068,104 @@ using cpp20_input_iterator_list =
 #endif
 } // namespace types
 
+//! @brief Test iterator that validates, that the iterator is only ever advanced and not incremented repeatedly
+class advance_only_iterator
+{
+  int* iter_ = nullptr;
+
+public:
+  using iterator_category = cuda::std::random_access_iterator_tag;
+  using value_type        = int;
+  using difference_type   = cuda::std::ptrdiff_t;
+  using pointer           = int*;
+  using reference         = int&;
+
+  __host__ __device__ constexpr advance_only_iterator() {}
+  __host__ __device__ constexpr advance_only_iterator(int* iter)
+      : iter_(iter)
+  {}
+
+  __host__ __device__ constexpr reference operator*() const
+  {
+    return *iter_;
+  }
+  __host__ __device__ constexpr reference operator[](difference_type n) const
+  {
+    return iter_[n];
+  }
+
+  __host__ __device__ constexpr advance_only_iterator& operator++()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr advance_only_iterator& operator--()
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr advance_only_iterator operator++(int)
+  {
+    return *this;
+  }
+  __host__ __device__ constexpr advance_only_iterator operator--(int)
+  {
+    return *this;
+  }
+
+  __host__ __device__ constexpr advance_only_iterator& operator+=(difference_type n)
+  {
+    iter_ += n;
+    return *this;
+  }
+  __host__ __device__ constexpr advance_only_iterator& operator-=(difference_type n)
+  {
+    iter_ -= n;
+    return *this;
+  }
+  __host__ __device__ friend constexpr advance_only_iterator operator+(advance_only_iterator x, difference_type n)
+  {
+    x += n;
+    return x;
+  }
+  __host__ __device__ friend constexpr advance_only_iterator operator+(difference_type n, advance_only_iterator x)
+  {
+    x += n;
+    return x;
+  }
+  __host__ __device__ friend constexpr advance_only_iterator operator-(advance_only_iterator x, difference_type n)
+  {
+    x -= n;
+    return x;
+  }
+  __host__ __device__ friend constexpr difference_type operator-(advance_only_iterator x, advance_only_iterator y)
+  {
+    return x.iter_ - y.iter_;
+  }
+
+  __host__ __device__ friend constexpr bool operator==(const advance_only_iterator& x, const advance_only_iterator& y)
+  {
+    return x.iter_ == y.iter_;
+  }
+  __host__ __device__ friend constexpr bool operator!=(const advance_only_iterator& x, const advance_only_iterator& y)
+  {
+    return x.iter_ != y.iter_;
+  }
+  __host__ __device__ friend constexpr bool operator<(const advance_only_iterator& x, const advance_only_iterator& y)
+  {
+    return x.iter_ < y.iter_;
+  }
+  __host__ __device__ friend constexpr bool operator<=(const advance_only_iterator& x, const advance_only_iterator& y)
+  {
+    return x.iter_ <= y.iter_;
+  }
+  __host__ __device__ friend constexpr bool operator>(const advance_only_iterator& x, const advance_only_iterator& y)
+  {
+    return x.iter_ > y.iter_;
+  }
+  __host__ __device__ friend constexpr bool operator>=(const advance_only_iterator& x, const advance_only_iterator& y)
+  {
+    return x.iter_ >= y.iter_;
+  }
+};
+static_assert(cuda::std::random_access_iterator<advance_only_iterator>, "");
+
 #endif // SUPPORT_TEST_ITERATORS_H


### PR DESCRIPTION
Our cuda iterators are modern C++20 style iterators

That means they are very versatile, but also that they conform to the C++20 iterator concepts and not the C++17 iterator categories.

This creates the issue that if a user calls e.g. `::std::distance(::cuda::counting_iterator, ::cuda::counting_iterator)` that will take the slow increment until equal path, because `::cuda::counting_iterator` is not a C++17 random_access_iterator.

We already solve this issue in our own implementations through `__has_meow_traversal_v` which looks both at the `iterator_category` and also if needed at the `iterator_concept`

A relatively simple solution is to provide overloads for the common `std` iterator functions `std::advance, ``std::distance`, `std::next` and `std::prev`

That should help most use cases and with all the ranges machinery we are save anyway 