### PR TITLE
Implement the new tuning API for `detail::reduce::dispatch_streaming_arg_reduce_t`

### DIFF
--- a/cub/benchmarks/bench/reduce/arg_extrema.cu
+++ b/cub/benchmarks/bench/reduce/arg_extrema.cu
@@ -3,7 +3,9 @@
 
 #include <cub/device/device_reduce.cuh>
 #include <cub/device/dispatch/dispatch_streaming_reduce.cuh>
+#include <cub/device/dispatch/tuning/tuning_reduce.cuh>
 
+#include <cuda/__device/arch_id.h>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
@@ -14,100 +16,97 @@
 // %RANGE% TUNE_ITEMS_PER_VEC_LOAD_POW2 ipv 1:2:1
 
 #if !TUNE_BASE
-#  error "Cannot tune until https://github.com/NVIDIA/cccl/pull/7807 is merged"
-#  define TUNE_ITEMS_PER_VEC_LOAD (1 << TUNE_ITEMS_PER_VEC_LOAD_POW2)
-template <typename AccumT, typename OffsetT>
-struct policy_hub_t
+struct tuned_policy_selector
 {
-  struct policy_t : cub::ChainedPolicy<300, policy_t, policy_t>
+  [[nodiscard]] _CCCL_API constexpr auto operator()(::cuda::arch_id) const -> cub::detail::reduce::reduce_policy
   {
-    static constexpr int threads_per_block  = TUNE_THREADS_PER_BLOCK;
-    static constexpr int items_per_thread   = TUNE_ITEMS_PER_THREAD;
-    static constexpr int items_per_vec_load = TUNE_ITEMS_PER_VEC_LOAD;
-
-    using ReducePolicy =
-      cub::AgentReducePolicy<threads_per_block,
-                             items_per_thread,
-                             AccumT,
-                             items_per_vec_load,
-                             cub::BLOCK_REDUCE_WARP_REDUCTIONS,
-                             cub::LOAD_DEFAULT>;
-
-    using SingleTilePolicy      = ReducePolicy;
-    using SegmentedReducePolicy = ReducePolicy;
-  };
+    cub::detail::reduce::agent_reduce_policy rp{
+      TUNE_THREADS_PER_BLOCK,
+      TUNE_ITEMS_PER_THREAD,
+      1 << TUNE_ITEMS_PER_VEC_LOAD_POW2,
+      cub::BLOCK_REDUCE_WARP_REDUCTIONS,
+      cub::LOAD_DEFAULT};
+    auto rp_nondet            = rp;
+    rp_nondet.block_algorithm = cub::BLOCK_REDUCE_WARP_REDUCTIONS_NONDETERMINISTIC;
+    return {rp, rp, rp_nondet};
+  }
+};
 #endif // !TUNE_BASE
 
-  template <typename T, typename OpT>
-  void arg_reduce(nvbench::state& state, nvbench::type_list<T, OpT>)
-  {
-    // Offset type used within the kernel and to index within one partition
-    using per_partition_offset_t = int;
+template <typename T, typename OpT>
+void arg_reduce(nvbench::state& state, nvbench::type_list<T, OpT>)
+{
+  // Offset type used within the kernel and to index within one partition
+  using per_partition_offset_t = int;
 
-    // Offset type used to index within the total input in the range [d_in, d_in + num_items)
-    using global_offset_t = ::cuda::std::int64_t;
+  // Offset type used to index within the total input in the range [d_in, d_in + num_items)
+  using global_offset_t = ::cuda::std::int64_t;
 
-    // The value type of the KeyValuePair<global_offset_t, output_value_t> returned by the ArgIndexInputIterator
-    using output_value_t = T;
+  // Iterator providing the values being reduced
+  using values_it_t = T*;
 
-    // Iterator providing the values being reduced
-    using values_it_t = T*;
+  // Type used for the final result
+  using output_tuple_t = cub::KeyValuePair<global_offset_t, T>;
 
-    // Iterator providing the input items for the reduction
-    using input_it_t = values_it_t;
+  auto const init = ::cuda::std::is_same_v<OpT, cub::ArgMin>
+                    ? ::cuda::std::numeric_limits<T>::max()
+                    : ::cuda::std::numeric_limits<T>::lowest();
 
-    // Type used for the final result
-    using output_tuple_t = cub::KeyValuePair<global_offset_t, T>;
+  // Retrieve axis parameters
+  const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));
+  thrust::device_vector<T> in = generate(elements);
+  thrust::device_vector<output_tuple_t> out(1);
 
-    auto const init = ::cuda::std::is_same_v<OpT, cub::ArgMin>
-                      ? ::cuda::std::numeric_limits<T>::max()
-                      : ::cuda::std::numeric_limits<T>::lowest();
+  values_it_t d_in      = thrust::raw_pointer_cast(in.data());
+  output_tuple_t* d_out = thrust::raw_pointer_cast(out.data());
+  auto const num_items  = static_cast<global_offset_t>(elements);
 
+  // Enable throughput calculations and add "Size" column to results.
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements, "Size");
+  state.add_global_memory_writes<output_tuple_t>(1);
+
+  // Allocate temporary storage
+  std::size_t temp_size;
+  cub::detail::reduce::dispatch_streaming_arg_reduce<per_partition_offset_t>(
+    nullptr,
+    temp_size,
+    d_in,
+    d_out,
+    num_items,
+    OpT{},
+    init,
+    0 /* stream */
 #if !TUNE_BASE
-    using policy_t   = policy_hub_t<output_tuple_t, per_partition_offset_t>;
-    using dispatch_t = cub::detail::reduce::dispatch_streaming_arg_reduce_t<
-      input_it_t,
-      output_tuple_t*,
-      per_partition_offset_t,
-      global_offset_t,
-      OpT,
-      T,
-      policy_t>;
-#else // TUNE_BASE
-  using dispatch_t = cub::detail::reduce::
-    dispatch_streaming_arg_reduce_t<input_it_t, output_tuple_t*, per_partition_offset_t, global_offset_t, OpT, T>;
+    ,
+    tuned_policy_selector{}
 #endif // TUNE_BASE
+  );
 
-    // Retrieve axis parameters
-    const auto elements         = static_cast<std::size_t>(state.get_int64("Elements{io}"));
-    thrust::device_vector<T> in = generate(elements);
-    thrust::device_vector<output_tuple_t> out(1);
+  thrust::device_vector<nvbench::uint8_t> temp(temp_size);
+  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
 
-    values_it_t d_in      = thrust::raw_pointer_cast(in.data());
-    output_tuple_t* d_out = thrust::raw_pointer_cast(out.data());
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
+    cub::detail::reduce::dispatch_streaming_arg_reduce<per_partition_offset_t>(
+      temp_storage,
+      temp_size,
+      d_in,
+      d_out,
+      num_items,
+      OpT{},
+      init,
+      launch.get_stream()
+#if !TUNE_BASE
+        ,
+      tuned_policy_selector{}
+#endif // TUNE_BASE
+    );
+  });
+}
 
-    // Enable throughput calculations and add "Size" column to results.
-    state.add_element_count(elements);
-    state.add_global_memory_reads<T>(elements, "Size");
-    state.add_global_memory_writes<output_tuple_t>(1);
+using op_types = nvbench::type_list<cub::ArgMin, cub::ArgMax>;
 
-    // Allocate temporary storage:
-    std::size_t temp_size;
-    dispatch_t::Dispatch(
-      nullptr, temp_size, d_in, d_out, static_cast<global_offset_t>(elements), OpT{}, init, 0 /* stream */);
-
-    thrust::device_vector<nvbench::uint8_t> temp(temp_size);
-    auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
-    state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-      dispatch_t::Dispatch(
-        temp_storage, temp_size, d_in, d_out, static_cast<global_offset_t>(elements), OpT{}, init, launch.get_stream());
-    });
-  }
-
-  using op_types = nvbench::type_list<cub::ArgMin, cub::ArgMax>;
-
-  NVBENCH_BENCH_TYPES(arg_reduce, NVBENCH_TYPE_AXES(fundamental_types, op_types))
-    .set_name("base")
-    .set_type_axes_names({"T{ct}", "Operation{ct}"})
-    .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));
+NVBENCH_BENCH_TYPES(arg_reduce, NVBENCH_TYPE_AXES(fundamental_types, op_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}", "Operation{ct}"})
+  .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4));

--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -1054,7 +1054,6 @@ public:
 
     // The value type used for the extremum
     using OutputExtremumT = detail::non_void_value_t<ExtremumOutIteratorT, InputValueT>;
-    using InitT           = OutputExtremumT;
 
     // Reduction operation
     using ReduceOpT = cub::ArgMin;
@@ -1066,20 +1065,15 @@ public:
     auto out_it = ::cuda::make_tabulate_output_iterator(
       detail::reduce::unzip_and_write_arg_extremum_op<ExtremumOutIteratorT, IndexOutIteratorT>{d_min_out, d_index_out});
 
-    return detail::reduce::dispatch_streaming_arg_reduce_t<
-      InputIteratorT,
-      decltype(out_it),
-      PerPartitionOffsetT,
-      GlobalOffsetT,
-      ReduceOpT,
-      InitT>::Dispatch(d_temp_storage,
-                       temp_storage_bytes,
-                       d_in,
-                       out_it,
-                       static_cast<GlobalOffsetT>(num_items),
-                       ReduceOpT{},
-                       initial_value,
-                       stream);
+    return detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      out_it,
+      static_cast<GlobalOffsetT>(num_items),
+      ReduceOpT{},
+      initial_value,
+      stream);
   }
 
   //! @rst
@@ -1181,7 +1175,6 @@ public:
     using GlobalOffsetT       = ::cuda::std::int64_t;
 
     using OutputExtremumT = detail::non_void_value_t<ExtremumOutIteratorT, InputValueT>;
-    using InitT           = OutputExtremumT;
 
     // Initial value
     OutputExtremumT initial_value{::cuda::std::numeric_limits<InputValueT>::max()};
@@ -1191,50 +1184,39 @@ public:
       detail::reduce::unzip_and_write_arg_extremum_op<ExtremumOutIteratorT, IndexOutIteratorT>{d_min_out, d_index_out});
 
     // Query the required temporary storage size
-    cudaError_t error = detail::reduce::dispatch_streaming_arg_reduce_t<
-      InputIteratorT,
-      decltype(out_it),
-      PerPartitionOffsetT,
-      GlobalOffsetT,
-      ReduceOpT,
-      InitT>::Dispatch(d_temp_storage,
-                       temp_storage_bytes,
-                       d_in,
-                       out_it,
-                       static_cast<GlobalOffsetT>(num_items),
-                       ReduceOpT{},
-                       initial_value,
-                       stream.get());
-    if (error != cudaSuccess)
+    if (const auto error = detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_in,
+          out_it,
+          static_cast<GlobalOffsetT>(num_items),
+          ReduceOpT{},
+          initial_value,
+          stream.get()))
     {
       return error;
     }
 
     // TODO(gevtushenko): use uninitialized buffer when it's available
-    error = CubDebug(detail::temporary_storage::allocate(stream, d_temp_storage, temp_storage_bytes, mr));
-    if (error != cudaSuccess)
+    if (const auto error =
+          CubDebug(detail::temporary_storage::allocate(stream, d_temp_storage, temp_storage_bytes, mr)))
     {
       return error;
     }
 
     // Run the algorithm
-    error = detail::reduce::dispatch_streaming_arg_reduce_t<
-      InputIteratorT,
-      decltype(out_it),
-      PerPartitionOffsetT,
-      GlobalOffsetT,
-      ReduceOpT,
-      InitT>::Dispatch(d_temp_storage,
-                       temp_storage_bytes,
-                       d_in,
-                       out_it,
-                       static_cast<GlobalOffsetT>(num_items),
-                       ReduceOpT{},
-                       initial_value,
-                       stream.get());
+    const auto error = detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      out_it,
+      static_cast<GlobalOffsetT>(num_items),
+      ReduceOpT{},
+      initial_value,
+      stream.get());
 
     // Try to deallocate regardless of the error to avoid memory leaks
-    cudaError_t deallocate_error =
+    const auto deallocate_error =
       CubDebug(detail::temporary_storage::deallocate(stream, d_temp_storage, temp_storage_bytes, mr));
 
     if (error != cudaSuccess)
@@ -1690,7 +1672,6 @@ public:
 
     // The value type used for the extremum
     using OutputExtremumT = detail::non_void_value_t<ExtremumOutIteratorT, InputValueT>;
-    using InitT           = OutputExtremumT;
 
     // Reduction operation
     using ReduceOpT = cub::ArgMax;
@@ -1702,20 +1683,15 @@ public:
     auto out_it = ::cuda::make_tabulate_output_iterator(
       detail::reduce::unzip_and_write_arg_extremum_op<ExtremumOutIteratorT, IndexOutIteratorT>{d_max_out, d_index_out});
 
-    return detail::reduce::dispatch_streaming_arg_reduce_t<
-      InputIteratorT,
-      decltype(out_it),
-      PerPartitionOffsetT,
-      GlobalOffsetT,
-      ReduceOpT,
-      InitT>::Dispatch(d_temp_storage,
-                       temp_storage_bytes,
-                       d_in,
-                       out_it,
-                       static_cast<GlobalOffsetT>(num_items),
-                       ReduceOpT{},
-                       initial_value,
-                       stream);
+    return detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      out_it,
+      static_cast<GlobalOffsetT>(num_items),
+      ReduceOpT{},
+      initial_value,
+      stream);
   }
 
   //! @rst
@@ -1944,7 +1920,6 @@ public:
     using GlobalOffsetT       = ::cuda::std::int64_t;
 
     using OutputExtremumT = detail::non_void_value_t<ExtremumOutIteratorT, InputValueT>;
-    using InitT           = OutputExtremumT;
 
     // Initial value
     OutputExtremumT initial_value{::cuda::std::numeric_limits<InputValueT>::lowest()};
@@ -1954,50 +1929,39 @@ public:
       detail::reduce::unzip_and_write_arg_extremum_op<ExtremumOutIteratorT, IndexOutIteratorT>{d_max_out, d_index_out});
 
     // Query the required temporary storage size
-    cudaError_t error = detail::reduce::dispatch_streaming_arg_reduce_t<
-      InputIteratorT,
-      decltype(out_it),
-      PerPartitionOffsetT,
-      GlobalOffsetT,
-      ReduceOpT,
-      InitT>::Dispatch(d_temp_storage,
-                       temp_storage_bytes,
-                       d_in,
-                       out_it,
-                       static_cast<GlobalOffsetT>(num_items),
-                       ReduceOpT{},
-                       initial_value,
-                       stream.get());
-    if (error != cudaSuccess)
+    if (const auto error = detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_in,
+          out_it,
+          static_cast<GlobalOffsetT>(num_items),
+          ReduceOpT{},
+          initial_value,
+          stream.get()))
     {
       return error;
     }
 
     // TODO(gevtushenko): use uninitialized buffer when it's available
-    error = CubDebug(detail::temporary_storage::allocate(stream, d_temp_storage, temp_storage_bytes, mr));
-    if (error != cudaSuccess)
+    if (const auto error =
+          CubDebug(detail::temporary_storage::allocate(stream, d_temp_storage, temp_storage_bytes, mr)))
     {
       return error;
     }
 
     // Run the algorithm
-    error = detail::reduce::dispatch_streaming_arg_reduce_t<
-      InputIteratorT,
-      decltype(out_it),
-      PerPartitionOffsetT,
-      GlobalOffsetT,
-      ReduceOpT,
-      InitT>::Dispatch(d_temp_storage,
-                       temp_storage_bytes,
-                       d_in,
-                       out_it,
-                       static_cast<GlobalOffsetT>(num_items),
-                       ReduceOpT{},
-                       initial_value,
-                       stream.get());
+    const auto error = detail::reduce::dispatch_streaming_arg_reduce<PerPartitionOffsetT>(
+      d_temp_storage,
+      temp_storage_bytes,
+      d_in,
+      out_it,
+      static_cast<GlobalOffsetT>(num_items),
+      ReduceOpT{},
+      initial_value,
+      stream.get());
 
     // Try to deallocate regardless of the error to avoid memory leaks
-    cudaError_t deallocate_error =
+    const auto deallocate_error =
       CubDebug(detail::temporary_storage::deallocate(stream, d_temp_storage, temp_storage_bytes, mr));
 
     if (error != cudaSuccess)

--- a/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
+++ b/cub/cub/device/dispatch/dispatch_streaming_reduce.cuh
@@ -116,18 +116,18 @@ struct local_to_global_op
  * Single-problem streaming reduction dispatch
  *****************************************************************************/
 
-// Utility class for dispatching a streaming device-wide argument extremum computation, like `ArgMin` and `ArgMax`.
+// Internal dispatch routine for computing a device-wide argument extremum, like `ArgMin` and `ArgMax`.
 // Streaming, here, refers to the approach used for large number of items that are processed in multiple partitions.
+//
+// @tparam PerPartitionOffsetT
+//   Offset type used as the index to access items within one partition, i.e., the offset type used within the kernel
+//   template specialization
 //
 // @tparam InputIteratorT
 //   Random-access input iterator type for reading input items @iterator
 //
 // @tparam OutputIteratorT
 //   Output iterator type for writing the result of the (index, extremum)-key-value-pair
-//
-// @tparam PerPartitionOffsetT
-//   Offset type used as the index to access items within one partition, i.e., the offset type used within the kernel
-// template specialization
 //
 // @tparam GlobalOffsetT
 //   Offset type used as the index to access items within the total input range, i.e., in the range [d_in, d_in +
@@ -143,180 +143,153 @@ struct local_to_global_op
 //
 // @tparam PolicySelector
 //   Selects the tuning policy
-template <typename InputIteratorT,
-          typename OutputIteratorT,
-          typename PerPartitionOffsetT,
-          typename GlobalOffsetT,
-          typename ReductionOpT,
-          typename InitT,
-          typename PolicySelector = detail::reduce::
-            policy_selector_from_types<KeyValuePair<PerPartitionOffsetT, InitT>, PerPartitionOffsetT, ReductionOpT>>
-struct dispatch_streaming_arg_reduce_t
+template <
+  typename PerPartitionOffsetT,
+  typename InputIteratorT,
+  typename OutputIteratorT,
+  typename GlobalOffsetT,
+  typename ReductionOpT,
+  typename InitT,
+  typename PolicySelector =
+    reduce::policy_selector_from_types<KeyValuePair<PerPartitionOffsetT, InitT>, PerPartitionOffsetT, ReductionOpT>>
+#  if _CCCL_HAS_CONCEPTS()
+  requires reduce_policy_selector<PolicySelector>
+#  endif // _CCCL_HAS_CONCEPTS()
+CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch_streaming_arg_reduce(
+  void* d_temp_storage,
+  size_t& temp_storage_bytes,
+  InputIteratorT d_in,
+  OutputIteratorT d_result_out,
+  GlobalOffsetT num_items,
+  ReductionOpT reduce_op,
+  InitT init,
+  cudaStream_t stream,
+  PolicySelector policy_selector = {})
 {
-  // Internal dispatch routine for computing a device-wide argument extremum, like `ArgMin` and `ArgMax`
-  //
-  // @param[in] d_temp_storage
-  //   Device-accessible allocation of temporary storage. When `nullptr`, the
-  //   required allocation size is written to `temp_storage_bytes` and no work
-  //   is done.
-  //
-  // @param[in,out] temp_storage_bytes
-  //   Reference to size in bytes of `d_temp_storage` allocation
-  //
-  // @param[in] d_in
-  //   Pointer to the input sequence of data items
-  //
-  // @param[out] d_result_out
-  //   Iterator to which the  (index, extremum)-key-value-pair is written
-  //
-  // @param[in] num_items
-  //   Total number of input items (i.e., length of `d_in`)
-  //
-  // @param[in] reduce_op
-  //   Reduction operator that returns the (index, extremum)-key-value-pair corresponding to the extremum of the two
-  // input items.
-  //
-  // @param[in] init
-  //   The extremum value to be returned for empty problems
-  //
-  // @param[in] stream
-  //   CUDA stream to launch kernels within.
-  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Dispatch(
-    void* d_temp_storage,
-    size_t& temp_storage_bytes,
-    InputIteratorT d_in,
-    OutputIteratorT d_result_out,
-    GlobalOffsetT num_items,
-    ReductionOpT reduce_op,
-    InitT init,
-    cudaStream_t stream)
+  // Wrapped input iterator to produce index-value tuples, i.e., <PerPartitionOffsetT, InputT>-tuples
+  // We make sure to offset the user-provided input iterator by the current partition's offset
+  using arg_index_input_iterator_t = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT, InitT>;
+
+  // The type used for the aggregate that the user wants to find the extremum for
+  using output_aggregate_t = InitT;
+
+  // The output tuple type (i.e., extremum plus index tuples)
+  using per_partition_accum_t = KeyValuePair<PerPartitionOffsetT, output_aggregate_t>;
+  using global_accum_t        = KeyValuePair<GlobalOffsetT, output_aggregate_t>;
+
+  // Unary promotion operator type that is used to transform a per-partition result to a global result
+  // operator()(per_partition_accum_t) -> global_accum_t
+  using local_to_global_op_t = local_to_global_op<GlobalOffsetT>;
+
+  // Empty problem initialization type
+  using empty_problem_init_t = empty_problem_init_t<per_partition_accum_t>;
+
+  // The current partition's input iterator is an ArgIndex iterator that generates indices relative to the beginning
+  // of the current partition, i.e., [0, partition_size) along with an OffsetIterator that offsets the user-provided
+  // input iterator by the current partition's offset
+  arg_index_input_iterator_t d_indexed_offset_in(d_in);
+
+  // Transforms the per-partition result to a global result by adding the current partition's offset to the arg result
+  // of a partition
+  local_to_global_op_t local_to_global_op{GlobalOffsetT{0}};
+
+  // Upper bound at which we want to cut the input into multiple partitions. Align to 4096 bytes for performance
+  // reasons
+  static constexpr PerPartitionOffsetT max_offset_size = ::cuda::std::numeric_limits<PerPartitionOffsetT>::max();
+  static constexpr PerPartitionOffsetT max_partition_size =
+    max_offset_size - (max_offset_size % PerPartitionOffsetT{4096});
+
+  // Whether the given number of items fits into a single partition
+  const bool is_single_partition =
+    static_cast<GlobalOffsetT>(max_partition_size) >= static_cast<GlobalOffsetT>(num_items);
+
+  // The largest partition size ever encountered
+  const auto largest_partition_size =
+    is_single_partition ? static_cast<PerPartitionOffsetT>(num_items) : max_partition_size;
+
+  // Reduction operator type that enables accumulating per-partition results to a global reduction result
+  using accumulating_transform_output_op_t =
+    accumulating_transform_output_op<global_accum_t, local_to_global_op_t, ReductionOpT, OutputIteratorT>;
+
+  auto accumulating_out_op = accumulating_transform_output_op_t{
+    true, is_single_partition, nullptr, nullptr, d_result_out, local_to_global_op, reduce_op};
+
+  empty_problem_init_t initial_value{{PerPartitionOffsetT{1}, init}};
+
+  void* allocations[2]       = {nullptr, nullptr};
+  size_t allocation_sizes[2] = {0, 2 * sizeof(global_accum_t)};
+
+  // Query temporary storage requirements for per-partition reduction
+
+  reduce::dispatch<per_partition_accum_t>(
+    nullptr,
+    allocation_sizes[0],
+    d_indexed_offset_in,
+    ::cuda::make_tabulate_output_iterator(accumulating_out_op),
+    static_cast<PerPartitionOffsetT>(largest_partition_size),
+    reduce_op,
+    initial_value,
+    stream,
+    ::cuda::std::identity{},
+    policy_selector);
+
+  // Alias the temporary allocations from the single storage blob (or compute the necessary size
+  // of the blob)
+  if (const auto error = CubDebug(alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes)))
   {
-    // Wrapped input iterator to produce index-value tuples, i.e., <PerPartitionOffsetT, InputT>-tuples
-    // We make sure to offset the user-provided input iterator by the current partition's offset
-    using arg_index_input_iterator_t = ArgIndexInputIterator<InputIteratorT, PerPartitionOffsetT, InitT>;
+    return error;
+  }
 
-    // The type used for the aggregate that the user wants to find the extremum for
-    using output_aggregate_t = InitT;
+  // Return if the caller is simply requesting the size of the storage allocation
+  if (d_temp_storage == nullptr)
+  {
+    return cudaSuccess;
+  }
 
-    // The output tuple type (i.e., extremum plus index tuples)
-    using per_partition_accum_t = KeyValuePair<PerPartitionOffsetT, output_aggregate_t>;
-    using global_accum_t        = KeyValuePair<GlobalOffsetT, output_aggregate_t>;
+  // Pointer to the double-buffer of global accumulators, which aggregate cross-partition results
+  global_accum_t* const d_global_aggregates = static_cast<global_accum_t*>(allocations[1]);
 
-    // Unary promotion operator type that is used to transform a per-partition result to a global result
-    // operator()(per_partition_accum_t) -> global_accum_t
-    using local_to_global_op_t = local_to_global_op<GlobalOffsetT>;
+  accumulating_out_op = accumulating_transform_output_op_t{
+    true,
+    is_single_partition,
+    d_global_aggregates,
+    (d_global_aggregates + 1),
+    d_result_out,
+    local_to_global_op,
+    reduce_op};
 
-    // Empty problem initialization type
-    using empty_problem_init_t = empty_problem_init_t<per_partition_accum_t>;
+  for (GlobalOffsetT current_partition_offset = 0; current_partition_offset < static_cast<GlobalOffsetT>(num_items);
+       current_partition_offset += static_cast<GlobalOffsetT>(max_partition_size))
+  {
+    const GlobalOffsetT remaining_items = (num_items - current_partition_offset);
+    const GlobalOffsetT current_num_items =
+      (remaining_items < max_partition_size) ? remaining_items : max_partition_size;
 
-    // The current partition's input iterator is an ArgIndex iterator that generates indices relative to the beginning
-    // of the current partition, i.e., [0, partition_size) along with an OffsetIterator that offsets the user-provided
-    // input iterator by the current partition's offset
-    arg_index_input_iterator_t d_indexed_offset_in(d_in);
+    d_indexed_offset_in = arg_index_input_iterator_t(d_in + current_partition_offset);
 
-    // Transforms the per-partition result to a global result by adding the current partition's offset to the arg result
-    // of a partition
-    local_to_global_op_t local_to_global_op{GlobalOffsetT{0}};
-
-    // Upper bound at which we want to cut the input into multiple partitions. Align to 4096 bytes for performance
-    // reasons
-    static constexpr PerPartitionOffsetT max_offset_size = ::cuda::std::numeric_limits<PerPartitionOffsetT>::max();
-    static constexpr PerPartitionOffsetT max_partition_size =
-      max_offset_size - (max_offset_size % PerPartitionOffsetT{4096});
-
-    // Whether the given number of items fits into a single partition
-    const bool is_single_partition =
-      static_cast<GlobalOffsetT>(max_partition_size) >= static_cast<GlobalOffsetT>(num_items);
-
-    // The largest partition size ever encountered
-    const auto largest_partition_size =
-      is_single_partition ? static_cast<PerPartitionOffsetT>(num_items) : max_partition_size;
-
-    // Reduction operator type that enables accumulating per-partition results to a global reduction result
-    using accumulating_transform_output_op_t =
-      accumulating_transform_output_op<global_accum_t, local_to_global_op_t, ReductionOpT, OutputIteratorT>;
-
-    auto accumulating_out_op = accumulating_transform_output_op_t{
-      true, is_single_partition, nullptr, nullptr, d_result_out, local_to_global_op, reduce_op};
-
-    empty_problem_init_t initial_value{{PerPartitionOffsetT{1}, init}};
-
-    void* allocations[2]       = {nullptr, nullptr};
-    size_t allocation_sizes[2] = {0, 2 * sizeof(global_accum_t)};
-
-    // Query temporary storage requirements for per-partition reduction
-
-    reduce::dispatch<per_partition_accum_t>(
-      nullptr,
-      allocation_sizes[0],
-      d_indexed_offset_in,
-      ::cuda::make_tabulate_output_iterator(accumulating_out_op),
-      static_cast<PerPartitionOffsetT>(largest_partition_size),
-      reduce_op,
-      initial_value,
-      stream,
-      ::cuda::std::identity{},
-      PolicySelector{});
-
-    // Alias the temporary allocations from the single storage blob (or compute the necessary size
-    // of the blob)
-    cudaError_t error = CubDebug(alias_temporaries(d_temp_storage, temp_storage_bytes, allocations, allocation_sizes));
-    if (error != cudaSuccess)
+    if (const auto error = reduce::dispatch<per_partition_accum_t>(
+          d_temp_storage,
+          temp_storage_bytes,
+          d_indexed_offset_in,
+          ::cuda::make_tabulate_output_iterator(accumulating_out_op),
+          static_cast<PerPartitionOffsetT>(current_num_items),
+          reduce_op,
+          initial_value,
+          stream,
+          ::cuda::std::identity{},
+          policy_selector))
     {
       return error;
     }
 
-    // Return if the caller is simply requesting the size of the storage allocation
-    if (d_temp_storage == nullptr)
-    {
-      return cudaSuccess;
-    }
-
-    // Pointer to the double-buffer of global accumulators, which aggregate cross-partition results
-    global_accum_t* const d_global_aggregates = static_cast<global_accum_t*>(allocations[1]);
-
-    accumulating_out_op = accumulating_transform_output_op_t{
-      true,
-      is_single_partition,
-      d_global_aggregates,
-      (d_global_aggregates + 1),
-      d_result_out,
-      local_to_global_op,
-      reduce_op};
-
-    for (GlobalOffsetT current_partition_offset = 0; current_partition_offset < static_cast<GlobalOffsetT>(num_items);
-         current_partition_offset += static_cast<GlobalOffsetT>(max_partition_size))
-    {
-      const GlobalOffsetT remaining_items = (num_items - current_partition_offset);
-      const GlobalOffsetT current_num_items =
-        (remaining_items < max_partition_size) ? remaining_items : max_partition_size;
-
-      d_indexed_offset_in = arg_index_input_iterator_t(d_in + current_partition_offset);
-
-      error = reduce::dispatch<per_partition_accum_t>(
-        d_temp_storage,
-        temp_storage_bytes,
-        d_indexed_offset_in,
-        ::cuda::make_tabulate_output_iterator(accumulating_out_op),
-        static_cast<PerPartitionOffsetT>(current_num_items),
-        reduce_op,
-        initial_value,
-        stream);
-
-      if (error != cudaSuccess)
-      {
-        return error;
-      }
-
-      // Whether the next partition will be the last partition
-      const bool next_partition_is_last =
-        (remaining_items - current_num_items) <= static_cast<GlobalOffsetT>(max_partition_size);
-      accumulating_out_op.advance(current_num_items, next_partition_is_last);
-    }
-
-    return cudaSuccess;
+    // Whether the next partition will be the last partition
+    const bool next_partition_is_last =
+      (remaining_items - current_num_items) <= static_cast<GlobalOffsetT>(max_partition_size);
+    accumulating_out_op.advance(current_num_items, next_partition_is_last);
   }
-};
+
+  return cudaSuccess;
+}
 } // namespace detail::reduce
 CUB_NAMESPACE_END
 


### PR DESCRIPTION
Depends on:

- [x] Merge #7805
- [x] No SASS changes for `cub.bench.reduce.arg_extrema.base` for SM `75;100`

Fixes: #7645