### PR TITLE
Expand `DeviceSelect::Unique` to accept a predicate

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -28,6 +28,8 @@
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
@@ -1500,6 +1502,138 @@ public:
         static_cast<offset_t>(num_items),
         stream);
     });
+  }
+
+  //! @rst
+  //! Given an input sequence ``d_in`` having runs of consecutive equal-valued keys,
+  //! only the first key from each run is selectively copied to ``d_out``.
+  //! The total number of items selected is written to ``d_num_selected_out``.
+  //!
+  //! .. versionadded:: 2.2.0
+  //!    First appears in CUDA Toolkit 12.3.
+  //!
+  //! - The user-provided equality operator, `equality_op`, is used to determine whether keys are equivalent
+  //! - Copies of the selected items are compacted into ``d_out`` and maintain their original relative ordering.
+  //! - | The range ``[d_out, d_out + *d_num_selected_out)`` shall not overlap
+  //!   | ``[d_in, d_in + num_items)`` nor ``d_num_selected_out`` in any way.
+  //! - @devicestorage
+  //!
+  //! Snippet
+  //! +++++++++++++++++++++++++++++++++++++++++++++
+  //!
+  //! The code snippet below illustrates the compaction of items selected from an ``int`` device vector.
+  //!
+  //! .. code-block:: c++
+  //!
+  //!    #include <cub/cub.cuh>   // or equivalently <cub/device/device_select.cuh>
+  //!
+  //!    // Declare, allocate, and initialize device-accessible pointers
+  //!    // for input and output
+  //!    int  num_items;              // e.g., 8
+  //!    int  *d_in;                  // e.g., [0, 2, 2, 9, 5, 5, 5, 8]
+  //!    int  *d_out;                 // e.g., [ ,  ,  ,  ,  ,  ,  ,  ]
+  //!    int  *d_num_selected_out;    // e.g., [ ]
+  //!    ...
+  //!
+  //!    // Determine temporary device storage requirements
+  //!    void     *d_temp_storage = nullptr;
+  //!    size_t   temp_storage_bytes = 0;
+  //!    cub::DeviceSelect::Unique(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_in, d_out, d_num_selected_out, num_items, cuda::std::equal_to<>{});
+  //!
+  //!    // Allocate temporary storage
+  //!    cudaMalloc(&d_temp_storage, temp_storage_bytes);
+  //!
+  //!    // Run selection
+  //!    cub::DeviceSelect::Unique(
+  //!      d_temp_storage, temp_storage_bytes,
+  //!      d_in, d_out, d_num_selected_out, num_items, cuda::std::equal_to<>{});
+  //!
+  //!    // d_out                 <-- [0, 2, 9, 5, 8]
+  //!    // d_num_selected_out    <-- [5]
+  //!
+  //! @endrst
+  //!
+  //! @tparam InputIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading input items @iterator
+  //!
+  //! @tparam OutputIteratorT
+  //!   **[inferred]** Random-access output iterator type for writing selected items @iterator
+  //!
+  //! @tparam NumSelectedIteratorT
+  //!   **[inferred]** Output iterator type for recording the number of items selected @iterator
+  //!
+  //! @tparam EqualityOpT
+  //!   **[inferred]** Type of equality_op
+  //!
+  //! @param[in] d_temp_storage
+  //!   Device-accessible allocation of temporary storage. When `nullptr`, the
+  //!   required allocation size is written to `temp_storage_bytes` and no work is done.
+  //!
+  //! @param[in,out] temp_storage_bytes
+  //!   Reference to size in bytes of `d_temp_storage` allocation
+  //!
+  //! @param[in] d_in
+  //!   Pointer to the input sequence of data items
+  //!
+  //! @param[out] d_out
+  //!   Pointer to the output sequence of selected data items
+  //!
+  //! @param[out] d_num_selected_out
+  //!   Pointer to the output total number of items selected
+  //!   (i.e., length of `d_out`)
+  //!
+  //! @param[in] num_items
+  //!   Total number of input items (i.e., length of `d_in`)
+  //!
+  //! @param[in] equality_op
+  //!   Binary predicate to determine equality
+  //!
+  //! @param[in] stream
+  //!   @rst
+  //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
+  //!   @endrst
+  template <
+    typename InputIteratorT,
+    typename OutputIteratorT,
+    typename NumSelectedIteratorT,
+    typename EqualityOpT,
+    ::cuda::std::enable_if_t<!::cuda::std::is_same_v<::cuda::std::remove_cvref_t<EqualityOpT>, cudaStream_t>, int> = 0>
+  CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
+    void* d_temp_storage,
+    size_t& temp_storage_bytes,
+    InputIteratorT d_in,
+    OutputIteratorT d_out,
+    NumSelectedIteratorT d_num_selected_out,
+    ::cuda::std::int64_t num_items,
+    EqualityOpT equality_op,
+    cudaStream_t stream = 0)
+  {
+    _CCCL_NVTX_RANGE_SCOPE_IF(d_temp_storage, "cub::DeviceSelect::Unique");
+
+    using OffsetT      = ::cuda::std::int64_t;
+    using FlagIterator = NullType*; // FlagT iterator type (not used)
+    using SelectOpT    = NullType; // Selection op (not used)
+
+    return DispatchSelectIf<
+      InputIteratorT,
+      FlagIterator,
+      OutputIteratorT,
+      NumSelectedIteratorT,
+      SelectOpT,
+      EqualityOpT,
+      OffsetT,
+      SelectImpl::Select>::Dispatch(d_temp_storage,
+                                    temp_storage_bytes,
+                                    d_in,
+                                    nullptr,
+                                    d_out,
+                                    d_num_selected_out,
+                                    SelectOpT(),
+                                    equality_op,
+                                    num_items,
+                                    stream);
   }
 
   //! @rst

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -26,10 +26,10 @@
 #include <cuda/__execution/require.h>
 #include <cuda/std/__execution/env.h>
 #include <cuda/std/__functional/operations.h>
+#include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_same.h>
-#include <cuda/std/__type_traits/remove_cvref.h>
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
@@ -1594,12 +1594,12 @@ public:
   //!   @rst
   //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
   //!   @endrst
-  template <
-    typename InputIteratorT,
-    typename OutputIteratorT,
-    typename NumSelectedIteratorT,
-    typename EqualityOpT,
-    ::cuda::std::enable_if_t<!::cuda::std::is_same_v<::cuda::std::remove_cvref_t<EqualityOpT>, cudaStream_t>, int> = 0>
+  template <typename InputIteratorT,
+            typename OutputIteratorT,
+            typename NumSelectedIteratorT,
+            typename EqualityOpT,
+            ::cuda::std::enable_if_t<::cuda::std::indirect_binary_predicate<EqualityOpT, InputIteratorT, InputIteratorT>,
+                                     int> = 0>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Unique(
     void* d_temp_storage,
     size_t& temp_storage_bytes,

--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -1509,8 +1509,8 @@ public:
   //! only the first key from each run is selectively copied to ``d_out``.
   //! The total number of items selected is written to ``d_num_selected_out``.
   //!
-  //! .. versionadded:: 2.2.0
-  //!    First appears in CUDA Toolkit 12.3.
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
   //!
   //! - The user-provided equality operator, `equality_op`, is used to determine whether keys are equivalent
   //! - Copies of the selected items are compacted into ``d_out`` and maintain their original relative ordering.

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -106,8 +106,16 @@ C2H_TEST("DeviceSelect::Unique handles none equal", "[device][select_unique]", t
   c2h::device_vector<int> num_selected_out(1, 0);
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
+  // test overload without predicate
   select_unique(cuda::counting_iterator<type>(0), cuda::discard_iterator(), d_first_num_selected_out, num_items);
+  REQUIRE(num_selected_out[0] == num_items);
 
+  // test overload with predicate
+  select_unique(cuda::counting_iterator<type>(0),
+                cuda::discard_iterator(),
+                d_first_num_selected_out,
+                num_items,
+                cuda::std::equal_to<type>{});
   REQUIRE(num_selected_out[0] == num_items);
 }
 
@@ -123,7 +131,15 @@ C2H_TEST("DeviceSelect::Unique handles all equal", "[device][select_unique]", ty
   c2h::device_vector<int> num_selected_out(1, 0);
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
+  // test overload without predicate
   select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items);
+
+  // At least one item is selected
+  REQUIRE(num_selected_out[0] == 1);
+  REQUIRE(out[0] == in[0]);
+
+  // test overload with predicate
+  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
 
   // At least one item is selected
   REQUIRE(num_selected_out[0] == 1);
@@ -146,8 +162,12 @@ C2H_TEST("DeviceSelect::Unique does not change input", "[device][select_unique]"
   // copy input first
   c2h::device_vector<type> reference = in;
 
+  // test overload without predicate
   select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items);
+  REQUIRE(reference == in);
 
+  // test overload with predicate
+  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
   REQUIRE(reference == in);
 }
 
@@ -164,15 +184,21 @@ C2H_TEST("DeviceSelect::Unique works with iterators", "[device][select_unique]",
   c2h::device_vector<int> num_selected_out(1, 0);
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
-  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items);
-
   // Ensure that we create the same output as std
   c2h::host_vector<type> reference = in;
   const auto boundary              = std::unique(reference.begin(), reference.end());
-  REQUIRE((boundary - reference.begin()) == num_selected_out[0]);
+  const auto num_selected_std      = cuda::std::distance(reference.begin(), boundary);
 
+  // test overload without predicate
+  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items);
+  REQUIRE(num_selected_std == num_selected_out[0]);
   out.resize(num_selected_out[0]);
   reference.resize(num_selected_out[0]);
+  REQUIRE(reference == out);
+
+  // test overload with predicate
+  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
+  REQUIRE(num_selected_std == num_selected_out[0]);
   REQUIRE(reference == out);
 }
 
@@ -189,16 +215,26 @@ C2H_TEST("DeviceSelect::Unique works with pointers", "[device][select_unique]", 
   c2h::device_vector<int> num_selected_out(1, 0);
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
-  select_unique(
-    thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), d_first_num_selected_out, num_items);
-
   // Ensure that we create the same output as std
   c2h::host_vector<type> reference = in;
   const auto boundary              = std::unique(reference.begin(), reference.end());
-  REQUIRE((boundary - reference.begin()) == num_selected_out[0]);
+  const auto num_selected_std      = cuda::std::distance(reference.begin(), boundary);
 
+  // test overload without predicate
+  select_unique(
+    thrust::raw_pointer_cast(in.data()), thrust::raw_pointer_cast(out.data()), d_first_num_selected_out, num_items);
+  REQUIRE(num_selected_std == num_selected_out[0]);
   out.resize(num_selected_out[0]);
   reference.resize(num_selected_out[0]);
+  REQUIRE(reference == out);
+
+  // test overload with predicate
+  select_unique(thrust::raw_pointer_cast(in.data()),
+                thrust::raw_pointer_cast(out.data()),
+                d_first_num_selected_out,
+                num_items,
+                cuda::std::equal_to<type>{});
+  REQUIRE(num_selected_std == num_selected_out[0]);
   REQUIRE(reference == out);
 }
 
@@ -235,15 +271,21 @@ C2H_TEST("DeviceSelect::Unique works with a different output type", "[device][se
   c2h::device_vector<int> num_selected_out(1, 0);
   int* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
-  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items);
-
   // Ensure that we create the same output as std
   c2h::host_vector<type> reference = in;
   const auto boundary              = std::unique(reference.begin(), reference.end());
-  REQUIRE((boundary - reference.begin()) == num_selected_out[0]);
+  const auto num_selected_std      = cuda::std::distance(reference.begin(), boundary);
 
+  // test overload without predicate
+  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items);
+  REQUIRE(num_selected_std == num_selected_out[0]);
   out.resize(num_selected_out[0]);
   reference.resize(num_selected_out[0]);
+  REQUIRE(reference == out);
+
+  // test overload with predicate
+  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
+  REQUIRE(num_selected_std == num_selected_out[0]);
   REQUIRE(reference == out);
 }
 
@@ -283,8 +325,15 @@ try
     c2h::device_vector<offset_t> num_selected_out(1, 0);
     offset_t* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
-    // Run test
+    // test overload without predicate
     select_unique(in, check_result_it, d_first_num_selected_out, num_items);
+
+    // Ensure that we created the correct output
+    REQUIRE(num_selected_out[0] == num_items);
+    check_result_helper.check_all_results_correct();
+
+    // test overload without predicate
+    select_unique(in, check_result_it, d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
 
     // Ensure that we created the correct output
     REQUIRE(num_selected_out[0] == num_items);
@@ -308,8 +357,15 @@ try
     c2h::device_vector<offset_t> num_selected_out(1, 0);
     offset_t* d_first_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
-    // Run test
+    // test overload without predicate
     select_unique(in, check_result_it, d_first_num_selected_out, num_items);
+
+    // Ensure that we created the correct output
+    REQUIRE(num_selected_out[0] == expected_num_unique);
+    check_result_helper.check_all_results_correct();
+
+    // test overload with predicate
+    select_unique(in, check_result_it, d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
 
     // Ensure that we created the correct output
     REQUIRE(num_selected_out[0] == expected_num_unique);

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -7,6 +7,7 @@
 
 #include <cuda/cmath>
 #include <cuda/iterator>
+#include <cuda/stream>
 
 #include <algorithm>
 
@@ -100,8 +101,12 @@ C2H_TEST("DeviceSelect::Unique can run with empty input", "[device][select_uniqu
   c2h::device_vector<int> num_selected_out(1, 42);
   int* d_num_selected_out = thrust::raw_pointer_cast(num_selected_out.data());
 
+  // test overload without predicate
   select_unique(in.begin(), out.begin(), d_num_selected_out, num_items);
+  REQUIRE(num_selected_out[0] == 0);
 
+  // test overload with stream
+  select_unique(in.begin(), out.begin(), d_num_selected_out, num_items, fake_equal_to{});
   REQUIRE(num_selected_out[0] == 0);
 }
 
@@ -123,6 +128,14 @@ C2H_TEST("DeviceSelect::Unique handles none equal", "[device][select_unique]", t
   select_unique(
     cuda::counting_iterator<type>(0), cuda::discard_iterator(), d_first_num_selected_out, num_items, fake_equal_to{});
   REQUIRE(num_selected_out[0] == num_items);
+
+  // test against predicate that gives a different result
+  select_unique(cuda::counting_iterator<type>(0),
+                cuda::discard_iterator(),
+                d_first_num_selected_out,
+                num_items,
+                cuda::std::not_equal_to<>{});
+  REQUIRE(num_selected_out[0] == 1);
 }
 
 C2H_TEST("DeviceSelect::Unique handles all equal", "[device][select_unique]", types)

--- a/cub/test/catch2_test_device_select_unique.cu
+++ b/cub/test/catch2_test_device_select_unique.cu
@@ -15,6 +15,15 @@
 #include "catch2_test_launch_helper.h"
 #include <c2h/catch2_test_helper.h>
 
+struct fake_equal_to
+{
+  template <class T, class U>
+  [[nodiscard]] _CCCL_HOST_DEVICE constexpr bool operator()(const T& lhs, const U& rhs) const noexcept
+  {
+    return lhs == rhs;
+  }
+};
+
 template <class T>
 inline T to_bound(const unsigned long long bound)
 {
@@ -111,11 +120,8 @@ C2H_TEST("DeviceSelect::Unique handles none equal", "[device][select_unique]", t
   REQUIRE(num_selected_out[0] == num_items);
 
   // test overload with predicate
-  select_unique(cuda::counting_iterator<type>(0),
-                cuda::discard_iterator(),
-                d_first_num_selected_out,
-                num_items,
-                cuda::std::equal_to<type>{});
+  select_unique(
+    cuda::counting_iterator<type>(0), cuda::discard_iterator(), d_first_num_selected_out, num_items, fake_equal_to{});
   REQUIRE(num_selected_out[0] == num_items);
 }
 
@@ -139,7 +145,7 @@ C2H_TEST("DeviceSelect::Unique handles all equal", "[device][select_unique]", ty
   REQUIRE(out[0] == in[0]);
 
   // test overload with predicate
-  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
+  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, fake_equal_to{});
 
   // At least one item is selected
   REQUIRE(num_selected_out[0] == 1);
@@ -167,7 +173,7 @@ C2H_TEST("DeviceSelect::Unique does not change input", "[device][select_unique]"
   REQUIRE(reference == in);
 
   // test overload with predicate
-  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
+  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, fake_equal_to{});
   REQUIRE(reference == in);
 }
 
@@ -197,7 +203,7 @@ C2H_TEST("DeviceSelect::Unique works with iterators", "[device][select_unique]",
   REQUIRE(reference == out);
 
   // test overload with predicate
-  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
+  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, fake_equal_to{});
   REQUIRE(num_selected_std == num_selected_out[0]);
   REQUIRE(reference == out);
 }
@@ -233,7 +239,7 @@ C2H_TEST("DeviceSelect::Unique works with pointers", "[device][select_unique]", 
                 thrust::raw_pointer_cast(out.data()),
                 d_first_num_selected_out,
                 num_items,
-                cuda::std::equal_to<type>{});
+                fake_equal_to{});
   REQUIRE(num_selected_std == num_selected_out[0]);
   REQUIRE(reference == out);
 }
@@ -284,7 +290,7 @@ C2H_TEST("DeviceSelect::Unique works with a different output type", "[device][se
   REQUIRE(reference == out);
 
   // test overload with predicate
-  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
+  select_unique(in.begin(), out.begin(), d_first_num_selected_out, num_items, fake_equal_to{});
   REQUIRE(num_selected_std == num_selected_out[0]);
   REQUIRE(reference == out);
 }
@@ -333,7 +339,7 @@ try
     check_result_helper.check_all_results_correct();
 
     // test overload without predicate
-    select_unique(in, check_result_it, d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
+    select_unique(in, check_result_it, d_first_num_selected_out, num_items, fake_equal_to{});
 
     // Ensure that we created the correct output
     REQUIRE(num_selected_out[0] == num_items);
@@ -365,7 +371,7 @@ try
     check_result_helper.check_all_results_correct();
 
     // test overload with predicate
-    select_unique(in, check_result_it, d_first_num_selected_out, num_items, cuda::std::equal_to<type>{});
+    select_unique(in, check_result_it, d_first_num_selected_out, num_items, fake_equal_to{});
 
     // Ensure that we created the correct output
     REQUIRE(num_selected_out[0] == expected_num_unique);


### PR DESCRIPTION
We want to use the public methods in the PSTL backend, so add an overload that takes a predicate.
