### PR TITLE
[libcu++] Improve copy_bytes and dynamic_shared_memory documentation

### DIFF
--- a/docs/libcudacxx/runtime/algorithm.rst
+++ b/docs/libcudacxx/runtime/algorithm.rst
@@ -12,10 +12,11 @@ The ``runtime`` part of the ``cuda/algorithm`` header provides stream-ordered, b
 
 Launch a byte-wise copy from source to destination on the provided stream.
 
+- Signature: ``copy_bytes(stream, src, dst, config = {})``
 - Overloads accept ``cuda::std::span``-convertible contiguous ranges or ``cuda::std::mdspan``-convertible multi-dimensional views.
 - Elements must be trivially copyable
 - ``cuda::std::mdspan``-convertible types must convert to an mdspan that is exhaustive
-- Source access order (during the copy call or in stream order) can be configured with ``cuda::copy_configuration``
+- The optional ``config`` argument is a ``cuda::copy_configuration`` that controls source access order and managed-memory location hints
 
 Availability: CCCL 3.1.0 / CUDA 13.1
 
@@ -23,12 +24,25 @@ Availability: CCCL 3.1.0 / CUDA 13.1
 
    #include <cuda/algorithm>
    #include <cuda/stream>
+   #include <cuda/std/algorithm>
    #include <cuda/std/span>
 
-   void copy_example(cuda::stream_ref s, int* d_dst, const int* d_src, std::size_t n) {
-     cuda::std::span<const int> src{d_src, n};
-     cuda::std::span<int>       dst{d_dst, n};
-     cuda::copy_bytes(s, src, dst);  // enqueued on s
+   void copy_example(cuda::stream_ref s, cuda::std::span<const int> src, cuda::std::span<int> dst) {
+     // copy_bytes copies up to src.size_bytes(); dst can be larger.
+     auto n = cuda::std::min(src.size(), dst.size());
+     auto src_prefix = src.first(n / 2);
+     auto dst_prefix = dst.first(n / 2);
+     auto src_suffix = src.subspan(n / 2);
+     auto dst_suffix = dst.subspan(n / 2);
+
+     // Default behavior: enqueue a stream-ordered byte-wise copy on stream s.
+     cuda::copy_bytes(s, src_prefix, dst_prefix);
+
+     // Advanced behavior: customize source access order for this copy.
+     auto config = cuda::copy_configuration{
+       .src_access_order = cuda::source_access_order::during_api_call,
+     };
+     cuda::copy_bytes(s, src_suffix, dst_suffix, config);
    }
 
 
@@ -48,9 +62,17 @@ Availability: CCCL 3.1.0 / CUDA 13.1
 
    #include <cuda/algorithm>
    #include <cuda/stream>
+   #include <cuda/std/algorithm>
    #include <cuda/std/span>
 
-   void fill_example(cuda::stream_ref s, int* d_dst, std::size_t n) {
-     cuda::std::span<int> dst{d_dst, n};
-     cuda::fill_bytes(s, dst, 0x00); // zero-fill device memory
+   void fill_example(cuda::stream_ref s, cuda::std::span<unsigned char> dst) {
+     // Reserve 16-byte red zones at both ends and clear the payload in between.
+     auto guard = cuda::std::min(static_cast<decltype(dst.size())>(16), dst.size() / 2);
+     auto head  = dst.first(guard);
+     auto body  = dst.subspan(guard, dst.size() - 2 * guard);
+     auto tail  = dst.last(guard);
+
+     cuda::fill_bytes(s, head, 0xCD); // debug guard pattern
+     cuda::fill_bytes(s, body, 0x00); // initialize payload
+     cuda::fill_bytes(s, tail, 0xCD); // debug guard pattern
    }

--- a/docs/libcudacxx/runtime/launch.rst
+++ b/docs/libcudacxx/runtime/launch.rst
@@ -182,6 +182,8 @@ Specifies dynamic shared memory configuration. It provides a type-safe way to sp
 - For non-array ``T`` (e.g., a struct), call ``cuda::dynamic_shared_memory<T>()`` with no size argument.
 - For bounded array ``T[n]`` (e.g., ``int[10]``), call ``cuda::dynamic_shared_memory<T[n]>()`` with no size argument.
 - For unbounded array ``T[]`` (e.g., ``float[]``), pass the element count: ``cuda::dynamic_shared_memory<T[]>(n)``.
+- To opt in to non-portable dynamic shared memory sizes (greater than 48 KiB per block), pass ``cuda::non_portable``:
+  ``cuda::dynamic_shared_memory<T>(cuda::non_portable)`` or ``cuda::dynamic_shared_memory<T[]>(n, cuda::non_portable)``.
 
 Availability: CCCL 3.2.0 / CUDA 13.2
 
@@ -202,6 +204,15 @@ Example:
       cuda::block_dims<128>(),
       cuda::grid_dims(4),
       cuda::dynamic_shared_memory<float[]>(1024)
+     );
+     cuda::launch(stream, config, kernel<decltype(config)>);
+   }
+
+   void launch_non_portable(cuda::stream_ref stream) {
+     auto config = cuda::make_config(
+      cuda::block_dims<128>(),
+      cuda::grid_dims(4),
+      cuda::dynamic_shared_memory<float[]>(32768, cuda::non_portable)
      );
      cuda::launch(stream, config, kernel<decltype(config)>);
    }


### PR DESCRIPTION
`copy_configuration` was not mentioned in the `copy_bytes` doc and there was no mention of `non_portable` argument to `dynamic_shared_memory` option. This PR also tries to provide a bit more interesting examples for `copy_bytes` and `fill_bytes` beyond just packing pointers into a span. Showing some span manipulation might highlight why its better than `cudaMemcpy` on plain pointers