### PR TITLE
Avoid more "pointless comparison" warnings

### DIFF
--- a/libcudacxx/include/cuda/std/span
+++ b/libcudacxx/include/cuda/std/span
@@ -208,14 +208,16 @@ public:
   template <size_t _Count>
   _CCCL_API constexpr span<element_type, _Count> first() const noexcept
   {
-    static_assert(_Count <= _Extent, "span<T, N>::first<Count>(): Count out of range");
+    // ternary avoids "pointless comparison of unsigned integer with zero" warning
+    static_assert(_Count == 0 ? true : _Count <= _Extent, "span<T, N>::first<Count>(): Count out of range");
     return span<element_type, _Count>{data(), _Count};
   }
 
   template <size_t _Count>
   _CCCL_API constexpr span<element_type, _Count> last() const noexcept
   {
-    static_assert(_Count <= _Extent, "span<T, N>::last<Count>(): Count out of range");
+    // ternary avoids "pointless comparison of unsigned integer with zero" warning
+    static_assert(_Count == 0 ? true : _Count <= _Extent, "span<T, N>::last<Count>(): Count out of range");
     return span<element_type, _Count>{data() + size() - _Count, _Count};
   }
 
@@ -237,8 +239,10 @@ public:
   template <size_t _Offset, size_t _Count = dynamic_extent>
   _CCCL_API constexpr __subspan_t<_Offset, _Count> subspan() const noexcept
   {
-    static_assert(_Offset <= _Extent, "span<T, N>::subspan<Offset, Count>(): Offset out of range");
-    static_assert(_Count == dynamic_extent || _Count <= _Extent - _Offset,
+    // ternary avoids "pointless comparison of unsigned integer with zero" warning
+    static_assert(_Offset == 0 ? true : _Offset <= _Extent,
+                  "span<T, N>::subspan<Offset, Count>(): Offset out of range");
+    static_assert(_Count == dynamic_extent || (_Count == 0 ? true : _Count <= _Extent - _Offset),
                   "span<T, N>::subspan<Offset, Count>(): Offset + Count out of range");
     return __subspan_t<_Offset, _Count>{data() + _Offset, _Count == dynamic_extent ? size() - _Offset : _Count};
   }
@@ -456,7 +460,7 @@ public:
   {
     // ternary avoids "pointless comparison of unsigned integer with zero" warning
     _CCCL_ASSERT(_Offset == 0 ? true : _Offset <= size(), "span<T>::subspan<Offset, Count>(): Offset out of range");
-    _CCCL_ASSERT(_Count == dynamic_extent || _Count == 0 ? true : _Count <= size() - _Offset,
+    _CCCL_ASSERT(_Count == dynamic_extent || (_Count == 0 ? true : _Count <= size() - _Offset),
                  "span<T>::subspan<Offset, Count>(): Offset + Count out of range");
     return __subspan_t<_Offset, _Count>{data() + _Offset, _Count == dynamic_extent ? size() - _Offset : _Count};
   }


### PR DESCRIPTION
MSVC is really fond of those warnings. Add some more ternaries to avoid them.

Addresses parts of nvbug5970910
