### PR TITLE
Use urlsafe_b64encode for hash generation.

### DIFF
--- a/.github/actions/workflow-build/build-workflow.py
+++ b/.github/actions/workflow-build/build-workflow.py
@@ -88,7 +88,7 @@ def generate_guids():
     i = 0
     while True:
         # Generates a base64 hash of an incrementing 16-bit integer:
-        hash = base64.b64encode(struct.pack(">H", i)).decode("ascii")
+        hash = base64.urlsafe_b64encode(struct.pack(">H", i)).decode("ascii")
         # Strips off up-to 2 leading 'A' characters and a single trailing '=' characters, if they exist:
         guid = re.sub(r"^A{0,2}", "", hash).removesuffix("=")
         yield guid


### PR DESCRIPTION
This replaces the b64 characters "+" and "/" with "-" and "_" and avoids parsing issues as the matrix grows.

Fixes artifact upload failures on nightlies: https://github.com/NVIDIA/cccl/actions/runs/22607449141/job/65502516962#step:4:16590

```
Error: The artifact name is not valid: zz_jobs-E:/. Contains the following character:  Colon :
```
