### PR TITLE
Support DLPack inclusion for both `<dlpack/dlpack.h>` and `<dlpack.h>`

### DIFF
--- a/libcudacxx/include/cuda/__internal/dlpack.h
+++ b/libcudacxx/include/cuda/__internal/dlpack.h
@@ -23,7 +23,11 @@
 
 #if _CCCL_HAS_DLPACK()
 
-#  include <dlpack/dlpack.h>
+#  if __has_include(<dlpack/dlpack.h>)
+#    include <dlpack/dlpack.h>
+#  elif __has_include(<dlpack.h>)
+#    include <dlpack.h>
+#  endif
 
 #  define _CCCL_DLPACK_AT_LEAST(_MAJOR, _MINOR) \
     (DLPACK_MAJOR_VERSION > (_MAJOR) || (DLPACK_MAJOR_VERSION == (_MAJOR) && DLPACK_MINOR_VERSION >= (_MINOR)))

--- a/libcudacxx/include/cuda/std/__internal/features.h
+++ b/libcudacxx/include/cuda/std/__internal/features.h
@@ -103,7 +103,8 @@
 
 // Third party libraries
 
-#if __has_include(<dlpack/dlpack.h>) && !_CCCL_COMPILER(NVRTC) && !defined(CCCL_DISABLE_DLPACK)
+#if (__has_include(<dlpack/dlpack.h>) || __has_include(<dlpack.h>)) && \
+     !_CCCL_COMPILER(NVRTC) && !defined(CCCL_DISABLE_DLPACK)
 #  define _CCCL_HAS_DLPACK() 1
 #else // ^^^ has dlpack ^^^ / vvv no dlpack vvv
 #  define _CCCL_HAS_DLPACK() 0


### PR DESCRIPTION
## Description

Close https://github.com/NVIDIA/cccl/issues/7871:  cuda-python (cuda.core) for `cuda::make_tma_descriptor` TMA descriptor construction.