### PR TITLE
[PSTL] move empty range check after NVTX range

### DIFF
--- a/libcudacxx/include/cuda/std/__pstl/all_of.h
+++ b/libcudacxx/include/cuda/std/__pstl/all_of.h
@@ -64,6 +64,7 @@ all_of([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _U
     {
       return true;
     }
+
     auto __res =
       __dispatch(__policy, ::cuda::std::move(__first), __last, ::cuda::std::not_fn(::cuda::std::move(__pred)));
     return __res == __last;

--- a/libcudacxx/include/cuda/std/__pstl/any_of.h
+++ b/libcudacxx/include/cuda/std/__pstl/any_of.h
@@ -65,6 +65,7 @@ any_of([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _U
     {
       return false;
     }
+
     auto __res = __dispatch(__policy, ::cuda::std::move(__first), __last, ::cuda::std::move(__pred));
     return __res != __last;
   }

--- a/libcudacxx/include/cuda/std/__pstl/copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/copy.h
@@ -60,6 +60,7 @@ copy([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIte
     {
       return __result;
     }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     return __dispatch(__policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__result));
   }

--- a/libcudacxx/include/cuda/std/__pstl/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/copy_if.h
@@ -59,16 +59,17 @@ _CCCL_HOST_API _OutputIterator copy_if(
   static_assert(indirect_unary_predicate<_UnaryPred, _InputIterator>,
                 "cuda::std::copy_if: UnaryPred must satisfy indirect_unary_predicate<InputIterator>");
 
-  if (__first == __last)
-  {
-    return __result;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__copy_if, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::copy_if");
+
+    if (__first == __last)
+    {
+      return __result;
+    }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     return __dispatch(
       __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__result), ::cuda::std::move(__pred));

--- a/libcudacxx/include/cuda/std/__pstl/copy_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/copy_n.h
@@ -59,6 +59,7 @@ copy_n([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _Size _
     {
       return __result;
     }
+
     return __dispatch(__policy,
                       ::cuda::std::move(__first),
                       static_cast<iter_difference_t<_InputIterator>>(__count),

--- a/libcudacxx/include/cuda/std/__pstl/count.h
+++ b/libcudacxx/include/cuda/std/__pstl/count.h
@@ -62,6 +62,12 @@ count([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIt
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::count");
+
+    if (__first == __last)
+    {
+      return iter_difference_t<_InputIterator>{0};
+    }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     return __dispatch(
       __policy,

--- a/libcudacxx/include/cuda/std/__pstl/count_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/count_if.h
@@ -62,6 +62,12 @@ _CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_po
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::count_if");
+
+    if (__first == __last)
+    {
+      return iter_difference_t<_InputIterator>{0};
+    }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     return __dispatch(
       __policy,

--- a/libcudacxx/include/cuda/std/__pstl/equal.h
+++ b/libcudacxx/include/cuda/std/__pstl/equal.h
@@ -62,16 +62,17 @@ equal([[maybe_unused]] const _Policy& __policy,
                 "cuda::std::equal: BinaryPred must satisfy "
                 "indirect_binary_predicate<BinaryPred, InputIter1, InputIter2>");
 
-  if (__first1 == __last1)
-  {
-    return true;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::equal");
+
+    if (__first1 == __last1)
+    {
+      return true;
+    }
+
     const auto __count    = ::cuda::std::distance(__first1, __last1);
     auto __zip_first      = ::cuda::zip_iterator{::cuda::std::move(__first1), ::cuda::std::move(__first2)};
     const auto __zip_last = __zip_first + __count;
@@ -105,23 +106,24 @@ _CCCL_REQUIRES(__has_forward_traversal<_InputIter1> _CCCL_AND __has_forward_trav
                 "cuda::std::equal: BinaryPred must satisfy "
                 "indirect_binary_predicate<BinaryPred, InputIter1, InputIter2>");
 
-  if (__first1 == __last1 && __first2 == __last2)
-  {
-    return true;
-  }
-
-  const auto __count1 = ::cuda::std::distance(__first1, __last1);
-  const auto __count2 = ::cuda::std::distance(__first2, __last2);
-  if (__count1 != __count2)
-  {
-    return false;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::equal");
+
+    if (__first1 == __last1 && __first2 == __last2)
+    {
+      return true;
+    }
+
+    const auto __count1 = ::cuda::std::distance(__first1, __last1);
+    const auto __count2 = ::cuda::std::distance(__first2, __last2);
+    if (__count1 != __count2)
+    {
+      return false;
+    }
+
     auto __zip_first      = ::cuda::zip_iterator{::cuda::std::move(__first1), ::cuda::std::move(__first2)};
     const auto __zip_last = ::cuda::zip_iterator{::cuda::std::move(__last1), ::cuda::std::move(__last2)};
     const auto __result   = __dispatch(

--- a/libcudacxx/include/cuda/std/__pstl/exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/exclusive_scan.h
@@ -65,6 +65,7 @@ _CCCL_HOST_API _OutputIterator exclusive_scan(
     {
       return __result;
     }
+
     return __dispatch(
       __policy,
       ::cuda::std::move(__first),

--- a/libcudacxx/include/cuda/std/__pstl/fill.h
+++ b/libcudacxx/include/cuda/std/__pstl/fill.h
@@ -69,16 +69,17 @@ fill([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIte
   static_assert(indirectly_writable<_InputIterator, const _Tp&>,
                 "cuda::std::fill requires InputIterator to be indirectly writable with const T&");
 
-  if (__first == __last)
-  {
-    return;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__generate_n, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::fill");
+
+    if (__first == __last)
+    {
+      return;
+    }
+
     // We do not want actually load anything, so pass a counting iterator instead
     const auto __count = ::cuda::std::distance(__first, __last);
     (void) __dispatch(__policy, ::cuda::std::move(__first), __count, __fill_constant_value{__value});

--- a/libcudacxx/include/cuda/std/__pstl/fill_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/fill_n.h
@@ -54,16 +54,17 @@ fill_n([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _Size _
   static_assert(indirectly_writable<_InputIterator, const _Tp&>,
                 "cuda::std::fill_n requires InputIterator to be indirectly writable with const T&");
 
-  if (__count == 0)
-  {
-    return __first;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__generate_n, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::fill_n");
+
+    if (__count == 0)
+    {
+      return __first;
+    }
+
     return __dispatch(__policy, ::cuda::std::move(__first), __count, __fill_constant_value{__value});
   }
   else

--- a/libcudacxx/include/cuda/std/__pstl/find.h
+++ b/libcudacxx/include/cuda/std/__pstl/find.h
@@ -55,16 +55,17 @@ find([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, cons
   static_assert(__is_cpp17_equality_comparable_v<_Tp, iter_value_t<_Iter>>,
                 "Parallel cuda::std::find requires that T is equality comparable with iter_value_t<Iter>");
 
-  if (__first == __last)
-  {
-    return __first;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::find");
+
+    if (__first == __last)
+    {
+      return __first;
+    }
+
     return __dispatch(
       __policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::equal_to_value<_Tp>{__val});
   }

--- a/libcudacxx/include/cuda/std/__pstl/find_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/find_if.h
@@ -52,16 +52,17 @@ find_if([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _
   static_assert(indirect_unary_predicate<_UnaryOp, _Iter>,
                 "cuda::std::find_if: UnaryOp must satisfy indirect_unary_predicate<Iter>");
 
-  if (__first == __last)
-  {
-    return __first;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::find_if");
+
+    if (__first == __last)
+    {
+      return __first;
+    }
+
     return __dispatch(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
   }
   else

--- a/libcudacxx/include/cuda/std/__pstl/find_if_not.h
+++ b/libcudacxx/include/cuda/std/__pstl/find_if_not.h
@@ -53,16 +53,17 @@ find_if_not([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __las
   static_assert(indirect_unary_predicate<_UnaryOp, _Iter>,
                 "cuda::std::find_if: UnaryOp must satisfy indirect_unary_predicate<Iter>");
 
-  if (__first == __last)
-  {
-    return __first;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::find_if_not");
+
+    if (__first == __last)
+    {
+      return __first;
+    }
+
     return __dispatch(
       __policy, ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::not_fn(::cuda::std::move(__pred)));
   }

--- a/libcudacxx/include/cuda/std/__pstl/for_each.h
+++ b/libcudacxx/include/cuda/std/__pstl/for_each.h
@@ -51,6 +51,12 @@ _CCCL_HOST_API void for_each([[maybe_unused]] const _Policy& __policy, _Iter __f
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::for_each");
+
+    if (__first == __last)
+    {
+      return;
+    }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     (void) __dispatch(__policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__func));
   }

--- a/libcudacxx/include/cuda/std/__pstl/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/for_each_n.h
@@ -51,6 +51,12 @@ _CCCL_HOST_API _Iter for_each_n([[maybe_unused]] const _Policy& __policy, _Iter 
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::for_each_n");
+
+    if (__orig_n == 0)
+    {
+      return __first;
+    }
+
     return __dispatch(__policy, ::cuda::std::move(__first), __orig_n, ::cuda::std::move(__func));
   }
   else

--- a/libcudacxx/include/cuda/std/__pstl/generate.h
+++ b/libcudacxx/include/cuda/std/__pstl/generate.h
@@ -56,16 +56,17 @@ generate([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _Inpu
                 "cuda::std::generate requires InputIterator to be indirectly writable with the return value of "
                 "Generator");
 
-  if (__first == __last)
-  {
-    return;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__generate_n, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::generate");
+
+    if (__first == __last)
+    {
+      return;
+    }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     (void) __dispatch(__policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__gen));
   }

--- a/libcudacxx/include/cuda/std/__pstl/generate_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/generate_n.h
@@ -56,16 +56,17 @@ generate_n([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _Si
                 "cuda::std::generate_n requires InputIterator to be indirectly writable with the return value of "
                 "Generator");
 
-  if (__count == 0)
-  {
-    return __first;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__generate_n, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::generate_n");
+
+    if (__count == 0)
+    {
+      return __first;
+    }
+
     return __dispatch(__policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__gen));
   }
   else

--- a/libcudacxx/include/cuda/std/__pstl/inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/inclusive_scan.h
@@ -65,6 +65,7 @@ _CCCL_HOST_API _OutputIterator inclusive_scan(
     {
       return __result;
     }
+
     return __dispatch(
       __policy,
       ::cuda::std::move(__first),

--- a/libcudacxx/include/cuda/std/__pstl/mismatch.h
+++ b/libcudacxx/include/cuda/std/__pstl/mismatch.h
@@ -64,16 +64,17 @@ _CCCL_REQUIRES(__has_forward_traversal<_InputIter1> _CCCL_AND __has_forward_trav
                 "cuda::std::mismatch: BinaryPred must satisfy "
                 "indirect_binary_predicate<BinaryPred, InputIter1, InputIter2>");
 
-  if (__first1 == __last1)
-  {
-    return pair<_InputIter1, _InputIter2>{__first1, __first2};
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::mismatch");
+
+    if (__first1 == __last1)
+    {
+      return pair<_InputIter1, _InputIter2>{__first1, __first2};
+    }
+
     const auto __count = ::cuda::std::distance(__first1, __last1);
     auto __zip_first   = ::cuda::zip_iterator{::cuda::std::move(__first1), ::cuda::std::move(__first2)};
     auto __zip_last    = __zip_first + __count;
@@ -108,17 +109,18 @@ _CCCL_REQUIRES(__has_forward_traversal<_InputIter1> _CCCL_AND __has_forward_trav
                 "cuda::std::mismatch: BinaryPred must satisfy "
                 "indirect_binary_predicate<BinaryPred, InputIter1, InputIter2>");
 
-  // Different than equal, if either range is empty we return {first1, first2}
-  if (__first1 == __last1 || __first2 == __last2)
-  {
-    return pair<_InputIter1, _InputIter2>{__first1, __first2};
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::mismatch");
+
+    // Different than equal, if either range is empty we return {first1, first2}
+    if (__first1 == __last1 || __first2 == __last2)
+    {
+      return pair<_InputIter1, _InputIter2>{__first1, __first2};
+    }
+
     auto __result = __dispatch(
       __policy,
       ::cuda::zip_iterator{::cuda::std::move(__first1), ::cuda::std::move(__first2)},

--- a/libcudacxx/include/cuda/std/__pstl/none_of.h
+++ b/libcudacxx/include/cuda/std/__pstl/none_of.h
@@ -65,6 +65,7 @@ none_of([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _
     {
       return true;
     }
+
     auto __res = __dispatch(__policy, ::cuda::std::move(__first), __last, ::cuda::std::move(__pred));
     return __res == __last;
   }

--- a/libcudacxx/include/cuda/std/__pstl/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/reduce.h
@@ -68,6 +68,12 @@ reduce([[maybe_unused]] const _Policy& __policy, _Iter __first, _Iter __last, _T
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::reduce");
+
+    if (__first == __last)
+    {
+      return __init;
+    }
+
     return __dispatch(
       __policy,
       ::cuda::std::move(__first),

--- a/libcudacxx/include/cuda/std/__pstl/remove.h
+++ b/libcudacxx/include/cuda/std/__pstl/remove.h
@@ -78,6 +78,7 @@ remove([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputI
     {
       return __first;
     }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     return __dispatch(__policy, __first, __count, __remove_compare_not_eq{__value});
   }

--- a/libcudacxx/include/cuda/std/__pstl/remove_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/remove_copy.h
@@ -59,16 +59,17 @@ _CCCL_HOST_API _OutputIterator remove_copy(
   _OutputIterator __result,
   const _Tp& __value)
 {
-  if (__first == __last)
-  {
-    return __result;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__copy_if, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::remove_copy");
+
+    if (__first == __last)
+    {
+      return __result;
+    }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     return __dispatch(
       __policy, ::cuda::std::move(__first), __count, ::cuda::std::move(__result), __remove_compare_not_eq{__value});

--- a/libcudacxx/include/cuda/std/__pstl/remove_copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/remove_copy_if.h
@@ -60,16 +60,17 @@ _CCCL_HOST_API _OutputIterator remove_copy_if(
   static_assert(indirect_unary_predicate<_UnaryPred, _InputIterator>,
                 "cuda::std::remove_copy_if: UnaryPred must satisfy indirect_unary_predicate<InputIterator>");
 
-  if (__first == __last)
-  {
-    return __result;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__copy_if, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::remove_copy_if");
+
+    if (__first == __last)
+    {
+      return __result;
+    }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     return __dispatch(
       __policy,

--- a/libcudacxx/include/cuda/std/__pstl/remove_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/remove_if.h
@@ -64,6 +64,7 @@ remove_if([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _Inp
     {
       return __first;
     }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     return __dispatch(__policy, __first, __count, ::cuda::std::not_fn(::cuda::std::move(__pred)));
   }

--- a/libcudacxx/include/cuda/std/__pstl/replace.h
+++ b/libcudacxx/include/cuda/std/__pstl/replace.h
@@ -77,16 +77,17 @@ _CCCL_HOST_API void replace(
   static_assert(__is_cpp17_equality_comparable_v<_Tp, iter_reference_t<_InputIterator>>,
                 "cuda::std::replace requires T to be comparable with iter_reference_t<InputIterator>");
 
-  if (__first == __last)
-  {
-    return;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::replace");
+
+    if (__first == __last)
+    {
+      return;
+    }
+
     (void) __dispatch(
       __policy,
       __first,

--- a/libcudacxx/include/cuda/std/__pstl/replace_copy.h
+++ b/libcudacxx/include/cuda/std/__pstl/replace_copy.h
@@ -80,16 +80,17 @@ _CCCL_HOST_API _OutputIterator replace_copy(
   static_assert(__is_cpp17_equality_comparable_v<_Tp, iter_reference_t<_InputIterator>>,
                 "cuda::std::replace_copy requires T to be comparable with iter_reference_t<InputIterator>");
 
-  if (__first == __last)
-  {
-    return __result;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::replace_copy");
+
+    if (__first == __last)
+    {
+      return __result;
+    }
+
     return __dispatch(
       __policy,
       ::cuda::std::move(__first),

--- a/libcudacxx/include/cuda/std/__pstl/replace_copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/replace_copy_if.h
@@ -81,16 +81,17 @@ _CCCL_HOST_API _OutputIterator replace_copy_if(
   static_assert(indirect_unary_predicate<_UnaryPred, _InputIterator>,
                 "cuda::std::replace_copy_if: UnaryPred must satisfy indirect_unary_predicate<InputIterator>");
 
-  if (__first == __last)
-  {
-    return __result;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::replace_copy_if");
+
+    if (__first == __last)
+    {
+      return __result;
+    }
+
     return __dispatch(
       __policy,
       ::cuda::std::move(__first),

--- a/libcudacxx/include/cuda/std/__pstl/replace_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/replace_if.h
@@ -58,16 +58,17 @@ _CCCL_HOST_API void replace_if(
   static_assert(indirect_unary_predicate<_UnaryPred, _InputIterator>,
                 "cuda::std::replace_if: UnaryPred must satisfy indirect_unary_predicate<InputIterator>");
 
-  if (__first == __last)
-  {
-    return;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::replace_if");
+
+    if (__first == __last)
+    {
+      return;
+    }
+
     (void) __dispatch(
       __policy,
       __first,

--- a/libcudacxx/include/cuda/std/__pstl/transform.h
+++ b/libcudacxx/include/cuda/std/__pstl/transform.h
@@ -62,16 +62,17 @@ _CCCL_HOST_API _OutputIterator transform(
                 "cuda::std::transform requires OutputIterator to be indirectly writable with the return value of "
                 "UnaryOp");
 
-  if (__first == __last)
-  {
-    return __result;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::transform");
+
+    if (__first == __last)
+    {
+      return __result;
+    }
+
     return __dispatch(
       __policy,
       ::cuda::std::move(__first),
@@ -107,16 +108,17 @@ _CCCL_HOST_API _OutputIterator transform(
                         invoke_result_t<_BinaryOp, iter_reference_t<_InputIterator1>, iter_reference_t<_InputIterator2>>>,
     "cuda::std::transform requires OutputIterator to be indirectly writable with the return value of BinaryOp");
 
-  if (__first1 == __last1)
-  {
-    return __result;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform, _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::transform");
+
+    if (__first1 == __last1)
+    {
+      return __result;
+    }
+
     return __dispatch(
       __policy,
       ::cuda::std::move(__first1),

--- a/libcudacxx/include/cuda/std/__pstl/transform_reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/transform_reduce.h
@@ -59,17 +59,18 @@ _CCCL_HOST_API _Tp transform_reduce(
   _ReductionOp __reduction_op,
   _TransformOp __transform_op)
 {
-  if (__first == __last)
-  {
-    return __init;
-  }
-
   [[maybe_unused]] auto __dispatch =
     ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform_reduce,
                                                    _Policy>();
   if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
   {
     _CCCL_NVTX_RANGE_SCOPE("cuda::std::transform_reduce");
+
+    if (__first == __last)
+    {
+      return __init;
+    }
+
     const auto __count = ::cuda::std::distance(__first, __last);
     return __dispatch(
       __policy,


### PR DESCRIPTION
We want to keep the nvtx range visible even if the range is empty.

It might otherwise confuse users.

Also add some spacing to make it more readable
