### PR TITLE
Detect non GNU getopt and error early

### DIFF
--- a/.devcontainer/launch.sh
+++ b/.devcontainer/launch.sh
@@ -41,6 +41,22 @@ parse_options() {
     local -;
     set -euo pipefail;
 
+    # Must disable set -e temporarily. Per man getopt:
+    #
+    # [getopt -T] generates no output, and sets the error status to 4. Other
+    # implementations of getopt(1), and this version if the environment variable
+    # GETOPT_COMPATIBLE is set, will return '--' and error status 0.
+    set +e
+    getopt -T 2>&1 > /dev/null
+    getopt_ret=$?
+    set -e
+
+    if [[ "${getopt_ret}" != '4' ]]; then
+      echo "Must use enhanced (GNU) version of getopt which understand long options to use this script."
+      echo "Either your version of getopt does not support them or you have GETOPT_COMPATIBLE set."
+      exit 1
+    fi
+
     # Read the name of the variable in which to return unparsed arguments
     local UNPARSED="${!#}";
     # Splice the unparsed arguments variable name from the arguments list


### PR DESCRIPTION
## Description

Detect non "enhanced" `getopt` early in `.devcontainer/launch.sh` (for example, BSD `getopt`) and give a more informative error message. BSD `getopt` for instance does not support long options and will silently skip them leading to strange errors later down the line

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
