### PR TITLE
Fix `index_type` contraints for `cuda::std::extents`

### DIFF
--- a/libcudacxx/include/cuda/std/__mdspan/extents.h
+++ b/libcudacxx/include/cuda/std/__mdspan/extents.h
@@ -34,6 +34,7 @@
 #include <cuda/std/__type_traits/fold.h>
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_integer.h>
 #include <cuda/std/__type_traits/is_nothrow_constructible.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/make_unsigned.h>
@@ -417,8 +418,7 @@ public:
   using size_type  = make_unsigned_t<index_type>;
   using rank_type  = size_t;
 
-  static_assert(is_integral_v<index_type> && !is_same_v<index_type, bool>,
-                "extents::index_type must be a signed or unsigned integer type");
+  static_assert(__cccl_is_integer_v<index_type>, "extents::index_type must be a signed or unsigned integer type");
   static_assert(
     __all<(__mdspan_detail::__is_representable_as<index_type>(_Extents) || (_Extents == dynamic_extent))...>::value,
     "extents ctor: arguments must be representable as index_type and nonnegative");

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/assign.pass.cpp
@@ -69,10 +69,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.copy.pass.cpp
@@ -48,10 +48,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.default.pass.cpp
@@ -78,10 +78,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<hc, mc, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
@@ -95,7 +95,7 @@ __host__ __device__ constexpr void mixin_layout(const H& handle, const A& acc)
   // Use weird layout, make sure it has the properties we want to test
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   static_assert(!cuda::std::is_default_constructible<
-                  typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<char, D>>>::value,
+                  typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<signed char, D>>>::value,
                 "");
   mixin_extents<hc, false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_array.pass.cpp
@@ -141,10 +141,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_extents.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_extents.pass.cpp
@@ -70,10 +70,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_integers.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_integers.pass.cpp
@@ -104,17 +104,19 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   // construct from just dynamic extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc, 7);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 2, 3, 2);
 
   // construct from all extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 4, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 7, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 7, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 7, 2, 4, 3, 2);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_map.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_map.pass.cpp
@@ -66,10 +66,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_map_acc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_map_acc.pass.cpp
@@ -54,10 +54,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_span.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.dh_span.pass.cpp
@@ -141,10 +141,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/ctor.move.pass.cpp
@@ -48,10 +48,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/deduction.pass.cpp
@@ -83,10 +83,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/index_operator.pass.cpp
@@ -159,7 +159,7 @@ __device__ constexpr void test_layout()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, D>(7)));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7>()));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7, 8>()));
-  test_iteration(construct_mapping(Layout(), cuda::std::extents<char, D, D, D, D>(1, 1, 1, 1)));
+  test_iteration(construct_mapping(Layout(), cuda::std::extents<signed char, D, D, D, D>(1, 1, 1, 1)));
 
 #if _CCCL_HAS_MULTIARG_OPERATOR_BRACKETS()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<int>()));

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/move.pass.cpp
@@ -51,10 +51,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/properties.pass.cpp
@@ -198,10 +198,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/device_mdspan/types.pass.cpp
@@ -104,9 +104,9 @@ __host__ __device__ constexpr void mixin_extents()
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<T, cuda::std::extents<int>, L, A>();
-  test_mdspan_types<T, cuda::std::extents<char, D>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 7>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 9>, L, A>();
+  test_mdspan_types<T, cuda::std::extents<signed char, D>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 7>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 9>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, 7>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, D, D, D>, L, A>();
   test_mdspan_types<T, cuda::std::extents<size_t, D, 7, D>, L, A>();

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/assign.pass.cpp
@@ -69,10 +69,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.copy.pass.cpp
@@ -48,10 +48,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.default.pass.cpp
@@ -78,10 +78,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<hc, mc, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
@@ -95,7 +95,7 @@ __host__ __device__ constexpr void mixin_layout(const H& handle, const A& acc)
   // Use weird layout, make sure it has the properties we want to test
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   static_assert(!cuda::std::is_default_constructible<
-                  typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<char, D>>>::value,
+                  typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<signed char, D>>>::value,
                 "");
   mixin_extents<hc, false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_array.pass.cpp
@@ -141,10 +141,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_extents.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_extents.pass.cpp
@@ -70,10 +70,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_integers.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_integers.pass.cpp
@@ -104,17 +104,19 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   // construct from just dynamic extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc, 7);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 2, 3, 2);
 
   // construct from all extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 4, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 7, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 7, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 7, 2, 4, 3, 2);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_map.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_map.pass.cpp
@@ -66,10 +66,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_map_acc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_map_acc.pass.cpp
@@ -54,10 +54,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_span.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.dh_span.pass.cpp
@@ -141,10 +141,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/ctor.move.pass.cpp
@@ -48,10 +48,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/deduction.pass.cpp
@@ -83,10 +83,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/index_operator.pass.cpp
@@ -158,7 +158,7 @@ constexpr void test_layout()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, D>(7)));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7>()));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7, 8>()));
-  test_iteration(construct_mapping(Layout(), cuda::std::extents<char, D, D, D, D>(1, 1, 1, 1)));
+  test_iteration(construct_mapping(Layout(), cuda::std::extents<signed char, D, D, D, D>(1, 1, 1, 1)));
 
 #if _CCCL_HAS_MULTIARG_OPERATOR_BRACKETS()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<int>()));

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/move.pass.cpp
@@ -51,10 +51,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/properties.pass.cpp
@@ -198,10 +198,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/host_mdspan/types.pass.cpp
@@ -103,9 +103,9 @@ __host__ __device__ constexpr void mixin_extents()
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<T, cuda::std::extents<int>, L, A>();
-  test_mdspan_types<T, cuda::std::extents<char, D>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 7>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 9>, L, A>();
+  test_mdspan_types<T, cuda::std::extents<signed char, D>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 7>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 9>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, 7>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, D, D, D>, L, A>();
   test_mdspan_types<T, cuda::std::extents<size_t, D, 7, D>, L, A>();

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/assign.pass.cpp
@@ -69,10 +69,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.copy.pass.cpp
@@ -48,10 +48,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.default.pass.cpp
@@ -78,10 +78,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<hc, mc, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
@@ -95,7 +95,7 @@ __host__ __device__ constexpr void mixin_layout(const H& handle, const A& acc)
   // Use weird layout, make sure it has the properties we want to test
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   static_assert(!cuda::std::is_default_constructible<
-                  typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<char, D>>>::value,
+                  typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<signed char, D>>>::value,
                 "");
   mixin_extents<hc, false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_array.pass.cpp
@@ -141,10 +141,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_extents.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_extents.pass.cpp
@@ -70,10 +70,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_integers.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_integers.pass.cpp
@@ -104,17 +104,19 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   // construct from just dynamic extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc, 7);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 2, 3, 2);
 
   // construct from all extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 4, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 7, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 7, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 7, 2, 4, 3, 2);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_map.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_map.pass.cpp
@@ -66,10 +66,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_map_acc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_map_acc.pass.cpp
@@ -54,10 +54,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_span.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.dh_span.pass.cpp
@@ -141,10 +141,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/ctor.move.pass.cpp
@@ -48,10 +48,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/deduction.pass.cpp
@@ -83,10 +83,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/index_operator.pass.cpp
@@ -160,7 +160,7 @@ __host__ __device__ constexpr void test_layout()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, D>(7)));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7>()));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7, 8>()));
-  test_iteration(construct_mapping(Layout(), cuda::std::extents<char, D, D, D, D>(1, 1, 1, 1)));
+  test_iteration(construct_mapping(Layout(), cuda::std::extents<signed char, D, D, D, D>(1, 1, 1, 1)));
 
 #if _CCCL_HAS_MULTIARG_OPERATOR_BRACKETS()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<int>()));

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/move.pass.cpp
@@ -51,10 +51,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/properties.pass.cpp
@@ -198,10 +198,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/managed_mdspan/types.pass.cpp
@@ -104,9 +104,9 @@ __host__ __device__ constexpr void mixin_extents()
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<T, cuda::std::extents<int>, L, A>();
-  test_mdspan_types<T, cuda::std::extents<char, D>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 7>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 9>, L, A>();
+  test_mdspan_types<T, cuda::std::extents<signed char, D>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 7>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 9>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, 7>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, D, D, D>, L, A>();
   test_mdspan_types<T, cuda::std::extents<size_t, D, 7, D>, L, A>();

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/assign.pass.cpp
@@ -49,10 +49,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.copy.pass.cpp
@@ -47,10 +47,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.default.pass.cpp
@@ -77,10 +77,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<hc, mc, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
@@ -94,7 +94,7 @@ __host__ __device__ constexpr void mixin_layout(const H& handle, const A& acc)
   // Use weird layout, make sure it has the properties we want to test
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   static_assert(!cuda::std::is_default_constructible<
-                  typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<char, D>>>::value,
+                  typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<signed char, D>>>::value,
                 "");
   mixin_extents<hc, false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_array.pass.cpp
@@ -140,10 +140,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_extents.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_extents.pass.cpp
@@ -69,10 +69,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_integers.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_integers.pass.cpp
@@ -103,17 +103,19 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   // construct from just dynamic extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc, 7);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 2, 3, 2);
 
   // construct from all extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 4, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 7, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 7, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 7, 2, 4, 3, 2);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_map.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_map.pass.cpp
@@ -65,10 +65,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_map_acc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_map_acc.pass.cpp
@@ -53,10 +53,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_span.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.dh_span.pass.cpp
@@ -140,10 +140,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/ctor.move.pass.cpp
@@ -47,10 +47,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/deduction.pass.cpp
@@ -83,10 +83,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/index_operator.pass.cpp
@@ -158,7 +158,7 @@ __host__ __device__ constexpr void test_layout()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, D>(7)));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7>()));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7, 8>()));
-  test_iteration(construct_mapping(Layout(), cuda::std::extents<char, D, D, D, D>(1, 1, 1, 1)));
+  test_iteration(construct_mapping(Layout(), cuda::std::extents<signed char, D, D, D, D>(1, 1, 1, 1)));
 
 #if _CCCL_HAS_MULTIARG_OPERATOR_BRACKETS()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<int>()));

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/move.pass.cpp
@@ -50,10 +50,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/properties.pass.cpp
@@ -202,10 +202,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/restrict_mdspan/types.pass.cpp
@@ -107,9 +107,9 @@ __host__ __device__ constexpr void mixin_extents()
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<T, cuda::std::extents<int>, L, A>();
-  test_mdspan_types<T, cuda::std::extents<char, D>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 7>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 9>, L, A>();
+  test_mdspan_types<T, cuda::std::extents<signed char, D>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 7>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 9>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, 7>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, D, D, D>, L, A>();
   test_mdspan_types<T, cuda::std::extents<size_t, D, 7, D>, L, A>();

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/assign.pass.cpp
@@ -49,10 +49,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.copy.pass.cpp
@@ -48,10 +48,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.default.pass.cpp
@@ -80,10 +80,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<hc, mc, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
@@ -97,7 +97,7 @@ __device__ constexpr void mixin_layout(const H& handle, const A& acc)
   // Use weird layout, make sure it has the properties we want to test
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   static_assert(!cuda::std::is_default_constructible_v<
-                typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<char, D>>>);
+                typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<signed char, D>>>);
   mixin_extents<hc, false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_array.pass.cpp
@@ -151,10 +151,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_extents.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_extents.pass.cpp
@@ -71,10 +71,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_integers.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_integers.pass.cpp
@@ -113,17 +113,19 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   // construct from just dynamic extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc, 7);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 2, 3, 2);
 
   // construct from all extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 4, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 7, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 7, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 7, 2, 4, 3, 2);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_map.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_map.pass.cpp
@@ -68,10 +68,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_map_acc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_map_acc.pass.cpp
@@ -55,10 +55,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_span.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.dh_span.pass.cpp
@@ -151,10 +151,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/ctor.move.pass.cpp
@@ -47,10 +47,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/deduction.pass.cpp
@@ -84,10 +84,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/index_operator.pass.cpp
@@ -160,7 +160,7 @@ __device__ void test_layout()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, D>(7)));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7>()));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7, 8>()));
-  test_iteration(construct_mapping(Layout(), cuda::std::extents<char, D, D, D, D>(1, 1, 1, 1)));
+  test_iteration(construct_mapping(Layout(), cuda::std::extents<signed char, D, D, D, D>(1, 1, 1, 1)));
 
 #if _CCCL_HAS_MULTIARG_OPERATOR_BRACKETS()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<int>()));

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/move.pass.cpp
@@ -50,10 +50,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/properties.pass.cpp
@@ -204,10 +204,10 @@ __device__ constexpr void mixin_extents(const H& handle, const L& layout, const 
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/shared_mem_mdspan/types.pass.cpp
@@ -108,9 +108,9 @@ __host__ __device__ constexpr void mixin_extents()
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<T, cuda::std::extents<int>, L, A>();
-  test_mdspan_types<T, cuda::std::extents<char, D>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 7>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 9>, L, A>();
+  test_mdspan_types<T, cuda::std::extents<signed char, D>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 7>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 9>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, 7>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, D, D, D>, L, A>();
   test_mdspan_types<T, cuda::std::extents<size_t, D, 7, D>, L, A>();

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/ConvertibleToIntegral.h
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/ConvertibleToIntegral.h
@@ -38,9 +38,9 @@ struct IntType
   {
     return static_cast<unsigned char>(val);
   }
-  __host__ __device__ constexpr operator char() const noexcept
+  __host__ __device__ constexpr operator signed char() const noexcept
   {
-    return static_cast<char>(val);
+    return static_cast<signed char>(val);
   }
 };
 
@@ -70,9 +70,9 @@ struct IntTypeNC
   {
     return static_cast<unsigned>(val);
   }
-  __host__ __device__ constexpr operator char() noexcept
+  __host__ __device__ constexpr operator signed char() noexcept
   {
-    return static_cast<char>(val);
+    return static_cast<signed char>(val);
   }
 };
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/extents/CtorTestCombinations.h
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/extents/CtorTestCombinations.h
@@ -118,11 +118,11 @@ __host__ __device__ constexpr bool test_index_type_combo()
   test<int, int, Test>();
   test<int, size_t, Test>();
   test<unsigned, int, Test>();
-  test<char, size_t, Test>();
+  test<signed char, size_t, Test>();
   test<long long, unsigned, Test>();
   test<size_t, int, Test>();
   test<size_t, size_t, Test>();
   test<int, IntType, Test>();
-  test<char, IntType, Test>();
+  test<signed char, IntType, Test>();
   return true;
 }

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/extents/obs_static.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/extents/obs_static.pass.cpp
@@ -104,7 +104,7 @@ int main(int, char**)
 {
   test<int>();
   test<unsigned>();
-  test<char>();
+  test<signed char>();
   test<long long>();
   test<size_t>();
   return 0;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/extents/types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/extents/types.pass.cpp
@@ -91,7 +91,7 @@ int main(int, char**)
 {
   test<int>();
   test<unsigned>();
-  test<char>();
+  test<signed char>();
   test<long long>();
   test<size_t>();
   return 0;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/extents.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/extents.verify.cpp
@@ -37,7 +37,7 @@ __host__ __device__ void representable()
 {
   // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}layout_left::mapping product of static
   // extents must be representable as index_type.}}
-  cuda::std::layout_left::mapping<cuda::std::extents<char, 20, 20>> mapping;
+  cuda::std::layout_left::mapping<cuda::std::extents<signed char, 20, 20>> mapping;
   unused(mapping);
 }
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/index_operator.pass.cpp
@@ -85,7 +85,7 @@ __host__ __device__ constexpr bool test()
   test_iteration<cuda::std::extents<unsigned, D>>(7);
   test_iteration<cuda::std::extents<unsigned, 7>>();
   test_iteration<cuda::std::extents<unsigned, 7, 8>>();
-  test_iteration<cuda::std::extents<char, D, D, D, D>>(1, 1, 1, 1);
+  test_iteration<cuda::std::extents<signed char, D, D, D, D>>(1, 1, 1, 1);
 
   // Check operator constraint for number of arguments
   static_assert(check_operator_constraints(

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/properties.pass.cpp
@@ -54,7 +54,7 @@ __host__ __device__ constexpr bool test()
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_layout_mapping_left<cuda::std::extents<int>>();
-  test_layout_mapping_left<cuda::std::extents<char, 4, 5>>();
+  test_layout_mapping_left<cuda::std::extents<signed char, 4, 5>>();
   test_layout_mapping_left<cuda::std::extents<unsigned, D, 4>>();
   test_layout_mapping_left<cuda::std::extents<size_t, D, D, D, D>>();
   return true;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/static_requirements.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/static_requirements.pass.cpp
@@ -141,7 +141,7 @@ int main(int, char**)
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_layout_mapping_left<cuda::std::extents<int>>();
-  test_layout_mapping_left<cuda::std::extents<char, 4, 5>>();
+  test_layout_mapping_left<cuda::std::extents<signed char, 4, 5>>();
   test_layout_mapping_left<cuda::std::extents<unsigned, D, 4>>();
   test_layout_mapping_left<cuda::std::extents<size_t, D, D, D, D>>();
   return 0;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/extents.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/extents.verify.cpp
@@ -37,7 +37,7 @@ __host__ __device__ void representable()
 {
   // expected-error-re@*:* {{{{(static_assert|static assertion)}} failed {{.*}}layout_right::mapping product of static
   // extents must be representable as index_type.}}
-  cuda::std::layout_right::mapping<cuda::std::extents<char, 20, 20>> mapping;
+  cuda::std::layout_right::mapping<cuda::std::extents<signed char, 20, 20>> mapping;
   unused(mapping)
 }
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/index_operator.pass.cpp
@@ -86,7 +86,7 @@ __host__ __device__ constexpr bool test()
   test_iteration<cuda::std::extents<unsigned, D>>(7);
   test_iteration<cuda::std::extents<unsigned, 7>>();
   test_iteration<cuda::std::extents<unsigned, 7, 8>>();
-  test_iteration<cuda::std::extents<char, D, D, D, D>>(1, 1, 1, 1);
+  test_iteration<cuda::std::extents<signed char, D, D, D, D>>(1, 1, 1, 1);
 
   // Check operator constraint for number of arguments
   static_assert(check_operator_constraints(

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/properties.pass.cpp
@@ -54,7 +54,7 @@ __host__ __device__ constexpr bool test()
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_layout_mapping_right<cuda::std::extents<int>>();
-  test_layout_mapping_right<cuda::std::extents<char, 4, 5>>();
+  test_layout_mapping_right<cuda::std::extents<signed char, 4, 5>>();
   test_layout_mapping_right<cuda::std::extents<unsigned, D, 4>>();
   test_layout_mapping_right<cuda::std::extents<size_t, D, D, D, D>>();
   return true;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/static_requirements.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/static_requirements.pass.cpp
@@ -141,7 +141,7 @@ int main(int, char**)
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_layout_mapping_right<cuda::std::extents<int>>();
-  test_layout_mapping_right<cuda::std::extents<char, 4, 5>>();
+  test_layout_mapping_right<cuda::std::extents<signed char, 4, 5>>();
   test_layout_mapping_right<cuda::std::extents<unsigned, D, 4>>();
   test_layout_mapping_right<cuda::std::extents<size_t, D, D, D, D>>();
   return 0;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/extents.verify.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/extents.verify.cpp
@@ -35,7 +35,7 @@ __host__ __device__ void representable()
 {
   // expected-error-re@*:* {{static assertion failed {{.*}}layout_stride::mapping product of static extents must be
   // representable as index_type.}}
-  cuda::std::layout_stride::mapping<cuda::std::extents<char, 20, 20>> mapping;
+  cuda::std::layout_stride::mapping<cuda::std::extents<signed char, 20, 20>> mapping;
   unused(mapping);
 }
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/index_operator.pass.cpp
@@ -93,7 +93,7 @@ __host__ __device__ constexpr bool test()
   test_iteration<cuda::std::extents<unsigned, D>>(cuda::std::array<int, 1>{3}, 7);
   test_iteration<cuda::std::extents<unsigned, 7>>(cuda::std::array<int, 1>{4});
   test_iteration<cuda::std::extents<unsigned, 7, 8>>(cuda::std::array<int, 2>{25, 3});
-  test_iteration<cuda::std::extents<char, D, D, D, D>>(cuda::std::array<int, 4>{1, 1, 1, 1}, 1, 1, 1, 1);
+  test_iteration<cuda::std::extents<signed char, D, D, D, D>>(cuda::std::array<int, 4>{1, 1, 1, 1}, 1, 1, 1, 1);
 
   // Check operator constraint for number of arguments
   static_assert(check_operator_constraints(

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/properties.pass.cpp
@@ -123,8 +123,8 @@ __host__ __device__ constexpr bool test()
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_layout_mapping_stride(cuda::std::extents<int>(), cuda::std::array<int, 0>{}, true);
-  test_layout_mapping_stride(cuda::std::extents<char, 4, 5>(), cuda::std::array<char, 2>{1, 4}, true);
-  test_layout_mapping_stride(cuda::std::extents<char, 4, 5>(), cuda::std::array<char, 2>{1, 5}, false);
+  test_layout_mapping_stride(cuda::std::extents<signed char, 4, 5>(), cuda::std::array<signed char, 2>{1, 4}, true);
+  test_layout_mapping_stride(cuda::std::extents<signed char, 4, 5>(), cuda::std::array<signed char, 2>{1, 5}, false);
   test_layout_mapping_stride(cuda::std::extents<unsigned, D, 4>(7), cuda::std::array<unsigned, 2>{20, 2}, false);
   test_layout_mapping_stride(
     cuda::std::extents<size_t, D, D, D, D>(3, 3, 3, 3), cuda::std::array<size_t, 4>{3, 1, 9, 27}, true);

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/static_requirements.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/static_requirements.pass.cpp
@@ -134,7 +134,7 @@ int main(int, char**)
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_layout_mapping_stride<cuda::std::extents<int>>();
-  test_layout_mapping_stride<cuda::std::extents<char, 4, 5>>();
+  test_layout_mapping_stride<cuda::std::extents<signed char, 4, 5>>();
   test_layout_mapping_stride<cuda::std::extents<unsigned, D, 4>>();
   test_layout_mapping_stride<cuda::std::extents<size_t, D, D, D, D>>();
   return 0;

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/assign.pass.cpp
@@ -68,10 +68,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.copy.pass.cpp
@@ -47,10 +47,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.default.pass.cpp
@@ -77,10 +77,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<hc, mc, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<hc, mc, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
@@ -94,7 +94,7 @@ __host__ __device__ constexpr void mixin_layout(const H& handle, const A& acc)
   // Use weird layout, make sure it has the properties we want to test
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   static_assert(!cuda::std::is_default_constructible<
-                  typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<char, D>>>::value,
+                  typename layout_wrapping_integral<4>::template mapping<cuda::std::extents<signed char, D>>>::value,
                 "");
   mixin_extents<hc, false, ac>(handle, layout_wrapping_integral<4>(), acc);
 }

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_array.pass.cpp
@@ -140,10 +140,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_extents.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_extents.pass.cpp
@@ -69,10 +69,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_integers.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_integers.pass.cpp
@@ -103,17 +103,19 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   // construct from just dynamic extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc, 7);
+  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 2, 3, 2);
 
   // construct from all extents
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc, 7);
   test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc, 2, 4, 3);
-  test_mdspan_types<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc, 0, 7, 3);
+  test_mdspan_types<mec, ac>(
+    handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc, 0, 7, 3);
   test_mdspan_types<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc, 1, 7, 2, 4, 3, 2);
 }

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_map.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_map.pass.cpp
@@ -65,10 +65,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types<ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types<ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_map_acc.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_map_acc.pass.cpp
@@ -53,10 +53,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.dh_span.pass.cpp
@@ -140,10 +140,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_ctor<mec, ac>(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_ctor<mec, ac>(
     handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/ctor.move.pass.cpp
@@ -47,10 +47,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/deduction.pass.cpp
@@ -83,10 +83,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/index_operator.pass.cpp
@@ -156,7 +156,7 @@ __host__ __device__ constexpr void test_layout()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, D>(7)));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7>()));
   test_iteration(construct_mapping(Layout(), cuda::std::extents<unsigned, 7, 8>()));
-  test_iteration(construct_mapping(Layout(), cuda::std::extents<char, D, D, D, D>(1, 1, 1, 1)));
+  test_iteration(construct_mapping(Layout(), cuda::std::extents<signed char, D, D, D, D>(1, 1, 1, 1)));
 
 #if _CCCL_HAS_MULTIARG_OPERATOR_BRACKETS()
   test_iteration(construct_mapping(Layout(), cuda::std::extents<int>()));

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/move.pass.cpp
@@ -50,10 +50,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/properties.pass.cpp
@@ -197,10 +197,10 @@ __host__ __device__ constexpr void mixin_extents(const H& handle, const L& layou
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int>()), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D>(7)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D>(7)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<unsigned, 7>()), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<size_t, D, 4, D>(2, 3)), acc);
-  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<char, D, 7, D>(0, 3)), acc);
+  test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<signed char, D, 7, D>(0, 3)), acc);
   test_mdspan_types(handle, construct_mapping(layout, cuda::std::extents<int64_t, D, 7, D, 4, D, D>(1, 2, 3, 2)), acc);
 }
 

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/types.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/mdspan/types.pass.cpp
@@ -159,9 +159,9 @@ __host__ __device__ constexpr void mixin_extents()
 {
   [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   test_mdspan_types<T, cuda::std::extents<int>, L, A>();
-  test_mdspan_types<T, cuda::std::extents<char, D>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 7>, L, A>();
-  test_mdspan_types<T, cuda::std::dextents<char, 9>, L, A>();
+  test_mdspan_types<T, cuda::std::extents<signed char, D>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 7>, L, A>();
+  test_mdspan_types<T, cuda::std::dextents<signed char, 9>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, 7>, L, A>();
   test_mdspan_types<T, cuda::std::extents<unsigned, D, D, D>, L, A>();
   test_mdspan_types<T, cuda::std::extents<size_t, D, 7, D>, L, A>();


### PR DESCRIPTION
From cppreference:
_"IndexType	-	the type of each non-dynamic Extents. Shall be a signed or unsigned integer type. Otherwise, the program is ill-formed"_

We allow character types to be used with `cuda::std::extents`, too, which is not correct. This PR fixes that.