### PR TITLE
Always use the latest devcontainer

### DIFF
--- a/.devcontainer/cuda12.0-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc10-cuda12.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc10-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc11-cuda12.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc11-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc12-cuda12.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc12-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc13-cuda12.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc13-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc7-cuda12.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc7-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc8-cuda12.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc8-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.0-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc9-cuda12.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc9-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.0-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.0-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm14-cuda12.0",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm14-cuda12.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc10/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc10/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc10-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc10-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc11/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc11-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc11-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc12/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc12-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc12-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc13/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc13-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc13-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc14/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc14-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc14-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc7/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc7-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc7-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc8/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc8/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc8-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc8-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-gcc9/devcontainer.json
+++ b/.devcontainer/cuda12.9-gcc9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc9-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc9-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm14/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm14-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm14-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm15/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm15/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm15-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm15-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm16/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm16/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm16-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm16-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm17/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm17/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm17-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm17-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm18/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm18/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm18-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm18-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm19/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm19/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm19-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm19-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-llvm20/devcontainer.json
+++ b/.devcontainer/cuda12.9-llvm20/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm20-cuda12.9",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm20-cuda12.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9-nvhpc25.7/devcontainer.json
+++ b/.devcontainer/cuda12.9-nvhpc25.7/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-nvhpc25.7",
+  "image": "rapidsai/devcontainers:latest-cpp-nvhpc25.7",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9ext-gcc14/devcontainer.json
+++ b/.devcontainer/cuda12.9ext-gcc14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc14-cuda12.9ext",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc14-cuda12.9ext",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda12.9ext-llvm20/devcontainer.json
+++ b/.devcontainer/cuda12.9ext-llvm20/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm20-cuda12.9ext",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm20-cuda12.9ext",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-gcc11/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc11-cuda13.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc11-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-gcc12/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc12-cuda13.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc12-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-gcc13/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc13-cuda13.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc13-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-gcc14/devcontainer.json
+++ b/.devcontainer/cuda13.0-gcc14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc14-cuda13.0",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc14-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm15/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm15/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm15-cuda13.0",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm15-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm16/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm16/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm16-cuda13.0",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm16-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm17/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm17/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm17-cuda13.0",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm17-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm18/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm18/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm18-cuda13.0",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm18-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm19/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm19/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm19-cuda13.0",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm19-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-llvm20/devcontainer.json
+++ b/.devcontainer/cuda13.0-llvm20/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm20-cuda13.0",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm20-cuda13.0",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0-nvhpc25.9/devcontainer.json
+++ b/.devcontainer/cuda13.0-nvhpc25.9/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-nvhpc25.9",
+  "image": "rapidsai/devcontainers:latest-cpp-nvhpc25.9",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0ext-gcc14/devcontainer.json
+++ b/.devcontainer/cuda13.0ext-gcc14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc14-cuda13.0ext",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc14-cuda13.0ext",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.0ext-llvm20/devcontainer.json
+++ b/.devcontainer/cuda13.0ext-llvm20/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm20-cuda13.0ext",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm20-cuda13.0ext",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1-gcc11/devcontainer.json
+++ b/.devcontainer/cuda13.1-gcc11/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc11-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc11-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1-gcc12/devcontainer.json
+++ b/.devcontainer/cuda13.1-gcc12/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc12-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc12-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1-gcc13/devcontainer.json
+++ b/.devcontainer/cuda13.1-gcc13/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc13-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc13-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1-gcc14/devcontainer.json
+++ b/.devcontainer/cuda13.1-gcc14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc14-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc14-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1-llvm15/devcontainer.json
+++ b/.devcontainer/cuda13.1-llvm15/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm15-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm15-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1-llvm16/devcontainer.json
+++ b/.devcontainer/cuda13.1-llvm16/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm16-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm16-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1-llvm17/devcontainer.json
+++ b/.devcontainer/cuda13.1-llvm17/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm17-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm17-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1-llvm18/devcontainer.json
+++ b/.devcontainer/cuda13.1-llvm18/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm18-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm18-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1-llvm19/devcontainer.json
+++ b/.devcontainer/cuda13.1-llvm19/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm19-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm19-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1-llvm20/devcontainer.json
+++ b/.devcontainer/cuda13.1-llvm20/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm20-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm20-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1ext-gcc14/devcontainer.json
+++ b/.devcontainer/cuda13.1ext-gcc14/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc14-cuda13.1ext",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc14-cuda13.1ext",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/cuda13.1ext-llvm20/devcontainer.json
+++ b/.devcontainer/cuda13.1ext-llvm20/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-llvm20-cuda13.1ext",
+  "image": "rapidsai/devcontainers:latest-cpp-llvm20-cuda13.1ext",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "shutdownAction": "stopContainer",
-  "image": "rapidsai/devcontainers:26.02-cpp-gcc14-cuda13.1",
+  "image": "rapidsai/devcontainers:latest-cpp-gcc14-cuda13.1",
   "runArgs": [
     "--init",
     "--name",

--- a/.devcontainer/docker-entrypoint.sh
+++ b/.devcontainer/docker-entrypoint.sh
@@ -57,19 +57,5 @@ else
     export XDG_STATE_HOME="$HOME_FOLDER/.local/state";
     export PYTHONHISTFILE="$HOME_FOLDER/.local/state/.python_history";
 
-    if command -V module 2>&1 | grep -q function; then
-        # "deactivate" lmod so it will be reactivated as the non-root user
-        export LMOD_CMD=
-        export LMOD_DEFAULT_MODULEPATH=
-        export LMOD_DIR=
-        export LMOD_PKG=
-        export LOADEDMODULES=
-        export MANPATH=
-        export MODULEPATH_ROOT=
-        export MODULEPATH=
-        export MODULESHOME=
-        export -fn module
-    fi
-
     exec su -p "$REMOTE_USER" -- "$(pwd)/.devcontainer/cccl-entrypoint.sh" "$@";
 fi

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -333,7 +333,7 @@ workflows:
 
 
 # The version of the devcontainer images to use from https://hub.docker.com/r/rapidsai/devcontainers
-devcontainer_version: '26.02'
+devcontainer_version: 'latest'
 
 # Compiler versions used for the cuda99.X internal builds:
 cuda99_gcc_version: 14

--- a/ci/rapids/cuda13.0-conda/devcontainer.json
+++ b/ci/rapids/cuda13.0-conda/devcontainer.json
@@ -1,10 +1,10 @@
 {
-  "image": "rapidsai/devcontainers:26.02-cpp-mambaforge",
+  "image": "rapidsai/devcontainers:latest-cpp-mambaforge",
   "runArgs": [
     "--init",
     "--rm",
     "--name",
-    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-26.02-cuda13.0-conda",
+    "${localEnv:USER:anon}-${localWorkspaceFolderBasename}-rapids-latest-cuda13.0-conda",
     "--ulimit",
     "nofile=500000"
   ],


### PR DESCRIPTION
Updating the version step by step is cumbersome and leads to frequent issues
