### PR TITLE
Fix typo in docs

### DIFF
--- a/docs/libcudacxx/extended_api/numeric.rst
+++ b/docs/libcudacxx/extended_api/numeric.rst
@@ -58,7 +58,7 @@ Numeric
      - CCCL 3.3.0
      - CUDA 13.3
 
-   * - :ref:`cuda::saturating_overflow_cast <libcudacxx-extended-api-numeric-saturating_overflow_cast>`
+   * - :ref:`cuda::saturate_overflow_cast <libcudacxx-extended-api-numeric-saturate_overflow_cast>`
      - Performs saturating cast of a value with overflow checking
      - CCCL 3.4.0
      - CUDA 13.4

--- a/docs/libcudacxx/extended_api/numeric/saturate_overflow_cast.rst
+++ b/docs/libcudacxx/extended_api/numeric/saturate_overflow_cast.rst
@@ -1,4 +1,4 @@
-.. _libcudacxx-extended-api-numeric-saturating_overflow_cast:
+.. _libcudacxx-extended-api-numeric-saturate_overflow_cast:
 
 ``cuda::overflow_cast``
 ==========================
@@ -10,9 +10,9 @@
 
    template <class To, class From>
    [[nodiscard]] __host__ __device__ inline constexpr
-   overflow_result<To> saturating_overflow_cast(From from) noexcept;
+   overflow_result<To> saturate_overflow_cast(From from) noexcept;
 
-The function ``cuda::saturating_overflow_cast`` does saturating cast of a value of type ``From`` to type ``To`` with overflow checking.
+The function ``cuda::saturate_overflow_cast`` does saturating cast of a value of type ``From`` to type ``To`` with overflow checking.
 
 **Parameters**
 
@@ -40,7 +40,7 @@ Example
         constexpr auto int_max = cuda::std::numeric_limits<int>::max();
         constexpr auto int_min = cuda::std::numeric_limits<int>::min();
 
-        if (auto result = cuda::saturating_overflow_cast<unsigned>(int_max))
+        if (auto result = cuda::saturate_overflow_cast<unsigned>(int_max))
         {
             assert(false); // Should not be reached
         }
@@ -49,7 +49,7 @@ Example
             assert(result.value == static_cast<unsigned>(int_max));
         }
 
-        if (auto result = cuda::saturating_overflow_cast<unsigned>(int_min)) // saturated
+        if (auto result = cuda::saturate_overflow_cast<unsigned>(int_min)) // saturated
         {
             assert(result.value == 0);
         }
@@ -65,4 +65,4 @@ Example
         cudaDeviceSynchronize();
     }
 
-`See it on Godbolt 🔗 <https://godbolt.org/z/qfojv7bYb>`_
+`See it on Godbolt 🔗 <https://godbolt.org/z/oKW81Eajx>`_


### PR DESCRIPTION
In docs, I was using `saturating_overflow_cast` instead of `saturate_overflow_cast`..