### PR TITLE
[libcu++] Fix stream construction in buffer docs example

### DIFF
--- a/docs/libcudacxx/runtime/buffer.rst
+++ b/docs/libcudacxx/runtime/buffer.rst
@@ -135,8 +135,8 @@ Example:
    #include <cuda/stream>
 
    void manage_stream_and_deallocate() {
-     cuda::stream stream1{};
-     cuda::stream stream2{};
+     cuda::stream stream1{cuda::devices[0]};
+     cuda::stream stream2{cuda::devices[0]};
      auto mr = cuda::device_default_memory_pool(cuda::devices[0]);
 
     // Allocate on stream1


### PR DESCRIPTION
An example in buffer docs shows default constructed `cuda::stream`, which is not supported. This PR adds explicit device argument