### PR TITLE
[Backport 3.3] Avoid GCC bug with dependent type template (#7857)

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -858,8 +858,11 @@ struct policy_hub
                              default_reduce_by_key_delay_constructor_t<AccumT, int>>;
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy500
+  using DefaultPolicy500 = DefaultPolicy<LOAD_LDG>;
+
   struct Policy500
-      : DefaultPolicy<LOAD_LDG>
+      : DefaultPolicy500
       , ChainedPolicy<500, Policy500, Policy500>
   {};
 
@@ -882,8 +885,11 @@ struct policy_hub
       decltype(select_agent_policy<sm80_tuning<KeyT, AccumT, is_primitive_op<ReductionOpT>()>>(0));
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy860
+  using DefaultPolicy860 = DefaultPolicy<LOAD_LDG>;
+
   struct Policy860
-      : DefaultPolicy<LOAD_LDG>
+      : DefaultPolicy860
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 

--- a/cub/cub/device/dispatch/tuning/tuning_run_length_encode.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_run_length_encode.cuh
@@ -301,8 +301,11 @@ struct policy_hub
                              default_reduce_by_key_delay_constructor_t<LengthT, int>>;
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy500
+  using DefaultPolicy500 = DefaultPolicy<LOAD_LDG>;
+
   struct Policy500
-      : DefaultPolicy<LOAD_LDG>
+      : DefaultPolicy500
       , ChainedPolicy<500, Policy500, Policy500>
   {};
 
@@ -323,8 +326,11 @@ struct policy_hub
     using ReduceByKeyPolicyT = decltype(select_agent_policy<sm80_tuning<LengthT, KeyT>>(0));
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy860
+  using DefaultPolicy860 = DefaultPolicy<LOAD_LDG>;
+
   struct Policy860
-      : DefaultPolicy<LOAD_LDG>
+      : DefaultPolicy860
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 
@@ -587,8 +593,12 @@ struct policy_hub
                      default_reduce_by_key_delay_constructor_t<DelayConstructorKey, int>>;
   };
 
+  // TODO(bgruber): I think we want `LengthT` instead of `int`
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy500
+  using DefaultPolicy500 = DefaultPolicy<BLOCK_LOAD_DIRECT, int, LOAD_LDG>;
+
   struct Policy500
-      : DefaultPolicy<BLOCK_LOAD_DIRECT, int, LOAD_LDG> // TODO(bgruber): I think we want `LengthT` instead of `int`
+      : DefaultPolicy500
       , ChainedPolicy<500, Policy500, Policy500>
   {};
 
@@ -611,8 +621,12 @@ struct policy_hub
     using RleSweepPolicyT = decltype(select_agent_policy<sm80_tuning<LengthT, KeyT>>(0));
   };
 
+  // TODO(bgruber): I think we want `LengthT` instead of `int`
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy860
+  using DefaultPolicy860 = DefaultPolicy<BLOCK_LOAD_DIRECT, int, LOAD_LDG>;
+
   struct Policy860
-      : DefaultPolicy<BLOCK_LOAD_DIRECT, int, LOAD_LDG> // TODO(bgruber): I think we want `LengthT` instead of `int`
+      : DefaultPolicy860
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 

--- a/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan_by_key.cuh
@@ -923,8 +923,11 @@ struct policy_hub
                            default_reduce_by_key_delay_constructor_t<DelayConstructurValueT, int>>;
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy520
+  using DefaultPolicy520 = DefaultPolicy<LOAD_CA, AccumT>;
+
   struct Policy520
-      : DefaultPolicy<LOAD_CA, AccumT>
+      : DefaultPolicy520
       , ChainedPolicy<520, Policy520, Policy500>
   {};
 
@@ -948,8 +951,11 @@ struct policy_hub
     using ScanByKeyPolicyT = decltype(select_agent_policy<sm80_tuning<key_t, ValueT, is_primitive_op<ScanOpT>()>>(0));
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy860
+  using DefaultPolicy860 = DefaultPolicy<LOAD_CA, AccumT>;
+
   struct Policy860
-      : DefaultPolicy<LOAD_CA, AccumT>
+      : DefaultPolicy860
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 

--- a/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_select_if.cuh
@@ -1487,8 +1487,11 @@ struct policy_hub
                           detail::fixed_delay_constructor_t<350, 450>>;
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy500
+  using DefaultPolicy500 = DefaultPolicy<may_alias ? LOAD_CA : LOAD_LDG>;
+
   struct Policy500
-      : DefaultPolicy<may_alias ? LOAD_CA : LOAD_LDG>
+      : DefaultPolicy500
       , ChainedPolicy<500, Policy500, Policy500>
   {};
 
@@ -1515,8 +1518,11 @@ struct policy_hub
                                                classify_input_size<InputT>()>>(0));
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy860
+  using DefaultPolicy860 = DefaultPolicy<may_alias ? LOAD_CA : LOAD_LDG>;
+
   struct Policy860
-      : DefaultPolicy<may_alias ? LOAD_CA : LOAD_LDG>
+      : DefaultPolicy860
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 

--- a/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_three_way_partition.cuh
@@ -356,8 +356,11 @@ struct policy_hub
                                    DelayConstructor>;
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy500
+  using DefaultPolicy500 = DefaultPolicy<fixed_delay_constructor_t<350, 450>>;
+
   struct Policy500
-      : DefaultPolicy<fixed_delay_constructor_t<350, 450>>
+      : DefaultPolicy500
       , ChainedPolicy<500, Policy500, Policy500>
   {};
 
@@ -380,8 +383,11 @@ struct policy_hub
     using ThreeWayPartitionPolicy = decltype(select_agent_policy<sm80_tuning<InputT, OffsetT>>(0));
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy860
+  using DefaultPolicy860 = DefaultPolicy<fixed_delay_constructor_t<350, 450>>;
+
   struct Policy860
-      : DefaultPolicy<fixed_delay_constructor_t<350, 450>>
+      : DefaultPolicy860
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 

--- a/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_unique_by_key.cuh
@@ -797,8 +797,11 @@ struct policy_hub
                              detail::default_delay_constructor_t<int>>;
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy500
+  using DefaultPolicy500 = DefaultPolicy<9, 128>;
+
   struct Policy500
-      : DefaultPolicy<9, 128>
+      : DefaultPolicy500
       , ChainedPolicy<500, Policy500, Policy500>
   {};
 
@@ -814,8 +817,11 @@ struct policy_hub
   template <typename Tuning>
   static _CCCL_HOST_DEVICE auto select_agent_policy(long) -> typename DefaultPolicy<11, 64>::UniqueByKeyPolicyT;
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy520
+  using DefaultPolicy520 = DefaultPolicy<11, 64>;
+
   struct Policy520
-      : DefaultPolicy<11, 64>
+      : DefaultPolicy520
       , ChainedPolicy<520, Policy520, Policy500>
   {};
 
@@ -824,8 +830,11 @@ struct policy_hub
     using UniqueByKeyPolicyT = decltype(select_agent_policy<sm80_tuning<KeyT, ValueT>>(0));
   };
 
+  // nvbug5935129: GCC-11.2 cannot directly use DefaultPolicy inside Policy860
+  using DefaultPolicy860 = DefaultPolicy<11, 64>;
+
   struct Policy860
-      : DefaultPolicy<11, 64>
+      : DefaultPolicy860
       , ChainedPolicy<860, Policy860, Policy800>
   {};
 


### PR DESCRIPTION
In our new policy definitions we often define a DefaultPolicy that is dependent on some other template parameters.

Older GCC, specifically gcc-11.2 cannot parse a type inheriting such a dependent type.

Luckily we can easily work around this by introducing an alias.

Fixes nvbug5935129
