### PR TITLE
Improve warpspeed scan tuning for sm120

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -655,7 +655,8 @@ struct policy_hub
 
     struct WarpspeedPolicy : Policy1000::WarpspeedPolicy
     {
-      static constexpr int items_per_thread = [] {
+      static _CCCL_API constexpr auto __compute_ipt()
+      {
         auto ipt = Policy1000::WarpspeedPolicy::items_per_thread;
 
         // based on cub.bench.scan.exclusive.custom.base, cap items per thread if we don't know the scan op
@@ -671,9 +672,10 @@ struct policy_hub
         }
 
         return ipt;
-      }();
+      }
 
-      static constexpr int tile_size = items_per_thread * Policy1000::WarpspeedPolicy::squad_reduce_thread_count;
+      static constexpr int items_per_thread = __compute_ipt();
+      static constexpr int tile_size        = items_per_thread * Policy1000::WarpspeedPolicy::squad_reduce_thread_count;
     };
   };
 


### PR DESCRIPTION
These tunings bring overall improvements and only introduce significant regressions for `cub.bench.scan.applications.P1.log-cdf-from-log-pdfs.base` for `F64`, but no regression when compared against the old implementation. No changes to `cub.bench.scan.exclusive.sum.base`.

Benchmarks:

`cub.bench.scan.exclusive.custom.base` warpspeed old tuning vs warpspeed this PR (this is the change of the status quo):
```
## [0] NVIDIA RTX PRO 6000 Blackwell Server Edition

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |          Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|---------------|---------|----------|
|   I8    |      I32      |      2^16      |  25.992 us |       1.62% |   6.430 us |      14.19% |    -19.562 us | -75.26% |   FAST   |
|   I8    |      I32      |      2^20      |  30.090 us |       0.54% |   9.876 us |       6.97% |    -20.214 us | -67.18% |   FAST   |
|   I8    |      I32      |      2^24      | 110.404 us |       1.20% |  40.263 us |       0.97% |    -70.141 us | -63.53% |   FAST   |
|   I8    |      I32      |      2^28      |   1.088 ms |       0.75% | 382.044 us |       0.38% |   -705.990 us | -64.89% |   FAST   |
|   I8    |      I64      |      2^16      |  26.397 us |       1.26% |   7.933 us |       3.86% |    -18.465 us | -69.95% |   FAST   |
|   I8    |      I64      |      2^20      |  29.351 us |       3.31% |   9.675 us |       4.01% |    -19.676 us | -67.04% |   FAST   |
|   I8    |      I64      |      2^24      | 110.070 us |       1.11% |  40.094 us |       1.49% |    -69.977 us | -63.57% |   FAST   |
|   I8    |      I64      |      2^28      |   1.082 ms |       0.40% | 381.147 us |       0.33% |   -700.978 us | -64.78% |   FAST   |
|   I8    |      I64      |      2^32      |  16.605 ms |       1.35% |   5.903 ms |       4.42% | -10702.056 us | -64.45% |   FAST   |
|   I16   |      I32      |      2^16      |  10.031 us |       3.81% |   7.978 us |       4.29% |     -2.053 us | -20.47% |   FAST   |
|   I16   |      I32      |      2^20      |  13.728 us |       2.17% |  11.708 us |       2.64% |     -2.020 us | -14.72% |   FAST   |
|   I16   |      I32      |      2^24      |  59.114 us |       1.59% |  49.128 us |       1.95% |     -9.986 us | -16.89% |   FAST   |
|   I16   |      I32      |      2^28      | 824.818 us |       0.22% | 736.180 us |       0.32% |    -88.638 us | -10.75% |   FAST   |
|   I16   |      I64      |      2^16      |   9.823 us |       6.60% |   7.551 us |       2.43% |     -2.272 us | -23.13% |   FAST   |
|   I16   |      I64      |      2^20      |  13.832 us |       3.86% |  11.644 us |       1.44% |     -2.188 us | -15.82% |   FAST   |
|   I16   |      I64      |      2^24      |  61.218 us |       1.38% |  48.525 us |       1.38% |    -12.693 us | -20.73% |   FAST   |
|   I16   |      I64      |      2^28      | 852.314 us |       0.23% | 735.958 us |       0.31% |   -116.356 us | -13.65% |   FAST   |
|   I16   |      I64      |      2^32      |  13.610 ms |       2.36% |  11.780 ms |       2.30% |  -1830.019 us | -13.45% |   FAST   |
|   I32   |      I32      |      2^16      |   7.978 us |       7.60% |   6.334 us |      13.10% |     -1.643 us | -20.60% |   FAST   |
|   I32   |      I32      |      2^20      |  14.589 us |       6.70% |  13.683 us |       1.24% |     -0.906 us |  -6.21% |   FAST   |
|   I32   |      I32      |      2^24      |  89.117 us |       1.25% |  90.231 us |       1.17% |      1.114 us |   1.25% |   SLOW   |
|   I32   |      I32      |      2^28      |   1.471 ms |       0.12% |   1.471 ms |       0.15% |     -0.090 us |  -0.01% |   SAME   |
|   I32   |      I64      |      2^16      |   7.681 us |       3.79% |   5.633 us |       5.06% |     -2.048 us | -26.66% |   FAST   |
|   I32   |      I64      |      2^20      |  14.405 us |       6.51% |  13.668 us |       1.21% |     -0.736 us |  -5.11% |   FAST   |
|   I32   |      I64      |      2^24      |  89.026 us |       1.30% |  89.575 us |       1.13% |      0.549 us |   0.62% |   SAME   |
|   I32   |      I64      |      2^28      |   1.472 ms |       0.12% |   1.471 ms |       0.15% |     -0.229 us |  -0.02% |   SAME   |
|   I32   |      I64      |      2^32      |  23.591 ms |       1.31% |  23.556 ms |       1.57% |    -35.064 us |  -0.15% |   SAME   |
|   I64   |      I32      |      2^16      |   8.868 us |      10.91% |   7.583 us |       2.96% |     -1.285 us | -14.49% |   FAST   |
|   I64   |      I32      |      2^20      |  17.975 us |       3.33% |  17.779 us |       0.80% |     -0.195 us |  -1.09% |   FAST   |
|   I64   |      I32      |      2^24      | 181.782 us |       0.60% | 184.715 us |       0.71% |      2.933 us |   1.61% |   SLOW   |
|   I64   |      I32      |      2^28      |   2.946 ms |       0.10% |   2.939 ms |       0.08% |     -6.692 us |  -0.23% |   FAST   |
|   I64   |      I64      |      2^16      |   7.768 us |       7.81% |   5.925 us |       8.46% |     -1.842 us | -23.72% |   FAST   |
|   I64   |      I64      |      2^20      |  18.153 us |       3.08% |  17.897 us |       2.96% |     -0.257 us |  -1.41% |   SAME   |
|   I64   |      I64      |      2^24      | 181.997 us |       0.85% | 186.267 us |       0.81% |      4.270 us |   2.35% |   SLOW   |
|   I64   |      I64      |      2^28      |   2.945 ms |       0.11% |   2.940 ms |       0.12% |     -5.863 us |  -0.20% |   FAST   |
|   I64   |      I64      |      2^32      |  47.203 ms |       0.04% |  47.108 ms |       0.04% |    -94.632 us |  -0.20% |   FAST   |
|  I128   |      I32      |      2^16      |  10.604 us |       9.66% |  10.424 us |       9.56% |     -0.181 us |  -1.70% |   SAME   |
|  I128   |      I32      |      2^20      |  45.458 us |       2.88% |  43.438 us |       6.32% |     -2.020 us |  -4.44% |   FAST   |
|  I128   |      I32      |      2^24      | 388.270 us |       0.60% | 388.237 us |       0.57% |     -0.034 us |  -0.01% |   SAME   |
|  I128   |      I32      |      2^28      |   5.943 ms |       0.09% |   5.943 ms |       0.10% |     -0.078 us |  -0.00% |   SAME   |
|  I128   |      I64      |      2^16      |   9.743 us |       5.51% |   9.841 us |       6.69% |      0.098 us |   1.00% |   SAME   |
|  I128   |      I64      |      2^20      |  40.775 us |       1.19% |  40.799 us |       1.21% |      0.024 us |   0.06% |   SAME   |
|  I128   |      I64      |      2^24      | 388.140 us |       0.65% | 388.275 us |       0.56% |      0.135 us |   0.03% |   SAME   |
|  I128   |      I64      |      2^28      |   5.944 ms |       0.09% |   5.943 ms |       0.10% |     -0.602 us |  -0.01% |   SAME   |
|   F32   |      I32      |      2^16      |   8.908 us |      11.26% |   7.523 us |       5.97% |     -1.385 us | -15.55% |   FAST   |
|   F32   |      I32      |      2^20      |  15.883 us |       3.48% |  13.862 us |       3.49% |     -2.021 us | -12.73% |   FAST   |
|   F32   |      I32      |      2^24      |  95.357 us |      10.88% |  98.464 us |      15.32% |      3.108 us |   3.26% |   SAME   |
|   F32   |      I32      |      2^28      |   1.472 ms |       0.13% |   1.472 ms |       0.15% |      0.329 us |   0.02% |   SAME   |
|   F32   |      I64      |      2^16      |   7.928 us |       7.08% |   6.937 us |      10.03% |     -0.991 us | -12.50% |   FAST   |
|   F32   |      I64      |      2^20      |  15.129 us |       5.23% |  13.881 us |       2.67% |     -1.248 us |  -8.25% |   FAST   |
|   F32   |      I64      |      2^24      |  89.410 us |       1.15% |  88.728 us |       1.40% |     -0.681 us |  -0.76% |   SAME   |
|   F32   |      I64      |      2^28      |   1.471 ms |       0.12% |   1.472 ms |       0.15% |      0.345 us |   0.02% |   SAME   |
|   F32   |      I64      |      2^32      |  23.592 ms |       1.32% |  23.554 ms |       1.55% |    -38.568 us |  -0.16% |   SAME   |
|   F64   |      I32      |      2^16      |  11.901 us |       4.22% |   9.223 us |      10.10% |     -2.679 us | -22.51% |   FAST   |
|   F64   |      I32      |      2^20      |  23.068 us |       4.62% |  19.898 us |       1.45% |     -3.170 us | -13.74% |   FAST   |
|   F64   |      I32      |      2^24      | 186.259 us |       0.65% | 189.732 us |       0.72% |      3.473 us |   1.86% |   SLOW   |
|   F64   |      I32      |      2^28      |   2.946 ms |       0.10% |   2.946 ms |       0.09% |      0.099 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^16      |  12.170 us |       2.21% |   8.383 us |       9.45% |     -3.787 us | -31.12% |   FAST   |
|   F64   |      I64      |      2^20      |  23.463 us |       4.37% |  19.916 us |       1.26% |     -3.547 us | -15.12% |   FAST   |
|   F64   |      I64      |      2^24      | 186.317 us |       0.73% | 189.897 us |       0.83% |      3.580 us |   1.92% |   SLOW   |
|   F64   |      I64      |      2^28      |   2.945 ms |       0.09% |   2.946 ms |       0.09% |      0.697 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^32      |  47.171 ms |       0.03% |  46.897 ms |       0.24% |   -274.088 us |  -0.58% |   FAST   |
|   C32   |      I32      |      2^16      | 114.704 us |       1.65% | 117.012 us |       1.04% |      2.308 us |   2.01% |   SLOW   |
|   C32   |      I32      |      2^20      | 139.389 us |       0.89% | 140.669 us |       3.82% |      1.280 us |   0.92% |   SLOW   |
|   C32   |      I32      |      2^24      | 788.921 us |       0.61% | 783.123 us |       0.62% |     -5.798 us |  -0.73% |   FAST   |
|   C32   |      I32      |      2^28      |  11.060 ms |       0.12% |  11.051 ms |       0.13% |     -8.509 us |  -0.08% |   SAME   |
|   C32   |      I64      |      2^16      | 108.385 us |       0.81% | 110.716 us |       0.85% |      2.331 us |   2.15% |   SLOW   |
|   C32   |      I64      |      2^20      | 138.170 us |       0.90% | 138.235 us |       0.90% |      0.066 us |   0.05% |   SAME   |
|   C32   |      I64      |      2^24      | 787.035 us |       0.59% | 783.598 us |       0.62% |     -3.437 us |  -0.44% |   SAME   |
|   C32   |      I64      |      2^28      |  11.047 ms |       0.13% |  11.045 ms |       0.14% |     -1.116 us |  -0.01% |   SAME   |
|   C32   |      I64      |      2^32      | 175.074 ms |       0.03% | 175.146 ms |       0.04% |     72.232 us |   0.04% |   SLOW   |
```

`cub.bench.scan.applications.P1.log-cdf-from-log-pdfs.base` warpspeed old tuning vs warpspeed this PR (this is the change of the status quo):
```
## [0] NVIDIA RTX PRO 6000 Blackwell Server Edition

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  Mu{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|----------|------------|-------------|------------|-------------|------------|---------|----------|
|   F32   |      I32      |      2^16      |  0.0001  |  30.754 us |       2.78% |  10.098 us |       6.12% | -20.656 us | -67.17% |   FAST   |
|   F32   |      I32      |      2^20      |  0.0001  |  36.654 us |       2.16% |  17.930 us |       2.97% | -18.724 us | -51.08% |   FAST   |
|   F32   |      I32      |      2^24      |  0.0001  | 144.325 us |       1.56% | 100.225 us |       2.07% | -44.100 us | -30.56% |   FAST   |
|   F32   |      I32      |      2^28      |  0.0001  |   1.512 ms |       0.15% |   1.507 ms |       0.21% |  -5.153 us |  -0.34% |   FAST   |
|   F32   |      I64      |      2^16      |  0.0001  |  33.988 us |       2.06% |  10.577 us |       8.35% | -23.412 us | -68.88% |   FAST   |
|   F32   |      I64      |      2^20      |  0.0001  |  26.348 us |       1.31% |  18.582 us |       3.50% |  -7.766 us | -29.47% |   FAST   |
|   F32   |      I64      |      2^24      |  0.0001  | 145.280 us |       1.40% |  98.858 us |       2.20% | -46.422 us | -31.95% |   FAST   |
|   F32   |      I64      |      2^28      |  0.0001  |   1.511 ms |       0.15% |   1.506 ms |       0.22% |  -5.098 us |  -0.34% |   FAST   |
|   F64   |      I32      |      2^16      |  0.0001  | 183.153 us |       0.55% | 109.391 us |       0.99% | -73.761 us | -40.27% |   FAST   |
|   F64   |      I32      |      2^20      |  0.0001  | 343.870 us |       0.96% | 367.429 us |       0.83% |  23.559 us |   6.85% |   SLOW   |
|   F64   |      I32      |      2^24      |  0.0001  |   3.417 ms |       0.18% |   4.915 ms |       0.05% |   1.498 ms |  43.85% |   SLOW   |
|   F64   |      I32      |      2^28      |  0.0001  |  52.841 ms |       0.05% |  77.814 ms |       0.02% |  24.974 ms |  47.26% |   SLOW   |
|   F64   |      I64      |      2^16      |  0.0001  | 175.797 us |       0.68% | 100.744 us |       1.32% | -75.054 us | -42.69% |   FAST   |
|   F64   |      I64      |      2^20      |  0.0001  | 344.260 us |       0.83% | 367.321 us |       0.73% |  23.060 us |   6.70% |   SLOW   |
|   F64   |      I64      |      2^24      |  0.0001  |   3.421 ms |       0.29% |   4.911 ms |       0.06% |   1.490 ms |  43.55% |   SLOW   |
|   F64   |      I64      |      2^28      |  0.0001  |  52.804 ms |       0.04% |  77.728 ms |       0.03% |  24.924 ms |  47.20% |   SLOW   |
```

`cub.bench.scan.applications.P1.scan-over-unitriangular-group.base` warpspeed old tuning vs warpspeed this PR (this is the change of the status quo):
```
## [0] NVIDIA RTX PRO 6000 Blackwell Server Edition

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I32   |      I32      |      2^16      |   8.053 us |       3.84% |   8.032 us |       4.18% |   -0.020 us |  -0.25% |   SAME   |
|   I32   |      I32      |      2^20      |  24.861 us |       3.35% |  24.957 us |       3.39% |    0.096 us |   0.39% |   SAME   |
|   I32   |      I32      |      2^24      | 276.360 us |       0.50% | 276.382 us |       0.52% |    0.023 us |   0.01% |   SAME   |
|   I32   |      I32      |      2^28      |   4.424 ms |       1.12% |   4.425 ms |       1.21% |    0.673 us |   0.02% |   SAME   |
|   I32   |      I64      |      2^16      |   9.791 us |       8.77% |   9.834 us |       7.88% |    0.042 us |   0.43% |   SAME   |
|   I32   |      I64      |      2^20      |  25.284 us |       3.84% |  25.224 us |       3.76% |   -0.059 us |  -0.23% |   SAME   |
|   I32   |      I64      |      2^24      | 276.277 us |       0.50% | 276.284 us |       0.53% |    0.007 us |   0.00% |   SAME   |
|   I32   |      I64      |      2^28      |   4.423 ms |       0.95% |   4.424 ms |       1.19% |    1.220 us |   0.03% |   SAME   |
|   U64   |      I32      |      2^16      |  10.582 us |      12.55% |  10.631 us |      12.76% |    0.049 us |   0.46% |   SAME   |
|   U64   |      I32      |      2^20      |  56.178 us |       2.60% |  56.248 us |       2.62% |    0.070 us |   0.12% |   SAME   |
|   U64   |      I32      |      2^24      | 580.116 us |       0.28% | 580.072 us |       0.27% |   -0.044 us |  -0.01% |   SAME   |
|   U64   |      I32      |      2^28      |   8.970 ms |       0.08% |   8.970 ms |       0.08% |    0.093 us |   0.00% |   SAME   |
|   U64   |      I64      |      2^16      |  13.095 us |       6.92% |  12.722 us |       7.23% |   -0.373 us |  -2.85% |   SAME   |
|   U64   |      I64      |      2^20      |  57.577 us |       2.15% |  57.411 us |       2.36% |   -0.166 us |  -0.29% |   SAME   |
|   U64   |      I64      |      2^24      | 580.200 us |       0.27% | 580.125 us |       0.27% |   -0.074 us |  -0.01% |   SAME   |
|   U64   |      I64      |      2^28      |   8.971 ms |       0.08% |   8.952 ms |       0.23% |  -19.317 us |  -0.22% |   FAST   |
|   F32   |      I32      |      2^16      |  10.060 us |      14.27% |   8.794 us |      12.29% |   -1.267 us | -12.59% |   FAST   |
|   F32   |      I32      |      2^20      |  24.802 us |       2.98% |  23.550 us |       4.32% |   -1.251 us |  -5.05% |   FAST   |
|   F32   |      I32      |      2^24      | 276.811 us |       0.47% | 275.740 us |       0.44% |   -1.071 us |  -0.39% |   SAME   |
|   F32   |      I32      |      2^28      |   4.424 ms |       1.09% |   4.421 ms |       1.00% |   -2.510 us |  -0.06% |   SAME   |
|   F32   |      I64      |      2^16      |  10.472 us |       5.68% |   9.944 us |       4.16% |   -0.528 us |  -5.05% |   FAST   |
|   F32   |      I64      |      2^20      |  25.054 us |       3.70% |  24.187 us |       3.72% |   -0.867 us |  -3.46% |   SAME   |
|   F32   |      I64      |      2^24      | 276.713 us |       0.52% | 276.421 us |       0.53% |   -0.292 us |  -0.11% |   SAME   |
|   F32   |      I64      |      2^28      |   4.424 ms |       1.18% |   4.421 ms |       1.06% |   -2.677 us |  -0.06% |   SAME   |
|   F64   |      I32      |      2^16      |  16.648 us |       6.90% |  14.998 us |       8.22% |   -1.650 us |  -9.91% |   FAST   |
|   F64   |      I32      |      2^20      |  72.325 us |       1.47% |  67.004 us |       1.29% |   -5.321 us |  -7.36% |   FAST   |
|   F64   |      I32      |      2^24      | 778.600 us |       0.18% | 698.192 us |       0.18% |  -80.407 us | -10.33% |   FAST   |
|   F64   |      I32      |      2^28      |  11.341 ms |       5.01% |  10.873 ms |       0.04% | -467.185 us |  -4.12% |   FAST   |
|   F64   |      I64      |      2^16      |  15.688 us |       9.26% |  15.971 us |       8.92% |    0.283 us |   1.80% |   SAME   |
|   F64   |      I64      |      2^20      |  67.102 us |       1.45% |  67.123 us |       1.56% |    0.021 us |   0.03% |   SAME   |
|   F64   |      I64      |      2^24      | 696.105 us |       0.19% | 695.743 us |       0.19% |   -0.362 us |  -0.05% |   SAME   |
|   F64   |      I64      |      2^28      |  10.843 ms |       0.14% |  10.839 ms |       0.03% |   -4.103 us |  -0.04% |   FAST   |
```

`cub.bench.scan.applications.P1.non-commutative-bicyclic-monoid.base` warpspeed old tuning vs warpspeed this PR (this is the change of the status quo):
```
## [0] NVIDIA RTX PRO 6000 Blackwell Server Edition

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-----------|---------|----------|
|   U32   |      I32      |      2^16      |   7.696 us |       6.40% |   7.750 us |       6.76% |  0.054 us |   0.70% |   SAME   |
|   U32   |      I32      |      2^20      |  20.069 us |       3.18% |  20.088 us |       2.87% |  0.020 us |   0.10% |   SAME   |
|   U32   |      I32      |      2^24      | 184.480 us |       0.74% | 184.626 us |       0.75% |  0.145 us |   0.08% |   SAME   |
|   U32   |      I32      |      2^28      |   2.950 ms |       0.10% |   2.949 ms |       0.11% | -0.090 us |  -0.00% |   SAME   |
|   U32   |      I64      |      2^16      |   9.616 us |       1.87% |   9.664 us |       3.91% |  0.049 us |   0.51% |   SAME   |
|   U32   |      I64      |      2^20      |  20.044 us |       2.90% |  20.185 us |       3.20% |  0.141 us |   0.70% |   SAME   |
|   U32   |      I64      |      2^24      | 184.862 us |       0.76% | 184.824 us |       0.78% | -0.038 us |  -0.02% |   SAME   |
|   U32   |      I64      |      2^28      |   2.949 ms |       0.11% |   2.949 ms |       0.11% | -0.044 us |  -0.00% |   SAME   |
|   U64   |      I32      |      2^16      |   9.658 us |       2.12% |   9.671 us |       2.35% |  0.013 us |   0.13% |   SAME   |
|   U64   |      I32      |      2^20      |  42.920 us |       2.10% |  43.008 us |       2.21% |  0.088 us |   0.21% |   SAME   |
|   U64   |      I32      |      2^24      | 387.232 us |       1.02% | 386.863 us |       1.04% | -0.369 us |  -0.10% |   SAME   |
|   U64   |      I32      |      2^28      |   5.926 ms |       0.07% |   5.926 ms |       0.07% | -0.018 us |  -0.00% |   SAME   |
|   U64   |      I64      |      2^16      |  10.016 us |       8.33% |  10.035 us |       8.38% |  0.019 us |   0.19% |   SAME   |
|   U64   |      I64      |      2^20      |  43.079 us |       1.93% |  43.156 us |       2.11% |  0.077 us |   0.18% |   SAME   |
|   U64   |      I64      |      2^24      | 387.235 us |       1.01% | 387.400 us |       1.01% |  0.165 us |   0.04% |   SAME   |
|   U64   |      I64      |      2^28      |   5.925 ms |       0.07% |   5.925 ms |       0.07% |  0.085 us |   0.00% |   SAME   |
|  U128   |      I32      |      2^16      |  14.745 us |       5.49% |  14.577 us |       4.68% | -0.168 us |  -1.14% |   SAME   |
|  U128   |      I32      |      2^20      |  79.733 us |       1.46% |  79.784 us |       1.39% |  0.051 us |   0.06% |   SAME   |
|  U128   |      I32      |      2^24      | 802.534 us |       0.35% | 802.602 us |       0.38% |  0.068 us |   0.01% |   SAME   |
|  U128   |      I32      |      2^28      |  12.529 ms |       0.31% |  12.528 ms |       0.32% | -1.471 us |  -0.01% |   SAME   |
|  U128   |      I64      |      2^16      |  14.216 us |       6.21% |  14.044 us |       6.42% | -0.172 us |  -1.21% |   SAME   |
|  U128   |      I64      |      2^20      |  77.444 us |       1.64% |  77.368 us |       1.49% | -0.075 us |  -0.10% |   SAME   |
|  U128   |      I64      |      2^24      | 797.224 us |       0.42% | 796.650 us |       0.38% | -0.574 us |  -0.07% |   SAME   |
|  U128   |      I64      |      2^28      |  12.483 ms |       0.10% |  12.482 ms |       0.10% | -1.247 us |  -0.01% |   SAME   |
```


---------



`cub.bench.scan.exclusive.custom.base` old scan vs warpspeed this PR (this is the change we will currently ship in CCCL 3.4):
```
## [0] NVIDIA RTX PRO 6000 Blackwell Server Edition

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |          Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|---------------|---------|----------|
|   I8    |      I32      |      2^16      |   5.617 us |       4.96% |   6.430 us |      14.19% |      0.813 us |  14.46% |   SLOW   |
|   I8    |      I32      |      2^20      |  11.614 us |       1.91% |   9.876 us |       6.97% |     -1.738 us | -14.96% |   FAST   |
|   I8    |      I32      |      2^24      |  38.186 us |       1.48% |  40.263 us |       0.97% |      2.077 us |   5.44% |   SLOW   |
|   I8    |      I32      |      2^28      | 498.029 us |       0.93% | 382.044 us |       0.38% |   -115.984 us | -23.29% |   FAST   |
|   I8    |      I64      |      2^16      |   7.983 us |       5.73% |   7.933 us |       3.86% |     -0.050 us |  -0.63% |   SAME   |
|   I8    |      I64      |      2^20      |  11.582 us |       2.80% |   9.675 us |       4.01% |     -1.907 us | -16.46% |   FAST   |
|   I8    |      I64      |      2^24      |  38.218 us |       1.43% |  40.094 us |       1.49% |      1.875 us |   4.91% |   SLOW   |
|   I8    |      I64      |      2^28      | 487.058 us |       1.29% | 381.147 us |       0.33% |   -105.910 us | -21.74% |   FAST   |
|   I8    |      I64      |      2^32      |   7.888 ms |       1.94% |   5.903 ms |       4.42% |  -1985.182 us | -25.17% |   FAST   |
|   I16   |      I32      |      2^16      |   7.605 us |      10.45% |   7.978 us |       4.29% |      0.373 us |   4.90% |   SLOW   |
|   I16   |      I32      |      2^20      |  11.706 us |       2.19% |  11.708 us |       2.64% |      0.001 us |   0.01% |   SAME   |
|   I16   |      I32      |      2^24      |  51.179 us |       1.89% |  49.128 us |       1.95% |     -2.051 us |  -4.01% |   FAST   |
|   I16   |      I32      |      2^28      | 764.905 us |       0.36% | 736.180 us |       0.32% |    -28.724 us |  -3.76% |   FAST   |
|   I16   |      I64      |      2^16      |   7.164 us |      10.72% |   7.551 us |       2.43% |      0.387 us |   5.40% |   SLOW   |
|   I16   |      I64      |      2^20      |  11.624 us |       0.82% |  11.644 us |       1.44% |      0.020 us |   0.17% |   SAME   |
|   I16   |      I64      |      2^24      |  51.168 us |       1.60% |  48.525 us |       1.38% |     -2.643 us |  -5.17% |   FAST   |
|   I16   |      I64      |      2^28      | 764.814 us |       0.35% | 735.958 us |       0.31% |    -28.857 us |  -3.77% |   FAST   |
|   I16   |      I64      |      2^32      |  11.942 ms |       2.80% |  11.780 ms |       2.30% |   -162.026 us |  -1.36% |   SAME   |
|   I32   |      I32      |      2^16      |   6.300 us |      13.38% |   6.334 us |      13.10% |      0.034 us |   0.54% |   SAME   |
|   I32   |      I32      |      2^20      |  13.681 us |       1.16% |  13.683 us |       1.24% |      0.002 us |   0.01% |   SAME   |
|   I32   |      I32      |      2^24      |  90.198 us |       1.25% |  90.231 us |       1.17% |      0.033 us |   0.04% |   SAME   |
|   I32   |      I32      |      2^28      |   1.471 ms |       0.17% |   1.471 ms |       0.15% |      0.061 us |   0.00% |   SAME   |
|   I32   |      I64      |      2^16      |   5.607 us |       4.97% |   5.633 us |       5.06% |      0.027 us |   0.48% |   SAME   |
|   I32   |      I64      |      2^20      |  13.661 us |       1.63% |  13.668 us |       1.21% |      0.007 us |   0.05% |   SAME   |
|   I32   |      I64      |      2^24      |  89.601 us |       1.10% |  89.575 us |       1.13% |     -0.026 us |  -0.03% |   SAME   |
|   I32   |      I64      |      2^28      |   1.471 ms |       0.16% |   1.471 ms |       0.15% |      0.054 us |   0.00% |   SAME   |
|   I32   |      I64      |      2^32      |  23.557 ms |       1.47% |  23.556 ms |       1.57% |     -0.736 us |  -0.00% |   SAME   |
|   I64   |      I32      |      2^16      |   7.610 us |       2.85% |   7.583 us |       2.96% |     -0.027 us |  -0.35% |   SAME   |
|   I64   |      I32      |      2^20      |  17.787 us |       1.52% |  17.779 us |       0.80% |     -0.008 us |  -0.04% |   SAME   |
|   I64   |      I32      |      2^24      | 184.743 us |       0.70% | 184.715 us |       0.71% |     -0.027 us |  -0.01% |   SAME   |
|   I64   |      I32      |      2^28      |   2.939 ms |       0.07% |   2.939 ms |       0.08% |     -0.115 us |  -0.00% |   SAME   |
|   I64   |      I64      |      2^16      |   5.933 us |       8.03% |   5.925 us |       8.46% |     -0.008 us |  -0.13% |   SAME   |
|   I64   |      I64      |      2^20      |  17.873 us |       3.02% |  17.897 us |       2.96% |      0.023 us |   0.13% |   SAME   |
|   I64   |      I64      |      2^24      | 186.303 us |       0.75% | 186.267 us |       0.81% |     -0.036 us |  -0.02% |   SAME   |
|   I64   |      I64      |      2^28      |   2.939 ms |       0.12% |   2.940 ms |       0.12% |      0.278 us |   0.01% |   SAME   |
|   I64   |      I64      |      2^32      |  47.108 ms |       0.04% |  47.108 ms |       0.04% |      0.227 us |   0.00% |   SAME   |
|  I128   |      I32      |      2^16      |  11.745 us |       2.29% |  10.424 us |       9.56% |     -1.321 us | -11.25% |   FAST   |
|  I128   |      I32      |      2^20      |  48.455 us |      10.88% |  43.438 us |       6.32% |     -5.017 us | -10.35% |   FAST   |
|  I128   |      I32      |      2^24      | 462.862 us |       0.53% | 388.237 us |       0.57% |    -74.626 us | -16.12% |   FAST   |
|  I128   |      I32      |      2^28      |   7.195 ms |       0.15% |   5.943 ms |       0.10% |  -1251.359 us | -17.39% |   FAST   |
|  I128   |      I64      |      2^16      |  11.417 us |       5.51% |   9.841 us |       6.69% |     -1.576 us | -13.80% |   FAST   |
|  I128   |      I64      |      2^20      |  42.793 us |       1.85% |  40.799 us |       1.21% |     -1.995 us |  -4.66% |   FAST   |
|  I128   |      I64      |      2^24      | 462.534 us |       0.54% | 388.275 us |       0.56% |    -74.258 us | -16.05% |   FAST   |
|  I128   |      I64      |      2^28      |   7.187 ms |       0.14% |   5.943 ms |       0.10% |  -1243.422 us | -17.30% |   FAST   |
|   F32   |      I32      |      2^16      |   7.472 us |       7.01% |   7.523 us |       5.97% |      0.051 us |   0.68% |   SAME   |
|   F32   |      I32      |      2^20      |  13.926 us |       4.05% |  13.862 us |       3.49% |     -0.064 us |  -0.46% |   SAME   |
|   F32   |      I32      |      2^24      |  89.304 us |       1.11% |  98.464 us |      15.32% |      9.160 us |  10.26% |   SLOW   |
|   F32   |      I32      |      2^28      |   1.472 ms |       0.16% |   1.472 ms |       0.15% |      0.018 us |   0.00% |   SAME   |
|   F32   |      I64      |      2^16      |   6.954 us |      10.00% |   6.937 us |      10.03% |     -0.017 us |  -0.25% |   SAME   |
|   F32   |      I64      |      2^20      |  13.804 us |       2.96% |  13.881 us |       2.67% |      0.077 us |   0.56% |   SAME   |
|   F32   |      I64      |      2^24      |  88.916 us |       1.31% |  88.728 us |       1.40% |     -0.187 us |  -0.21% |   SAME   |
|   F32   |      I64      |      2^28      |   1.472 ms |       0.16% |   1.472 ms |       0.15% |     -0.063 us |  -0.00% |   SAME   |
|   F32   |      I64      |      2^32      |  23.555 ms |       1.53% |  23.554 ms |       1.55% |     -1.006 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^16      |   9.174 us |      10.16% |   9.223 us |      10.10% |      0.049 us |   0.53% |   SAME   |
|   F64   |      I32      |      2^20      |  19.921 us |       1.40% |  19.898 us |       1.45% |     -0.023 us |  -0.11% |   SAME   |
|   F64   |      I32      |      2^24      | 189.734 us |       0.79% | 189.732 us |       0.72% |     -0.002 us |  -0.00% |   SAME   |
|   F64   |      I32      |      2^28      |   2.946 ms |       0.08% |   2.946 ms |       0.09% |     -0.044 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^16      |   8.473 us |       9.96% |   8.383 us |       9.45% |     -0.090 us |  -1.06% |   SAME   |
|   F64   |      I64      |      2^20      |  19.947 us |       1.28% |  19.916 us |       1.26% |     -0.031 us |  -0.16% |   SAME   |
|   F64   |      I64      |      2^24      | 189.864 us |       0.75% | 189.897 us |       0.83% |      0.033 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^28      |   2.946 ms |       0.08% |   2.946 ms |       0.09% |     -0.117 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^32      |  46.885 ms |       0.22% |  46.897 ms |       0.24% |     12.035 us |   0.03% |   SAME   |
|   C32   |      I32      |      2^16      |  57.881 us |       1.94% | 117.012 us |       1.04% |     59.131 us | 102.16% |   SLOW   |
|   C32   |      I32      |      2^20      |  95.151 us |       3.90% | 140.669 us |       3.82% |     45.518 us |  47.84% |   SLOW   |
|   C32   |      I32      |      2^24      | 872.957 us |       0.15% | 783.123 us |       0.62% |    -89.834 us | -10.29% |   FAST   |
|   C32   |      I32      |      2^28      |  13.402 ms |       0.05% |  11.051 ms |       0.13% |  -2351.046 us | -17.54% |   FAST   |
|   C32   |      I64      |      2^16      |  53.508 us |       1.99% | 110.716 us |       0.85% |     57.208 us | 106.92% |   SLOW   |
|   C32   |      I64      |      2^20      |  93.156 us |       1.42% | 138.235 us |       0.90% |     45.079 us |  48.39% |   SLOW   |
|   C32   |      I64      |      2^24      | 873.221 us |       0.14% | 783.598 us |       0.62% |    -89.623 us | -10.26% |   FAST   |
|   C32   |      I64      |      2^28      |  13.402 ms |       0.04% |  11.045 ms |       0.14% |  -2356.544 us | -17.58% |   FAST   |
|   C32   |      I64      |      2^32      | 213.954 ms |       0.02% | 175.146 ms |       0.04% | -38807.922 us | -18.14% |   FAST   |
```

`cub.bench.scan.applications.P1.log-cdf-from-log-pdfs.base` old scan vs warpspeed this PR (this is the change we ship in CCCL 3.4):
```
## [0] NVIDIA RTX PRO 6000 Blackwell Server Edition

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |  Mu{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |      Diff |   %Diff |  Status  |
|---------|---------------|----------------|----------|------------|-------------|------------|-------------|-----------|---------|----------|
|   F32   |      I32      |      2^16      |  0.0001  |  10.029 us |       5.93% |  10.098 us |       6.12% |  0.069 us |   0.69% |   SAME   |
|   F32   |      I32      |      2^20      |  0.0001  |  17.899 us |       2.78% |  17.930 us |       2.97% |  0.031 us |   0.17% |   SAME   |
|   F32   |      I32      |      2^24      |  0.0001  | 100.245 us |       2.01% | 100.225 us |       2.07% | -0.020 us |  -0.02% |   SAME   |
|   F32   |      I32      |      2^28      |  0.0001  |   1.507 ms |       0.24% |   1.507 ms |       0.21% | -0.261 us |  -0.02% |   SAME   |
|   F32   |      I64      |      2^16      |  0.0001  |  10.451 us |       8.15% |  10.577 us |       8.35% |  0.126 us |   1.20% |   SAME   |
|   F32   |      I64      |      2^20      |  0.0001  |  18.548 us |       3.68% |  18.582 us |       3.50% |  0.034 us |   0.18% |   SAME   |
|   F32   |      I64      |      2^24      |  0.0001  |  98.868 us |       2.20% |  98.858 us |       2.20% | -0.010 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^28      |  0.0001  |   1.506 ms |       0.22% |   1.506 ms |       0.22% | -0.210 us |  -0.01% |   SAME   |
|   F64   |      I32      |      2^16      |  0.0001  | 109.342 us |       1.01% | 109.391 us |       0.99% |  0.050 us |   0.05% |   SAME   |
|   F64   |      I32      |      2^20      |  0.0001  | 367.685 us |       0.86% | 367.429 us |       0.83% | -0.257 us |  -0.07% |   SAME   |
|   F64   |      I32      |      2^24      |  0.0001  |   4.914 ms |       0.05% |   4.915 ms |       0.05% |  1.110 us |   0.02% |   SAME   |
|   F64   |      I32      |      2^28      |  0.0001  |  77.810 ms |       0.03% |  77.814 ms |       0.02% |  4.647 us |   0.01% |   SAME   |
|   F64   |      I64      |      2^16      |  0.0001  | 100.749 us |       1.28% | 100.744 us |       1.32% | -0.005 us |  -0.00% |   SAME   |
|   F64   |      I64      |      2^20      |  0.0001  | 367.382 us |       0.76% | 367.321 us |       0.73% | -0.062 us |  -0.02% |   SAME   |
|   F64   |      I64      |      2^24      |  0.0001  |   4.910 ms |       0.06% |   4.911 ms |       0.06% |  1.187 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^28      |  0.0001  |  77.724 ms |       0.03% |  77.728 ms |       0.03% |  4.269 us |   0.01% |   SAME   |
```


Fixes a part of: #7813 