### PR TITLE
[CUB] Use `BlockLoadToShared` in `DeviceFind`

### DIFF
--- a/cub/cub/agent/agent_find.cuh
+++ b/cub/cub/agent/agent_find.cuh
@@ -4,23 +4,28 @@
 #pragma once
 #include <cub/config.cuh>
 
+#include <cub/block/block_load_to_shared.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
 #include <cub/thread/thread_load.cuh>
 #include <cub/util_arch.cuh>
 #include <cub/util_type.cuh>
 
 #include <thrust/detail/raw_reference_cast.h>
+#include <thrust/type_traits/is_contiguous_iterator.h>
 #include <thrust/type_traits/is_trivially_relocatable.h>
 
 #include <cuda/__memory/is_aligned.h>
 #include <cuda/atomic>
+#include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/optional>
 
 CUB_NAMESPACE_BEGIN
 namespace detail::find
 {
 template <int BlockThreads,
           int ItemsPerThread,
+          bool AttemptBlockLoadToShared,
           int VectorLoadLength,
           CacheLoadModifier LoadModifier,
           typename InputIteratorT,
@@ -36,19 +41,41 @@ struct agent_t
 
   static constexpr int tile_size = BlockThreads * ItemsPerThread;
 
+  static constexpr bool use_bl2sh =
+    AttemptBlockLoadToShared && (sizeof(InputT) == alignof(InputT))
+    && THRUST_NS_QUALIFIER::is_trivially_relocatable_v<InputT>
+    && THRUST_NS_QUALIFIER::is_contiguous_iterator_v<InputIteratorT>;
+  static constexpr int input_buffer_align = cub::detail::LoadToSharedBufferAlignBytes<InputT>();
+  static constexpr int input_buffer_size =
+    cub::detail::LoadToSharedBufferSizeBytes<InputT>(ItemsPerThread * BlockThreads);
+  using block_load_to_shared = cub::detail::BlockLoadToShared<BlockThreads>;
+
   // Can vectorize according to the policy if the input iterator is a native pointer to a primitive type
   static constexpr bool attempt_vectorization =
     (VectorLoadLength > 1) && (ItemsPerThread % VectorLoadLength == 0)
-    && (::cuda::std::contiguous_iterator<InputIteratorT>) && THRUST_NS_QUALIFIER::is_trivially_relocatable_v<InputT>;
+    && (THRUST_NS_QUALIFIER::is_contiguous_iterator_v<InputIteratorT>)
+    && THRUST_NS_QUALIFIER::is_trivially_relocatable_v<InputT>;
 
   static constexpr CacheLoadModifier load_modifier = LoadModifier;
+  struct alignas(input_buffer_align) input_buffer_t
+  {
+    char c_array[input_buffer_size];
+  };
 
   // Shared memory type required by this thread block
-  struct _TempStorage
+  struct temp_storage_without_bl2sh
   {
     OffsetT global_result;
     OffsetT block_result;
   };
+
+  struct temp_storage_with_bl2sh : temp_storage_without_bl2sh
+  {
+    typename block_load_to_shared::TempStorage load2sh;
+    input_buffer_t input_buffer;
+  };
+
+  using _TempStorage = ::cuda::std::conditional_t<use_bl2sh, temp_storage_with_bl2sh, temp_storage_without_bl2sh>;
 
   // Alias wrapper allowing storage to be unioned
   using TempStorage = Uninitialized<_TempStorage>;
@@ -59,21 +86,20 @@ struct agent_t
   OffsetT* found_pos_ptr;
   OffsetT num_items;
 
-  template <typename Iterator = InputIteratorT, bool CanVectorize = attempt_vectorization>
-  _CCCL_DEVICE _CCCL_FORCEINLINE bool is_aligned_and_full_tile(OffsetT tile_offset)
+  template <typename Iterator, bool CanVectorize = attempt_vectorization>
+  _CCCL_DEVICE _CCCL_FORCEINLINE bool is_aligned_and_full_tile(Iterator in_iter, OffsetT tile_offset)
   {
     if constexpr (CanVectorize)
     {
-      static_assert(::cuda::std::is_pointer_v<Iterator>);
-
-      // Retrieve the value type from the iterator to determine the vector type
-      using InputT  = typename ::cuda::std::iterator_traits<Iterator>::value_type;
-      using VectorT = typename CubVector<InputT, VectorLoadLength>::Type;
+      static_assert(THRUST_NS_QUALIFIER::is_contiguous_iterator_v<Iterator>);
 
       const bool full_tile = (tile_offset + tile_size) <= num_items;
 
-      // Check alignment at the actual load position (d_in + tile_offset)
-      return full_tile && ::cuda::is_aligned(d_in + tile_offset, sizeof(VectorT));
+      // Check alignment at the actual load position (in_iter + tile_offset)
+      return full_tile
+          && ::cuda::is_aligned(
+               THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(in_iter + (use_bl2sh ? 0 : tile_offset)),
+               alignof(VectorT));
     }
     else
     {
@@ -81,17 +107,20 @@ struct agent_t
     }
   }
 
+  template <class Iterator>
   _CCCL_DEVICE _CCCL_FORCEINLINE bool
-  ConsumeTile(OffsetT tile_offset, ::cuda::std::integral_constant<bool, true> /*CAN_VECTORIZE*/)
+  ConsumeTile(Iterator in_iter, OffsetT tile_offset, ::cuda::std::integral_constant<bool, true> /*CAN_VECTORIZE*/)
   {
-    using InputT  = typename ::cuda::std::iterator_traits<InputIteratorT>::value_type;
-    using VectorT = typename CubVector<InputT, VectorLoadLength>::Type;
-
     // vectorized loads begin
-    auto load_ptr = reinterpret_cast<const VectorT*>(d_in + tile_offset + (threadIdx.x * VectorLoadLength));
-    CacheModifiedInputIterator<LoadModifier, VectorT> d_vec_in(load_ptr);
+    const auto local_thread_offset = static_cast<int>(threadIdx.x) * VectorLoadLength;
+    const auto thread_offset       = tile_offset + static_cast<OffsetT>(local_thread_offset);
+    const auto load_ptr            = reinterpret_cast<const VectorT*>(
+      THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(in_iter + (use_bl2sh ? local_thread_offset : thread_offset)));
+    using modified_iterator_t = typename ::cuda::std::
+      conditional_t<use_bl2sh, decltype(load_ptr), CacheModifiedInputIterator<LoadModifier, VectorT>>;
+    const auto d_vec_in = modified_iterator_t{load_ptr};
 
-    alignas(InputT) unsigned char input_bytes[ItemsPerThread * sizeof(InputT)];
+    alignas(VectorT) unsigned char input_bytes[ItemsPerThread * sizeof(InputT)];
     auto* vec_items = reinterpret_cast<VectorT*>(input_bytes);
 
     constexpr int number_of_vectors = ItemsPerThread / VectorLoadLength;
@@ -122,17 +151,19 @@ struct agent_t
     return false;
   }
 
+  template <class Iterator>
   _CCCL_DEVICE _CCCL_FORCEINLINE bool
-  ConsumeTile(OffsetT tile_offset, ::cuda::std::integral_constant<bool, false> /*CAN_VECTORIZE*/)
+  ConsumeTile(Iterator in_iter, OffsetT tile_offset, ::cuda::std::integral_constant<bool, false> /*CAN_VECTORIZE*/)
   {
     for (int i = 0; i < ItemsPerThread; ++i)
     {
-      const auto index = tile_offset + threadIdx.x + i * blockDim.x;
+      const int local_index = static_cast<int>(threadIdx.x) + i * BlockThreads;
+      const OffsetT index   = tile_offset + static_cast<OffsetT>(local_index);
       if (index < num_items)
       {
         // using raw_reference_cast and passing directly to predicate should avoid creating a copy, and thus prevent
         // bugs like: http://github.com/NVIDIA/cccl/issues/3591
-        if (predicate(THRUST_NS_QUALIFIER::raw_reference_cast(d_in[index])))
+        if (predicate(THRUST_NS_QUALIFIER::raw_reference_cast(in_iter[use_bl2sh ? local_index : index])))
         {
           atomicMin(&temp_storage.block_result, index);
           return true;
@@ -145,6 +176,16 @@ struct agent_t
 
   _CCCL_DEVICE _CCCL_FORCEINLINE void Process()
   {
+    [[maybe_unused]] auto load2sh = [&] {
+      if constexpr (use_bl2sh)
+      {
+        return block_load_to_shared{temp_storage.load2sh};
+      }
+      else
+      {
+        return NullType{};
+      }
+    }();
     if (threadIdx.x == 0)
     {
       temp_storage.block_result = num_items;
@@ -157,6 +198,19 @@ struct agent_t
          tile_offset < num_items;
          tile_offset += grid_stride)
     {
+      using token_type = typename block_load_to_shared::CommitToken;
+      [[maybe_unused]] ::cuda::std::optional<token_type> token{};
+      [[maybe_unused]] InputT* s_in{};
+      if constexpr (use_bl2sh)
+      {
+        auto buffer                 = ::cuda::std::span{temp_storage.input_buffer.c_array};
+        const auto shared_num_items = ::cuda::std::min(static_cast<OffsetT>(tile_size), num_items - tile_offset);
+        auto src = ::cuda::std::span{THRUST_NS_QUALIFIER::unwrap_contiguous_iterator(d_in + tile_offset),
+                                     static_cast<::cuda::std::size_t>(shared_num_items)};
+        src      = load2sh.CopyAsync(buffer, src);
+        token    = load2sh.Commit();
+        s_in     = src.data();
+      }
       // Only one thread reads atomically and propagates it to other threads of the block through shared memory
       if (threadIdx.x == 0)
       {
@@ -175,11 +229,23 @@ struct agent_t
       {
         return;
       }
-
-      const bool found_thread =
-        is_aligned_and_full_tile(tile_offset)
-          ? ConsumeTile(tile_offset, ::cuda::std::bool_constant<attempt_vectorization>{})
-          : ConsumeTile(tile_offset, ::cuda::std::false_type{});
+      auto consume_tile = [&](auto iter) {
+        return is_aligned_and_full_tile(iter, tile_offset)
+               ? ConsumeTile(iter, tile_offset, ::cuda::std::bool_constant<attempt_vectorization>{})
+               : ConsumeTile(iter, tile_offset, ::cuda::std::false_type{});
+      };
+      auto found_thread = false;
+      if constexpr (use_bl2sh)
+      {
+        load2sh.Wait(::cuda::std::move(token).value());
+        // TODO: As we always have a full tile of smem, we could still vectorize even when we have a partial tile.
+        //       The vectorized ConsumeTile() does only apply the predicate for in-bounds items.
+        found_thread = consume_tile(s_in);
+      }
+      else
+      {
+        found_thread = consume_tile(d_in);
+      }
 
       const bool found_block = __syncthreads_or(found_thread);
       if (found_block)

--- a/cub/cub/block/block_load_to_shared.cuh
+++ b/cub/cub/block/block_load_to_shared.cuh
@@ -219,6 +219,10 @@ private:
 
     token_impl(const token_impl&)            = delete;
     token_impl& operator=(const token_impl&) = delete;
+
+  public:
+    token_impl(token_impl&&)            = default;
+    token_impl& operator=(token_impl&&) = default;
   };
 
 public:

--- a/cub/cub/device/dispatch/dispatch_find.cuh
+++ b/cub/cub/device/dispatch/dispatch_find.cuh
@@ -62,6 +62,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block
   using agent_find_t =
     agent_t<policy.block_threads,
             policy.items_per_thread,
+            policy.attempt_block_load_to_shared,
             policy.vector_load_length,
             policy.load_modifier,
             IteratorT,

--- a/cub/cub/device/dispatch/tuning/tuning_find.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_find.cuh
@@ -31,12 +31,14 @@ struct find_policy
 {
   int block_threads;
   int items_per_thread;
+  bool attempt_block_load_to_shared;
   int vector_load_length;
   CacheLoadModifier load_modifier;
 
   [[nodiscard]] _CCCL_API constexpr friend bool operator==(const find_policy& lhs, const find_policy& rhs)
   {
     return lhs.block_threads == rhs.block_threads && lhs.items_per_thread == rhs.items_per_thread
+        && lhs.attempt_block_load_to_shared == rhs.attempt_block_load_to_shared
         && lhs.vector_load_length == rhs.vector_load_length && lhs.load_modifier == rhs.load_modifier;
   }
 
@@ -49,6 +51,7 @@ struct find_policy
   friend ::std::ostream& operator<<(::std::ostream& os, const find_policy& p)
   {
     return os << "find_policy { .block_threads = " << p.block_threads << ", .items_per_thread = " << p.items_per_thread
+              << ", .attempt_block_load_to_shared = " << p.attempt_block_load_to_shared
               << ", .vector_load_length = " << p.vector_load_length << ", .load_modifier = " << p.load_modifier << " }";
   }
 #endif // !_CCCL_COMPILER(NVRTC)
@@ -67,7 +70,7 @@ struct policy_selector
   {
     // FindPolicy (GTX670: 154.0 @ 48M 4B items) - single policy for all arches
     const auto scaled = scale_mem_bound(128, 16, input_type_size);
-    return find_policy{scaled.block_threads, scaled.items_per_thread, 4, LOAD_LDG};
+    return find_policy{scaled.block_threads, scaled.items_per_thread, true, 4, LOAD_LDG};
   }
 };
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #6412

<!-- Provide a standalone description of changes in this PR. -->
- Use `BlockLoadToShared` to accelerate global loads in `cub::detail::find::agent_t`.
- Also adds a boolean tuning parameter to opt out of using `BlockLoadToShared`.
- `BlockLoadToShared`'s token type had to be slightly modified to allow for move construction and assignment to make it more manageable.

TODO: Benchmarking and tuning.
<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
- [x] I am familiar with the [Contributing Guidelines]().
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
