### PR TITLE
Use the public `DeviceTransform` API in Thrust

### DIFF
--- a/cub/cub/device/device_transform.cuh
+++ b/cub/cub/device/device_transform.cuh
@@ -792,6 +792,31 @@ public:
       stream);
   }
 #endif // _CCCL_DOXYGEN_INVOKED
+
+  // internal, used only by Thrust
+  template <typename... RandomAccessIteratorsIn,
+            typename RandomAccessIteratorOut,
+            typename NumItemsT,
+            typename Predicate,
+            typename TransformOp,
+            typename Env = ::cuda::std::execution::env<>>
+  CUB_RUNTIME_FUNCTION static cudaError_t __transform_if_stable_argument_addresses(
+    ::cuda::std::tuple<RandomAccessIteratorsIn...> inputs,
+    RandomAccessIteratorOut output,
+    NumItemsT num_items,
+    Predicate predicate,
+    TransformOp transform_op,
+    Env env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cub::DeviceTransform::TransformIfStableArgumentAddresses");
+    return TransformInternal<detail::transform::requires_stable_address::yes>(
+      ::cuda::std::move(inputs),
+      ::cuda::std::move(output),
+      num_items,
+      ::cuda::std::move(predicate),
+      ::cuda::std::move(transform_op),
+      ::cuda::std::move(env));
+  }
 };
 
 CUB_NAMESPACE_END

--- a/thrust/thrust/system/cuda/detail/generate.h
+++ b/thrust/thrust/system/cuda/detail/generate.h
@@ -29,18 +29,18 @@ template <class Derived, class OutputIt, class Size, class Generator>
 OutputIt _CCCL_HOST_DEVICE
 generate_n(execution_policy<Derived>& policy, OutputIt result, Size count, Generator generator)
 {
-  THRUST_CDP_DISPATCH(
-    (using Predicate = CUB_NS_QUALIFIER::detail::transform::always_true_predicate; //
-     cudaError_t status;
-     THRUST_INDEX_TYPE_DISPATCH(
-       status,
-       (CUB_NS_QUALIFIER::detail::transform::dispatch<CUB_NS_QUALIFIER::detail::transform::requires_stable_address::no>),
-       count,
-       (::cuda::std::tuple<>{}, result, count_fixed, Predicate{}, generator, cuda_cub::stream(policy)));
-     throw_on_error(status, "generate_n: failed inside CUB");
-     throw_on_error(synchronize_optional(policy), "generate_n: failed to synchronize");
-     return result + count;),
-    (return thrust::generate_n(cvt_to_seq(derived_cast(policy)), result, count, generator);));
+  THRUST_CDP_DISPATCH(({
+                        cudaError_t status;
+                        THRUST_INDEX_TYPE_DISPATCH(
+                          status,
+                          (CUB_NS_QUALIFIER::DeviceTransform::Generate),
+                          count,
+                          (result, count_fixed, generator, cuda_cub::stream(policy)));
+                        throw_on_error(status, "generate_n: failed inside CUB");
+                        throw_on_error(synchronize_optional(policy), "generate_n: failed to synchronize");
+                        return result + count;
+                      }),
+                      ({ return thrust::generate_n(cvt_to_seq(derived_cast(policy)), result, count, generator); }));
 }
 
 template <class Derived, class OutputIt, class Generator>


### PR DESCRIPTION
I'll do a quick, non-serious SASS check since I assume the refactoring had no impact:

- [x] No SASS changes for `thrust.bench.fill.basic.base` on SM `80;90;100`
- [x]  No SASS changes for `thrust.bench.generate.basic.base` on SM `80;90;100`
- [x]  No SASS changes for `thrust.bench.transform.babelstream.base` on SM `80;90;100`

There were only changes in the kernel symbol name, because some functors are taken from different namespaces now.