### PR TITLE
reformulate `__as_type_list` to avoid MSVC overload resolution bug

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -381,7 +381,7 @@ template <class _Ret, class... _Args>
 extern __fn_ptr_t<__type_list<_Ret, _Args...>> __as_type_list_v<_Ret(_Args...)>;
 } // namespace __detail
 
-//! \brief Given a type that is can be interpreted as a type list, return its
+//! \brief Given a type that can be interpreted as a type list, return its
 //! type list interpretation. Types that can be interpreted as a type
 //! list are of the following forms:
 //!


### PR DESCRIPTION
## Description

closes [nvbugs#5970910](https://nvbugspro.nvidia.com/bug/5970910)

a new version of MSVC has a problem with overload resolution that causes the template parameters of arguments to be prematurely instantiated. one of `__type_list`'s tests (for `__as_type_list`) was getting tripped up by this.

this PR changes `__as_type_list` to use variable templates instead of function overloads, thus avoiding the problem.

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
