### PR TITLE
Remove unreachable `break`

### DIFF
--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -477,7 +477,6 @@ template <>
 #else // ^^^ _CCCL_HAS_CTK() ^^^ / vvv !_CCCL_HAS_CTK() vvv
       _CCCL_THROW(::cuda::cuda_error, /*cudaErrorInvalidValue*/ 1, "Traits requested for an unknown architecture");
 #endif // ^^^ !_CCCL_HAS_CTK() ^^^
-      break;
   }
 }
 


### PR DESCRIPTION
This is again fixing nvhpc warning. This `break` is unreachable due to using `_CCCL_THROW` instead of `__throw_cuda_error`.