### PR TITLE
Don't assume CUDA is available for thrust single config

### DIFF
--- a/thrust/cmake/ThrustMultiConfig.cmake
+++ b/thrust/cmake/ThrustMultiConfig.cmake
@@ -128,9 +128,25 @@ function(thrust_configure_multiconfig)
     if (DEFINED THRUST_DEVICE_SYSTEM)
       set_property(CACHE THRUST_DEVICE_SYSTEM PROPERTY TYPE STRING)
     else()
+      # This is a chicken-egg problem. We have not run thrust_update_system_found_flags()
+      # yet (to set THRUST_CUDA_FOUND, THRUST_OMP_FOUND etc) because that requires us to
+      # find and configure thrust first via thrust_find_thrust(). But we cannot do that
+      # without first setting defaults here.
+      #
+      # So we make a best effort attempt at deducing suitable default values here.
+      find_package(CUDAToolkit QUIET)
+      find_package(OpenMP QUIET)
+      if (CUDAToolkit_FOUND)
+        set(thrust_device_system CUDA)
+      elseif (OpenMP_FOUND)
+        set(thrust_device_system OMP)
+      else()
+        set(thrust_device_system CPP)
+      endif()
+
       set(
         THRUST_DEVICE_SYSTEM
-        "CUDA"
+        "${thrust_device_system}"
         CACHE STRING
         "The targeted device system: ${THRUST_DEVICE_SYSTEM_OPTIONS}"
       )


### PR DESCRIPTION
## Description

Thrust single-config assumes CUDA is available as a device backend without first checking that it exists on the system. Without these changes, the user must manually specify `-DTHRUST_DEVICE_SYSTEM=CPP`, which we should be able to figure out on our own.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
