### PR TITLE
Small improvement for nvrtc testing

### DIFF
--- a/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc_build.h
+++ b/libcudacxx/test/utils/nvidia/nvrtc/nvrtcc_build.h
@@ -20,6 +20,7 @@
 #include "nvrtcc_common.h"
 
 inline bool enable_float128 = false;
+extern std::string inputFile;
 
 // Arch configs are strings and bools determining architecture and ptx/sass compilation
 using ArchConfig          = std::tuple<std::string, bool>;
@@ -77,7 +78,7 @@ GpuProg nvrtc_build_prog(const std::string& testCu, const ArchConfig& config, co
 
   fprintf(stderr, "Compiling program...\r\n");
   nvrtcProgram prog;
-  NVRTC_SAFE_CALL(nvrtcCreateProgram(&prog, testCu.c_str(), "test.cu", 0, nullptr, nullptr));
+  NVRTC_SAFE_CALL(nvrtcCreateProgram(&prog, testCu.c_str(), inputFile.c_str(), 0, nullptr, nullptr));
 
   nvrtcResult compile_result = nvrtcCompileProgram(prog, optList.size(), optList.data());
 


### PR DESCRIPTION
Currently when nvrtc lit test emits an error, we get:
```
test.cu(188): error: A function without execution space annotations (__host__/__device__/__global__) is considered ...
```
which is not ideal, because you need to manually scroll through the file to find the line yourself.

If we pass the `inputFile` as the program name, we get:
```
/home/dabayer/cccl/libcudacxx/test/libcudacxx/cuda/utility/basic_any.pass.cpp(188): error: A function without execution space annotations (__host__/__device__/__global__) is considered ...
```
which can be read by the IDE and it directly brings you to the desired line in the right file.