### PR TITLE
[libcu++] Change default pool getters to return memory_pool_ref&

### DIFF
--- a/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
@@ -81,11 +81,11 @@ public:
 //! @brief  Returns the default ``cudaMemPool_t`` from the specified device.
 //! @throws cuda_error if retrieving the default ``cudaMemPool_t`` fails.
 //! @returns The default memory pool of the specified device.
-[[nodiscard]] inline device_memory_pool_ref device_default_memory_pool(::cuda::device_ref __device)
+[[nodiscard]] inline device_memory_pool_ref& device_default_memory_pool(::cuda::device_ref __device)
 {
-  static ::cudaMemPool_t __pool = ::cuda::__get_default_memory_pool(
-    ::CUmemLocation{::CU_MEM_LOCATION_TYPE_DEVICE, __device.get()}, ::CU_MEM_ALLOCATION_TYPE_PINNED);
-  return device_memory_pool_ref(__pool);
+  static device_memory_pool_ref __pool{::cuda::__get_default_memory_pool(
+    ::CUmemLocation{::CU_MEM_LOCATION_TYPE_DEVICE, __device.get()}, ::CU_MEM_ALLOCATION_TYPE_PINNED)};
+  return __pool;
 }
 
 //! @rst

--- a/libcudacxx/include/cuda/__memory_pool/managed_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/managed_memory_pool.h
@@ -77,11 +77,11 @@ public:
 //! @brief Returns the default managed memory pool.
 //! @throws cuda_error if retrieving the default \c cudaMemPool_t fails.
 //! @returns The default managed memory pool.
-[[nodiscard]] inline managed_memory_pool_ref managed_default_memory_pool()
+[[nodiscard]] inline managed_memory_pool_ref& managed_default_memory_pool()
 {
-  static ::cudaMemPool_t __pool = ::cuda::__get_default_memory_pool(
-    ::CUmemLocation{::CU_MEM_LOCATION_TYPE_NONE, 0}, ::CU_MEM_ALLOCATION_TYPE_MANAGED);
-  return managed_memory_pool_ref(__pool);
+  static managed_memory_pool_ref __pool{::cuda::__get_default_memory_pool(
+    ::CUmemLocation{::CU_MEM_LOCATION_TYPE_NONE, 0}, ::CU_MEM_ALLOCATION_TYPE_MANAGED)};
+  return __pool;
 }
 
 //! @rst

--- a/libcudacxx/include/cuda/__memory_pool/pinned_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/pinned_memory_pool.h
@@ -41,8 +41,6 @@ _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
 // clang complains about missing braces in CUmemLocation constructor but GCC complains if we add them
 
-static ::cudaMemPool_t __get_default_host_pinned_pool();
-
 //! @rst
 //! .. _libcudacxx-memory-resource-async:
 //!
@@ -83,14 +81,6 @@ public:
 
   using default_queries = ::cuda::mr::properties_list<::cuda::mr::device_accessible, ::cuda::mr::host_accessible>;
 };
-
-//! @brief Returns the default pinned memory pool.
-//! @throws cuda_error if retrieving the default \c cudaMemPool_t fails.
-//! @returns The default pinned memory pool.
-[[nodiscard]] inline pinned_memory_pool_ref pinned_default_memory_pool()
-{
-  return pinned_memory_pool_ref{::cuda::__get_default_host_pinned_pool()};
-}
 
 //! @rst
 //! .. _libcudacxx-memory-resource-async:
@@ -188,23 +178,26 @@ static_assert(::cuda::mr::resource_with<pinned_memory_pool_ref, ::cuda::mr::host
 static_assert(::cuda::mr::resource_with<pinned_memory_pool, ::cuda::mr::device_accessible>, "");
 static_assert(::cuda::mr::resource_with<pinned_memory_pool, ::cuda::mr::host_accessible>, "");
 
-[[nodiscard]] static ::cudaMemPool_t __get_default_host_pinned_pool()
+//! @brief Returns the default pinned memory pool.
+//! @throws cuda_error if retrieving the default \c cudaMemPool_t fails.
+//! @returns The default pinned memory pool.
+[[nodiscard]] inline pinned_memory_pool_ref& pinned_default_memory_pool()
 {
 #    if _CCCL_CTK_AT_LEAST(13, 0)
-  static ::cudaMemPool_t __default_pool = []() {
+  static pinned_memory_pool_ref __default_pool{[]() {
     ::cudaMemPool_t __pool = ::cuda::__get_default_memory_pool(
       ::CUmemLocation{::CU_MEM_LOCATION_TYPE_HOST, 0}, ::CU_MEM_ALLOCATION_TYPE_PINNED);
     // TODO should we be more careful with setting access from all devices?
     // Maybe only if it was not set for any device?
     ::cuda::__mempool_set_access(__pool, ::cuda::devices, ::CU_MEM_ACCESS_FLAGS_PROT_READWRITE);
     return __pool;
-  }();
+  }()};
 
 #    else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
-  static ::cudaMemPool_t __default_pool = []() {
+  static pinned_memory_pool_ref __default_pool{[]() {
     cuda::pinned_memory_pool __pool(0);
     return __pool.release();
-  }();
+  }()};
 #    endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
   return __default_pool;
 }


### PR DESCRIPTION
Creating a `resource_ref` for a default memory pool creates a reference to a temporary returned from the default pool getter.
This PR changes the return type of those getters to `X_memory_pool_ref&` that references a static variable where we keep the pool.
