### PR TITLE
Avoid setting context in `cuda::launch` since 13.0

### DIFF
--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -727,21 +727,31 @@ _CCCL_HOST_API inline void __eventSynchronize(::CUevent __evnt)
 
 // Library management
 
+[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
+__kernelGetAttributeNoThrow(int& __value, ::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdevice __device)
+{
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuKernelGetAttribute);
+  return static_cast<::cudaError_t>(__driver_fn(&__value, __attr, __kernel, __device));
+}
+
+[[nodiscard]] _CCCL_HOST_API inline int
+__kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdevice __device)
+{
+  int __value;
+  const auto __status = ::cuda::__driver::__kernelGetAttributeNoThrow(__value, __attr, __kernel, __device);
+  if (__status != ::cudaSuccess)
+  {
+    _CCCL_THROW(::cuda::cuda_error, __status, "Failed to synchronize a stream");
+  }
+  return __value;
+}
+
 [[nodiscard]] _CCCL_HOST_API inline ::CUfunction __kernelGetFunction(::CUkernel __kernel)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuKernelGetFunction);
   ::CUfunction __result;
   ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get kernel function", &__result, __kernel);
   return __result;
-}
-
-[[nodiscard]] _CCCL_HOST_API inline int
-__kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdevice __dev)
-{
-  int __value;
-  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuKernelGetAttribute);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to get kernel attribute", &__value, __attr, __kernel, __dev);
-  return __value;
 }
 
 #  if _CCCL_CTK_AT_LEAST(12, 3)
@@ -753,6 +763,13 @@ __kernelGetAttribute(::CUfunction_attribute __attr, ::CUkernel __kernel, ::CUdev
   return __name;
 }
 #  endif // _CCCL_CTK_AT_LEAST(12, 3)
+
+[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
+__kernelSetAttributeNoThrow(::CUfunction_attribute __attr, int __value, ::CUkernel __kernel, ::CUdevice __dev)
+{
+  static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuKernelSetAttribute);
+  return static_cast<::cudaError_t>(__driver_fn(__attr, __value, __kernel, __dev));
+}
 
 [[nodiscard]] _CCCL_HOST_API inline ::CUlibrary __libraryLoadData(
   const void* __code,

--- a/libcudacxx/include/cuda/__launch/configuration.h
+++ b/libcudacxx/include/cuda/__launch/configuration.h
@@ -41,6 +41,16 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
+struct __cccl_cukernel_handle
+{
+#if _CCCL_CTK_AT_LEAST(13, 0)
+  ::CUkernel __kernel_;
+  ::CUdevice __device_;
+#else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
+  ::CUfunction __kernel_;
+#endif // ^^^ _CCCL_CTK_BELOW(13, 0) ^^^
+};
+
 template <typename Dimensions, typename... Options>
 struct kernel_config;
 
@@ -139,16 +149,16 @@ struct cooperative_launch : public __detail::launch_option
   static constexpr __detail::launch_option_kind kind = __detail::launch_option_kind::cooperative_launch;
 };
 
-[[nodiscard]] _CCCL_API inline cudaError_t
-__apply_launch_option(const cooperative_launch&, CUlaunchConfig& config, CUfunction) noexcept
+[[nodiscard]] _CCCL_API inline ::cudaError_t
+__apply_launch_option(const cooperative_launch&, ::CUlaunchConfig& __config, __cccl_cukernel_handle) noexcept
 {
-  CUlaunchAttribute attr;
-  attr.id                = CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
-  attr.value.cooperative = true;
+  ::CUlaunchAttribute __attr;
+  __attr.id                = ::CU_LAUNCH_ATTRIBUTE_COOPERATIVE;
+  __attr.value.cooperative = true;
 
-  config.attrs[config.numAttrs++] = attr;
+  __config.attrs[__config.numAttrs++] = __attr;
 
-  return cudaSuccess;
+  return ::cudaSuccess;
 }
 
 template <class _Tp>
@@ -318,10 +328,11 @@ private:
 
 template <class _Tp>
 [[nodiscard]] ::cudaError_t __apply_launch_option(
-  const dynamic_shared_memory_option<_Tp>& __opt, ::CUlaunchConfig& __config, ::CUfunction __kernel) noexcept
+  const dynamic_shared_memory_option<_Tp>& __opt, ::CUlaunchConfig& __config, __cccl_cukernel_handle __kernel_handle) noexcept
 {
   ::cudaError_t __status = ::cudaSuccess;
 
+#if _CCCL_CTK_BELOW(13, 0)
   // Since CUDA 12.4, querying CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES requires
   // the function to be loaded.
   if (::cuda::__driver::__version_at_least(12, 4))
@@ -332,21 +343,38 @@ template <class _Tp>
       return __status;
     }
   }
+#endif // _CCCL_CTK_BELOW(13, 0)
 
   int __static_smem_size{};
-  __status = ::cuda::__driver::__functionGetAttributeNoThrow(
-    __static_smem_size, ::CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, __kernel);
-  if (__status != ::cudaSuccess)
   {
-    return __status;
+    constexpr auto __attr = ::CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES;
+#if _CCCL_CTK_AT_LEAST(13, 0)
+  __status = ::cuda::__driver::__kernelGetAttributeNoThrow(
+    __static_smem_size, __attr, __kernel_handle.__kernel_, __kernel_handle.__device_);
+#else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
+  __status = ::cuda::__driver::__functionGetAttributeNoThrow(
+    __static_smem_size, __attr, __kernel_handle.__kernel_);
+#endif // ^^^ _CCCL_CTK_BELOW(13, 0)
+    if (__status != ::cudaSuccess)
+    {
+      return __status;
+    }
   }
 
   int __max_dyn_smem_size{};
-  __status = ::cuda::__driver::__functionGetAttributeNoThrow(
-    __max_dyn_smem_size, ::CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES, __kernel);
-  if (__status != ::cudaSuccess)
   {
-    return __status;
+    constexpr auto __attr = ::CU_FUNC_ATTRIBUTE_SHARED_SIZE_BYTES;
+#if _CCCL_CTK_AT_LEAST(13, 0)
+    __status = ::cuda::__driver::__kernelGetAttributeNoThrow(
+      __max_dyn_smem_size, __attr, __kernel_handle.__kernel_, __kernel_handle.__device_);
+#else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
+    __status = ::cuda::__driver::__functionGetAttributeNoThrow(
+      __max_dyn_smem_size, __attr, __kernel_handle.__kernel_);
+#endif // ^^^ _CCCL_CTK_BELOW(13, 0)
+    if (__status != ::cudaSuccess)
+    {
+      return __status;
+    }
   }
 
   const auto __dyn_smem_size = ::cuda::overflow_cast<int>(__opt.size_bytes());
@@ -363,8 +391,14 @@ template <class _Tp>
 
   if (__max_dyn_smem_size < __dyn_smem_size.value)
   {
+    constexpr auto __attr = ::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES;
+#if _CCCL_CTK_AT_LEAST(13, 0)
+    __status = ::cuda::__driver::__kernelSetAttributeNoThrow(
+      __attr, __dyn_smem_size.value, __kernel_handle.__kernel_, __kernel_handle.__device_);
+#else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
     __status = ::cuda::__driver::__functionSetAttributeNoThrow(
-      __kernel, ::CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, __dyn_smem_size.value);
+      __kernel_handle.__kernel_, __attr, __dyn_smem_size.value);
+#endif // ^^^ _CCCL_CTK_BELOW(13, 0)
     if (__status != ::cudaSuccess)
     {
       return __status;
@@ -458,16 +492,16 @@ struct launch_priority : public __detail::launch_option
   {}
 };
 
-[[nodiscard]] _CCCL_HOST_API inline cudaError_t
-__apply_launch_option(const launch_priority& __opt, CUlaunchConfig& config, CUfunction) noexcept
+[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t
+__apply_launch_option(const launch_priority& __opt, ::CUlaunchConfig& __config, __cccl_cukernel_handle) noexcept
 {
-  CUlaunchAttribute attr;
-  attr.id             = CU_LAUNCH_ATTRIBUTE_PRIORITY;
-  attr.value.priority = __opt.priority;
+  ::CUlaunchAttribute __attr;
+  __attr.id             = ::CU_LAUNCH_ATTRIBUTE_PRIORITY;
+  __attr.value.priority = __opt.priority;
 
-  config.attrs[config.numAttrs++] = attr;
+  __config.attrs[__config.numAttrs++] = __attr;
 
-  return cudaSuccess;
+  return ::cudaSuccess;
 }
 
 template <typename... _OptionsToFilter>
@@ -772,23 +806,23 @@ inline unsigned int constexpr kernel_config_count_attr_space(const kernel_config
 
 template <typename Dimensions, typename... Options>
 [[nodiscard]] cudaError_t apply_kernel_config(
-  const kernel_config<Dimensions, Options...>& config, CUlaunchConfig& cuda_config, CUfunction kernel) noexcept
+  const kernel_config<Dimensions, Options...>& __config, ::CUlaunchConfig& __cuda_config, __cccl_cukernel_handle __kernel_handle) noexcept
 {
   return ::cuda::std::apply(
-    [&](auto&... config_options) {
-      cudaError_t __status = cudaSuccess;
+    [&](auto&... __config_options) {
+      ::cudaError_t __status = ::cudaSuccess;
 
       // Use short-cutting && to skip the rest on error, is this too
       // convoluted?
       // For some reason gcc 7 complains about __status capture, so we pass it as a reference
-      (void) (... && [](cudaError_t call_status, cudaError_t& __status_out) {
-        __status_out = call_status;
-        return call_status == cudaSuccess;
-      }(::cuda::__apply_launch_option(config_options, cuda_config, kernel), __status));
+      (void) (... && [](::cudaError_t __call_status, ::cudaError_t& __status_out) {
+        __status_out = __call_status;
+        return __call_status == ::cudaSuccess;
+      }(::cuda::__apply_launch_option(__config_options, __cuda_config, __kernel_handle), __status));
 
       return __status;
     },
-    config.options());
+    __config.options());
 }
 } // namespace __detail
 

--- a/libcudacxx/include/cuda/__launch/launch.h
+++ b/libcudacxx/include/cuda/__launch/launch.h
@@ -375,27 +375,34 @@ template <class _Kernel, class _Config, class... _Args>
 #  endif // _CCCL_CUDA_COMPILATION()
 
 template <class... _Args>
-[[nodiscard]] _CCCL_HOST_API ::CUfunction __get_cufunction_of(void (*__kernel)(_Args...))
+[[nodiscard]] _CCCL_HOST_API __cccl_cukernel_handle __get_cukernel_handle_of(stream_ref __stream, void (*__kernel)(_Args...))
 {
-  ::cudaFunction_t __kernel_cufunction{};
+  __cccl_cukernel_handle __ret{};
+#if _CCCL_CTK_AT_LEAST(13, 0)
   _CCCL_TRY_CUDA_API(
-    ::cudaGetFuncBySymbol, "Failed to get function from symbol", &__kernel_cufunction, (const void*) __kernel);
-  return (::CUfunction) __kernel_cufunction;
+    ::cudaGetKernel, "Failed to get kernel from symbol", &__ret.__kernel_, (const void*) __kernel);
+  __ret.__device_ = ::cuda::__driver::__deviceGet(__stream.device().get());
+#else // ^^^ _CCCL_CTK_AT_LEAST(13, 0) ^^^ / vvv _CCCL_CTK_BELOW(13, 0) vvv
+  __ensure_current_context __dev_setter{__submitter};
+  _CCCL_TRY_CUDA_API(
+    ::cudaGetFuncBySymbol, "Failed to get function from symbol", &__ret.__kernel_, (const void*) __kernel);
+#endif // ^^^ _CCCL_CTK_BELOW(13, 0)  
+  return __ret;
 }
 
 _CCCL_HOST_API void inline __do_launch(
-  ::cuda::stream_ref __stream, ::CUlaunchConfig& __config, ::CUfunction __kernel, void** __args_ptrs)
+  ::cuda::stream_ref __stream, ::CUlaunchConfig& __config, __cccl_cukernel_handle __kernel_handle, void** __args_ptrs)
 {
   __config.hStream = __stream.get();
 #  if defined(_CCCLRT_LAUNCH_CONFIG_TEST)
-  test_launch_kernel_replacement(__config, __kernel, __args_ptrs);
+  test_launch_kernel_replacement(__config, (::CUfunction)__kernel_handle.__kernel_, __args_ptrs);
 #  else // ^^^ _CUDAX_LAUNCH_CONFIG_TEST ^^^ / vvv !_CUDAX_LAUNCH_CONFIG_TEST vvv
-  ::cuda::__driver::__launchKernel(__config, __kernel, __args_ptrs);
+  ::cuda::__driver::__launchKernel(__config, (::CUfunction)__kernel_handle.__kernel_, __args_ptrs);
 #  endif // ^^^ !_CUDAX_LAUNCH_CONFIG_TEST ^^^
 }
 
 template <typename... _ExpTypes, typename _Dst, typename _Config>
-_CCCL_HOST_API auto __launch_impl(_Dst&& __dst, _Config __conf, ::CUfunction __kernel, _ExpTypes... __args)
+_CCCL_HOST_API auto __launch_impl(_Dst&& __dst, _Config __conf, __cccl_cukernel_handle __kernel_handle, _ExpTypes... __args)
 {
   static_assert(!::cuda::std::is_same_v<decltype(__conf.hierarchy()), no_init_t>,
                 "Can't launch a configuration without hierarchy dimensions");
@@ -409,7 +416,7 @@ _CCCL_HOST_API auto __launch_impl(_Dst&& __dst, _Config __conf, ::CUfunction __k
   __config.attrs    = &__attrs[0];
   __config.numAttrs = 0;
 
-  ::cudaError_t __status = __detail::apply_kernel_config(__conf, __config, __kernel);
+  ::cudaError_t __status = __detail::apply_kernel_config(__conf, __config, __kernel_handle);
   if (__status != ::cudaSuccess)
   {
     _CCCL_THROW(::cuda::cuda_error, __status, "Failed to prepare a launch configuration");
@@ -433,7 +440,7 @@ _CCCL_HOST_API auto __launch_impl(_Dst&& __dst, _Config __conf, ::CUfunction __k
   }
 
   const void* __pArgs[(sizeof...(__args) > 0) ? sizeof...(__args) : 1]{::cuda::std::addressof(__args)...};
-  return ::cuda::__do_launch(::cuda::std::forward<_Dst>(__dst), __config, __kernel, const_cast<void**>(__pArgs));
+  return ::cuda::__do_launch(::cuda::std::forward<_Dst>(__dst), __config, __kernel_handle, const_cast<void**>(__pArgs));
 }
 
 _CCCL_HOST_API ::cuda::stream_ref inline __stream_or_invalid(::cuda::stream_ref __stream)
@@ -503,18 +510,19 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            const _Kernel& __kernel,
                            _Args&&... __args)
 {
-  __ensure_current_context __dev_setter{__submitter};
+  stream_ref __stream{::cuda::std::forward<_Submitter>(__submitter)};
+
   auto __combined = __conf.combine_with_default(__kernel);
   auto __launcher = ::cuda::__get_kernel_launcher<_Kernel,
                                                   decltype(__combined),
                                                   ::cuda::std::decay_t<transformed_device_argument_t<_Args>>...>();
   return ::cuda::__launch_impl(
-    cuda::__forward_or_cast_to_stream_ref<_Submitter>(::cuda::std::forward<_Submitter>(__submitter)),
+    __stream,
     __combined,
-    ::cuda::__get_cufunction_of(__launcher),
+    ::cuda::__get_cukernel_handle_of(__stream, __launcher),
     __combined,
     __kernel,
-    launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_Args>(__args))...);
+    launch_transform(__stream, ::cuda::std::forward<_Args>(__args))...);
 }
 
 #  endif // _CCCL_CUDA_COMPILATION()
@@ -566,14 +574,14 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            void (*__kernel)(kernel_config<_Dimensions, _Config...>, _ExpArgs...),
                            _ActArgs&&... __args)
 {
-  __ensure_current_context __dev_setter{__submitter};
+  stream_ref __stream{::cuda::std::forward<_Submitter>(__submitter)};
   return ::cuda::__launch_impl<kernel_config<_Dimensions, _Config...>,
                                _ExpArgs...>(
-    cuda::__forward_or_cast_to_stream_ref<_Submitter>(__submitter), //
+    __stream,
     __conf,
-    ::cuda::__get_cufunction_of(__kernel),
+    ::cuda::__get_cukernel_handle_of(__stream, __kernel),
     __conf,
-    launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
+    launch_transform(__stream, ::cuda::std::forward<_ActArgs>(__args))...);
 }
 
 //! @brief Launch a kernel function with specified configuration and arguments
@@ -622,12 +630,12 @@ _CCCL_HOST_API auto launch(_Submitter&& __submitter,
                            void (*__kernel)(_ExpArgs...),
                            _ActArgs&&... __args)
 {
-  __ensure_current_context __dev_setter{__submitter};
+  stream_ref __stream{::cuda::std::forward<_Submitter>(__submitter)};
   return ::cuda::__launch_impl<_ExpArgs...>(
-    cuda::__forward_or_cast_to_stream_ref<_Submitter>(::cuda::std::forward<_Submitter>(__submitter)), //
+    __stream,
     __conf,
-    ::cuda::__get_cufunction_of(__kernel),
-    launch_transform(::cuda::__stream_or_invalid(__submitter), ::cuda::std::forward<_ActArgs>(__args))...);
+    ::cuda::__get_cukernel_handle_of(__stream, __kernel),
+    launch_transform(__stream, ::cuda::std::forward<_ActArgs>(__args))...);
 }
 
 _CCCL_END_NAMESPACE_CUDA


### PR DESCRIPTION
Implements #6986.