### PR TITLE
Fix `_CCCL_CATCH(...)` for `cicc`

### DIFF
--- a/libcudacxx/include/cuda/std/__exception/exception_macros.h
+++ b/libcudacxx/include/cuda/std/__exception/exception_macros.h
@@ -82,10 +82,11 @@ _CCCL_END_NAMESPACE_CUDA_STD
 #  define _CCCL_TRY     \
     if constexpr (true) \
     {
-#  define _CCCL_CATCH(...)                                                                       \
-    }                                                                                            \
-    else if constexpr (false) for (__VA_ARGS__ = ::cuda::std::__cccl_catch_any_lvalue{}; false;) \
-    {
+#  define _CCCL_CATCH(...)    \
+    }                         \
+    else if constexpr (false) \
+    {                         \
+      for (__VA_ARGS__ = ::cuda::std::__cccl_catch_any_lvalue{}; false;)
 #  define _CCCL_CATCH_ALL \
     }                     \
     else


### PR DESCRIPTION
`cicc` sometimes has problems parsing the code generated by exception macros. This PR should fix that. I need to investigate what is the exact problem.