### PR TITLE
[Backport 3.3] Buffer changes

### DIFF
--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -664,9 +664,8 @@ _CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
 //! @brief Copy-constructs elements in the range `[__first, __first + __count)`.
 //! @param __first Pointer to the first element to be initialized.
 //! @param __count The number of elements to be initialized.
-template <typename _Tp, mr::__memory_accessability _Accessability>
-_CCCL_HIDE_FROM_ABI void
-__fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::std::size_t __count, const _Tp& __value)
+template <typename _Tp, mr::__memory_accessibility _Accessability>
+_CCCL_HOST_API void __fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::std::size_t __count, const _Tp& __value)
 {
   if (__count == 0)
   {
@@ -675,7 +674,7 @@ __fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::std::size_t __count, c
 
   // We don't know what to do with both device and host accessible buffers, so
   // we need to check the attributes
-  if constexpr (_Accessability == mr::__memory_accessability::__host_device)
+  if constexpr (_Accessability == mr::__memory_accessibility ::__host_device)
   {
     __driver::__pointer_attribute_value_type_t<CU_POINTER_ATTRIBUTE_MEMORY_TYPE> __type;
     bool __is_managed{};
@@ -688,14 +687,14 @@ __fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::std::size_t __count, c
     }
     if (__type == ::CU_MEMORYTYPE_HOST && !__is_managed)
     {
-      __fill_n<_Tp, mr::__memory_accessability::__host>(__stream, __first, __count, __value);
+      __fill_n<_Tp, mr::__memory_accessibility ::__host>(__stream, __first, __count, __value);
     }
     else
     {
-      __fill_n<_Tp, mr::__memory_accessability::__device>(__stream, __first, __count, __value);
+      __fill_n<_Tp, mr::__memory_accessibility ::__device>(__stream, __first, __count, __value);
     }
   }
-  else if constexpr (_Accessability == mr::__memory_accessability::__host)
+  else if constexpr (_Accessability == mr::__memory_accessibility ::__host)
   {
     ::cuda::host_launch(
       __stream, ::cuda::std::uninitialized_fill_n<_Tp*, ::cuda::std::size_t, _Tp>, __first, __count, __value);
@@ -790,7 +789,7 @@ buffer<_Tp, _FirstProperty, _RestProperties...> make_buffer(
 {
   auto __res =
     buffer<_Tp, _FirstProperty, _RestProperties...>{__stream, ::cuda::std::forward<_Resource>(__mr), __size, no_init};
-  __fill_n<_Tp, mr::__memory_accessability_from_properties<_FirstProperty, _RestProperties...>::value>(
+  __fill_n<_Tp, mr::__memory_accessibility_from_properties<_FirstProperty, _RestProperties...>::value>(
     __stream, __res.__unwrapped_begin(), __size, __value);
   return __res;
 }
@@ -804,7 +803,7 @@ auto make_buffer(
   using __default_queries = typename ::cuda::std::decay_t<_Resource>::default_queries;
   using __buffer_type     = __buffer_type_for_props<_Tp, __default_queries>;
   auto __res              = __buffer_type{__stream, ::cuda::std::forward<_Resource>(__mr), __size, no_init};
-  __fill_n<_Tp, __default_queries::template rebind<mr::__memory_accessability_from_properties>::value>(
+  __fill_n<_Tp, __default_queries::template rebind<mr::__memory_accessibility_from_properties>::value>(
     __stream, __res.__unwrapped_begin(), __size, __value);
   return __res;
 }

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -30,6 +30,7 @@
 #  include <cuda/__container/heterogeneous_iterator.h>
 #  include <cuda/__container/uninitialized_async_buffer.h>
 #  include <cuda/__launch/host_launch.h>
+#  include <cuda/__memory_resource/allocation_alignment.h>
 #  include <cuda/__memory_resource/any_resource.h>
 #  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__memory_resource/properties.h>
@@ -56,10 +57,10 @@
 //! @file The \c buffer class provides a container of contiguous memory
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-// Once we add support from options taken from the env we can list them here in
-// addition to using is_same_v
 template <class _Env>
-inline constexpr bool __buffer_compatible_env = ::cuda::std::is_same_v<_Env, ::cuda::std::execution::env<>>;
+inline constexpr bool __buffer_compatible_env =
+  ::cuda::std::is_same_v<::cuda::std::decay_t<_Env>, ::cuda::std::execution::env<>>
+  || ::cuda::std::execution::__queryable_with<const _Env&, allocation_alignment_t>;
 
 //! @rst
 //! .. _libcudacxx-containers-async-vector:
@@ -135,6 +136,14 @@ private:
     return const_cast<__resource_t&>(__buf_.memory_resource());
   }
 
+  template <class _Env>
+  static size_t __alignment_from_env(const _Env& __env)
+  {
+    const auto __align = ::cuda::__call_or(::cuda::allocation_alignment, alignof(_Tp), __env);
+    ::cuda::__validate_allocation_alignment(__align, alignof(_Tp));
+    return __align;
+  }
+
   //! @brief Copies \p __count elements from `[__first, __last)` to \p __dest,
   //! where \p __first and \p __dest reside in the different memory spaces
   //! @param __first Pointer to the start of the input segment.
@@ -165,8 +174,8 @@ public:
 
   //! @brief Copy-constructs from a buffer
   //! @param __other The other buffer.
-  _CCCL_HIDE_FROM_ABI explicit buffer(const buffer& __other)
-      : __buf_(__other.memory_resource(), __other.stream(), __other.size())
+  _CCCL_HOST_API explicit buffer(const buffer& __other)
+      : __buf_(__other.memory_resource(), __other.stream(), __other.size(), __other.__buf_.alignment())
   {
     this->__copy_cross<const_pointer>(
       __other.__unwrapped_begin(), __other.__unwrapped_end(), __unwrapped_begin(), __other.size());
@@ -183,8 +192,8 @@ public:
   //! @param __other The other buffer.
   _CCCL_TEMPLATE(class... _OtherProperties)
   _CCCL_REQUIRES(__properties_match<_OtherProperties...>)
-  _CCCL_HIDE_FROM_ABI explicit buffer(const buffer<_Tp, _OtherProperties...>& __other)
-      : __buf_(__other.memory_resource(), __other.stream(), __other.size())
+  _CCCL_HOST_API explicit buffer(const buffer<_Tp, _OtherProperties...>& __other)
+      : __buf_(__other.memory_resource(), __other.stream(), __other.size(), __other.__buf_.alignment())
   {
     this->__copy_cross<const_pointer>(
       __other.__unwrapped_begin(), __other.__unwrapped_end(), __unwrapped_begin(), __other.size());
@@ -205,9 +214,11 @@ public:
   _CCCL_TEMPLATE(class _Resource, class _Env = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES(
     ::cuda::mr::synchronous_resource<::cuda::std::decay_t<_Resource>> _CCCL_AND __buffer_compatible_env<_Env>)
-  _CCCL_HIDE_FROM_ABI
-  buffer(::cuda::stream_ref __stream, _Resource&& __resource, [[maybe_unused]] const _Env& __env = {})
-      : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)), __stream, 0)
+  _CCCL_HOST_API buffer(::cuda::stream_ref __stream, _Resource&& __resource, [[maybe_unused]] const _Env& __env = {})
+      : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
+               __stream,
+               0,
+               __alignment_from_env(__env))
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
                   "Buffer owns a copy of the memory resource, which means it must be copy constructible. "
@@ -232,7 +243,10 @@ public:
     const size_type __size,
     ::cuda::no_init_t,
     [[maybe_unused]] const _Env& __env = {})
-      : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)), __stream, __size)
+      : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
+               __stream,
+               __size,
+               __alignment_from_env(__env))
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
                   "Buffer owns a copy of the memory resource, which means it must be copy constructible. "
@@ -257,7 +271,8 @@ public:
          [[maybe_unused]] const _Env& __env = {})
       : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
                __stream,
-               static_cast<size_type>(::cuda::std::distance(__first, __last)))
+               static_cast<size_type>(::cuda::std::distance(__first, __last)),
+               __alignment_from_env(__env))
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
                   "Buffer owns a copy of the memory resource, which means it must be copy constructible. "
@@ -273,12 +288,14 @@ public:
   _CCCL_TEMPLATE(class _Resource, class _Env = ::cuda::std::execution::env<>)
   _CCCL_REQUIRES(
     ::cuda::mr::synchronous_resource<::cuda::std::decay_t<_Resource>> _CCCL_AND __buffer_compatible_env<_Env>)
-  _CCCL_HIDE_FROM_ABI
-  buffer(::cuda::stream_ref __stream,
-         _Resource&& __resource,
-         ::cuda::std::initializer_list<_Tp> __ilist,
-         [[maybe_unused]] const _Env& __env = {})
-      : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)), __stream, __ilist.size())
+  _CCCL_HOST_API buffer(::cuda::stream_ref __stream,
+                        _Resource&& __resource,
+                        ::cuda::std::initializer_list<_Tp> __ilist,
+                        [[maybe_unused]] const _Env& __env = {})
+      : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
+               __stream,
+               __ilist.size(),
+               __alignment_from_env(__env))
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
                   "Buffer owns a copy of the memory resource, which means it must be copy constructible. "
@@ -298,7 +315,8 @@ public:
   buffer(::cuda::stream_ref __stream, _Resource&& __resource, _Range&& __range, [[maybe_unused]] const _Env& __env = {})
       : __buf_(::cuda::mr::__adapt_if_synchronous(::cuda::std::forward<_Resource>(__resource)),
                __stream,
-               static_cast<size_type>(::cuda::std::ranges::size(__range)))
+               static_cast<size_type>(::cuda::std::ranges::size(__range)),
+               __alignment_from_env(__env))
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
                   "Buffer owns a copy of the memory resource, which means it must be copy constructible. "
@@ -322,7 +340,7 @@ public:
                __stream,
                static_cast<size_type>(
                  ::cuda::std::ranges::distance(::cuda::std::ranges::begin(__range), ::cuda::std::ranges::end(__range))),
-               __env)
+               __alignment_from_env(__env))
   {
     static_assert(::cuda::std::is_copy_constructible_v<::cuda::std::decay_t<_Resource>>,
                   "Buffer owns a copy of the memory resource, which means it must be copy constructible. "
@@ -518,6 +536,12 @@ public:
     return __buf_.size() == 0;
   }
   //! @}
+
+  //! @brief Returns the alignment used for the allocation.
+  [[nodiscard]] _CCCL_HOST_API constexpr size_type alignment() const noexcept
+  {
+    return __buf_.alignment();
+  }
 
   //! @rst
   //! Returns a \c const reference to the :ref:`any_resource <libcudacxx-memory-resource-any-resource>` that holds the

--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -62,6 +62,7 @@ inline constexpr bool __buffer_compatible_env =
   ::cuda::std::is_same_v<::cuda::std::decay_t<_Env>, ::cuda::std::execution::env<>>
   || ::cuda::std::execution::__queryable_with<const _Env&, allocation_alignment_t>;
 
+_CCCL_BEGIN_NAMESPACE_ABI_VER4_BUMP
 //! @rst
 //! .. _libcudacxx-containers-async-vector:
 //!
@@ -638,6 +639,8 @@ public:
   _CCCL_REQUIRES((!property_with_value<_Property>) _CCCL_AND ::cuda::std::__is_included_in_v<_Property, _Properties...>)
   _CCCL_HIDE_FROM_ABI friend void get_property(const buffer&, _Property) noexcept {}
 };
+
+_CCCL_END_NAMESPACE_ABI_VER4_BUMP
 
 template <class _Tp>
 using device_buffer = buffer<_Tp, ::cuda::mr::device_accessible>;

--- a/libcudacxx/include/cuda/__container/heterogeneous_iterator.h
+++ b/libcudacxx/include/cuda/__container/heterogeneous_iterator.h
@@ -38,7 +38,7 @@
 //! @file The \c heterogeneous_iterator class is an iterator that provides typed execution space safety.
 _CCCL_BEGIN_NAMESPACE_CUDA
 
-enum class _IsConstIter
+enum class __is_heterogeneous_const_iter
 {
   __no,
   __yes,
@@ -72,8 +72,8 @@ public:
   using iterator_category = ::cuda::std::random_access_iterator_tag;
   using value_type        = _Tp;
   using difference_type   = ::cuda::std::ptrdiff_t;
-  using pointer           = ::cuda::std::__maybe_const<_IsConst == _IsConstIter::__yes, _Tp>*;
-  using reference         = ::cuda::std::__maybe_const<_IsConst == _IsConstIter::__yes, _Tp>&;
+  using pointer           = ::cuda::std::__maybe_const<_IsConst == __is_heterogeneous_const_iter::__yes, _Tp>*;
+  using reference         = ::cuda::std::__maybe_const<_IsConst == __is_heterogeneous_const_iter::__yes, _Tp>&;
 
   _CCCL_HIDE_FROM_ABI __heterogeneous_iterator_access() = default;
 
@@ -119,8 +119,8 @@ public:
   using iterator_category = ::cuda::std::random_access_iterator_tag;
   using value_type        = _Tp;
   using difference_type   = ::cuda::std::ptrdiff_t;
-  using pointer           = ::cuda::std::__maybe_const<_IsConst == _IsConstIter::__yes, _Tp>*;
-  using reference         = ::cuda::std::__maybe_const<_IsConst == _IsConstIter::__yes, _Tp>&;
+  using pointer           = ::cuda::std::__maybe_const<_IsConst == __is_heterogeneous_const_iter::__yes, _Tp>*;
+  using reference         = ::cuda::std::__maybe_const<_IsConst == __is_heterogeneous_const_iter::__yes, _Tp>&;
 
   _CCCL_HIDE_FROM_ABI __heterogeneous_iterator_access() = default;
 
@@ -166,8 +166,8 @@ public:
   using iterator_category = ::cuda::std::random_access_iterator_tag;
   using value_type        = _Tp;
   using difference_type   = ::cuda::std::ptrdiff_t;
-  using pointer           = ::cuda::std::__maybe_const<_IsConst == _IsConstIter::__yes, _Tp>*;
-  using reference         = ::cuda::std::__maybe_const<_IsConst == _IsConstIter::__yes, _Tp>&;
+  using pointer           = ::cuda::std::__maybe_const<_IsConst == __is_heterogeneous_const_iter::__yes, _Tp>*;
+  using reference         = ::cuda::std::__maybe_const<_IsConst == __is_heterogeneous_const_iter::__yes, _Tp>&;
 
   _CCCL_HIDE_FROM_ABI __heterogeneous_iterator_access() = default;
 

--- a/libcudacxx/include/cuda/__container/heterogeneous_iterator.h
+++ b/libcudacxx/include/cuda/__container/heterogeneous_iterator.h
@@ -61,11 +61,11 @@ template <class _CvTp, class... _Properties>
 class heterogeneous_iterator;
 
 // We restrict all accessors of the iterator based on the execution space
-template <class _Tp, _IsConstIter _IsConst, ::cuda::mr::__memory_accessability _Space>
+template <class _Tp, __is_heterogeneous_const_iter _IsConst, ::cuda::mr::__memory_accessibility _Space>
 class __heterogeneous_iterator_access;
 
-template <class _Tp, _IsConstIter _IsConst>
-class __heterogeneous_iterator_access<_Tp, _IsConst, ::cuda::mr::__memory_accessability::__host>
+template <class _Tp, __is_heterogeneous_const_iter _IsConst>
+class __heterogeneous_iterator_access<_Tp, _IsConst, ::cuda::mr::__memory_accessibility ::__host>
 {
 public:
   using iterator_concept  = ::cuda::std::contiguous_iterator_tag;
@@ -111,8 +111,8 @@ protected:
   friend class heterogeneous_iterator;
 };
 
-template <class _Tp, _IsConstIter _IsConst>
-class __heterogeneous_iterator_access<_Tp, _IsConst, ::cuda::mr::__memory_accessability::__device>
+template <class _Tp, __is_heterogeneous_const_iter _IsConst>
+class __heterogeneous_iterator_access<_Tp, _IsConst, ::cuda::mr::__memory_accessibility ::__device>
 {
 public:
   using iterator_concept  = ::cuda::std::contiguous_iterator_tag;
@@ -158,8 +158,8 @@ protected:
   friend class heterogeneous_iterator;
 };
 
-template <class _Tp, _IsConstIter _IsConst>
-class __heterogeneous_iterator_access<_Tp, _IsConst, ::cuda::mr::__memory_accessability::__host_device>
+template <class _Tp, __is_heterogeneous_const_iter _IsConst>
+class __heterogeneous_iterator_access<_Tp, _IsConst, ::cuda::mr::__memory_accessibility ::__host_device>
 {
 public:
   using iterator_concept  = ::cuda::std::contiguous_iterator_tag;
@@ -207,14 +207,15 @@ protected:
 
 template <class _CvTp, class... _Properties>
 class heterogeneous_iterator
-    : public __heterogeneous_iterator_access<::cuda::std::remove_const_t<_CvTp>,
-                                             ::cuda::std::is_const_v<_CvTp> ? _IsConstIter::__yes : _IsConstIter::__no,
-                                             ::cuda::mr::__memory_accessability_from_properties<_Properties...>::value>
+    : public __heterogeneous_iterator_access<
+        ::cuda::std::remove_const_t<_CvTp>,
+        ::cuda::std::is_const_v<_CvTp> ? __is_heterogeneous_const_iter::__yes : __is_heterogeneous_const_iter::__no,
+        ::cuda::mr::__memory_accessibility_from_properties<_Properties...>::value>
 {
-  using __base =
-    __heterogeneous_iterator_access<::cuda::std::remove_const_t<_CvTp>,
-                                    ::cuda::std::is_const_v<_CvTp> ? _IsConstIter::__yes : _IsConstIter::__no,
-                                    ::cuda::mr::__memory_accessability_from_properties<_Properties...>::value>;
+  using __base = __heterogeneous_iterator_access<
+    ::cuda::std::remove_const_t<_CvTp>,
+    ::cuda::std::is_const_v<_CvTp> ? __is_heterogeneous_const_iter::__yes : __is_heterogeneous_const_iter::__no,
+    ::cuda::mr::__memory_accessibility_from_properties<_Properties...>::value>;
 
 public:
   using iterator_concept  = ::cuda::std::contiguous_iterator_tag;

--- a/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
+++ b/libcudacxx/include/cuda/__container/uninitialized_async_buffer.h
@@ -23,6 +23,7 @@
 
 #if _CCCL_HAS_CTK()
 
+#  include <cuda/__memory_resource/allocation_alignment.h>
 #  include <cuda/__memory_resource/any_resource.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -85,6 +86,7 @@ private:
   __async_resource __mr_;
   ::cuda::stream_ref __stream_ = {::cudaStream_t{}};
   size_t __count_              = 0;
+  size_t __alignment_          = alignof(_Tp);
   void* __buf_                 = nullptr;
 
   template <class, class...>
@@ -99,21 +101,19 @@ private:
     && ::cuda::std::__type_set_contains_v<::cuda::std::__make_type_set<_OtherProperties...>, _Properties...>;
 
   //! @brief Determines the allocation size given the alignment and size of `T`
-  [[nodiscard]] _CCCL_HIDE_FROM_ABI static constexpr size_t __get_allocation_size(const size_t __count) noexcept
+  [[nodiscard]] _CCCL_HOST_API size_t __get_allocation_size(const size_t __count) const noexcept
   {
-    constexpr size_t __alignment = alignof(_Tp);
-    return (__count * sizeof(_Tp) + (__alignment - 1)) & ~(__alignment - 1);
+    return (__count * sizeof(_Tp) + (__alignment_ - 1)) & ~(__alignment_ - 1);
   }
 
   //! @brief Determines the properly aligned start of the buffer given the
   //! alignment and size of `T`
   [[nodiscard]] _CCCL_HIDE_FROM_ABI _Tp* __get_data() const noexcept
   {
-    constexpr size_t __alignment = alignof(_Tp);
-    size_t __space               = __get_allocation_size(__count_);
-    void* __ptr                  = __buf_;
+    size_t __space = __get_allocation_size(__count_);
+    void* __ptr    = __buf_;
     return ::cuda::std::launder(
-      static_cast<_Tp*>(::cuda::std::align(__alignment, __count_ * sizeof(_Tp), __ptr, __space)));
+      static_cast<_Tp*>(::cuda::std::align(__alignment_, __count_ * sizeof(_Tp), __ptr, __space)));
   }
 
   //! @brief Causes the buffer to be treated as a span when passed to
@@ -200,16 +200,28 @@ public:
   //! @note Depending on the alignment requirements of `T` the size of the
   //! underlying allocation might be larger than `count * sizeof(T)`. Only
   //! allocates memory when \p __count > 0
-  _CCCL_HIDE_FROM_ABI
-  __uninitialized_async_buffer(__async_resource __mr, const ::cuda::stream_ref __stream, const size_t __count)
+  _CCCL_HOST_API __uninitialized_async_buffer(
+    __async_resource __mr,
+    const ::cuda::stream_ref __stream,
+    const size_t __count,
+    const size_t __alignment = alignof(_Tp))
       : __mr_(::cuda::std::move(__mr))
       , __stream_(__stream)
       , __count_(__count)
-      , __buf_(__count_ == 0 ? nullptr : __mr_.allocate(__stream_, __get_allocation_size(__count_), alignof(_Tp)))
+      , __alignment_(__validate_alignment_param(__alignment))
+      , __buf_(__count_ == 0 ? nullptr : __mr_.allocate(__stream_, __get_allocation_size(__count_), __alignment_))
   {}
 
-  _CCCL_HIDE_FROM_ABI __uninitialized_async_buffer(const __uninitialized_async_buffer&)            = delete;
-  _CCCL_HIDE_FROM_ABI __uninitialized_async_buffer& operator=(const __uninitialized_async_buffer&) = delete;
+private:
+  static size_t __validate_alignment_param(size_t __a)
+  {
+    ::cuda::__validate_allocation_alignment(__a, alignof(_Tp));
+    return __a;
+  }
+
+public:
+  __uninitialized_async_buffer(const __uninitialized_async_buffer&)            = delete;
+  __uninitialized_async_buffer& operator=(const __uninitialized_async_buffer&) = delete;
 
   //! @brief Move-constructs a \c __uninitialized_async_buffer from \p __other
   //! @param __other Another \c __uninitialized_async_buffer
@@ -218,6 +230,7 @@ public:
       : __mr_(::cuda::std::move(__other.__mr_))
       , __stream_(::cuda::std::exchange(__other.__stream_, ::cuda::stream_ref{::cudaStream_t{}}))
       , __count_(::cuda::std::exchange(__other.__count_, 0))
+      , __alignment_(::cuda::std::exchange(__other.__alignment_, alignof(_Tp)))
       , __buf_(::cuda::std::exchange(__other.__buf_, nullptr))
   {}
 
@@ -231,6 +244,7 @@ public:
       : __mr_(::cuda::std::move(__other.__mr_))
       , __stream_(::cuda::std::exchange(__other.__stream_, ::cuda::stream_ref{::cudaStream_t{}}))
       , __count_(::cuda::std::exchange(__other.__count_, 0))
+      , __alignment_(::cuda::std::exchange(__other.__alignment_, alignof(_Tp)))
       , __buf_(::cuda::std::exchange(__other.__buf_, nullptr))
   {}
 
@@ -247,12 +261,13 @@ public:
 
     if (__buf_)
     {
-      __mr_.deallocate(__stream_, __buf_, __get_allocation_size(__count_), alignof(_Tp));
+      __mr_.deallocate(__stream_, __buf_, __get_allocation_size(__count_), __alignment_);
     }
-    __mr_     = ::cuda::std::move(__other.__mr_);
-    __stream_ = ::cuda::std::exchange(__other.__stream_, ::cuda::stream_ref{::cudaStream_t{}});
-    __count_  = ::cuda::std::exchange(__other.__count_, 0);
-    __buf_    = ::cuda::std::exchange(__other.__buf_, nullptr);
+    __mr_        = ::cuda::std::move(__other.__mr_);
+    __stream_    = ::cuda::std::exchange(__other.__stream_, ::cuda::stream_ref{::cudaStream_t{}});
+    __count_     = ::cuda::std::exchange(__other.__count_, 0);
+    __alignment_ = ::cuda::std::exchange(__other.__alignment_, alignof(_Tp));
+    __buf_       = ::cuda::std::exchange(__other.__buf_, nullptr);
     return *this;
   }
 
@@ -267,7 +282,7 @@ public:
   {
     if (__buf_)
     {
-      __mr_.deallocate(__stream, __buf_, __get_allocation_size(__count_), alignof(_Tp));
+      __mr_.deallocate(__stream, __buf_, __get_allocation_size(__count_), __alignment_);
       __buf_   = nullptr;
       __count_ = 0;
     }
@@ -342,6 +357,12 @@ public:
     return __count_;
   }
 
+  //! @brief Returns the alignment used for the allocation
+  [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr size_type alignment() const noexcept
+  {
+    return __alignment_;
+  }
+
   //! @brief Returns the size of the buffer in bytes
   [[nodiscard]] _CCCL_HIDE_FROM_ABI constexpr size_type size_bytes() const noexcept
   {
@@ -402,8 +423,10 @@ public:
   {
     // Create a new buffer with a reference to the stored memory resource and
     // swap allocation information
-    __uninitialized_async_buffer __ret{__fake_resource_ref{::cuda::std::addressof(__mr_)}, __stream_, __count};
+    __uninitialized_async_buffer __ret{
+      __fake_resource_ref{::cuda::std::addressof(__mr_)}, __stream_, __count, __alignment_};
     ::cuda::std::swap(__count_, __ret.__count_);
+    ::cuda::std::swap(__alignment_, __ret.__alignment_);
     ::cuda::std::swap(__buf_, __ret.__buf_);
     return __ret;
   }

--- a/libcudacxx/include/cuda/__memory_resource/allocation_alignment.h
+++ b/libcudacxx/include/cuda/__memory_resource/allocation_alignment.h
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+//
+//! @file
+//! @brief Execution property and helpers for specifying allocation alignment.
+//!
+//! Provides the \c allocation_alignment execution property: when present in an
+//! execution environment passed to container constructors (e.g. \c buffer),
+//! it specifies the alignment to use for the allocation. The value must be a
+//! power of two and not less than the element type's alignment.
+//!
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___MEMORY_RESOURCE_ALLOCATION_ALIGNMENT_H
+#define _CUDA___MEMORY_RESOURCE_ALLOCATION_ALIGNMENT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_CTK()
+
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__concepts/convertible_to.h>
+#  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__execution/env.h>
+#  include <cuda/std/__host_stdlib/stdexcept>
+#  include <cuda/std/cstddef>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+//! @brief True for types that expose allocation alignment via a member \c alignment().
+template <class _Tp>
+_CCCL_CONCEPT __has_member_alignment = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)(
+  requires(::cuda::std::convertible_to<decltype(__t.alignment()), ::cuda::std::size_t>));
+
+//! @brief Execution property type for querying allocation alignment from an environment or a buffer.
+struct allocation_alignment_t
+{
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Env)
+  _CCCL_REQUIRES(::cuda::std::execution::__queryable_with<_Env, allocation_alignment_t>)
+  [[nodiscard]] _CCCL_NODEBUG_API constexpr auto operator()(const _Env& __env) const noexcept -> ::cuda::std::size_t
+  {
+    static_assert(noexcept(__env.query(*this)));
+    return __env.query(*this);
+  }
+
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Tp)
+  _CCCL_REQUIRES(__has_member_alignment<_Tp> _CCCL_AND(
+    !::cuda::std::execution::__queryable_with<const _Tp&, allocation_alignment_t>))
+  [[nodiscard]] _CCCL_NODEBUG_API constexpr auto operator()(const _Tp& __t) const noexcept(noexcept(__t.alignment()))
+    -> ::cuda::std::size_t
+  {
+    return __t.alignment();
+  }
+
+  [[nodiscard]]
+  _CCCL_NODEBUG_API static constexpr auto query(::cuda::std::execution::forwarding_query_t) noexcept -> bool
+  {
+    return true;
+  }
+};
+
+//! @brief Execution property object: when bound in an environment (e.g. via \c execution::prop),
+//! specifies the alignment to use for allocations. Used by \c buffer and related containers.
+_CCCL_GLOBAL_CONSTANT auto allocation_alignment = allocation_alignment_t{};
+
+//! @brief Returns true if \p __alignment is a power of two and not less than \p __min_alignment.
+_CCCL_HOST_DEVICE inline constexpr bool
+__is_valid_allocation_alignment(::cuda::std::size_t __alignment, ::cuda::std::size_t __min_alignment) noexcept
+{
+  return __alignment >= __min_alignment && __alignment != 0 && (__alignment & (__alignment - 1)) == 0;
+}
+
+//! @brief Throws std::invalid_argument if \p __alignment is not a valid allocation alignment
+//! (power of two and at least \p __min_alignment).
+_CCCL_HOST inline void
+__validate_allocation_alignment(::cuda::std::size_t __alignment, ::cuda::std::size_t __min_alignment)
+{
+  if (!__is_valid_allocation_alignment(__alignment, __min_alignment))
+  {
+    _CCCL_THROW(::std::invalid_argument,
+                "Invalid allocation alignment: must be a power of two and at least the "
+                "type's alignment.");
+  }
+}
+
+_CCCL_END_NAMESPACE_CUDA
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HAS_CTK()
+
+#endif // _CUDA___MEMORY_RESOURCE_ALLOCATION_ALIGNMENT_H

--- a/libcudacxx/include/cuda/__memory_resource/allocation_alignment.h
+++ b/libcudacxx/include/cuda/__memory_resource/allocation_alignment.h
@@ -96,7 +96,7 @@ __validate_allocation_alignment(::cuda::std::size_t __alignment, ::cuda::std::si
 {
   if (!__is_valid_allocation_alignment(__alignment, __min_alignment))
   {
-    _CCCL_THROW(::std::invalid_argument,
+    _CCCL_THROW(std::invalid_argument,
                 "Invalid allocation alignment: must be a power of two and at least the "
                 "type's alignment.");
   }

--- a/libcudacxx/include/cuda/__memory_resource/any_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/any_resource.h
@@ -88,7 +88,8 @@ template <class _Property>
 using __iproperty = typename __with_property<_Property>::template __iproperty<>;
 
 template <class... _Properties>
-using __iproperty_set = ::cuda::__iset<__iproperty<_Properties>...>;
+using __iproperty_set =
+  ::cuda::__iset<__iproperty<_Properties>..., __iproperty<::cuda::mr::dynamic_accessibility_property>>;
 
 // Wrap the calls of the allocate and deallocate member functions
 // because of NVBUG#4967486
@@ -358,6 +359,15 @@ private:
     return *this;
   }
 };
+
+template <class... _Properties>
+inline constexpr bool __disable_default_dynamic_accessibility_property<any_resource<_Properties...>> = true;
+template <class... _Properties>
+inline constexpr bool __disable_default_dynamic_accessibility_property<resource_ref<_Properties...>> = true;
+template <class... _Properties>
+inline constexpr bool __disable_default_dynamic_accessibility_property<any_synchronous_resource<_Properties...>> = true;
+template <class... _Properties>
+inline constexpr bool __disable_default_dynamic_accessibility_property<synchronous_resource_ref<_Properties...>> = true;
 
 _CCCL_TEMPLATE(class... _Properties, class _Resource)
 _CCCL_REQUIRES(mr::synchronous_resource_with<_Resource, _Properties...>)

--- a/libcudacxx/include/cuda/__memory_resource/any_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/any_resource.h
@@ -195,6 +195,8 @@ struct __with_try_get_property
   }
 };
 
+_CCCL_BEGIN_NAMESPACE_ABI_VER4_BUMP
+
 template <class... _Properties>
 struct _CCCL_DECLSPEC_EMPTY_BASES any_resource;
 
@@ -359,6 +361,8 @@ private:
     return *this;
   }
 };
+
+_CCCL_END_NAMESPACE_ABI_VER4_BUMP
 
 template <class... _Properties>
 inline constexpr bool __disable_default_dynamic_accessibility_property<any_resource<_Properties...>> = true;

--- a/libcudacxx/include/cuda/__memory_resource/get_property.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_property.h
@@ -23,6 +23,7 @@
 
 #if _CCCL_HAS_CTK()
 
+#  include <cuda/__memory_resource/properties.h>
 #  include <cuda/std/__concepts/same_as.h>
 #  include <cuda/std/__type_traits/remove_const_ref.h>
 #  include <cuda/std/__type_traits/void_t.h>
@@ -92,20 +93,21 @@ _CCCL_CONCEPT property_with_value = _CCCL_REQUIRES_EXPR((_Property))(typename(__
 //!
 //! @endrst
 template <class _Resource, class _Property, class _Return>
-_CCCL_CONCEPT_FRAGMENT(__has_property_with_,
-                       requires(const _Resource& __res)(
-                         requires(property_with_value<_Property>),
-                         requires(::cuda::std::same_as<_Return, decltype(get_property(__res, _Property{}))>)));
-template <class _Resource, class _Property, class _Return>
-_CCCL_CONCEPT has_property_with = _CCCL_FRAGMENT(__has_property_with_, _Resource, _Property, _Return);
+_CCCL_CONCEPT has_property_with = _CCCL_REQUIRES_EXPR((_Resource, _Property, _Return), const _Resource& __res)(
+  requires(property_with_value<_Property>), _Same_as(_Return) get_property(__res, _Property{}));
 
 template <class _Resource, class _Upstream>
-_CCCL_CONCEPT_FRAGMENT(
-  __has_upstream_resource_,
-  requires(const _Resource& __res)(
-    requires(::cuda::std::same_as<::cuda::std::__remove_const_ref_t<decltype(__res.upstream_resource())>, _Upstream>)));
+_CCCL_CONCEPT __has_upstream_resource = _CCCL_REQUIRES_EXPR((_Resource, _Upstream), const _Resource& __res)(
+  requires(::cuda::std::same_as<::cuda::std::__remove_const_ref_t<decltype(__res.upstream_resource())>, _Upstream>));
+
 template <class _Resource, class _Upstream>
-_CCCL_CONCEPT __has_upstream_resource = _CCCL_FRAGMENT(__has_upstream_resource_, _Resource, _Upstream);
+_CCCL_CONCEPT __has_get_resource = _CCCL_REQUIRES_EXPR((_Resource, _Upstream), const _Resource& __res)(
+  requires(::cuda::std::same_as<::cuda::std::__remove_const_ref_t<decltype(__res.get())>, _Upstream>));
+#endif // ^^^ _CCCL_DOXYGEN_INVOKED ^^^
+
+template <class _Resource, class _Upstream>
+_CCCL_CONCEPT __has_forwarded_resource =
+  __has_upstream_resource<_Resource, _Upstream> || __has_get_resource<_Resource, _Upstream>;
 
 _CCCL_BEGIN_NAMESPACE_CPO(__forward_property)
 template <class _Derived, class _Upstream>
@@ -116,14 +118,35 @@ struct __fn
   _CCCL_REQUIRES((!property_with_value<_Property>) _CCCL_AND has_property<_Upstream, _Property>)
   _CCCL_API friend constexpr void get_property(const _Derived&, _Property) noexcept {}
 
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_API friend constexpr auto
+  get_property(const _Derived& __res, ::cuda::mr::dynamic_accessibility_property __prop) noexcept
+  {
+    if constexpr (__has_upstream_resource<_Derived, _Upstream>)
+    {
+      return get_property(__res.upstream_resource(), __prop);
+    }
+    else
+    {
+      return get_property(__res.get(), __prop);
+    }
+  }
+
   // The indirection is needed, otherwise the compiler might believe that _Derived is an incomplete type
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Property, class _Derived2 = _Derived)
   _CCCL_REQUIRES(property_with_value<_Property> _CCCL_AND has_property<_Upstream, _Property> _CCCL_AND
-                   __has_upstream_resource<_Derived2, _Upstream>)
+                   __has_forwarded_resource<_Derived2, _Upstream>)
   _CCCL_API friend constexpr __property_value_t<_Property> get_property(const _Derived& __res, _Property __prop)
   {
-    return get_property(__res.upstream_resource(), __prop);
+    if constexpr (__has_upstream_resource<_Derived, _Upstream>)
+    {
+      return get_property(__res.upstream_resource(), __prop);
+    }
+    else
+    {
+      return get_property(__res.get(), __prop);
+    }
   }
 };
 _CCCL_END_NAMESPACE_CPO
@@ -141,8 +164,9 @@ _CCCL_END_NAMESPACE_CPO
 //!
 //! .. note::
 //!
-//!    In order to forward stateful properties, a type needs do implement an `upstream_resource()` method that returns
-//!    an instance of the upstream.
+//!    In order to forward stateful properties, a type needs to implement either:
+//!    - an `upstream_resource()` method returning the upstream resource, or
+//!    - a `get()` method returning the upstream resource.
 //!
 //! @endrst
 template <class _Derived, class _Upstream>
@@ -150,7 +174,27 @@ using forward_property = __forward_property::__fn<_Derived, _Upstream>;
 
 _CCCL_END_NAMESPACE_CUDA
 
-#  include <cuda/std/__cccl/epilogue.h>
+_CCCL_BEGIN_NAMESPACE_CUDA_MR
+
+template <class _Tp>
+inline constexpr bool __disable_default_dynamic_accessibility_property = false;
+
+//! Default implementation: infer from has_property<Resource, host_accessible> and
+//! has_property<Resource, device_accessible>. Resources can override by providing
+//! their own get_property(..., dynamic_accessibility_property).
+//! Excluded for type-erased wrappers (any_resource, resource_ref, etc.) so that
+//! get_property dispatches via their interface to the stored concrete resource.
+_CCCL_TEMPLATE(class _Resource)
+_CCCL_REQUIRES((!__disable_default_dynamic_accessibility_property<_Resource>) )
+_CCCL_API constexpr __memory_accessibility
+get_property([[maybe_unused]] const _Resource& __res, dynamic_accessibility_property) noexcept
+{
+  return __memory_accessibility_from_static_properties<::cuda::has_property<_Resource, host_accessible>,
+                                                       ::cuda::has_property<_Resource, device_accessible>>();
+}
+_CCCL_END_NAMESPACE_CUDA_MR
+
+#include <cuda/std/__cccl/epilogue.h>
 
 #endif // _CCCL_HAS_CTK()
 

--- a/libcudacxx/include/cuda/__memory_resource/get_property.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_property.h
@@ -92,6 +92,7 @@ _CCCL_CONCEPT property_with_value = _CCCL_REQUIRES_EXPR((_Property))(typename(__
 //!    static_assert(!cuda::has_property_with<OtherResource, stateful_property, double>);
 //!
 //! @endrst
+#  ifndef _CCCL_DOXYGEN_INVOKED // Doxygen chokes here
 template <class _Resource, class _Property, class _Return>
 _CCCL_CONCEPT has_property_with = _CCCL_REQUIRES_EXPR((_Resource, _Property, _Return), const _Resource& __res)(
   requires(property_with_value<_Property>), _Same_as(_Return) get_property(__res, _Property{}));
@@ -103,7 +104,7 @@ _CCCL_CONCEPT __has_upstream_resource = _CCCL_REQUIRES_EXPR((_Resource, _Upstrea
 template <class _Resource, class _Upstream>
 _CCCL_CONCEPT __has_get_resource = _CCCL_REQUIRES_EXPR((_Resource, _Upstream), const _Resource& __res)(
   requires(::cuda::std::same_as<::cuda::std::__remove_const_ref_t<decltype(__res.get())>, _Upstream>));
-#endif // ^^^ _CCCL_DOXYGEN_INVOKED ^^^
+#  endif // ^^^ _CCCL_DOXYGEN_INVOKED ^^^
 
 template <class _Resource, class _Upstream>
 _CCCL_CONCEPT __has_forwarded_resource =
@@ -194,7 +195,7 @@ get_property([[maybe_unused]] const _Resource& __res, dynamic_accessibility_prop
 }
 _CCCL_END_NAMESPACE_CUDA_MR
 
-#include <cuda/std/__cccl/epilogue.h>
+#  include <cuda/std/__cccl/epilogue.h>
 
 #endif // _CCCL_HAS_CTK()
 

--- a/libcudacxx/include/cuda/__memory_resource/properties.h
+++ b/libcudacxx/include/cuda/__memory_resource/properties.h
@@ -108,21 +108,37 @@ template <typename _Resource>
 struct __copy_default_queries<_Resource, false>
 {};
 
-enum class __memory_accessability
+enum class __memory_accessibility
 {
+  __unknown,
   __host,
   __device,
   __host_device,
 };
 
-template <class... _Properties>
-struct __memory_accessability_from_properties
+//! @brief The dynamic_accessibility_property reports the resource's memory accessibility at runtime.
+//! Compared to the static properties, it can be used to query the memory accessibility of a resource that is not known
+//! at compile time.
+struct dynamic_accessibility_property
 {
-  static constexpr __memory_accessability value =
-    ::cuda::mr::__is_host_device_accessible<_Properties...> ? __memory_accessability::__host_device
-    : ::cuda::mr::__is_device_accessible<_Properties...>
-      ? __memory_accessability::__device
-      : __memory_accessability::__host;
+  using value_type = __memory_accessibility;
+};
+
+template <bool _HostAccessible, bool _DeviceAccessible>
+_CCCL_API constexpr __memory_accessibility __memory_accessibility_from_static_properties() noexcept
+{
+  return _HostAccessible && _DeviceAccessible ? __memory_accessibility ::__host_device
+       : _DeviceAccessible                    ? __memory_accessibility ::__device
+       : _HostAccessible                      ? __memory_accessibility ::__host
+                                              : __memory_accessibility ::__unknown;
+}
+
+template <class... _Properties>
+struct __memory_accessibility_from_properties
+{
+  static constexpr __memory_accessibility value =
+    __memory_accessibility_from_static_properties<::cuda::mr::__is_host_accessible<_Properties...>,
+                                                  ::cuda::mr::__is_device_accessible<_Properties...>>();
 };
 
 _CCCL_END_NAMESPACE_CUDA_MR

--- a/libcudacxx/include/cuda/__memory_resource/shared_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/shared_resource.h
@@ -50,7 +50,9 @@ _CCCL_BEGIN_NAMESPACE_CUDA_MR
 //! @tparam _Resource The resource type to hold.
 //! @endrst
 template <class _Resource>
-struct shared_resource : ::cuda::mr::__copy_default_queries<_Resource>
+struct shared_resource
+    : ::cuda::mr::__copy_default_queries<_Resource>
+    , ::cuda::forward_property<shared_resource<_Resource>, _Resource>
 {
   static_assert(::cuda::mr::synchronous_resource<_Resource>, "");
 
@@ -252,19 +254,6 @@ struct shared_resource : ::cuda::mr::__copy_default_queries<_Resource>
   [[nodiscard]] friend bool operator!=(const shared_resource& __lhs, const shared_resource& __rhs)
   {
     return !(__lhs == __rhs);
-  }
-
-  //! @brief Forwards the stateless properties
-  _CCCL_TEMPLATE(class _Property)
-  _CCCL_REQUIRES((!property_with_value<_Property>) _CCCL_AND(has_property<_Resource, _Property>))
-  friend void get_property(const shared_resource&, _Property) noexcept {}
-
-  //! @brief Forwards the stateful properties
-  _CCCL_TEMPLATE(class _Property)
-  _CCCL_REQUIRES(property_with_value<_Property> _CCCL_AND(has_property<_Resource, _Property>))
-  [[nodiscard]] friend __property_value_t<_Property> get_property(const shared_resource& __self, _Property) noexcept
-  {
-    return get_property(__self.__control_block->__resource, _Property{});
   }
 
 private:

--- a/libcudacxx/include/cuda/memory_resource
+++ b/libcudacxx/include/cuda/memory_resource
@@ -29,6 +29,7 @@
 #include <cuda/__memory_pool/device_memory_pool.h>
 #include <cuda/__memory_pool/managed_memory_pool.h>
 #include <cuda/__memory_pool/pinned_memory_pool.h>
+#include <cuda/__memory_resource/allocation_alignment.h>
 #include <cuda/__memory_resource/any_resource.h>
 #include <cuda/__memory_resource/get_memory_resource.h>
 #include <cuda/__memory_resource/get_property.h>

--- a/libcudacxx/include/cuda/std/__internal/namespaces.h
+++ b/libcudacxx/include/cuda/std/__internal/namespaces.h
@@ -47,6 +47,16 @@
   }                              \
   _CCCL_END_NAMESPACE_NOVERSION(_NS)
 
+// Open a namespace for APIs that were version bumped in a minor release
+// Version bump namespace should be removed from the APIs at the next major release
+#define _CCCL_BEGIN_NAMESPACE_ABI_VER4_BUMP                                           \
+  static_assert(_LIBCUDACXX_CUDA_ABI_VERSION == 4, "Version bump should be removed"); \
+  inline namespace __version_bump_ver4_                                               \
+  {
+#define _CCCL_END_NAMESPACE_ABI_VER4_BUMP                                             \
+  static_assert(_LIBCUDACXX_CUDA_ABI_VERSION == 4, "Version bump should be removed"); \
+  }
+
 // Standard namespaces with or without versioning
 #define _CCCL_BEGIN_NAMESPACE_CUDA_STD_NOVERSION _CCCL_BEGIN_NAMESPACE_NOVERSION(cuda::std)
 #define _CCCL_END_NAMESPACE_CUDA_STD_NOVERSION   _CCCL_END_NAMESPACE_NOVERSION(cuda::std)

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/conversion.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/conversion.cu
@@ -17,8 +17,9 @@
 #include <cuda/std/tuple>
 #include <cuda/std/type_traits>
 
+#include <test_resources.h>
+
 #include "helper.h"
-#include "test_resources.h"
 #include "types.h"
 
 C2H_CCCLRT_TEST("cuda::buffer conversion", "[container][buffer]", test_types)

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
@@ -21,7 +21,7 @@
 #include <cuda/std/iterator>
 #include <cuda/std/type_traits>
 
-#include "test_resources.h"
+#include <test_resources.h>
 
 // Default data to compare against
 

--- a/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
+++ b/libcudacxx/test/libcudacxx/cuda/containers/uninitialized_async_buffer.cu
@@ -16,11 +16,14 @@
 #include <cuda/memory_pool>
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
+#include <cuda/std/cstddef>
 #include <cuda/std/cstdint>
 #include <cuda/std/span>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
 #include <cuda/stream>
+
+#include <test_resources.h>
 
 #include "testing.cuh"
 
@@ -68,6 +71,14 @@ C2H_TEST_LIST(
       __uninitialized_async_buffer from_stream_count{resource, stream, 42};
       CCCLRT_CHECK(from_stream_count.data() != nullptr);
       CCCLRT_CHECK(from_stream_count.size() == 42);
+    }
+
+    {
+      const ::cuda::std::size_t alignment = 64;
+      offset_by_alignment_resource aligned_resource{resource};
+      __uninitialized_async_buffer from_stream_count{aligned_resource, stream, 42, alignment};
+      CCCLRT_CHECK(is_pointer_aligned(from_stream_count.data(), alignment));
+      CCCLRT_CHECK(from_stream_count.alignment() == alignment);
     }
 
     {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/any_resource/any_resource.cu
@@ -228,6 +228,34 @@ struct host_device_resource
 static_assert(cuda::has_property<host_device_resource, cuda::mr::device_accessible>);
 static_assert(cuda::has_property<host_device_resource, cuda::mr::host_accessible>);
 
+struct explicit_dynamic_resource
+{
+  void* allocate(cuda::stream_ref, size_t, size_t)
+  {
+    return nullptr;
+  }
+  void deallocate(cuda::stream_ref, void*, size_t, size_t) noexcept {}
+  void* allocate_sync(size_t, size_t)
+  {
+    return nullptr;
+  }
+  void deallocate_sync(void*, size_t, size_t) noexcept {}
+  friend bool operator==(const explicit_dynamic_resource&, const explicit_dynamic_resource&) noexcept
+  {
+    return true;
+  }
+  friend bool operator!=(const explicit_dynamic_resource&, const explicit_dynamic_resource&) noexcept
+  {
+    return false;
+  }
+  friend constexpr void get_property(const explicit_dynamic_resource&, cuda::mr::host_accessible) noexcept {}
+  friend constexpr cuda::mr::__memory_accessibility
+  get_property(const explicit_dynamic_resource&, cuda::mr::dynamic_accessibility_property) noexcept
+  {
+    return cuda::mr::__memory_accessibility ::__device;
+  }
+};
+
 void requires_host(cuda::mr::resource_ref<cuda::mr::host_accessible>) {}
 void requires_device(cuda::mr::resource_ref<cuda::mr::device_accessible>) {}
 
@@ -263,6 +291,22 @@ TEST_CASE("resource_ref regression test for cccl#6839", "[container][resource]")
   cuda::mr::any_resource<cuda::mr::host_accessible> res = host_device_mr;
   CHECK(checks_device_runtime_any_resource(res)); // Test that we are device accessible
   CHECK(checks_device_runtime_resource_ref(ref)); // Test that we are device accessible
+}
+
+TEST_CASE("dynamic_accessibility_property in type-erased wrappers", "[container][resource]")
+{
+  cuda::mr::any_resource<cuda::mr::host_accessible> host_device_any{host_device_resource{}};
+  CHECK(get_property(host_device_any, cuda::mr::dynamic_accessibility_property{})
+        == cuda::mr::__memory_accessibility ::__host_device);
+
+  cuda::mr::any_resource<cuda::mr::host_accessible> explicit_any{explicit_dynamic_resource{}};
+  CHECK(get_property(explicit_any, cuda::mr::dynamic_accessibility_property{})
+        == cuda::mr::__memory_accessibility ::__device);
+
+  host_device_resource host_device_mr{};
+  cuda::mr::resource_ref<cuda::mr::host_accessible> host_device_ref{host_device_mr};
+  CHECK(get_property(host_device_ref, cuda::mr::dynamic_accessibility_property{})
+        == cuda::mr::__memory_accessibility ::__host_device);
 }
 
 TEMPLATE_TEST_CASE_METHOD(test_fixture, "Empty property set", "[container][resource]", big_resource, small_resource)

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/get_property/forward_property.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/get_property/forward_property.pass.cpp
@@ -14,7 +14,7 @@
 #include <cuda/memory_resource>
 #include <cuda/std/cassert>
 
-namespace has_upstream_resource
+namespace has_forwarded_resource
 {
 struct Upstream
 {};
@@ -28,7 +28,7 @@ struct with_reference
     return upstream;
   }
 };
-static_assert(cuda::__has_upstream_resource<with_reference, Upstream>, "");
+static_assert(cuda::__has_forwarded_resource<with_reference, Upstream>, "");
 
 struct with_const_reference
 {
@@ -37,7 +37,7 @@ struct with_const_reference
     return upstream;
   }
 };
-static_assert(cuda::__has_upstream_resource<with_const_reference, Upstream>, "");
+static_assert(cuda::__has_forwarded_resource<with_const_reference, Upstream>, "");
 
 struct with_value
 {
@@ -46,7 +46,7 @@ struct with_value
     return Upstream{};
   }
 };
-static_assert(cuda::__has_upstream_resource<with_value, Upstream>, "");
+static_assert(cuda::__has_forwarded_resource<with_value, Upstream>, "");
 
 struct with_const_value
 {
@@ -55,7 +55,7 @@ struct with_const_value
     return Upstream{};
   }
 };
-static_assert(cuda::__has_upstream_resource<with_const_value, Upstream>, "");
+static_assert(cuda::__has_forwarded_resource<with_const_value, Upstream>, "");
 
 struct Convertible
 {
@@ -72,8 +72,26 @@ struct with_conversion
     return Convertible{};
   }
 };
-static_assert(!cuda::__has_upstream_resource<with_conversion, Upstream>, "");
-} // namespace has_upstream_resource
+static_assert(!cuda::__has_forwarded_resource<with_conversion, Upstream>, "");
+
+struct with_get_reference
+{
+  Upstream& get() const
+  {
+    return upstream;
+  }
+};
+static_assert(cuda::__has_forwarded_resource<with_get_reference, Upstream>, "");
+
+struct with_get_conversion
+{
+  Convertible get() const
+  {
+    return Convertible{};
+  }
+};
+static_assert(!cuda::__has_forwarded_resource<with_get_conversion, Upstream>, "");
+} // namespace has_forwarded_resource
 
 namespace forward_property
 {

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/properties/properties.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/properties/properties.pass.cpp
@@ -36,6 +36,46 @@ static_assert(!cuda::mr::__is_host_device_accessible<cuda::mr::host_accessible>,
 static_assert(!cuda::mr::__is_host_device_accessible<cuda::mr::device_accessible>, "");
 static_assert(cuda::mr::__is_host_device_accessible<cuda::mr::host_accessible, cuda::mr::device_accessible>, "");
 
+struct host_only_resource
+{
+  friend constexpr void get_property(const host_only_resource&, cuda::mr::host_accessible) noexcept {}
+};
+
+struct device_only_resource
+{
+  friend constexpr void get_property(const device_only_resource&, cuda::mr::device_accessible) noexcept {}
+};
+
+struct host_device_resource
+{
+  friend constexpr void get_property(const host_device_resource&, cuda::mr::host_accessible) noexcept {}
+  friend constexpr void get_property(const host_device_resource&, cuda::mr::device_accessible) noexcept {}
+};
+
+struct explicit_dynamic_resource
+{
+  friend constexpr void get_property(const explicit_dynamic_resource&, cuda::mr::host_accessible) noexcept {}
+  friend constexpr cuda::mr::__memory_accessibility
+  get_property(const explicit_dynamic_resource&, cuda::mr::dynamic_accessibility_property) noexcept
+  {
+    return cuda::mr::__memory_accessibility ::__device;
+  }
+};
+
+static_assert(cuda::has_property<host_only_resource, cuda::mr::dynamic_accessibility_property>);
+static_assert(cuda::has_property<device_only_resource, cuda::mr::dynamic_accessibility_property>);
+static_assert(cuda::has_property<host_device_resource, cuda::mr::dynamic_accessibility_property>);
+static_assert(cuda::has_property<explicit_dynamic_resource, cuda::mr::dynamic_accessibility_property>);
+
+static_assert(get_property(host_only_resource{}, cuda::mr::dynamic_accessibility_property{})
+              == cuda::mr::__memory_accessibility ::__host);
+static_assert(get_property(device_only_resource{}, cuda::mr::dynamic_accessibility_property{})
+              == cuda::mr::__memory_accessibility ::__device);
+static_assert(get_property(host_device_resource{}, cuda::mr::dynamic_accessibility_property{})
+              == cuda::mr::__memory_accessibility ::__host_device);
+static_assert(get_property(explicit_dynamic_resource{}, cuda::mr::dynamic_accessibility_property{})
+              == cuda::mr::__memory_accessibility ::__device);
+
 int main(int, char**)
 {
   return 0;

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_resource.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/shared_resource.cu
@@ -163,6 +163,12 @@ TEMPLATE_TEST_CASE_METHOD(test_fixture, "shared_resource", "[container][resource
     CHECK(this->counts == expected);
   }
 
+  SECTION("dynamic_accessibility_property forwards through shared_resource")
+  {
+    cuda::mr::shared_resource mr{cuda::std::in_place_type<TestResource>, 42, this};
+    CHECK(get_property(mr, cuda::mr::dynamic_accessibility_property{}) == cuda::mr::__memory_accessibility ::__host);
+  }
+
   // Reset the counters:
   this->counts = Counts();
 

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/synchronous_adapter.cu
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/synchronous_adapter.cu
@@ -28,7 +28,23 @@ constexpr bool passed_property =
 template <class Resource>
 constexpr bool same_properties =
   passed_property<Resource, cuda::mr::device_accessible> && passed_property<Resource, cuda::mr::host_accessible>
-  && passed_property<Resource, extra_property> && passed_property<Resource, get_data>;
+  && passed_property<Resource, extra_property> && passed_property<Resource, get_data>
+  && passed_property<Resource, cuda::mr::dynamic_accessibility_property>;
+
+struct explicit_dynamic_resource
+{
+  void* allocate_sync(size_t, size_t)
+  {
+    return nullptr;
+  }
+  void deallocate_sync(void*, size_t, size_t) noexcept {}
+  friend constexpr void get_property(const explicit_dynamic_resource&, cuda::mr::host_accessible) noexcept {}
+  friend constexpr cuda::mr::__memory_accessibility
+  get_property(const explicit_dynamic_resource&, cuda::mr::dynamic_accessibility_property) noexcept
+  {
+    return cuda::mr::__memory_accessibility ::__device;
+  }
+};
 
 C2H_CCCLRT_TEST("synchronous_resource_adapter", "[memory_resource]")
 {
@@ -69,5 +85,13 @@ C2H_CCCLRT_TEST("synchronous_resource_adapter", "[memory_resource]")
     STATIC_CHECK(same_default_queries<cuda::device_memory_pool_ref>);
     STATIC_CHECK(same_default_queries<cuda::mr::legacy_pinned_memory_resource>);
     STATIC_CHECK(same_default_queries<small_resource>);
+  }
+
+  SECTION("explicit dynamic_accessibility_property overrides template")
+  {
+    cuda::mr::synchronous_resource_adapter<explicit_dynamic_resource> adapter{explicit_dynamic_resource{}};
+    STATIC_CHECK(cuda::has_property<decltype(adapter), cuda::mr::dynamic_accessibility_property>);
+    CHECK(get_property(adapter, cuda::mr::dynamic_accessibility_property{})
+          == cuda::mr::__memory_accessibility ::__device);
   }
 }

--- a/libcudacxx/test/support/test_resources.h
+++ b/libcudacxx/test/support/test_resources.h
@@ -8,8 +8,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef CUDA_TEST_CONTAINER_VECTOR_TEST_RESOURCES_H
-#define CUDA_TEST_CONTAINER_VECTOR_TEST_RESOURCES_H
+#ifndef CUDA_TEST_CONTAINERS_TEST_RESOURCES_H
+#define CUDA_TEST_CONTAINERS_TEST_RESOURCES_H
 
 #include <cuda/__stream/stream_ref.h>
 #include <cuda/memory_resource>
@@ -75,8 +75,11 @@ struct memory_resource_wrapper
   friend void get_property(const memory_resource_wrapper&, other_property) noexcept {}
 };
 
-// Adapter that offsets the pointer by the alignment to enable testing that the resource was passed the correct
-// alignment.
+//! @brief Resource adapter for alignment testing.
+//! Allocates \c size + alignment from the upstream resource, then returns a pointer offset by
+//! \c alignment so that the returned pointer has the requested alignment. Use this to verify that
+//! containers pass the correct alignment to allocate: check that the returned pointer satisfies
+//! \c is_pointer_aligned(ptr, expected_alignment).
 template <typename Resource>
 struct offset_by_alignment_resource
     : ::cuda::mr::__copy_default_queries<Resource>
@@ -138,4 +141,11 @@ struct offset_by_alignment_resource
   }
 };
 
-#endif // CUDA_TEST_CONTAINER_VECTOR_TEST_RESOURCES_H
+//! @brief Returns true if \p ptr is aligned to \p alignment (power-of-two).
+template <typename T>
+inline bool is_pointer_aligned(const T* ptr, ::cuda::std::size_t alignment) noexcept
+{
+  return ptr != nullptr && (reinterpret_cast<std::uintptr_t>(ptr) % alignment == 0);
+}
+
+#endif // CUDA_TEST_CONTAINERS_TEST_RESOURCES_H


### PR DESCRIPTION
We changed the ABI of the buffer types to account for alignment as well as a potentialy dynamic memory accessibility property.

This backports 
#7623, #7727 and #7833