### PR TITLE
Use proper CUB namespace wrapper in pstl

### DIFF
--- a/libcudacxx/include/cuda/__container/buffer.h
+++ b/libcudacxx/include/cuda/__container/buffer.h
@@ -703,7 +703,7 @@ _CCCL_HOST_API void __fill_n(cuda::stream_ref __stream, _Tp* __first, ::cuda::st
     {
 #  if _CCCL_CUDA_COMPILATION()
       ::cuda::__ensure_current_context __guard(__stream);
-      ::cub::DeviceTransform::Fill(__first, __count, __value, __stream.get());
+      CUB_NS_QUALIFIER::DeviceTransform::Fill(__first, __count, __value, __stream.get());
 #  else // ^^^ _CCCL_CUDA_COMPILATION() ^^^ / vvv !_CCCL_CUDA_COMPILATION() vvv
       static_assert(sizeof(_Tp) <= 4,
                     "CUDA compiler is required to initialize an async_buffer with elements larger than 4 bytes");

--- a/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/adjacent_difference.h
@@ -73,7 +73,7 @@ struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_back
     // Determine temporary device storage requirements for device_merge
     size_t __num_bytes = 0;
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceAdjacentDifference::SubtractLeftCopy,
+      CUB_NS_QUALIFIER::DeviceAdjacentDifference::SubtractLeftCopy,
       "__pstl_cuda_merge: determination of device storage for cub::DeviceAdjacentDifference::SubtractLeftCopy failed",
       static_cast<void*>(nullptr),
       __num_bytes,
@@ -92,7 +92,7 @@ struct __pstl_dispatch<__pstl_algorithm::__adjacent_difference, __execution_back
 
       // Run the kernel, the standard requires that the input and output range do not overlap
       _CCCL_TRY_CUDA_API(
-        ::cub::DeviceAdjacentDifference::SubtractLeftCopy,
+        CUB_NS_QUALIFIER::DeviceAdjacentDifference::SubtractLeftCopy,
         "__pstl_cuda_merge: kernel launch of cub::DeviceAdjacentDifference::SubtractLeftCopy failed",
         __storage.__get_temp_storage(),
         __num_bytes,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_if.h
@@ -81,7 +81,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
     void* __temp_storage = nullptr;
     size_t __num_bytes   = 0;
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceSelect::If,
+      CUB_NS_QUALIFIER::DeviceSelect::If,
       "__pstl_cuda_select_if: determination of device storage for cub::DeviceSelect::If failed",
       __temp_storage,
       __num_bytes,
@@ -97,7 +97,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_if, __execution_backend::__cuda>
 
       // Run the kernel
       _CCCL_TRY_CUDA_API(
-        ::cub::DeviceSelect::If,
+        CUB_NS_QUALIFIER::DeviceSelect::If,
         "__pstl_cuda_select_if: kernel launch of cub::DeviceSelect::If failed",
         __storage.__get_temp_storage(),
         __num_bytes,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/copy_n.h
@@ -73,7 +73,7 @@ struct __pstl_dispatch<__pstl_algorithm::__copy_n, __execution_backend::__cuda>
     auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
 
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceTransform::TransformIf,
+      CUB_NS_QUALIFIER::DeviceTransform::TransformIf,
       "__pstl_cuda_copy_n: kernel launch of device_transform failed",
       tuple<_InputIterator>{::cuda::std::move(__first)},
       __result,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/exclusive_scan.h
@@ -76,7 +76,7 @@ struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::
     // Determine temporary device storage requirements for reduce
     size_t __num_bytes = 0;
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceScan::ExclusiveScan,
+      CUB_NS_QUALIFIER::DeviceScan::ExclusiveScan,
       "__pstl_cuda_exclusive_scan: determination of device storage for cub::DeviceScan::ExclusiveScan failed",
       static_cast<void*>(nullptr),
       __num_bytes,
@@ -96,7 +96,7 @@ struct __pstl_dispatch<__pstl_algorithm::__exclusive_scan, __execution_backend::
 
       // Run the scan
       _CCCL_TRY_CUDA_API(
-        ::cub::DeviceScan::ExclusiveScan,
+        CUB_NS_QUALIFIER::DeviceScan::ExclusiveScan,
         "__pstl_cuda_exclusive_scan: kernel launch of cub::DeviceScan::ExclusiveScan failed",
         __storage.__get_temp_storage(),
         __num_bytes,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/find_if.h
@@ -78,7 +78,7 @@ struct __pstl_dispatch<__pstl_algorithm::__find_if, __execution_backend::__cuda>
     void* __temp_storage = nullptr;
     size_t __num_bytes   = 0;
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceFind::FindIf,
+      CUB_NS_QUALIFIER::DeviceFind::FindIf,
       "__pstl_cuda_find_if: determining temporary storage failed",
       __temp_storage,
       __num_bytes,
@@ -96,7 +96,7 @@ struct __pstl_dispatch<__pstl_algorithm::__find_if, __execution_backend::__cuda>
 
       // Run the find operation
       _CCCL_TRY_CUDA_API(
-        ::cub::DeviceFind::FindIf,
+        CUB_NS_QUALIFIER::DeviceFind::FindIf,
         "__pstl_cuda_find_if: cub::DeviceFind failed",
         __storage.__get_temp_storage(),
         __num_bytes,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/for_each_n.h
@@ -71,7 +71,7 @@ struct __pstl_dispatch<__pstl_algorithm::__for_each_n, __execution_backend::__cu
     auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
 
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceFor::ForEachN,
+      CUB_NS_QUALIFIER::DeviceFor::ForEachN,
       "__pstl_dispatch: kernel launch failed",
       __first,
       __count,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/generate_n.h
@@ -71,7 +71,7 @@ struct __pstl_dispatch<__pstl_algorithm::__generate_n, __execution_backend::__cu
 
     // We pass the policy as an environment to device_transform
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceTransform::Generate,
+      CUB_NS_QUALIFIER::DeviceTransform::Generate,
       "__pstl_cuda_generate: call to cub device_transform::Generate failed",
       ::cuda::std::move(__result),
       __count,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/inclusive_scan.h
@@ -76,7 +76,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
     // Determine temporary device storage requirements for reduce
     size_t __num_bytes = 0;
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceScan::InclusiveScanInit,
+      CUB_NS_QUALIFIER::DeviceScan::InclusiveScanInit,
       "__pstl_cuda_inclusive_scan: determination of device storage for cub::DeviceScan::InclusiveScanInit failed",
       static_cast<void*>(nullptr),
       __num_bytes,
@@ -96,7 +96,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
 
       // Run the scan
       _CCCL_TRY_CUDA_API(
-        ::cub::DeviceScan::InclusiveScanInit,
+        CUB_NS_QUALIFIER::DeviceScan::InclusiveScanInit,
         "__pstl_cuda_exclusive_scan: kernel launch of cub::DeviceScan::InclusiveScanInit failed",
         __storage.__get_temp_storage(),
         __num_bytes,
@@ -125,7 +125,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
     // Determine temporary device storage requirements for reduce
     size_t __num_bytes = 0;
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceScan::InclusiveScan,
+      CUB_NS_QUALIFIER::DeviceScan::InclusiveScan,
       "__pstl_cuda_inclusive_scan: determination of device storage for cub::DeviceScan::InclusiveScan failed",
       static_cast<void*>(nullptr),
       __num_bytes,
@@ -144,7 +144,7 @@ struct __pstl_dispatch<__pstl_algorithm::__inclusive_scan, __execution_backend::
 
       // Run the scan
       _CCCL_TRY_CUDA_API(
-        ::cub::DeviceScan::InclusiveScan,
+        CUB_NS_QUALIFIER::DeviceScan::InclusiveScan,
         "__pstl_cuda_exclusive_scan: kernel launch of cub::DeviceScan::InclusiveScan failed",
         __storage.__get_temp_storage(),
         __num_bytes,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/merge.h
@@ -80,7 +80,7 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
     // Determine temporary device storage requirements for device_merge
     size_t __num_bytes = 0;
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceMerge::MergeKeys,
+      CUB_NS_QUALIFIER::DeviceMerge::MergeKeys,
       "__pstl_cuda_merge: determination of device storage for cub::DeviceMerge::MergeKeys failed",
       static_cast<void*>(nullptr),
       __num_bytes,
@@ -100,7 +100,7 @@ struct __pstl_dispatch<__pstl_algorithm::__merge, __execution_backend::__cuda>
 
       // Run the kernel
       _CCCL_TRY_CUDA_API(
-        ::cub::DeviceMerge::MergeKeys,
+        CUB_NS_QUALIFIER::DeviceMerge::MergeKeys,
         "__pstl_cuda_merge: kernel launch of cub::DeviceMerge::MergeKeys failed",
         __storage.__get_temp_storage(),
         __num_bytes,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/reduce.h
@@ -83,7 +83,7 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
     void* __temp_storage = nullptr;
     size_t __num_bytes   = 0;
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceReduce::Reduce,
+      CUB_NS_QUALIFIER::DeviceReduce::Reduce,
       "__pstl_cuda_reduce: determination of device storage for cub::DeviceReduce::Reduce failed",
       __temp_storage,
       __num_bytes,
@@ -103,7 +103,7 @@ struct __pstl_dispatch<__pstl_algorithm::__reduce, __execution_backend::__cuda>
 
       // Run the reduction
       _CCCL_TRY_CUDA_API(
-        ::cub::DeviceReduce::Reduce,
+        CUB_NS_QUALIFIER::DeviceReduce::Reduce,
         "__pstl_cuda_reduce: kernel launch of cub::DeviceReduce::Reduce failed",
         __storage.__get_temp_storage(),
         __num_bytes,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/remove_if.h
@@ -76,7 +76,7 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
     void* __temp_storage = nullptr;
     size_t __num_bytes   = 0;
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceSelect::If,
+      CUB_NS_QUALIFIER::DeviceSelect::If,
       "__pstl_cuda_select_if: determination of device storage for cub::DeviceSelect::If failed",
       __temp_storage,
       __num_bytes,
@@ -91,7 +91,7 @@ struct __pstl_dispatch<__pstl_algorithm::__remove_if, __execution_backend::__cud
 
       // Run the kernel
       _CCCL_TRY_CUDA_API(
-        ::cub::DeviceSelect::If,
+        CUB_NS_QUALIFIER::DeviceSelect::If,
         "__pstl_cuda_select_if: kernel launch of cub::DeviceSelect::If failed",
         __storage.__get_temp_storage(),
         __num_bytes,

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform.h
@@ -76,7 +76,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform, __execution_backend::__cud
 
     // We pass the policy as an environment to device_transform
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceTransform::TransformIf,
+      CUB_NS_QUALIFIER::DeviceTransform::TransformIf,
       "cuda::std::transform: failed inside CUDA backend",
       ::cuda::std::move(__first),
       ::cuda::std::move(__result),

--- a/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/transform_reduce.h
@@ -82,7 +82,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform_reduce, __execution_backend
     void* __temp_storage = nullptr;
     size_t __num_bytes   = 0;
     _CCCL_TRY_CUDA_API(
-      ::cub::DeviceReduce::TransformReduce,
+      CUB_NS_QUALIFIER::DeviceReduce::TransformReduce,
       "__pstl_cuda_transform_reduce: determination of device storage for cub::DeviceReduce::TransformReduce failed",
       __temp_storage,
       __num_bytes,
@@ -103,7 +103,7 @@ struct __pstl_dispatch<__pstl_algorithm::__transform_reduce, __execution_backend
 
       // Run the reduction
       _CCCL_TRY_CUDA_API(
-        ::cub::DeviceReduce::TransformReduce,
+        CUB_NS_QUALIFIER::DeviceReduce::TransformReduce,
         "__pstl_cuda_transform_reduce: kernel launch of cub::DeviceReduce::TransformReduce failed",
         __storage.__get_temp_storage(),
         __num_bytes,


### PR DESCRIPTION
We cannot use plain `::cub` because the user might have wrappped the namespace
