### PR TITLE
Avoid use of class static variable in device function

### DIFF
--- a/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
+++ b/cub/test/catch2_test_device_segmented_reduce_large_offsets.cu
@@ -194,13 +194,13 @@ struct dispatch_helper
   template <typename ActivePolicyT>
   CUB_RUNTIME_FUNCTION cudaError_t Invoke()
   {
-    thresholds = {ActivePolicyT::SmallReducePolicy::ITEMS_PER_TILE,
-                  ActivePolicyT::MediumReducePolicy::ITEMS_PER_TILE,
-                  ActivePolicyT::ReducePolicy::BLOCK_THREADS * ActivePolicyT::ReducePolicy::ITEMS_PER_THREAD};
+    thresholds = {+ActivePolicyT::SmallReducePolicy::ITEMS_PER_TILE,
+                  +ActivePolicyT::MediumReducePolicy::ITEMS_PER_TILE,
+                  +ActivePolicyT::ReducePolicy::BLOCK_THREADS * +ActivePolicyT::ReducePolicy::ITEMS_PER_THREAD};
     return cudaSuccess;
   }
 
-  static __host__ tuple_t get_thresholds()
+  static tuple_t get_thresholds()
   {
     // Get PTX version
     int ptx_version = 0;


### PR DESCRIPTION
We should not use a class static member in a device function, because it is not defined there.

Luckily those tests do not need to be defined as `__device__` anyway

Fixes nvbug5925530
