### PR TITLE
[libcu++] Use __builtin_bswapg in cuda::std::byteswap

### DIFF
--- a/libcudacxx/include/cuda/std/__bit/byteswap.h
+++ b/libcudacxx/include/cuda/std/__bit/byteswap.h
@@ -50,12 +50,17 @@
 #  define _CCCL_BUILTIN_BSWAP128(...) __builtin_bswap128(__VA_ARGS__)
 #endif // _CCCL_CHECK_BUILTIN(builtin_bswap128)
 
+#if _CCCL_CHECK_BUILTIN(builtin_bswapg)
+#  define _CCCL_BUILTIN_BSWAPG(...) __builtin_bswapg(__VA_ARGS__)
+#endif // _CCCL_CHECK_BUILTIN(builtin_bswapg)
+
 // nvcc doesn't support these builtins in device code
 #if _CCCL_CUDA_COMPILER(NVCC) && _CCCL_DEVICE_COMPILATION()
 #  undef _CCCL_BUILTIN_BSWAP16
 #  undef _CCCL_BUILTIN_BSWAP32
 #  undef _CCCL_BUILTIN_BSWAP64
 #  undef _CCCL_BUILTIN_BSWAP128
+#  undef _CCCL_BUILTIN_BSWAPG
 #endif // _CCCL_CUDA_COMPILER(NVCC) && _CCCL_DEVICE_COMPILATION()
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
@@ -194,7 +199,11 @@ _CCCL_REQUIRES(is_integral_v<_Integer>)
 {
   if constexpr (sizeof(_Integer) > 1)
   {
+#if defined(_CCCL_BUILTIN_BSWAPG)
+    return static_cast<_Integer>(_CCCL_BUILTIN_BSWAPG(::cuda::std::__to_unsigned_like(__val)));
+#else // ^^^ _CCCL_BUILTIN_BSWAPG ^^^ / vvv !_CCCL_BUILTIN_BSWAPG vvv
     return static_cast<_Integer>(::cuda::std::__byteswap_impl(::cuda::std::__to_unsigned_like(__val)));
+#endif // !_CCCL_BUILTIN_BSWAPG
   }
   else
   {


### PR DESCRIPTION
## Description

Closes #7778

Clang 22 introduced `__builtin_bswapg`, a generic builtin that performs byteswap on any integer type without needing type-specific variants. This PR uses it as a fast path in `cuda::std::byteswap()` when available.

## Changes

- Added `_CCCL_BUILTIN_BSWAPG` detection macro using `_CCCL_CHECK_BUILTIN(builtin_bswapg)`, consistent with the existing `_CCCL_BUILTIN_BSWAP16/32/64/128` pattern
- Added `#undef _CCCL_BUILTIN_BSWAPG` to the NVCC device compilation guard block (NVCC does not support this builtin in device code)
- Updated `byteswap()` to use `_CCCL_BUILTIN_BSWAPG` when available, falling back to `__byteswap_impl()` otherwise

## Pattern Reference

This follows the same pattern used in `countl.h` where `_CCCL_BUILTIN_CLZG` is used as a fast path in `countl_zero()` when `__builtin_clzg` is available.