### PR TITLE
[libcu++] Version bump buffer and resource wrappers

### DIFF
--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -65,6 +65,7 @@ inline constexpr bool __buffer_compatible_env =
   ::cuda::std::is_same_v<::cuda::std::decay_t<_Env>, ::cuda::std::execution::env<>>
   || ::cuda::std::execution::__queryable_with<const _Env&, allocation_alignment_t>;
 
+_CCCL_BEGIN_NAMESPACE_ABI_VER4_BUMP
 //! @rst
 //! .. _libcudacxx-containers-buffer:
 //!
@@ -629,6 +630,8 @@ public:
   _CCCL_REQUIRES((!property_with_value<_Property>) _CCCL_AND ::cuda::std::__is_included_in_v<_Property, _Properties...>)
   _CCCL_HOST_API friend void get_property(const buffer&, _Property) noexcept {}
 };
+
+_CCCL_END_NAMESPACE_ABI_VER4_BUMP
 
 template <class _Tp>
 using device_buffer = buffer<_Tp, ::cuda::mr::device_accessible>;

--- a/libcudacxx/include/cuda/__memory_resource/any_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/any_resource.h
@@ -195,6 +195,8 @@ struct __with_try_get_property
   }
 };
 
+_CCCL_BEGIN_NAMESPACE_ABI_VER4_BUMP
+
 template <class... _Properties>
 struct _CCCL_DECLSPEC_EMPTY_BASES any_resource;
 
@@ -359,6 +361,8 @@ private:
     return *this;
   }
 };
+
+_CCCL_END_NAMESPACE_ABI_VER4_BUMP
 
 template <class... _Properties>
 inline constexpr bool __disable_default_dynamic_accessibility_property<any_resource<_Properties...>> = true;

--- a/libcudacxx/include/cuda/std/__internal/namespaces.h
+++ b/libcudacxx/include/cuda/std/__internal/namespaces.h
@@ -47,6 +47,16 @@
   }                              \
   _CCCL_END_NAMESPACE_NOVERSION(_NS)
 
+// Open a namespace for APIs that were version bumped in a minor release
+// Version bump namespace should be removed from the APIs at the next major release
+#define _CCCL_BEGIN_NAMESPACE_ABI_VER4_BUMP                                           \
+  static_assert(_LIBCUDACXX_CUDA_ABI_VERSION == 4, "Version bump should be removed"); \
+  inline namespace __version_bump_ver4_                                               \
+  {
+#define _CCCL_END_NAMESPACE_ABI_VER4_BUMP                                             \
+  static_assert(_LIBCUDACXX_CUDA_ABI_VERSION == 4, "Version bump should be removed"); \
+  }
+
 // Standard namespaces with or without versioning
 #define _CCCL_BEGIN_NAMESPACE_CUDA_STD_NOVERSION _CCCL_BEGIN_NAMESPACE_NOVERSION(cuda::std)
 #define _CCCL_END_NAMESPACE_CUDA_STD_NOVERSION   _CCCL_END_NAMESPACE_NOVERSION(cuda::std)


### PR DESCRIPTION
We changed the ABI of `buffer` and type erased wrappers in https://github.com/NVIDIA/cccl/pull/7623 and https://github.com/NVIDIA/cccl/pull/7727.

We need to add special version bump namespace to them until the next major version, so objects using old and new versions fail to link