### PR TITLE
Make all algorithms in `cuda/std/algorithm` available through `cuda/std/algorithm.meow.h`

### DIFF
--- a/docs/libcudacxx/standard_api/algorithms_library.rst
+++ b/docs/libcudacxx/standard_api/algorithms_library.rst
@@ -22,6 +22,8 @@ Extensions
 
   - All supported algorithms are available from C++17 onwards.
   - All supported algorithms are constexpr, except the allocating ones.
+  - Because `<cuda/std/algorithm>` is a huge header with a considerable compile-time cost, we provide each algorithm
+    through a minimal subheader named e.g `<cuda/std/algorithm.find.h>`
 
 Restrictions
 ------------
@@ -32,7 +34,7 @@ Restrictions
     * ``inplace_merge``
     * ``nth_element``
     * ``sort``
-    * ``stable_partiin``
+    * ``stable_partition``
     * ``stable_sort``
 
 Parallel standard algorithms

--- a/libcudacxx/include/cuda/std/__algorithm/copy.h
+++ b/libcudacxx/include/cuda/std/__algorithm/copy.h
@@ -27,6 +27,7 @@
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__type_traits/is_trivially_copyable.h>
 #include <cuda/std/__type_traits/remove_const.h>
+#include <cuda/std/__utility/pair.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/cstdlib>
 #include <cuda/std/cstring> // memmove
@@ -107,7 +108,7 @@ _CCCL_API constexpr pair<_Tp*, _Up*> __copy(_Tp* __first, _Tp* __last, _Up* __re
   {
     if (__dispatch_memmove(__result, __first, __n))
     {
-      return {__last, __result + __n};
+      return pair{__last, __result + __n};
     }
     if ((!::cuda::std::is_constant_evaluated() && __first < __result)
         || __constexpr_tail_overlap(__first, __result, __last))
@@ -125,7 +126,7 @@ _CCCL_API constexpr pair<_Tp*, _Up*> __copy(_Tp* __first, _Tp* __last, _Up* __re
       }
     }
   }
-  return {__last, __result + __n};
+  return pair{__last, __result + __n};
 }
 
 template <class _InputIterator, class _OutputIterator>

--- a/libcudacxx/include/cuda/std/algorithm.adjacent_find.h
+++ b/libcudacxx/include/cuda/std/algorithm.adjacent_find.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_ADJACENT_FIND_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_ADJACENT_FIND_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/adjacent_find.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_ADJACENT_FIND_H

--- a/libcudacxx/include/cuda/std/algorithm.all_of.h
+++ b/libcudacxx/include/cuda/std/algorithm.all_of.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_ALL_OF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_ALL_OF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/all_of.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_ALL_OF_H

--- a/libcudacxx/include/cuda/std/algorithm.any_of.h
+++ b/libcudacxx/include/cuda/std/algorithm.any_of.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_ANY_OF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_ANY_OF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/any_of.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_ANY_OF_H

--- a/libcudacxx/include/cuda/std/algorithm.binary_search.h
+++ b/libcudacxx/include/cuda/std/algorithm.binary_search.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_BINARY_SEARCH_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_BINARY_SEARCH_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/binary_search.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_BINARY_SEARCH_H

--- a/libcudacxx/include/cuda/std/algorithm.clamp.h
+++ b/libcudacxx/include/cuda/std/algorithm.clamp.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_CLAMP_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_CLAMP_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/clamp.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_CLAMP_H

--- a/libcudacxx/include/cuda/std/algorithm.copy.h
+++ b/libcudacxx/include/cuda/std/algorithm.copy.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_COPY_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_COPY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/copy.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_COPY_H

--- a/libcudacxx/include/cuda/std/algorithm.copy_backward.h
+++ b/libcudacxx/include/cuda/std/algorithm.copy_backward.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_COPY_BACKWARD_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_COPY_BACKWARD_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/copy_backward.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_COPY_BACKWARD_H

--- a/libcudacxx/include/cuda/std/algorithm.copy_if.h
+++ b/libcudacxx/include/cuda/std/algorithm.copy_if.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_COPY_IF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_COPY_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/copy_if.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_COPY_IF_H

--- a/libcudacxx/include/cuda/std/algorithm.copy_n.h
+++ b/libcudacxx/include/cuda/std/algorithm.copy_n.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_COPY_N_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_COPY_N_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/copy_n.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_COPY_N_H

--- a/libcudacxx/include/cuda/std/algorithm.count.h
+++ b/libcudacxx/include/cuda/std/algorithm.count.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_COUNT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_COUNT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/count.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_COUNT_H

--- a/libcudacxx/include/cuda/std/algorithm.count_if.h
+++ b/libcudacxx/include/cuda/std/algorithm.count_if.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_COUNT_IF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_COUNT_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/count_if.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_COUNT_IF_H

--- a/libcudacxx/include/cuda/std/algorithm.equal.h
+++ b/libcudacxx/include/cuda/std/algorithm.equal.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_EQUAL_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_EQUAL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/equal.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_EQUAL_H

--- a/libcudacxx/include/cuda/std/algorithm.equal_range.h
+++ b/libcudacxx/include/cuda/std/algorithm.equal_range.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_EQUAL_RANGE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_EQUAL_RANGE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/equal_range.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_EQUAL_RANGE_H

--- a/libcudacxx/include/cuda/std/algorithm.fill.h
+++ b/libcudacxx/include/cuda/std/algorithm.fill.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_FILL_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_FILL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/fill.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_FILL_H

--- a/libcudacxx/include/cuda/std/algorithm.fill_n.h
+++ b/libcudacxx/include/cuda/std/algorithm.fill_n.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_FILL_N_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_FILL_N_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/fill_n.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_FILL_N_H

--- a/libcudacxx/include/cuda/std/algorithm.find.h
+++ b/libcudacxx/include/cuda/std/algorithm.find.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_FIND_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_FIND_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/find.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_FIND_H

--- a/libcudacxx/include/cuda/std/algorithm.find_end.h
+++ b/libcudacxx/include/cuda/std/algorithm.find_end.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_FIND_END_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_FIND_END_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/find_end.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_FIND_END_H

--- a/libcudacxx/include/cuda/std/algorithm.find_first_of.h
+++ b/libcudacxx/include/cuda/std/algorithm.find_first_of.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_FIND_FIRST_OF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_FIND_FIRST_OF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/find_first_of.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_FIND_FIRST_OF_H

--- a/libcudacxx/include/cuda/std/algorithm.find_if.h
+++ b/libcudacxx/include/cuda/std/algorithm.find_if.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_FIND_IF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_FIND_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/find_if.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_FIND_IF_H

--- a/libcudacxx/include/cuda/std/algorithm.find_if_not.h
+++ b/libcudacxx/include/cuda/std/algorithm.find_if_not.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_FIND_IF_NOT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_FIND_IF_NOT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/find_if_not.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_FIND_IF_NOT_H

--- a/libcudacxx/include/cuda/std/algorithm.for_each.h
+++ b/libcudacxx/include/cuda/std/algorithm.for_each.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_FOR_EACH_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_FOR_EACH_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/for_each.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_FOR_EACH_H

--- a/libcudacxx/include/cuda/std/algorithm.for_each_n.h
+++ b/libcudacxx/include/cuda/std/algorithm.for_each_n.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_FOR_EACH_N_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_FOR_EACH_N_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/for_each_n.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_FOR_EACH_N_H

--- a/libcudacxx/include/cuda/std/algorithm.generate.h
+++ b/libcudacxx/include/cuda/std/algorithm.generate.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_GENERATE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_GENERATE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/generate.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_GENERATE_H

--- a/libcudacxx/include/cuda/std/algorithm.generate_n.h
+++ b/libcudacxx/include/cuda/std/algorithm.generate_n.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_GENERATE_N_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_GENERATE_N_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/generate_n.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_GENERATE_N_H

--- a/libcudacxx/include/cuda/std/algorithm.includes.h
+++ b/libcudacxx/include/cuda/std/algorithm.includes.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_INCLUDES_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_INCLUDES_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/includes.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_INCLUDES_H

--- a/libcudacxx/include/cuda/std/algorithm.is_heap.h
+++ b/libcudacxx/include/cuda/std/algorithm.is_heap.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_IS_HEAP_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_IS_HEAP_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/is_heap.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_IS_HEAP_H

--- a/libcudacxx/include/cuda/std/algorithm.is_heap_until.h
+++ b/libcudacxx/include/cuda/std/algorithm.is_heap_until.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_IS_HEAP_UNTIL_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_IS_HEAP_UNTIL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/is_heap_until.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_IS_HEAP_UNTIL_H

--- a/libcudacxx/include/cuda/std/algorithm.is_partitioned.h
+++ b/libcudacxx/include/cuda/std/algorithm.is_partitioned.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_IS_PARTITIONED_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_IS_PARTITIONED_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/is_partitioned.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_IS_PARTITIONED_H

--- a/libcudacxx/include/cuda/std/algorithm.is_permutation.h
+++ b/libcudacxx/include/cuda/std/algorithm.is_permutation.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_IS_PERMUTATION_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_IS_PERMUTATION_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/is_permutation.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_IS_PERMUTATION_H

--- a/libcudacxx/include/cuda/std/algorithm.is_sorted.h
+++ b/libcudacxx/include/cuda/std/algorithm.is_sorted.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_IS_SORTED_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_IS_SORTED_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/is_sorted.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_IS_SORTED_H

--- a/libcudacxx/include/cuda/std/algorithm.is_sorted_until.h
+++ b/libcudacxx/include/cuda/std/algorithm.is_sorted_until.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_IS_SORTED_UNTIL_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_IS_SORTED_UNTIL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/is_sorted_until.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_IS_SORTED_UNTIL_H

--- a/libcudacxx/include/cuda/std/algorithm.iter_swap.h
+++ b/libcudacxx/include/cuda/std/algorithm.iter_swap.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_ITER_SWAP_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_ITER_SWAP_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/iter_swap.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_ITER_SWAP_H

--- a/libcudacxx/include/cuda/std/algorithm.lexicographical_compare.h
+++ b/libcudacxx/include/cuda/std/algorithm.lexicographical_compare.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_LEXICOGRAPHICAL_COMPARE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_LEXICOGRAPHICAL_COMPARE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/lexicographical_compare.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_LEXICOGRAPHICAL_COMPARE_H

--- a/libcudacxx/include/cuda/std/algorithm.lower_bound.h
+++ b/libcudacxx/include/cuda/std/algorithm.lower_bound.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_LOWER_BOUND_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_LOWER_BOUND_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/lower_bound.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_LOWER_BOUND_H

--- a/libcudacxx/include/cuda/std/algorithm.make_heap.h
+++ b/libcudacxx/include/cuda/std/algorithm.make_heap.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MAKE_HEAP_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MAKE_HEAP_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/make_heap.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MAKE_HEAP_H

--- a/libcudacxx/include/cuda/std/algorithm.max.h
+++ b/libcudacxx/include/cuda/std/algorithm.max.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MAX_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MAX_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/max.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MAX_H

--- a/libcudacxx/include/cuda/std/algorithm.max_element.h
+++ b/libcudacxx/include/cuda/std/algorithm.max_element.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MAX_ELEMENT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MAX_ELEMENT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/max_element.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MAX_ELEMENT_H

--- a/libcudacxx/include/cuda/std/algorithm.merge.h
+++ b/libcudacxx/include/cuda/std/algorithm.merge.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MERGE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MERGE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/merge.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MERGE_H

--- a/libcudacxx/include/cuda/std/algorithm.min.h
+++ b/libcudacxx/include/cuda/std/algorithm.min.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MIN_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MIN_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/min.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MIN_H

--- a/libcudacxx/include/cuda/std/algorithm.min_element.h
+++ b/libcudacxx/include/cuda/std/algorithm.min_element.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MIN_ELEMENT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MIN_ELEMENT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/min_element.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MIN_ELEMENT_H

--- a/libcudacxx/include/cuda/std/algorithm.minmax.h
+++ b/libcudacxx/include/cuda/std/algorithm.minmax.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MINMAX_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MINMAX_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/minmax.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MINMAX_H

--- a/libcudacxx/include/cuda/std/algorithm.minmax_element.h
+++ b/libcudacxx/include/cuda/std/algorithm.minmax_element.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MINMAX_ELEMENT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MINMAX_ELEMENT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/minmax_element.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MINMAX_ELEMENT_H

--- a/libcudacxx/include/cuda/std/algorithm.mismatch.h
+++ b/libcudacxx/include/cuda/std/algorithm.mismatch.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MISMATCH_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MISMATCH_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/mismatch.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MISMATCH_H

--- a/libcudacxx/include/cuda/std/algorithm.move.h
+++ b/libcudacxx/include/cuda/std/algorithm.move.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MOVE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MOVE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/move.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MOVE_H

--- a/libcudacxx/include/cuda/std/algorithm.move_backward.h
+++ b/libcudacxx/include/cuda/std/algorithm.move_backward.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_MOVE_BACKWARD_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_MOVE_BACKWARD_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/move_backward.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_MOVE_BACKWARD_H

--- a/libcudacxx/include/cuda/std/algorithm.next_permutation.h
+++ b/libcudacxx/include/cuda/std/algorithm.next_permutation.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_NEXT_PERMUTATION_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_NEXT_PERMUTATION_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/next_permutation.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_NEXT_PERMUTATION_H

--- a/libcudacxx/include/cuda/std/algorithm.none_of.h
+++ b/libcudacxx/include/cuda/std/algorithm.none_of.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_NONE_OF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_NONE_OF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/none_of.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_NONE_OF_H

--- a/libcudacxx/include/cuda/std/algorithm.partial_sort.h
+++ b/libcudacxx/include/cuda/std/algorithm.partial_sort.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_PARTIAL_SORT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_PARTIAL_SORT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/partial_sort.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_PARTIAL_SORT_H

--- a/libcudacxx/include/cuda/std/algorithm.partial_sort_copy.h
+++ b/libcudacxx/include/cuda/std/algorithm.partial_sort_copy.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_PARTIAL_SORT_COPY_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_PARTIAL_SORT_COPY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/partial_sort_copy.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_PARTIAL_SORT_COPY_H

--- a/libcudacxx/include/cuda/std/algorithm.partition.h
+++ b/libcudacxx/include/cuda/std/algorithm.partition.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_PARTITION_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_PARTITION_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/partition.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_PARTITION_H

--- a/libcudacxx/include/cuda/std/algorithm.partition_copy.h
+++ b/libcudacxx/include/cuda/std/algorithm.partition_copy.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_PARTITION_COPY_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_PARTITION_COPY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/partition_copy.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_PARTITION_COPY_H

--- a/libcudacxx/include/cuda/std/algorithm.partition_point.h
+++ b/libcudacxx/include/cuda/std/algorithm.partition_point.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_PARTITION_POINT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_PARTITION_POINT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/partition_point.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_PARTITION_POINT_H

--- a/libcudacxx/include/cuda/std/algorithm.pop_heap.h
+++ b/libcudacxx/include/cuda/std/algorithm.pop_heap.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_POP_HEAP_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_POP_HEAP_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/pop_heap.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_POP_HEAP_H

--- a/libcudacxx/include/cuda/std/algorithm.prev_permutation.h
+++ b/libcudacxx/include/cuda/std/algorithm.prev_permutation.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_PREV_PERMUTATION_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_PREV_PERMUTATION_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/prev_permutation.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_PREV_PERMUTATION_H

--- a/libcudacxx/include/cuda/std/algorithm.push_heap.h
+++ b/libcudacxx/include/cuda/std/algorithm.push_heap.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_PUSH_HEAP_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_PUSH_HEAP_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/push_heap.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_PUSH_HEAP_H

--- a/libcudacxx/include/cuda/std/algorithm.ranges.find_if.h
+++ b/libcudacxx/include/cuda/std/algorithm.ranges.find_if.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_IF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_find_if.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_IF_H

--- a/libcudacxx/include/cuda/std/algorithm.ranges.find_if_not.h
+++ b/libcudacxx/include/cuda/std/algorithm.ranges.find_if_not.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_IF_NOT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_IF_NOT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_find_if_not.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FIND_IF_NOT_H

--- a/libcudacxx/include/cuda/std/algorithm.ranges.for_each.h
+++ b/libcudacxx/include/cuda/std/algorithm.ranges.for_each.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FOR_EACH_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FOR_EACH_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_for_each.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FOR_EACH_H

--- a/libcudacxx/include/cuda/std/algorithm.ranges.for_each_n.h
+++ b/libcudacxx/include/cuda/std/algorithm.ranges.for_each_n.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FOR_EACH_N_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FOR_EACH_N_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_for_each_n.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_FOR_EACH_N_H

--- a/libcudacxx/include/cuda/std/algorithm.ranges.min.h
+++ b/libcudacxx/include/cuda/std/algorithm.ranges.min.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_MIN_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_MIN_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_min.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_MIN_H

--- a/libcudacxx/include/cuda/std/algorithm.ranges.min_element.h
+++ b/libcudacxx/include/cuda/std/algorithm.ranges.min_element.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_MIN_ELEMENT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_MIN_ELEMENT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/ranges_min_element.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_RANGES_MIN_ELEMENT_H

--- a/libcudacxx/include/cuda/std/algorithm.remove.h
+++ b/libcudacxx/include/cuda/std/algorithm.remove.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/remove.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_H

--- a/libcudacxx/include/cuda/std/algorithm.remove_copy.h
+++ b/libcudacxx/include/cuda/std/algorithm.remove_copy.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_COPY_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_COPY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/remove_copy.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_COPY_H

--- a/libcudacxx/include/cuda/std/algorithm.remove_copy_if.h
+++ b/libcudacxx/include/cuda/std/algorithm.remove_copy_if.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_COPY_IF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_COPY_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/remove_copy_if.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_COPY_IF_H

--- a/libcudacxx/include/cuda/std/algorithm.remove_if.h
+++ b/libcudacxx/include/cuda/std/algorithm.remove_if.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_IF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/remove_if.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_REMOVE_IF_H

--- a/libcudacxx/include/cuda/std/algorithm.replace.h
+++ b/libcudacxx/include/cuda/std/algorithm.replace.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/replace.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_H

--- a/libcudacxx/include/cuda/std/algorithm.replace_copy.h
+++ b/libcudacxx/include/cuda/std/algorithm.replace_copy.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_COPY_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_COPY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/replace_copy.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_COPY_H

--- a/libcudacxx/include/cuda/std/algorithm.replace_copy_if.h
+++ b/libcudacxx/include/cuda/std/algorithm.replace_copy_if.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_COPY_IF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_COPY_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/replace_copy_if.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_COPY_IF_H

--- a/libcudacxx/include/cuda/std/algorithm.replace_if.h
+++ b/libcudacxx/include/cuda/std/algorithm.replace_if.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_IF_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_IF_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/replace_if.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_REPLACE_IF_H

--- a/libcudacxx/include/cuda/std/algorithm.reverse.h
+++ b/libcudacxx/include/cuda/std/algorithm.reverse.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_REVERSE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_REVERSE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/reverse.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_REVERSE_H

--- a/libcudacxx/include/cuda/std/algorithm.reverse_copy.h
+++ b/libcudacxx/include/cuda/std/algorithm.reverse_copy.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_REVERSE_COPY_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_REVERSE_COPY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/reverse_copy.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_REVERSE_COPY_H

--- a/libcudacxx/include/cuda/std/algorithm.rotate.h
+++ b/libcudacxx/include/cuda/std/algorithm.rotate.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_ROTATE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_ROTATE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/rotate.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_ROTATE_H

--- a/libcudacxx/include/cuda/std/algorithm.rotate_copy.h
+++ b/libcudacxx/include/cuda/std/algorithm.rotate_copy.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_ROTATE_COPY_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_ROTATE_COPY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/rotate_copy.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_ROTATE_COPY_H

--- a/libcudacxx/include/cuda/std/algorithm.sample.h
+++ b/libcudacxx/include/cuda/std/algorithm.sample.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SAMPLE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SAMPLE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/sample.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SAMPLE_H

--- a/libcudacxx/include/cuda/std/algorithm.search.h
+++ b/libcudacxx/include/cuda/std/algorithm.search.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SEARCH_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SEARCH_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/search.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SEARCH_H

--- a/libcudacxx/include/cuda/std/algorithm.search_n.h
+++ b/libcudacxx/include/cuda/std/algorithm.search_n.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SEARCH_N_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SEARCH_N_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/search_n.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SEARCH_N_H

--- a/libcudacxx/include/cuda/std/algorithm.set_difference.h
+++ b/libcudacxx/include/cuda/std/algorithm.set_difference.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SET_DIFFERENCE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SET_DIFFERENCE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/set_difference.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SET_DIFFERENCE_H

--- a/libcudacxx/include/cuda/std/algorithm.set_intersection.h
+++ b/libcudacxx/include/cuda/std/algorithm.set_intersection.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SET_INTERSECTION_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SET_INTERSECTION_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/set_intersection.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SET_INTERSECTION_H

--- a/libcudacxx/include/cuda/std/algorithm.set_symmetric_difference.h
+++ b/libcudacxx/include/cuda/std/algorithm.set_symmetric_difference.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SET_SYMMETRIC_DIFFERENCE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SET_SYMMETRIC_DIFFERENCE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/set_symmetric_difference.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SET_SYMMETRIC_DIFFERENCE_H

--- a/libcudacxx/include/cuda/std/algorithm.set_union.h
+++ b/libcudacxx/include/cuda/std/algorithm.set_union.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SET_UNION_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SET_UNION_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/set_union.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SET_UNION_H

--- a/libcudacxx/include/cuda/std/algorithm.shift_left.h
+++ b/libcudacxx/include/cuda/std/algorithm.shift_left.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SHIFT_LEFT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SHIFT_LEFT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/shift_left.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SHIFT_LEFT_H

--- a/libcudacxx/include/cuda/std/algorithm.shift_right.h
+++ b/libcudacxx/include/cuda/std/algorithm.shift_right.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SHIFT_RIGHT_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SHIFT_RIGHT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/shift_right.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SHIFT_RIGHT_H

--- a/libcudacxx/include/cuda/std/algorithm.shuffle.h
+++ b/libcudacxx/include/cuda/std/algorithm.shuffle.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SHUFFLE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SHUFFLE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/shuffle.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SHUFFLE_H

--- a/libcudacxx/include/cuda/std/algorithm.sort_heap.h
+++ b/libcudacxx/include/cuda/std/algorithm.sort_heap.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SORT_HEAP_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SORT_HEAP_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/sort_heap.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SORT_HEAP_H

--- a/libcudacxx/include/cuda/std/algorithm.swap_ranges.h
+++ b/libcudacxx/include/cuda/std/algorithm.swap_ranges.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_SWAP_RANGES_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_SWAP_RANGES_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/swap_ranges.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_SWAP_RANGES_H

--- a/libcudacxx/include/cuda/std/algorithm.transform.h
+++ b/libcudacxx/include/cuda/std/algorithm.transform.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_TRANSFORM_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_TRANSFORM_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/transform.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_TRANSFORM_H

--- a/libcudacxx/include/cuda/std/algorithm.unique.h
+++ b/libcudacxx/include/cuda/std/algorithm.unique.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_UNIQUE_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_UNIQUE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/unique.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_UNIQUE_H

--- a/libcudacxx/include/cuda/std/algorithm.unique_copy.h
+++ b/libcudacxx/include/cuda/std/algorithm.unique_copy.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_UNIQUE_COPY_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_UNIQUE_COPY_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/unique_copy.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_UNIQUE_COPY_H

--- a/libcudacxx/include/cuda/std/algorithm.upper_bound.h
+++ b/libcudacxx/include/cuda/std/algorithm.upper_bound.h
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD_ALGORITHM_ALGORITHM_UPPER_BOUND_H
+#define _CUDA_STD_ALGORITHM_ALGORITHM_UPPER_BOUND_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__algorithm/upper_bound.h>
+
+#endif // _CUDA_STD_ALGORITHM_ALGORITHM_UPPER_BOUND_H

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/adjacent_find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/adjacent_find.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.adjacent_find.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct equal_to
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a == b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 2, 3, 4};
+  assert(cuda::std::adjacent_find(a, a + 5) == a + 1);
+  assert(cuda::std::adjacent_find(a, a + 5, equal_to{}) == a + 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/all_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/all_of.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.all_of.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct all_of_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {2, 4, 6};
+  assert(cuda::std::all_of(a, a + 3, all_of_even{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/any_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/any_of.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.any_of.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct any_of_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 3, 4};
+  assert(cuda::std::any_of(a, a + 3, any_of_even{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/binary_search.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/binary_search.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.binary_search.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  assert(cuda::std::binary_search(a, a + 3, 2));
+  assert(cuda::std::binary_search(a, a + 3, 2, less{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/clamp.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/clamp.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.clamp.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  const int one{1};
+  const int three{3};
+  const int five{5};
+
+  assert(cuda::std::clamp(five, one, three) == 3);
+  assert(cuda::std::clamp(five, one, three, less{}) == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy.pass.cpp
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.copy.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  int o[3]          = {};
+  auto r            = cuda::std::copy(a, a + 3, o);
+  assert(r == o + 3 && o[0] == 1 && o[2] == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+
+#if !TEST_COMPILER(GCC, <, 8)
+  static_assert(test());
+#endif // !TEST_COMPILER(GCC, <, 8)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy_backward.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy_backward.pass.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.copy_backward.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ TEST_CONSTEXPR_CXX20 bool test()
+{
+  int a[] = {1, 2, 3, 0, 0};
+
+  auto r = cuda::std::copy_backward(a, a + 3, a + 5);
+  assert(r == a + 2 && a[3] == 2 && a[4] == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if TEST_STD_VER >= 2020
+  static_assert(test());
+#endif // TEST_STD_VER >= 2020
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy_if.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.copy_if.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct copy_if_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3, 4};
+  int o[4]          = {};
+  auto r            = cuda::std::copy_if(a, a + 4, o, copy_if_even{});
+  assert(r == o + 2 && o[0] == 2 && o[1] == 4);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/copy_n.pass.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.copy_n.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {5, 6, 7};
+  int o[2]          = {};
+  auto r            = cuda::std::copy_n(a, 2, o);
+  assert(r == o + 2 && o[0] == 5 && o[1] == 6);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if !TEST_COMPILER(GCC, <, 8)
+  static_assert(test());
+#endif // !TEST_COMPILER(GCC, <, 8)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/count.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/count.pass.cpp
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.count.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 2, 3};
+  assert(cuda::std::count(a, a + 4, 2) == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/count_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/count_if.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.count_if.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct count_if_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3, 4};
+  assert(cuda::std::count_if(a, a + 4, count_if_even{}) == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/equal.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/equal.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.equal.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct equal_to
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a == b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  constexpr int b[] = {1, 2, 3};
+  constexpr int c[] = {1, 2, 4};
+  assert(cuda::std::equal(a, a + 3, b));
+  assert(cuda::std::equal(a, a + 3, b, equal_to{}));
+  assert(cuda::std::equal(a, a + 3, b, b + 3));
+  assert(!cuda::std::equal(a, a + 3, c, c + 3, equal_to{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/equal_range.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/equal_range.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.equal_range.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 2, 3};
+  auto p            = cuda::std::equal_range(a, a + 4, 2);
+  assert(p.first == a + 1 && p.second == a + 3);
+  auto q = cuda::std::equal_range(a, a + 4, 2, less{});
+  assert(q.first == a + 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/fill.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/fill.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.fill.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[3] = {};
+  cuda::std::fill(a, a + 3, 7);
+  assert(a[0] == 7 && a[2] == 7);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/fill_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/fill_n.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.fill_n.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[3] = {};
+  auto r   = cuda::std::fill_n(a, 3, 4);
+  assert(r == a + 3 && a[1] == 4);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find.pass.cpp
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.find.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int arr[] = {2, 4, 6, 8};
+
+  const int* iter = cuda::std::find(arr, arr + 4, 2);
+  assert(*iter == 2);
+  assert(iter == arr);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_end.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_end.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.find_end.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct equal_to
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a == b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int h[] = {1, 2, 1, 2, 3};
+  constexpr int n[] = {1, 2};
+  assert(cuda::std::find_end(h, h + 5, n, n + 2) == h + 2);
+  assert(cuda::std::find_end(h, h + 5, n, n + 2, equal_to{}) == h + 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_first_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_first_of.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.find_first_of.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct equal_to
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a == b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {0, 1, 2};
+  constexpr int b[] = {3, 1};
+  assert(cuda::std::find_first_of(a, a + 3, b, b + 2) == a + 1);
+  assert(cuda::std::find_first_of(a, a + 3, b, b + 2, equal_to{}) == a + 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.find_if.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct find_if_is_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  assert(*cuda::std::find_if(a, a + 3, find_if_is_even{}) == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/find_if_not.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.find_if_not.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct find_if_not_is_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {2, 4, 5};
+  assert(*cuda::std::find_if_not(a, a + 3, find_if_not_is_even{}) == 5);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/for_each.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/for_each.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.for_each.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct acc
+{
+  int* ps;
+  __host__ __device__ void operator()(int x) const
+  {
+    *ps += x;
+  }
+};
+
+__host__ __device__ bool test()
+{
+  int a[] = {1, 2, 3};
+  int s   = 0;
+
+  auto g = cuda::std::for_each(a, a + 3, acc{&s});
+  (void) g;
+  assert(s == 6);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/for_each_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/for_each_n.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.for_each_n.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct acc
+{
+  int* ps;
+  __host__ __device__ void operator()(int x) const
+  {
+    *ps += x;
+  }
+};
+
+__host__ __device__ bool test()
+{
+  int a[] = {1, 2, 3, 4};
+  int s   = 0;
+
+  auto last = cuda::std::for_each_n(a, 3, acc{&s});
+  assert(last == a + 3);
+  assert(s == 6);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/generate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/generate.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.generate.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct gen
+{
+  int* pc;
+  __host__ __device__ int operator()() const
+  {
+    return ++(*pc);
+  }
+};
+
+__host__ __device__ bool test()
+{
+  int a[3] = {};
+  int c    = 0;
+
+  cuda::std::generate(a, a + 3, gen{&c});
+  assert(a[0] == 1 && a[2] == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/generate_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/generate_n.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.generate_n.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct gen
+{
+  int* pc;
+  __host__ __device__ int operator()() const
+  {
+    return ++(*pc);
+  }
+};
+
+__host__ __device__ bool test()
+{
+  int a[3] = {};
+  int c    = 0;
+
+  auto r = cuda::std::generate_n(a, 3, gen{&c});
+  assert(r == a + 3 && a[2] == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/includes.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/includes.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.includes.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3, 4};
+  constexpr int b[] = {2, 3};
+  assert(cuda::std::includes(a, a + 4, b, b + 2));
+  assert(cuda::std::includes(a, a + 4, b, b + 2, less{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_heap.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.is_heap.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {3, 1, 2};
+  assert(cuda::std::is_heap(a, a + 3));
+  assert(cuda::std::is_heap(a, a + 3, less{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_heap_until.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_heap_until.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.is_heap_until.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {3, 1, 2};
+  assert(cuda::std::is_heap_until(a, a + 3) == a + 3);
+  assert(cuda::std::is_heap_until(a, a + 3, less{}) == a + 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_partitioned.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_partitioned.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.is_partitioned.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct is_partitioned_is_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {2, 4, 1, 3};
+  assert(cuda::std::is_partitioned(a, a + 4, is_partitioned_is_even{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_permutation.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_permutation.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.is_permutation.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct equal_to
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a == b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  constexpr int b[] = {3, 1, 2};
+  assert(cuda::std::is_permutation(a, a + 3, b));
+  assert(cuda::std::is_permutation(a, a + 3, b, equal_to{}));
+  assert(cuda::std::is_permutation(a, a + 3, b, b + 3));
+  assert(cuda::std::is_permutation(a, a + 3, b, b + 3, equal_to{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_sorted.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_sorted.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.is_sorted.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  assert(cuda::std::is_sorted(a, a + 3));
+  assert(cuda::std::is_sorted(a, a + 3, less{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_sorted_until.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/is_sorted_until.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.is_sorted_until.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 3, 2};
+  assert(cuda::std::is_sorted_until(a, a + 3) == a + 2);
+  assert(cuda::std::is_sorted_until(a, a + 3, less{}) == a + 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/iter_swap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/iter_swap.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.iter_swap.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct iter_swap_iter
+{
+  int v;
+};
+
+__host__ __device__ constexpr void iter_swap(iter_swap_iter* a, iter_swap_iter* b)
+{
+  cuda::std::swap(a->v, b->v);
+}
+
+__host__ __device__ constexpr bool test()
+{
+  int x = 1, y = 2;
+  cuda::std::iter_swap(&x, &y);
+  assert(x == 2 && y == 1);
+  iter_swap_iter p{3}, q{4};
+  cuda::std::iter_swap(&p, &q);
+  assert(p.v == 4 && q.v == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/lexicographical_compare.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/lexicographical_compare.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.lexicographical_compare.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2};
+  constexpr int b[] = {1, 3};
+  assert(cuda::std::lexicographical_compare(a, a + 2, b, b + 2));
+  assert(cuda::std::lexicographical_compare(a, a + 2, b, b + 2, less{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/lower_bound.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/lower_bound.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.lower_bound.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 2, 3};
+  assert(*cuda::std::lower_bound(a, a + 4, 2) == 2);
+  assert(*cuda::std::lower_bound(a, a + 4, 2, less{}) == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/make_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/make_heap.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.make_heap.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 3, 2};
+  cuda::std::make_heap(a, a + 3);
+  assert(a[0] == 3);
+  int b[] = {1, 3, 2};
+  cuda::std::make_heap(b, b + 3, less{});
+  assert(b[0] == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/max.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.max.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct greater
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a > b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  const int one{1};
+  const int two{2};
+  const int three{3};
+
+  assert(cuda::std::max(one, two) == two);
+  assert(cuda::std::max(one, two, greater{}) == one);
+  assert(cuda::std::max({three, one, two}) == three);
+  assert(cuda::std::max({three, one, two}, greater{}) == one);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/max_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/max_element.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.max_element.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct greater
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a > b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 3, 2};
+  assert(*cuda::std::max_element(a, a + 3) == 3);
+  assert(*cuda::std::max_element(a, a + 3, greater{}) == 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/merge.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/merge.pass.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.merge.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 3};
+  constexpr int b[] = {2, 4};
+  int o[4]          = {};
+  auto r            = cuda::std::merge(a, a + 2, b, b + 2, o);
+  assert(r == o + 4 && o[0] == 1 && o[3] == 4);
+  int o2[4] = {};
+  auto r2   = cuda::std::merge(a, a + 2, b, b + 2, o2, less{});
+  assert(r2 == o2 + 4);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if !TEST_COMPILER(GCC, <, 8)
+  static_assert(test());
+#endif // !TEST_COMPILER(GCC, <, 8)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/min.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.min.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct greater
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a > b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  const int one{1};
+  const int two{2};
+  const int three{3};
+
+  assert(cuda::std::min(one, two) == one);
+  assert(cuda::std::min(one, two, greater{}) == two);
+  assert(cuda::std::min({three, one, two}) == one);
+  assert(cuda::std::min({three, one, two}, greater{}) == three);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/min_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/min_element.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.min_element.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct greater
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a > b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {3, 1, 2};
+  assert(*cuda::std::min_element(a, a + 3) == 1);
+  assert(*cuda::std::min_element(a, a + 3, greater{}) == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/minmax.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/minmax.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.minmax.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct greater
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a > b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  const int one{1};
+  const int two{2};
+  const int three{3};
+
+  auto a = cuda::std::minmax(one, two);
+  assert(a.first == 1 && a.second == 2);
+  auto b = cuda::std::minmax(one, two, greater{});
+  assert(b.first == 2 && b.second == 1);
+  auto c = cuda::std::minmax({three, one, two});
+  assert(c.first == 1 && c.second == 3);
+  auto d = cuda::std::minmax({three, one, two}, greater{});
+  assert(d.first == 3 && d.second == 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/minmax_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/minmax_element.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.minmax_element.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct greater
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a > b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {3, 1, 2};
+  auto p            = cuda::std::minmax_element(a, a + 3);
+  assert(*p.first == 1 && *p.second == 3);
+  auto q = cuda::std::minmax_element(a, a + 3, greater{});
+  assert(*q.first == 3 && *q.second == 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/mismatch.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/mismatch.pass.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.mismatch.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct equal_to
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a == b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  constexpr int b[] = {1, 9, 3};
+  auto p1           = cuda::std::mismatch(a, a + 3, b);
+  assert(p1.first == a + 1 && p1.second == b + 1);
+  auto p2 = cuda::std::mismatch(a, a + 3, b, equal_to{});
+  assert(p2.first == a + 1);
+  auto p3 = cuda::std::mismatch(a, a + 3, b, b + 3);
+  assert(p3.first == a + 1);
+  auto p4 = cuda::std::mismatch(a, a + 3, b, b + 3, equal_to{});
+  assert(p4.first == a + 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/move.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/move.pass.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.move.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[]  = {1, 2, 3};
+  int b[3] = {};
+  auto r   = cuda::std::move(a, a + 3, b);
+
+  assert(r == b + 3);
+  assert(b[0] == 1 && b[2] == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/move_backward.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/move_backward.pass.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.move_backward.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3, 0, 0};
+  auto r  = cuda::std::move_backward(a, a + 3, a + 5);
+  assert(r == a + 2);
+  assert(a[3] == 2 && a[4] == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/next_permutation.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/next_permutation.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.next_permutation.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3};
+  assert(cuda::std::next_permutation(a, a + 3));
+  assert(cuda::std::next_permutation(a, a + 3, less{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/none_of.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/none_of.pass.cpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.none_of.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct none_of_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 3, 5};
+  assert(cuda::std::none_of(a, a + 3, none_of_even{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partial_sort.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partial_sort.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.partial_sort.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct greater
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a > b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {3, 1, 4, 2};
+  cuda::std::partial_sort(a, a + 2, a + 4);
+  assert(a[0] == 1 && a[1] == 2);
+  int b[] = {3, 1, 4, 2};
+  cuda::std::partial_sort(b, b + 2, b + 4, greater{});
+  assert(b[0] == 4);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partial_sort_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partial_sort_copy.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.partial_sort_copy.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct greater
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a > b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int src[] = {3, 1, 4};
+  int dst[2]          = {};
+  cuda::std::partial_sort_copy(src, src + 3, dst, dst + 2);
+  assert(dst[0] == 1 && dst[1] == 3);
+  int dst2[2] = {};
+  cuda::std::partial_sort_copy(src, src + 3, dst2, dst2 + 2, greater{});
+  assert(dst2[0] == 4);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.partition.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct partition_is_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3, 4};
+  auto p  = cuda::std::partition(a, a + 4, partition_is_even{});
+  assert(p == a + 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_copy.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.partition_copy.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct partition_copy_is_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3, 4};
+  int t[4]          = {};
+  int f[4]          = {};
+  auto p            = cuda::std::partition_copy(a, a + 4, t, f, partition_copy_is_even{});
+  assert(p.first == t + 2 && p.second == f + 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_point.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/partition_point.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.partition_point.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct partition_point_is_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {2, 4, 5, 7};
+  auto p            = cuda::std::partition_point(a, a + 4, partition_point_is_even{});
+  assert(p == a + 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/pop_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/pop_heap.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.pop_heap.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {2, 1, 3};
+  cuda::std::pop_heap(a, a + 3);
+  assert(a[0] == 3 && a[1] == 1 && a[2] == 2);
+
+  int b[] = {2, 1, 3};
+  cuda::std::pop_heap(b, b + 3, less{});
+  assert(b[0] == 3 && b[1] == 1 && b[2] == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/prev_permutation.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/prev_permutation.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.prev_permutation.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct greater
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a > b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {3, 2, 1};
+  assert(cuda::std::prev_permutation(a, a + 3));
+  assert(cuda::std::prev_permutation(a, a + 3, greater{}));
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/push_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/push_heap.pass.cpp
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.push_heap.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3};
+  cuda::std::push_heap(a, a + 3);
+  assert(a[0] == 3 && a[1] == 2 && a[2] == 1);
+
+  int b[] = {1, 2, 3};
+  cuda::std::push_heap(b, b + 3, less{});
+  assert(b[0] == 3 && b[1] == 2 && b[2] == 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_find_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_find_if.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.ranges.find_if.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct ranges_find_if_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+struct ranges_find_if_gt2
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x > 2;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3};
+  auto it = cuda::std::ranges::find_if(a, a + 3, ranges_find_if_even{});
+  assert(*it == 2);
+  auto it2 = cuda::std::ranges::find_if(a, ranges_find_if_gt2{});
+  assert(*it2 == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_find_if_not.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_find_if_not.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.ranges.find_if_not.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct ranges_find_if_not_even
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 0;
+  }
+};
+struct ranges_find_if_not_lt10
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x < 10;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {2, 4, 5};
+  auto it = cuda::std::ranges::find_if_not(a, a + 3, ranges_find_if_not_even{});
+  assert(*it == 5);
+  auto it2 = cuda::std::ranges::find_if_not(a, ranges_find_if_not_lt10{});
+  assert(it2 == a + 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_for_each.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_for_each.pass.cpp
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.ranges.for_each.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct acc
+{
+  int* ps;
+  __host__ __device__ void operator()(int x) const
+  {
+    *ps += x;
+  }
+};
+
+__host__ __device__ bool test()
+{
+  int a[] = {1, 2, 3};
+  int s   = 0;
+
+  auto res = cuda::std::ranges::for_each(a, a + 3, acc{&s});
+  assert(res.in == a + 3 && s == 6);
+  s         = 0;
+  auto res2 = cuda::std::ranges::for_each(a, acc{&s});
+  assert(s == 6);
+  (void) res2;
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_for_each_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_for_each_n.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.ranges.for_each_n.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct acc
+{
+  int* ps;
+  __host__ __device__ void operator()(int x) const
+  {
+    *ps += x;
+  }
+};
+
+__host__ __device__ bool test()
+{
+  int a[] = {1, 2, 3, 4};
+  int s   = 0;
+
+  auto res = cuda::std::ranges::for_each_n(a, 3, acc{&s});
+  assert(res.in == a + 3 && s == 6);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_min.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.ranges.min.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  const int one{1};
+  const int two{2};
+  const int three{3};
+  const int four{4};
+  const int five{5};
+  const int eight{8};
+
+  assert(cuda::std::ranges::min(one, two) == one);
+  assert(cuda::std::ranges::min(three, one, cuda::std::ranges::greater{}) == three);
+  int a[] = {three, one, four};
+  assert(cuda::std::ranges::min(a) == one);
+  assert(cuda::std::ranges::min({five, two, eight}) == two);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_min_element.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/ranges_min_element.pass.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.ranges.min_element.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {3, 1, 4};
+  assert(*cuda::std::ranges::min_element(a, a + 3) == 1);
+  assert(*cuda::std::ranges::min_element(a, a + 3, cuda::std::ranges::greater{}) == 4);
+  assert(*cuda::std::ranges::min_element(a) == 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/remove.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/remove.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.remove.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 1, 3};
+  auto r  = cuda::std::remove(a, a + 4, 1);
+  assert(r == a + 2 && a[0] == 2 && a[1] == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/remove_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/remove_copy.pass.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.remove_copy.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 1};
+  int o[3]          = {};
+  auto r            = cuda::std::remove_copy(a, a + 3, o, 1);
+  assert(r == o + 1 && o[0] == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/remove_copy_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/remove_copy_if.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.remove_copy_if.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct remove_copy_if_is_odd
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 1;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  int o[3]          = {};
+  auto r            = cuda::std::remove_copy_if(a, a + 3, o, remove_copy_if_is_odd{});
+  assert(r == o + 1 && o[0] == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/remove_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/remove_if.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.remove_if.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct remove_if_is_odd
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 1;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3, 4};
+  auto r  = cuda::std::remove_if(a, a + 4, remove_if_is_odd{});
+  assert(r == a + 2 && a[0] == 2 && a[1] == 4);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/replace.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/replace.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.replace.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 1};
+  cuda::std::replace(a, a + 3, 1, 9);
+  assert(a[0] == 9 && a[2] == 9);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/replace_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/replace_copy.pass.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.replace_copy.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 1};
+  int o[3]          = {};
+  auto r            = cuda::std::replace_copy(a, a + 3, o, 1, 7);
+  assert(r == o + 3 && o[0] == 7 && o[2] == 7);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/replace_copy_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/replace_copy_if.pass.cpp
@@ -1,0 +1,40 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.replace_copy_if.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct replace_copy_if_is_odd
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 1;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  int o[3]          = {};
+  auto r            = cuda::std::replace_copy_if(a, a + 3, o, replace_copy_if_is_odd{}, 0);
+  assert(r == o + 3 && o[0] == 0 && o[1] == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/replace_if.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/replace_if.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.replace_if.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct replace_if_is_odd
+{
+  __host__ __device__ constexpr bool operator()(int x) const
+  {
+    return x % 2 == 1;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3};
+  cuda::std::replace_if(a, a + 3, replace_if_is_odd{}, 0);
+  assert(a[0] == 0 && a[1] == 2 && a[2] == 0);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/reverse.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/reverse.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.reverse.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3};
+  cuda::std::reverse(a, a + 3);
+  assert(a[0] == 3 && a[2] == 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/reverse_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/reverse_copy.pass.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.reverse_copy.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  int o[3]          = {};
+  auto r            = cuda::std::reverse_copy(a, a + 3, o);
+  assert(r == o + 3 && o[0] == 3 && o[2] == 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/rotate.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/rotate.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.rotate.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3, 4};
+  auto r  = cuda::std::rotate(a, a + 2, a + 4);
+  assert(r == a + 2 && a[0] == 3 && a[1] == 4 && a[2] == 1 && a[3] == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/rotate_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/rotate_copy.pass.cpp
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.rotate_copy.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3, 4};
+  int o[4]          = {};
+  auto r            = cuda::std::rotate_copy(a, a + 2, a + 4, o);
+  assert(r == o + 4 && o[0] == 3 && o[3] == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if !TEST_COMPILER(GCC, <, 8)
+  static_assert(test());
+#endif // !TEST_COMPILER(GCC, <, 8)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/sample.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/sample.pass.cpp
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.sample.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct urbg
+{
+  using result_type = unsigned;
+  unsigned s        = 1;
+
+  __host__ __device__ static constexpr result_type min()
+  {
+    return 0;
+  }
+  __host__ __device__ static constexpr result_type max()
+  {
+    return 0xFFFFFFFFu;
+  }
+  __host__ __device__ result_type operator()()
+  {
+    s = s * 48271u % 2147483647u;
+    return s;
+  }
+};
+
+__host__ __device__ bool test()
+{
+  constexpr int pop[] = {1, 2, 3, 4, 5};
+  int out[3]          = {};
+  urbg g{};
+  auto r = cuda::std::sample(pop, pop + 5, out, 3, g);
+  (void) r;
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search.pass.cpp
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.search.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct equal_to
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a == b;
+  }
+};
+
+struct searcher
+{
+  const int *pf, *pl;
+  template <class It>
+  __host__ __device__ constexpr cuda::std::pair<It, It> operator()(It f, It l) const
+  {
+    return cuda::std::__search(
+      f, l, pf, pl, equal_to{}, cuda::std::random_access_iterator_tag{}, cuda::std::random_access_iterator_tag{});
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int h[] = {1, 2, 3, 4};
+  constexpr int n[] = {2, 3};
+  assert(cuda::std::search(h, h + 4, n, n + 2) == h + 1);
+  assert(cuda::std::search(h, h + 4, n, n + 2, equal_to{}) == h + 1);
+
+  assert(cuda::std::search(h, h + 4, searcher{n, n + 2}) == h + 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search_n.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/search_n.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.search_n.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct equal_to
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a == b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int h[] = {1, 2, 2, 2, 3};
+  assert(cuda::std::search_n(h, h + 5, 3, 2) == h + 1);
+  assert(cuda::std::search_n(h, h + 5, 3, 2, equal_to{}) == h + 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_difference.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_difference.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.set_difference.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  constexpr int b[] = {2, 4};
+  int o[3]          = {};
+  auto r            = cuda::std::set_difference(a, a + 3, b, b + 2, o);
+  assert(r == o + 2);
+  int o2[3] = {};
+  auto r2   = cuda::std::set_difference(a, a + 3, b, b + 2, o2, less{});
+  assert(r2 == o2 + 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_intersection.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_intersection.pass.cpp
@@ -1,0 +1,44 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.set_intersection.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  constexpr int b[] = {2, 3, 4};
+  int o[3]          = {};
+  auto r            = cuda::std::set_intersection(a, a + 3, b, b + 3, o);
+  assert(r == o + 2);
+  int o2[3] = {};
+  auto r2   = cuda::std::set_intersection(a, a + 3, b, b + 3, o2, less{});
+  assert(r2 == o2 + 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_symmetric_difference.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_symmetric_difference.pass.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.set_symmetric_difference.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2};
+  constexpr int b[] = {2, 3};
+  int o[4]          = {};
+  auto r            = cuda::std::set_symmetric_difference(a, a + 2, b, b + 2, o);
+  assert(r == o + 2);
+  int o2[4] = {};
+  auto r2   = cuda::std::set_symmetric_difference(a, a + 2, b, b + 2, o2, less{});
+  assert(r2 == o2 + 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if !TEST_COMPILER(GCC, <, 8)
+  static_assert(test());
+#endif // !TEST_COMPILER(GCC, <, 8)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_union.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/set_union.pass.cpp
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.set_union.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2};
+  constexpr int b[] = {2, 3};
+  int o[4]          = {};
+  auto r            = cuda::std::set_union(a, a + 2, b, b + 2, o);
+  assert(r == o + 3);
+  int o2[4] = {};
+  auto r2   = cuda::std::set_union(a, a + 2, b, b + 2, o2, less{});
+  assert(r2 == o2 + 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+#if !TEST_COMPILER(GCC, <, 8)
+  static_assert(test());
+#endif // !TEST_COMPILER(GCC, <, 8)
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/shift_left.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/shift_left.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.shift_left.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3, 4};
+  auto r  = cuda::std::shift_left(a, a + 4, 1);
+  assert(r == a + 3 && a[0] == 2);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/shift_right.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/shift_right.pass.cpp
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.shift_right.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3, 4};
+  auto r  = cuda::std::shift_right(a, a + 4, 1);
+  assert(r == a + 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/shuffle.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/shuffle.pass.cpp
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.shuffle.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct urbg
+{
+  using result_type = unsigned;
+  unsigned s        = 1;
+
+  __host__ __device__ static constexpr result_type min()
+  {
+    return 0;
+  }
+  __host__ __device__ static constexpr result_type max()
+  {
+    return 0xFFFFFFFFu;
+  }
+  __host__ __device__ result_type operator()()
+  {
+    s = s * 48271u % 2147483647u;
+    return s;
+  }
+};
+
+__host__ __device__ bool test()
+{
+  int a[] = {1, 2, 3, 4};
+  urbg g{};
+  cuda::std::shuffle(a, a + 4, g);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/sort_heap.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/sort_heap.pass.cpp
@@ -1,0 +1,48 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.sort_heap.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2, 3};
+  cuda::std::push_heap(a, a + 1);
+  cuda::std::push_heap(a, a + 2);
+  cuda::std::push_heap(a, a + 3);
+  cuda::std::sort_heap(a, a + 3);
+  assert(a[0] == 1 && a[2] == 3);
+  int b[] = {1, 2, 3};
+  cuda::std::push_heap(b, b + 1);
+  cuda::std::push_heap(b, b + 2);
+  cuda::std::push_heap(b, b + 3);
+  cuda::std::sort_heap(b, b + 3, less{});
+  assert(b[0] == 1 && b[2] == 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/swap_ranges.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/swap_ranges.pass.cpp
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.swap_ranges.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 2};
+  int b[] = {9, 8};
+  auto r  = cuda::std::swap_ranges(a, a + 2, b);
+  assert(r == b + 2 && a[0] == 9 && b[0] == 1);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/transform.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/transform.pass.cpp
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.transform.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct transform_double
+{
+  __host__ __device__ constexpr int operator()(int x) const
+  {
+    return x * 2;
+  }
+};
+struct transform_add
+{
+  __host__ __device__ constexpr int operator()(int x, int y) const
+  {
+    return x + y;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 3};
+  int o[3]          = {};
+  cuda::std::transform(a, a + 3, o, transform_double{});
+  assert(o[1] == 4);
+  constexpr int b[] = {10, 20, 30};
+  int o2[3]         = {};
+  cuda::std::transform(a, a + 3, b, o2, transform_add{});
+  assert(o2[0] == 11 && o2[2] == 33);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/unique.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/unique.pass.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.unique.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct equal_to
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a == b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  int a[] = {1, 1, 2, 2, 3};
+  auto r  = cuda::std::unique(a, a + 5);
+  assert(r == a + 3 && a[0] == 1 && a[1] == 2 && a[2] == 3);
+  auto r2 = cuda::std::unique(a, a + 3, equal_to{});
+  assert(r2 == a + 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/unique_copy.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/unique_copy.pass.cpp
@@ -1,0 +1,42 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.unique_copy.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct equal_to
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a == b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 1, 2, 2, 3};
+  int o[5]          = {};
+  auto r            = cuda::std::unique_copy(a, a + 5, o);
+  assert(r == o + 3 && o[0] == 1 && o[1] == 2 && o[2] == 3);
+  auto r2 = cuda::std::unique_copy(a, a + 5, o, equal_to{});
+  assert(r2 == o + 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/upper_bound.pass.cpp
+++ b/libcudacxx/test/libcudacxx/libcxx/module_headers/cuda/std/algorithm/upper_bound.pass.cpp
@@ -1,0 +1,39 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <cuda/std/algorithm.upper_bound.h>
+#include <cuda/std/cassert>
+
+#include "test_macros.h"
+
+struct less
+{
+  __host__ __device__ constexpr bool operator()(int a, int b) const
+  {
+    return a < b;
+  }
+};
+
+__host__ __device__ constexpr bool test()
+{
+  constexpr int a[] = {1, 2, 2, 3};
+  assert(cuda::std::upper_bound(a, a + 4, 2) == a + 3);
+  assert(cuda::std::upper_bound(a, a + 4, 2, less{}) == a + 3);
+
+  return true;
+}
+
+int main(int, char**)
+{
+  test();
+  static_assert(test());
+
+  return 0;
+}


### PR DESCRIPTION
We had a [poll](https://github.com/NVIDIA/cccl/discussions/7905) to see how users would like to access individual features of umbrella headers like `<cuda/std/algorithm>`

The vast majority preferred a pattern like `<cuda/std/algorithms/find.h>`

However, we can get away with finding a similar but different name if we use the pattern `umbrella_header.feature`

We can create a wrapper for the internal file and also instruct our IDE to ignore all files that match the pattern `[a-z_]*\.[a-z_]*` This works because we do not have any `.h` files in neither `<cuda/>` not `<cuda/std/>` 