### PR TITLE
Implement parallel `cuda::std::iota`

### DIFF
--- a/libcudacxx/benchmarks/bench/iota/basic.cu
+++ b/libcudacxx/benchmarks/bench/iota/basic.cu
@@ -1,0 +1,66 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in(elements, thrust::no_init);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(1);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               cuda::iota(cuda_policy(alloc, launch), in.begin(), in.end(), T{42});
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));
+
+template <typename T>
+static void stepped(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in(elements, thrust::no_init);
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(1);
+  state.add_global_memory_writes<T>(elements);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               cuda::iota(cuda_policy(alloc, launch), in.begin(), in.end(), T{42}, T{2});
+             });
+}
+
+NVBENCH_BENCH_TYPES(stepped, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("stepped")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/libcudacxx/include/cuda/__pstl/iota.h
+++ b/libcudacxx/include/cuda/__pstl/iota.h
@@ -1,0 +1,266 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___PSTL_IOTA_H
+#define _CUDA___PSTL_IOTA_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__iterator/counting_iterator.h>
+#  include <cuda/__iterator/strided_iterator.h>
+#  include <cuda/__nvtx/nvtx.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/not_fn.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/incrementable_traits.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__numeric/iota.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_arithmetic.h>
+#  include <cuda/std/__type_traits/is_convertible.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__type_traits/is_integral.h>
+#  include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#  include <cuda/std/__type_traits/is_same.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/transform.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+template <class _Tp>
+_CCCL_CONCEPT __can_operator_plus_integral = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __val, const uint64_t __index)(
+  requires(::cuda::std::is_convertible_v<decltype(__val + __index), _Tp>));
+
+template <class _Tp>
+_CCCL_CONCEPT __can_operator_plus_conversion = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __val, const uint64_t __index)(
+  requires(::cuda::std::is_convertible_v<decltype(__val + static_cast<_Tp>(__index)), _Tp>));
+
+template <class _Tp>
+struct __iota_init_fn
+{
+  _Tp __init_;
+
+  _CCCL_API constexpr __iota_init_fn(const _Tp& __init) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Tp>)
+      : __init_(__init)
+  {}
+
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE _Tp constexpr operator()(const uint64_t __index) const
+  {
+#  if _LIBCUDACXX_HAS_NVFP16()
+    // We cannot rely on operator+ and constructors from integers to be available for the extended fp types
+    if constexpr (::cuda::std::is_same_v<_Tp, __half>)
+    {
+      return ::__hadd(__init_, ::__ull2half_rn(__index));
+    }
+    else
+#  endif // _LIBCUDACXX_HAS_NVFP16()
+#  if _LIBCUDACXX_HAS_NVBF16()
+      if constexpr (::cuda::std::is_same_v<_Tp, __nv_bfloat16>)
+    {
+      return ::__hadd(__init_, ::__ull2bfloat16_rn(__index));
+    }
+    else
+#  endif // _LIBCUDACXX_HAS_NVBF16()
+      if constexpr (::cuda::std::is_arithmetic_v<_Tp>)
+      { // avoid warnings about integer conversions
+        return static_cast<_Tp>(__init_ + static_cast<_Tp>(__index));
+      }
+      else if constexpr (__can_operator_plus_integral<_Tp>)
+      {
+        return __init_ + __index;
+      }
+      else if constexpr (__can_operator_plus_conversion<_Tp>)
+      {
+        return __init_ + static_cast<_Tp>(__index);
+      }
+      else
+      {
+        static_assert(::cuda::std::__always_false_v<_Tp>,
+                      "cuda::iota(iter, iter, init) requires that T supports operator+");
+      }
+  }
+};
+
+template <class _Tp>
+_CCCL_CONCEPT __can_operator_plus_times_integral = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __val, const uint64_t __index)(
+  requires(::cuda::std::is_convertible_v<decltype(__val + __val * __index), _Tp>));
+
+template <class _Tp>
+_CCCL_CONCEPT __can_operator_plus_times_conversion =
+  _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __val, const uint64_t __index) //
+  (requires(::cuda::std::is_convertible_v<decltype(__val + __val * static_cast<_Tp>(__index)), _Tp>));
+
+template <class _Tp>
+struct __iota_init_step_fn
+{
+  _Tp __init_;
+  _Tp __step_;
+
+  _CCCL_API constexpr __iota_init_step_fn(const _Tp& __init,
+                                          const _Tp& __step) noexcept(::cuda::std::is_nothrow_copy_constructible_v<_Tp>)
+      : __init_(__init)
+      , __step_(__step)
+  {}
+
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE constexpr _Tp operator()(const uint64_t __index) const
+  {
+#  if _LIBCUDACXX_HAS_NVFP16()
+    // We cannot rely on operator+ and constructors from integers to be available for the extended fp types
+    if constexpr (::cuda::std::is_same_v<_Tp, __half>)
+    {
+      return ::__hadd(__init_, ::__hmul(__step_, ::__ull2half_rn(__index)));
+    }
+    else
+#  endif // _LIBCUDACXX_HAS_NVFP16()
+#  if _LIBCUDACXX_HAS_NVBF16()
+      if constexpr (::cuda::std::is_same_v<_Tp, __nv_bfloat16>)
+    {
+      return ::__hadd(__init_, ::__hmul(__step_, ::__ull2bfloat16_rn(__index)));
+    }
+    else
+#  endif // _LIBCUDACXX_HAS_NVBF16()
+      if constexpr (::cuda::std::is_arithmetic_v<_Tp>)
+      { // avoid warnings about integer conversions
+        return static_cast<_Tp>(__init_ + __step_ * static_cast<_Tp>(__index));
+      }
+      else if constexpr (__can_operator_plus_times_integral<_Tp>)
+      {
+        return __init_ + __step_ * __index;
+      }
+      else if constexpr (__can_operator_plus_times_conversion<_Tp>)
+      {
+        return __init_ + __step_ * static_cast<_Tp>(__index);
+      }
+      else
+      {
+        static_assert(::cuda::std::__always_false_v<_Tp>,
+                      "cuda::iota(iter, iter, init, step) requires that T supports operator+ and operator*");
+      }
+  }
+};
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _Tp = ::cuda::std::iter_value_t<_InputIterator>)
+_CCCL_REQUIRES(
+  ::cuda::std::__has_forward_traversal<_InputIterator> _CCCL_AND ::cuda::std::is_execution_policy_v<_Policy>)
+_CCCL_HOST_API void
+iota([[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, const _Tp& __init = _Tp{})
+{
+  static_assert(::cuda::std::indirectly_writable<_InputIterator, _Tp>,
+                "cuda::iota requires InputIterator to be indirectly writable with T");
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::iota");
+
+    if (__first == __last)
+    {
+      return;
+    }
+
+    // Note: using a different offset type than uint64_t degrades performance considerably for larger integer types
+    const auto __count = static_cast<uint64_t>(::cuda::std::distance(__first, __last));
+    // For whatever reason __iota_init_step_fn is much faster for int64_t and __int128
+    if constexpr (::cuda::std::is_arithmetic_v<_Tp>)
+    {
+      (void) __dispatch(
+        __policy,
+        ::cuda::counting_iterator<uint64_t>{0},
+        ::cuda::counting_iterator<uint64_t>{__count},
+        ::cuda::std::move(__first),
+        __iota_init_step_fn{__init, _Tp{1}});
+    }
+    else
+    {
+      (void) __dispatch(
+        __policy,
+        ::cuda::counting_iterator<uint64_t>{0},
+        ::cuda::counting_iterator<uint64_t>{static_cast<uint64_t>(__count)},
+        ::cuda::std::move(__first),
+        __iota_init_fn{__init});
+    }
+  }
+  else
+  {
+    static_assert(::cuda::std::__always_false_v<_Policy>, "Parallel cuda::iota requires at least one selected backend");
+    return ::cuda::iota(::cuda::std::move(__first), ::cuda::std::move(__last), __init);
+  }
+}
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _Tp = ::cuda::std::iter_value_t<_InputIterator>)
+_CCCL_REQUIRES(
+  ::cuda::std::__has_forward_traversal<_InputIterator> _CCCL_AND ::cuda::std::is_execution_policy_v<_Policy>)
+_CCCL_HOST_API void
+iota([[maybe_unused]] const _Policy& __policy,
+     _InputIterator __first,
+     _InputIterator __last,
+     const _Tp& __init,
+     const _Tp& __step)
+{
+  static_assert(::cuda::std::indirectly_writable<_InputIterator, _Tp>,
+                "cuda::iota requires InputIterator to be indirectly writable with T");
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__transform, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::iota");
+
+    if (__first == __last)
+    {
+      return;
+    }
+
+    // Note: using a different offset type than uint64_t degrades performance considerably for larger integer types
+    const auto __count = static_cast<uint64_t>(::cuda::std::distance(__first, __last));
+    (void) __dispatch(
+      __policy,
+      ::cuda::counting_iterator<uint64_t>{0},
+      ::cuda::counting_iterator<uint64_t>{__count},
+      ::cuda::std::move(__first),
+      __iota_init_step_fn{__init, __step});
+  }
+  else
+  {
+    static_assert(::cuda::std::__always_false_v<_Policy>, "Parallel cuda::iota requires at least one selected backend");
+    // TODO(miscco): Consider adding that overload to serial iota
+    return ::cuda::iota(::cuda::std::move(__first), ::cuda::std::move(__last), __init /*, __step*/);
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA___PSTL_IOTA_H

--- a/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
@@ -35,8 +35,6 @@ _CCCL_DIAG_POP
 
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
-#  include <cuda/__memory_pool/device_memory_pool.h>
-#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
 #  include <cuda/std/__exception/cuda_error.h>
@@ -84,11 +82,9 @@ struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_back
       0);
 
     // Allocate memory for result
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
     {
-      __temporary_storage<decltype(__resource)> __storage{__stream, __resource, __num_bytes};
+      __temporary_storage<> __storage{__policy, __num_bytes};
 
       // Run the kernel, the standard requires that the input and output range do not overlap
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
@@ -35,8 +35,6 @@ _CCCL_DIAG_POP
 
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
-#  include <cuda/__memory_pool/device_memory_pool.h>
-#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -73,9 +71,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
     using _OffsetType = iter_difference_t<_InputIterator>;
     _OffsetType __ret;
 
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
 
     // Determine temporary device storage requirements
     void* __temp_storage = nullptr;
@@ -93,7 +89,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
       __stream.get());
 
     {
-      __temporary_storage<decltype(__resource), _OffsetType> __storage{__stream, __resource, __num_bytes, 1};
+      __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};
 
       // Run the kernel
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
@@ -36,8 +36,6 @@ _CCCL_DIAG_POP
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
 #  include <cuda/__iterator/tabulate_output_iterator.h>
-#  include <cuda/__memory_pool/device_memory_pool.h>
-#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -87,12 +85,10 @@ struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::
       __count);
 
     // Allocate memory for result
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
 
     {
-      __temporary_storage<decltype(__resource)> __storage{__stream, __resource, __num_bytes};
+      __temporary_storage<> __storage{__policy, __num_bytes};
 
       // Run the scan
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
@@ -35,8 +35,6 @@ _CCCL_DIAG_POP
 
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
-#  include <cuda/__memory_pool/device_memory_pool.h>
-#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -54,8 +52,6 @@ _CCCL_DIAG_POP
 #  include <cuda/std/__type_traits/always_false.h>
 #  include <cuda/std/__type_traits/is_execution_policy.h>
 #  include <cuda/std/__utility/move.h>
-
-#  include <cuda_runtime.h>
 
 #  include <cuda/std/__cccl/prologue.h>
 
@@ -88,11 +84,10 @@ struct __pstl_dispatch<__pstl_algorithm::__find_if, __execution_backend::__cuda>
       __num_items);
 
     // Allocate memory for result
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+
     {
-      __temporary_storage<decltype(__resource), _OffsetType> __storage{__stream, __resource, __num_bytes, 1};
+      __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};
 
       // Run the find operation
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
@@ -36,8 +36,6 @@ _CCCL_DIAG_POP
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
 #  include <cuda/__iterator/tabulate_output_iterator.h>
-#  include <cuda/__memory_pool/device_memory_pool.h>
-#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -87,12 +85,10 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
       __count);
 
     // Allocate memory for result
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
 
     {
-      __temporary_storage<decltype(__resource)> __storage{__stream, __resource, __num_bytes};
+      __temporary_storage<> __storage{__policy, __num_bytes};
 
       // Run the scan
       _CCCL_TRY_CUDA_API(
@@ -135,12 +131,10 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
       __count);
 
     // Allocate memory for result
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
 
     {
-      __temporary_storage<decltype(__resource)> __storage{__stream, __resource, __num_bytes};
+      __temporary_storage<> __storage{__policy, __num_bytes};
 
       // Run the scan
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
@@ -35,8 +35,6 @@ _CCCL_DIAG_POP
 
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
-#  include <cuda/__memory_pool/device_memory_pool.h>
-#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
 #  include <cuda/std/__algorithm/merge.h>
@@ -92,11 +90,10 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
       __comp);
 
     // Allocate memory for result
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+
     {
-      __temporary_storage<decltype(__resource)> __storage{__stream, __resource, __num_bytes};
+      __temporary_storage<> __storage{__policy, __num_bytes};
 
       // Run the kernel
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
@@ -36,8 +36,6 @@ _CCCL_DIAG_POP
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
 #  include <cuda/__iterator/tabulate_output_iterator.h>
-#  include <cuda/__memory_pool/device_memory_pool.h>
-#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -94,12 +92,10 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
       __init);
 
     // Allocate memory for result
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
 
     {
-      __temporary_storage<decltype(__resource), _Tp> __storage{__stream, __resource, __num_bytes, 1};
+      __temporary_storage<_Tp> __storage{__policy, __num_bytes, 1};
 
       // Run the reduction
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
@@ -34,8 +34,6 @@ _CCCL_DIAG_POP
 
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
-#  include <cuda/__memory_pool/device_memory_pool.h>
-#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -68,9 +66,7 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
     using _OffsetType = iter_difference_t<_InputIterator>;
     _OffsetType __ret;
 
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
 
     // Determine temporary device storage requirements
     void* __temp_storage = nullptr;
@@ -87,7 +83,7 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
       __stream.get());
 
     {
-      __temporary_storage<decltype(__resource), _OffsetType> __storage{__stream, __resource, __num_bytes, 1};
+      __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};
 
       // Run the kernel
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/temporary_storage.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/temporary_storage.h
@@ -24,12 +24,18 @@
 #if _CCCL_HAS_BACKEND_CUDA()
 
 #  include <cuda/__cmath/round_up.h>
+#  include <cuda/__functional/call_or.h>
 #  include <cuda/__iterator/tabulate_output_iterator.h>
 #  include <cuda/__memory/align_up.h>
+#  include <cuda/__memory_pool/device_memory_pool.h>
+#  include <cuda/__memory_resource/any_resource.h>
+#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__memory_resource/properties.h>
+#  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
 #  include <cuda/std/__concepts/concept_macros.h>
 #  include <cuda/std/__memory/construct_at.h>
+#  include <cuda/std/__type_traits/is_callable.h>
 #  include <cuda/std/__type_traits/type_list.h>
 #  include <cuda/std/__utility/forward.h>
 #  include <cuda/std/__utility/integer_sequence.h>
@@ -58,11 +64,11 @@ struct __temporary_storage_construct_result
 
 //! @brief Provides device accessible storage for a number of typed sequences and temporary storage the algorithm might
 //! need.
-template <class _Resource, class... _StoredTypes>
+template <class... _StoredTypes>
 class __temporary_storage
 {
   ::cuda::stream_ref __stream_;
-  _Resource& __resource_;
+  ::cuda::mr::resource_ref<::cuda::mr::device_accessible> __resource_;
   size_t __total_bytes_allocated_;
   array<void*, 1 + sizeof...(_StoredTypes)> __storage_;
 
@@ -105,21 +111,44 @@ class __temporary_storage
     return __get_storage<0>(__storage, __num_elements);
   }
 
+  //! @brief Helper function to retrieve a memory resource from a policy
+  //!        In contrast to `__call_or` it does not require us to always call .device() on the stream
+  template <class _Policy>
+  [[nodiscard]] _CCCL_HOST_API static ::cuda::mr::resource_ref<::cuda::mr::device_accessible>
+  __get_memory_resource_or(const _Policy& __policy) noexcept
+  {
+    if constexpr (::cuda::std::__is_callable_v<::cuda::mr::get_memory_resource_t, const _Policy&>)
+    {
+      return ::cuda::mr::get_memory_resource(__policy);
+    }
+    else if constexpr (::cuda::std::__is_callable_v<::cuda::get_stream_t, const _Policy&>)
+    {
+      return ::cuda::device_default_memory_pool(::cuda::get_stream(__policy).device());
+    }
+    else
+    { // no stream no memory resource, assume device 0
+      return ::cuda::device_default_memory_pool(0);
+    }
+  }
+
 public:
-  _CCCL_TEMPLATE(class... _Sizes)
+  _CCCL_TEMPLATE(class _Policy, class... _Sizes)
   _CCCL_REQUIRES((sizeof...(_Sizes) == sizeof...(_StoredTypes)))
-  _CCCL_HOST_API __temporary_storage(
-    ::cuda::stream_ref __stream,
-    _Resource& __resource,
-    const size_t __num_bytes_storage,
-    const _Sizes... __elements_stored)
-      : __stream_(__stream)
-      , __resource_(__resource)
+  _CCCL_HOST_API
+  __temporary_storage(const _Policy& __policy, const size_t __num_bytes_storage, const _Sizes... __elements_stored)
+      : __stream_(::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy))
+      , __resource_(__get_memory_resource_or(__policy))
       , __total_bytes_allocated_(__get_total_bytes_allocated(__num_bytes_storage, __elements_stored...))
       , __storage_(__get_storage(
           __resource_.allocate(__stream_, __total_bytes_allocated_, ::cuda::mr::default_cuda_malloc_alignment),
           __elements_stored...))
   {}
+
+  _CCCL_HOST_API ~__temporary_storage()
+  {
+    __resource_.deallocate(
+      __stream_, __storage_[0], __total_bytes_allocated_, ::cuda::mr::default_cuda_malloc_alignment);
+  }
 
   //! We are dealing with uninitialized storage, so we might need to go through construct_at
   template <size_t _Index, class _OtherType = __type_at_c<_Index, __type_list<_StoredTypes...>>>

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
@@ -35,8 +35,6 @@ _CCCL_DIAG_POP
 
 #  include <cuda/__execution/policy.h>
 #  include <cuda/__functional/call_or.h>
-#  include <cuda/__memory_pool/device_memory_pool.h>
-#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -94,12 +92,10 @@ struct __pstl_dispatch<__pstl_algorithm::__transform_reduce, __execution_backend
       __init);
 
     // Allocate memory for result
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
 
     {
-      __temporary_storage<decltype(__resource), _Tp> __storage{__stream, __resource, __num_bytes, 1};
+      __temporary_storage<_Tp> __storage{__policy, __num_bytes, 1};
 
       // Run the reduction
       _CCCL_TRY_CUDA_API(

--- a/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/unique.h
@@ -33,8 +33,6 @@ _CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
 _CCCL_DIAG_POP
 
 #  include <cuda/__execution/policy.h>
-#  include <cuda/__memory_pool/device_memory_pool.h>
-#  include <cuda/__memory_resource/get_memory_resource.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/__stream/get_stream.h>
 #  include <cuda/__stream/stream_ref.h>
@@ -106,12 +104,10 @@ struct __pstl_dispatch<__pstl_algorithm::__unique, __execution_backend::__cuda>
       __count,
       0);
 
-    auto __stream   = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
-    auto __resource = ::cuda::__call_or(
-      ::cuda::mr::get_memory_resource, ::cuda::device_default_memory_pool(__stream.device()), __policy);
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
 
     { // Create temporary storage for the return value as well as a copy of the input sequence as Unique is not inplace
-      __temporary_storage<decltype(__resource), _OffsetType> __storage{__stream, __resource, __num_bytes, 1};
+      __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};
 
       _CCCL_TRY_CUDA_API(
         DispatchUnique::Dispatch,

--- a/libcudacxx/include/cuda/std/__pstl_algorithm
+++ b/libcudacxx/include/cuda/std/__pstl_algorithm
@@ -61,6 +61,9 @@
 #include <cuda/std/__pstl/unique.h>
 #include <cuda/std/__pstl/unique_copy.h>
 
+// Nonstandard extensions
+#include <cuda/__pstl/iota.h>
+
 // [algorithm.syn]
 #include <cuda/std/initializer_list>
 #include <cuda/std/version>

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.iota/pstl_iota.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/numeric.iota/pstl_iota.cu
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template <class Policy, class InputIterator, class T = iter_value_t<T>>
+// void iota(const Policy&  policy,
+//           InputIterator  first,
+//           InputIterator  last,
+//           const T& init = T{});
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 1000;
+
+template <class Policy>
+void test_iota(const Policy& policy, thrust::device_vector<int>& output)
+{
+  cuda::std::fill(policy, output.begin(), output.end(), -1);
+  { // With default value
+    cuda::iota(policy, output.begin(), output.end());
+    CHECK(cuda::std::equal(output.begin(), output.end(), cuda::counting_iterator{0}));
+  }
+
+  cuda::std::fill(policy, output.begin(), output.end(), -1);
+  { // With init
+    cuda::iota(policy, output.begin(), output.end(), 42);
+    CHECK(cuda::std::equal(output.begin(), output.end(), cuda::counting_iterator{42}));
+  }
+
+  cuda::std::fill(policy, output.begin(), output.end(), -1);
+  { // With init and step
+    cuda::iota(policy, output.begin(), output.end(), 42, 2);
+    CHECK(cuda::std::equal(output.begin(), output.end(), cuda::strided_iterator{cuda::counting_iterator{42}, 2}));
+  }
+}
+
+C2H_TEST("cuda::iota", "[parallel algorithm]")
+{
+  thrust::device_vector<int> output(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+
+    test_iota(policy, output);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+
+    test_iota(policy, output);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+
+    test_iota(policy, output);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+
+    test_iota(policy, output);
+  }
+}


### PR DESCRIPTION
This implements the `iota` algorithm for the cuda backend.

* `std::iota` see https://en.cppreference.com/w/cpp/algorithm/iota.html

It provides tests and benchmarks similar to Thrust and some boilerplate for libcu++

The functionality is publicly available yet and implemented in a private internal header

Fixes #7927
