### PR TITLE
Drop more umbrella headers in cub

### DIFF
--- a/cub/benchmarks/bench/for_each/extents.cu
+++ b/cub/benchmarks/bench/for_each/extents.cu
@@ -3,6 +3,7 @@
 
 #include <cub/device/device_for.cuh>
 
+#include <cuda/cmath>
 #include <cuda/std/mdspan>
 
 #include <nvbench_helper.cuh>

--- a/cub/benchmarks/bench/scan/applications/P1/rabin-karp-second-fingerprinting.cu
+++ b/cub/benchmarks/bench/scan/applications/P1/rabin-karp-second-fingerprinting.cu
@@ -6,6 +6,7 @@
 
 #include <thrust/host_vector.h>
 
+#include <cuda/cmath>
 #include <cuda/std/limits>
 
 #include <iostream>

--- a/cub/cub/block/block_load_to_shared.cuh
+++ b/cub/cub/block/block_load_to_shared.cuh
@@ -23,11 +23,23 @@
 
 #include <thrust/type_traits/is_trivially_relocatable.h>
 
-#include <cuda/cmath>
-#include <cuda/memory>
-#include <cuda/ptx>
+#include <cuda/__cmath/round_down.h>
+#include <cuda/__cmath/round_up.h>
+#include <cuda/__memory/address_space.h>
+#include <cuda/__memory/align_up.h>
+#include <cuda/__memory/is_aligned.h>
+#include <cuda/__memory/ptr_rebind.h>
+#include <cuda/__ptx/instructions/cp_async_bulk.h>
+#include <cuda/__ptx/instructions/elect_sync.h>
+#include <cuda/__ptx/instructions/mbarrier_arrive.h>
+#include <cuda/__ptx/instructions/mbarrier_init.h>
+#include <cuda/__ptx/instructions/mbarrier_inval.h>
+#include <cuda/__ptx/instructions/mbarrier_wait.h>
 #include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__bit/has_single_bit.h>
+#include <cuda/std/__iterator/data.h>
+#include <cuda/std/__iterator/size.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/span>
 

--- a/cub/cub/detail/segmented_params.cuh
+++ b/cub/cub/detail/segmented_params.cuh
@@ -13,8 +13,10 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__iterator/iterator_traits.h>
+#include <cuda/std/__type_traits/integral_constant.h>
+#include <cuda/std/__utility/forward.h>
 #include <cuda/std/cstdint>
-#include <cuda/std/iterator>
 #include <cuda/std/limits>
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/device/dispatch/dispatch_batched_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_batched_topk.cuh
@@ -27,7 +27,7 @@
 
 #include <thrust/system/cuda/detail/core/triple_chevron_launch.h>
 
-#include <cuda/cmath>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/limits>
 

--- a/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
+++ b/cub/cub/device/dispatch/dispatch_copy_mdspan.cuh
@@ -20,7 +20,7 @@
 #include <cub/device/device_transform.cuh>
 #include <cub/util_debug.cuh>
 
-#include <cuda/std/functional>
+#include <cuda/std/__functional/identity.h>
 #include <cuda/std/mdspan>
 
 CUB_NAMESPACE_BEGIN

--- a/cub/cub/device/dispatch/dispatch_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_topk.cuh
@@ -25,7 +25,12 @@
 #include <cub/util_math.cuh>
 #include <cub/util_temporary_storage.cuh>
 
-#include <cuda/cmath>
+#include <cuda/__cmath/ceil_div.h>
+#include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__algorithm/min.h>
+#include <cuda/std/__type_traits/common_type.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -20,9 +20,10 @@
 #include <cub/detail/segmented_params.cuh>
 #include <cub/util_arch.cuh>
 
+#include <cuda/std/__type_traits/conditional.h>
+#include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstdint>
 #include <cuda/std/tuple>
-#include <cuda/std/type_traits>
 
 CUB_NAMESPACE_BEGIN
 

--- a/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_reduce_by_key.cuh
@@ -22,9 +22,10 @@
 #include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
 
+#include <cuda/__cmath/ceil_div.h>
 #include <cuda/__device/arch_id.h>
-#include <cuda/cmath>
 #include <cuda/std/__algorithm/clamp.h>
+#include <cuda/std/__type_traits/is_trivially_copyable.h>
 #include <cuda/std/concepts>
 
 #if !_CCCL_COMPILER(NVRTC)

--- a/cub/cub/device/dispatch/tuning/tuning_transform.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_transform.cuh
@@ -22,6 +22,7 @@
 #include <cuda/__functional/address_stability.h>
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__cccl/execution_space.h>
+#include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/array>
 #include <cuda/std/concepts>
 #include <cuda/std/tuple>

--- a/cub/cub/util_math.cuh
+++ b/cub/cub/util_math.cuh
@@ -18,7 +18,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/cmath>
+#include <cuda/__cmath/ceil_div.h>
 #include <cuda/std/__algorithm/clamp.h>
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -25,6 +25,7 @@
 #include <cub/util_type.cuh>
 
 #include <cuda/__ptx/instructions/get_sreg.h>
+#include <cuda/__warp/warp_shuffle.h>
 #include <cuda/std/__algorithm/clamp.h>
 #include <cuda/std/__bit/has_single_bit.h>
 #include <cuda/std/__bit/integral.h>
@@ -32,7 +33,6 @@
 #include <cuda/std/__type_traits/integral_constant.h>
 #include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/is_unsigned.h>
-#include <cuda/warp>
 
 CUB_NAMESPACE_BEGIN
 namespace detail

--- a/cudax/test/cuco/hyperloglog/test_hyperloglog.cu
+++ b/cudax/test/cuco/hyperloglog/test_hyperloglog.cu
@@ -11,6 +11,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>
 
+#include <cuda/functional>
 #include <cuda/std/cstddef>
 #include <cuda/std/span>
 

--- a/thrust/thrust/system/cuda/detail/core/triple_chevron_launch.h
+++ b/thrust/thrust/system/cuda/detail/core/triple_chevron_launch.h
@@ -14,7 +14,7 @@
 
 #include <thrust/system/cuda/config.h>
 
-#include <cuda/cmath>
+#include <cuda/__cmath/ceil_div.h>
 
 THRUST_NAMESPACE_BEGIN
 

--- a/thrust/thrust/system/detail/generic/scan.h
+++ b/thrust/thrust/system/detail/generic/scan.h
@@ -17,7 +17,7 @@
 #include <thrust/scan.h>
 #include <thrust/system/detail/generic/scan.h>
 
-#include <cuda/functional>
+#include <cuda/std/__functional/operations.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace system::detail::generic

--- a/thrust/thrust/zip_function.h
+++ b/thrust/thrust/zip_function.h
@@ -18,7 +18,10 @@
 
 #include <thrust/detail/type_deduction.h>
 
-#include <cuda/functional>
+#include <cuda/__functional/address_stability.h>
+#include <cuda/std/__type_traits/decay.h>
+#include <cuda/std/__utility/forward.h>
+#include <cuda/std/__utility/move.h>
 #include <cuda/std/tuple>
 
 THRUST_NAMESPACE_BEGIN


### PR DESCRIPTION
This is dropping more of the umbrella headers in CUB

The remaining larger header is `<cuda/atomic>` which is really big. 

We should consider providing a simpler type for integrals only, which should improve most cases