### PR TITLE
Enable launch dims assumptions for `clang` and `nvc++`

### DIFF
--- a/libcudacxx/include/cuda/__launch/launch.h
+++ b/libcudacxx/include/cuda/__launch/launch.h
@@ -105,6 +105,9 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 #      define _CCCL_GRID_DIM_Z                     gridDim.z
 #    endif // ^^^ !_CCCL_CUDA_COMPILER(CLANG) ^^^
 
+// clang-cuda sometimes warns about the assumption being ignored because it contains (potential) side-effects. We can
+// just suppress it, because in the worst case, the assumption will be just ignored.
+// note(dabayer): I haven't found out when exactly the assumption fails.
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wassume")
 


### PR DESCRIPTION
Actually I found out that we should be fine using the assumptions with `nvc++` in CUDA mode, because the dimensions don't depend on the target architecture.

I've also retested clang-cuda and it seems to be working fine. Maybe there are some circumstances under which the assumption is ignored, so I've locally suppressed the `-Wassume` warning.