### PR TITLE
Avoid including nvfp headers in `<cuda/std/limits>`

### DIFF
--- a/libcudacxx/include/cuda/std/__floating_point/format.h
+++ b/libcudacxx/include/cuda/std/__floating_point/format.h
@@ -21,7 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__floating_point/cuda_fp_types.h>
 #include <cuda/std/__fwd/fp.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cfloat>

--- a/libcudacxx/include/cuda/std/__floating_point/storage.h
+++ b/libcudacxx/include/cuda/std/__floating_point/storage.h
@@ -22,7 +22,6 @@
 #endif // no system header
 
 #include <cuda/std/__bit/bit_cast.h>
-#include <cuda/std/__floating_point/cuda_fp_types.h>
 #include <cuda/std/__floating_point/format.h>
 #include <cuda/std/__floating_point/traits.h>
 #include <cuda/std/__type_traits/always_false.h>
@@ -72,19 +71,11 @@ using __fp_storage_t = decltype(__fp_storage_type_impl<_Fmt>());
 template <class _Tp>
 using __fp_storage_of_t = __fp_storage_t<__fp_format_of_v<_Tp>>;
 
-#if _CCCL_HAS_NVFP16()
-struct __cccl_nvfp16_manip_helper : __half
+template <class _Tp>
+struct __cccl_nvfp_manip_helper : _Tp
 {
-  using __half::__x;
+  using _Tp::__x;
 };
-#endif // _CCCL_HAS_NVFP16()
-
-#if _CCCL_HAS_NVBF16()
-struct __cccl_nvbf16_manip_helper : __nv_bfloat16
-{
-  using __nv_bfloat16::__x;
-};
-#endif // _CCCL_HAS_NVBF16()
 
 template <class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp __fp_from_storage(__fp_storage_of_t<_Tp> __v) noexcept
@@ -102,7 +93,7 @@ template <class _Tp>
 #if _CCCL_HAS_NVFP16()
   else if constexpr (is_same_v<_Tp, __half>)
   {
-    __cccl_nvfp16_manip_helper __helper{};
+    __cccl_nvfp_manip_helper<_Tp> __helper{};
     __helper.__x = __v;
     return __helper;
   }
@@ -110,7 +101,7 @@ template <class _Tp>
 #if _CCCL_HAS_NVBF16()
   else if constexpr (is_same_v<_Tp, __nv_bfloat16>)
   {
-    __cccl_nvbf16_manip_helper __helper{};
+    __cccl_nvfp_manip_helper<_Tp> __helper{};
     __helper.__x = __v;
     return __helper;
   }
@@ -118,7 +109,7 @@ template <class _Tp>
 #if _CCCL_HAS_NVFP8_E4M3()
   else if constexpr (is_same_v<_Tp, __nv_fp8_e4m3>)
   {
-    __nv_fp8_e4m3 __ret{};
+    _Tp __ret{};
     __ret.__x = __v;
     return __ret;
   }
@@ -126,7 +117,7 @@ template <class _Tp>
 #if _CCCL_HAS_NVFP8_E5M2()
   else if constexpr (is_same_v<_Tp, __nv_fp8_e5m2>)
   {
-    __nv_fp8_e5m2 __ret{};
+    _Tp __ret{};
     __ret.__x = __v;
     return __ret;
   }
@@ -134,7 +125,7 @@ template <class _Tp>
 #if _CCCL_HAS_NVFP8_E8M0()
   else if constexpr (is_same_v<_Tp, __nv_fp8_e8m0>)
   {
-    __nv_fp8_e8m0 __ret{};
+    _Tp __ret{};
     __ret.__x = __v;
     return __ret;
   }
@@ -143,7 +134,7 @@ template <class _Tp>
   else if constexpr (is_same_v<_Tp, __nv_fp6_e2m3>)
   {
     _CCCL_ASSERT((__v & 0xc0u) == 0u, "Invalid __nv_fp6_e2m3 storage value");
-    __nv_fp6_e2m3 __ret{};
+    _Tp __ret{};
     __ret.__x = __v;
     return __ret;
   }
@@ -152,7 +143,7 @@ template <class _Tp>
   else if constexpr (is_same_v<_Tp, __nv_fp6_e3m2>)
   {
     _CCCL_ASSERT((__v & 0xc0u) == 0u, "Invalid __nv_fp6_e3m2 storage value");
-    __nv_fp6_e3m2 __ret{};
+    _Tp __ret{};
     __ret.__x = __v;
     return __ret;
   }
@@ -161,7 +152,7 @@ template <class _Tp>
   else if constexpr (is_same_v<_Tp, __nv_fp4_e2m1>)
   {
     _CCCL_ASSERT((__v & 0xf0u) == 0u, "Invalid __nv_fp4_e2m1 storage value");
-    __nv_fp4_e2m1 __ret{};
+    _Tp __ret{};
     __ret.__x = __v;
     return __ret;
   }
@@ -190,13 +181,13 @@ template <class _Tp>
 #if _CCCL_HAS_NVFP16()
   else if constexpr (is_same_v<_Tp, __half>)
   {
-    return __cccl_nvfp16_manip_helper{__v}.__x;
+    return __cccl_nvfp_manip_helper<_Tp>{__v}.__x;
   }
 #endif // _CCCL_HAS_NVFP16()
 #if _CCCL_HAS_NVBF16()
   else if constexpr (is_same_v<_Tp, __nv_bfloat16>)
   {
-    return __cccl_nvbf16_manip_helper{__v}.__x;
+    return __cccl_nvfp_manip_helper<_Tp>{__v}.__x;
   }
 #endif // _CCCL_HAS_NVBF16()
 #if _CCCL_HAS_NVFP8_E4M3()

--- a/libcudacxx/include/cuda/std/__floating_point/traits.h
+++ b/libcudacxx/include/cuda/std/__floating_point/traits.h
@@ -21,7 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__floating_point/cuda_fp_types.h>
 #include <cuda/std/__floating_point/properties.h>
 #include <cuda/std/__fwd/fp.h>
 

--- a/libcudacxx/include/cuda/std/__limits/numeric_limits.h
+++ b/libcudacxx/include/cuda/std/__limits/numeric_limits.h
@@ -58,7 +58,7 @@ enum class __numeric_limits_type
 };
 
 template <class _Tp>
-_CCCL_API constexpr __numeric_limits_type __make_numeric_limits_type()
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL __numeric_limits_type __make_numeric_limits_type() noexcept
 {
   if constexpr (is_same_v<_Tp, bool>)
   {
@@ -78,7 +78,16 @@ _CCCL_API constexpr __numeric_limits_type __make_numeric_limits_type()
   }
 }
 
-template <class _Tp, __numeric_limits_type = __make_numeric_limits_type<_Tp>()>
+// To avoid including nvfp headers, we add the _Up type defaulted to _Tp which makes the specialization still be a
+// template, which won't be instantiated unless the numeric_limits<_Tp> class is instantiated. The specialization should
+// look as:
+//
+// template <class _Tp>
+// class __numeric_limits_impl<__nvfp_type, __numeric_limits_type::__floating_point, _Tp>
+// { ... };
+//
+// and _Tp should be used everywhere instead of __nvfp_type.
+template <class _Tp, __numeric_limits_type = __make_numeric_limits_type<_Tp>(), class _Up = _Tp>
 class __numeric_limits_impl
 {
 public:

--- a/libcudacxx/include/cuda/std/__limits/numeric_limits_ext.h
+++ b/libcudacxx/include/cuda/std/__limits/numeric_limits_ext.h
@@ -33,11 +33,11 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 // nvfp16
 
 #if _CCCL_HAS_NVFP16()
-template <>
-class __numeric_limits_impl<__half, __numeric_limits_type::__floating_point>
+template <class _Tp>
+class __numeric_limits_impl<__half, __numeric_limits_type::__floating_point, _Tp>
 {
 public:
-  using type = __half;
+  using type = _Tp;
 
   static constexpr bool is_specialized = true;
 
@@ -45,29 +45,29 @@ public:
   static constexpr int digits       = 11;
   static constexpr int digits10     = 3;
   static constexpr int max_digits10 = 5;
-  _CCCL_API static constexpr type min() noexcept
+  _CCCL_API static constexpr _Tp min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__half>(uint16_t(0x0400u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x0400u));
   }
-  _CCCL_API static constexpr type max() noexcept
+  _CCCL_API static constexpr _Tp max() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__half>(uint16_t(0x7bffu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x7bffu));
   }
-  _CCCL_API static constexpr type lowest() noexcept
+  _CCCL_API static constexpr _Tp lowest() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__half>(uint16_t(0xfbffu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0xfbffu));
   }
 
   static constexpr bool is_integer = false;
   static constexpr bool is_exact   = false;
   static constexpr int radix       = FLT_RADIX;
-  _CCCL_API static constexpr type epsilon() noexcept
+  _CCCL_API static constexpr _Tp epsilon() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__half>(uint16_t(0x1400u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x1400u));
   }
-  _CCCL_API static constexpr type round_error() noexcept
+  _CCCL_API static constexpr _Tp round_error() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__half>(uint16_t(0x3800u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x3800u));
   }
 
   static constexpr int min_exponent   = -13;
@@ -80,21 +80,21 @@ public:
   static constexpr bool has_signaling_NaN                                  = true;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
-  _CCCL_API static constexpr type infinity() noexcept
+  _CCCL_API static constexpr _Tp infinity() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__half>(uint16_t(0x7c00u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x7c00u));
   }
-  _CCCL_API static constexpr type quiet_NaN() noexcept
+  _CCCL_API static constexpr _Tp quiet_NaN() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__half>(uint16_t(0x7e00u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x7e00u));
   }
-  _CCCL_API static constexpr type signaling_NaN() noexcept
+  _CCCL_API static constexpr _Tp signaling_NaN() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__half>(uint16_t(0x7d00u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x7d00u));
   }
-  _CCCL_API static constexpr type denorm_min() noexcept
+  _CCCL_API static constexpr _Tp denorm_min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__half>(uint16_t(0x0001u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x0001u));
   }
 
   static constexpr bool is_iec559  = true;
@@ -110,11 +110,11 @@ public:
 // nvbf16
 
 #if _CCCL_HAS_NVBF16()
-template <>
-class __numeric_limits_impl<__nv_bfloat16, __numeric_limits_type::__floating_point>
+template <class _Tp>
+class __numeric_limits_impl<__nv_bfloat16, __numeric_limits_type::__floating_point, _Tp>
 {
 public:
-  using type = __nv_bfloat16;
+  using type = _Tp;
 
   static constexpr bool is_specialized = true;
 
@@ -122,29 +122,29 @@ public:
   static constexpr int digits       = 8;
   static constexpr int digits10     = 2;
   static constexpr int max_digits10 = 4;
-  _CCCL_API static constexpr type min() noexcept
+  _CCCL_API static constexpr _Tp min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_bfloat16>(uint16_t(0x0080u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x0080u));
   }
-  _CCCL_API static constexpr type max() noexcept
+  _CCCL_API static constexpr _Tp max() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_bfloat16>(uint16_t(0x7f7fu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x7f7fu));
   }
-  _CCCL_API static constexpr type lowest() noexcept
+  _CCCL_API static constexpr _Tp lowest() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_bfloat16>(uint16_t(0xff7fu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0xff7fu));
   }
 
   static constexpr bool is_integer = false;
   static constexpr bool is_exact   = false;
   static constexpr int radix       = FLT_RADIX;
-  _CCCL_API static constexpr type epsilon() noexcept
+  _CCCL_API static constexpr _Tp epsilon() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_bfloat16>(uint16_t(0x3c00u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x3c00u));
   }
-  _CCCL_API static constexpr type round_error() noexcept
+  _CCCL_API static constexpr _Tp round_error() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_bfloat16>(uint16_t(0x3f00u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x3f00u));
   }
 
   static constexpr int min_exponent   = -125;
@@ -157,21 +157,21 @@ public:
   static constexpr bool has_signaling_NaN                                  = true;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
-  _CCCL_API static constexpr type infinity() noexcept
+  _CCCL_API static constexpr _Tp infinity() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_bfloat16>(uint16_t(0x7f80u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x7f80u));
   }
-  _CCCL_API static constexpr type quiet_NaN() noexcept
+  _CCCL_API static constexpr _Tp quiet_NaN() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_bfloat16>(uint16_t(0x7fc0u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x7fc0u));
   }
-  _CCCL_API static constexpr type signaling_NaN() noexcept
+  _CCCL_API static constexpr _Tp signaling_NaN() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_bfloat16>(uint16_t(0x7fa0u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x7fa0u));
   }
-  _CCCL_API static constexpr type denorm_min() noexcept
+  _CCCL_API static constexpr _Tp denorm_min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_bfloat16>(uint16_t(0x0001u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint16_t(0x0001u));
   }
 
   static constexpr bool is_iec559  = true;
@@ -187,11 +187,11 @@ public:
 // nvfp8_e4m3
 
 #if _CCCL_HAS_NVFP8_E4M3()
-template <>
-class __numeric_limits_impl<__nv_fp8_e4m3, __numeric_limits_type::__floating_point>
+template <class _Tp>
+class __numeric_limits_impl<__nv_fp8_e4m3, __numeric_limits_type::__floating_point, _Tp>
 {
 public:
-  using type = __nv_fp8_e4m3;
+  using type = _Tp;
 
   static constexpr bool is_specialized = true;
 
@@ -199,29 +199,29 @@ public:
   static constexpr int digits       = 4;
   static constexpr int digits10     = 0;
   static constexpr int max_digits10 = 3;
-  _CCCL_API static constexpr type min() noexcept
+  _CCCL_API static constexpr _Tp min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e4m3>(uint8_t(0x08u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x08u));
   }
-  _CCCL_API static constexpr type max() noexcept
+  _CCCL_API static constexpr _Tp max() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e4m3>(uint8_t(0x7eu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x7eu));
   }
-  _CCCL_API static constexpr type lowest() noexcept
+  _CCCL_API static constexpr _Tp lowest() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e4m3>(uint8_t(0xfeu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0xfeu));
   }
 
   static constexpr bool is_integer = false;
   static constexpr bool is_exact   = false;
   static constexpr int radix       = FLT_RADIX;
-  _CCCL_API static constexpr type epsilon() noexcept
+  _CCCL_API static constexpr _Tp epsilon() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e4m3>(uint8_t(0x20u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x20u));
   }
-  _CCCL_API static constexpr type round_error() noexcept
+  _CCCL_API static constexpr _Tp round_error() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e4m3>(uint8_t(0x30u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x30u));
   }
 
   static constexpr int min_exponent   = -6;
@@ -234,21 +234,21 @@ public:
   static constexpr bool has_signaling_NaN                                  = false;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
-  _CCCL_API static constexpr type infinity() noexcept
+  _CCCL_API static constexpr _Tp infinity() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type quiet_NaN() noexcept
+  _CCCL_API static constexpr _Tp quiet_NaN() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e4m3>(uint8_t(0x7fu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x7fu));
   }
-  _CCCL_API static constexpr type signaling_NaN() noexcept
+  _CCCL_API static constexpr _Tp signaling_NaN() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type denorm_min() noexcept
+  _CCCL_API static constexpr _Tp denorm_min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e4m3>(uint8_t(0x01u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x01u));
   }
 
   static constexpr bool is_iec559  = false;
@@ -264,11 +264,11 @@ public:
 // nvfp8_e5m2
 
 #if _CCCL_HAS_NVFP8_E5M2()
-template <>
-class __numeric_limits_impl<__nv_fp8_e5m2, __numeric_limits_type::__floating_point>
+template <class _Tp>
+class __numeric_limits_impl<__nv_fp8_e5m2, __numeric_limits_type::__floating_point, _Tp>
 {
 public:
-  using type = __nv_fp8_e5m2;
+  using type = _Tp;
 
   static constexpr bool is_specialized = true;
 
@@ -276,29 +276,29 @@ public:
   static constexpr int digits       = 3;
   static constexpr int digits10     = 0;
   static constexpr int max_digits10 = 2;
-  _CCCL_API static constexpr type min() noexcept
+  _CCCL_API static constexpr _Tp min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e5m2>(uint8_t(0x04u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x04u));
   }
-  _CCCL_API static constexpr type max() noexcept
+  _CCCL_API static constexpr _Tp max() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e5m2>(uint8_t(0x7bu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x7bu));
   }
-  _CCCL_API static constexpr type lowest() noexcept
+  _CCCL_API static constexpr _Tp lowest() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e5m2>(uint8_t(0xfbu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0xfbu));
   }
 
   static constexpr bool is_integer = false;
   static constexpr bool is_exact   = false;
   static constexpr int radix       = FLT_RADIX;
-  _CCCL_API static constexpr type epsilon() noexcept
+  _CCCL_API static constexpr _Tp epsilon() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e5m2>(uint8_t(0x34u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x34u));
   }
-  _CCCL_API static constexpr type round_error() noexcept
+  _CCCL_API static constexpr _Tp round_error() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e5m2>(uint8_t(0x38u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x38u));
   }
 
   static constexpr int min_exponent   = -15;
@@ -311,21 +311,21 @@ public:
   static constexpr bool has_signaling_NaN                                  = true;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
-  _CCCL_API static constexpr type infinity() noexcept
+  _CCCL_API static constexpr _Tp infinity() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e5m2>(uint8_t(0x7cu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x7cu));
   }
-  _CCCL_API static constexpr type quiet_NaN() noexcept
+  _CCCL_API static constexpr _Tp quiet_NaN() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e5m2>(uint8_t(0x7eu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x7eu));
   }
-  _CCCL_API static constexpr type signaling_NaN() noexcept
+  _CCCL_API static constexpr _Tp signaling_NaN() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e5m2>(uint8_t(0x7du));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x7du));
   }
-  _CCCL_API static constexpr type denorm_min() noexcept
+  _CCCL_API static constexpr _Tp denorm_min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e5m2>(uint8_t(0x01u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x01u));
   }
 
   static constexpr bool is_iec559  = false;
@@ -341,11 +341,11 @@ public:
 // nvfp8_e8m0
 
 #if _CCCL_HAS_NVFP8_E8M0()
-template <>
-class __numeric_limits_impl<__nv_fp8_e8m0, __numeric_limits_type::__floating_point>
+template <class _Tp>
+class __numeric_limits_impl<__nv_fp8_e8m0, __numeric_limits_type::__floating_point, _Tp>
 {
 public:
-  using type = __nv_fp8_e8m0;
+  using type = _Tp;
 
   static constexpr bool is_specialized = true;
 
@@ -353,29 +353,29 @@ public:
   static constexpr int digits       = 1;
   static constexpr int digits10     = 0;
   static constexpr int max_digits10 = 2;
-  _CCCL_API static constexpr type min() noexcept
+  _CCCL_API static constexpr _Tp min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e8m0>(uint8_t(0x00u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x00u));
   }
-  _CCCL_API static constexpr type max() noexcept
+  _CCCL_API static constexpr _Tp max() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e8m0>(uint8_t(0xfeu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0xfeu));
   }
-  _CCCL_API static constexpr type lowest() noexcept
+  _CCCL_API static constexpr _Tp lowest() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e8m0>(uint8_t(0x00u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x00u));
   }
 
   static constexpr bool is_integer = false;
   static constexpr bool is_exact   = false;
   static constexpr int radix       = FLT_RADIX;
-  _CCCL_API static constexpr type epsilon() noexcept
+  _CCCL_API static constexpr _Tp epsilon() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e8m0>(uint8_t(0x7fu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x7fu));
   }
-  _CCCL_API static constexpr type round_error() noexcept
+  _CCCL_API static constexpr _Tp round_error() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e8m0>(uint8_t(0x7fu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x7fu));
   }
 
   static constexpr int min_exponent   = -127;
@@ -388,21 +388,21 @@ public:
   static constexpr bool has_signaling_NaN                                  = false;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_absent;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
-  _CCCL_API static constexpr type infinity() noexcept
+  _CCCL_API static constexpr _Tp infinity() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type quiet_NaN() noexcept
+  _CCCL_API static constexpr _Tp quiet_NaN() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp8_e8m0>(uint8_t(0xffu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0xffu));
   }
-  _CCCL_API static constexpr type signaling_NaN() noexcept
+  _CCCL_API static constexpr _Tp signaling_NaN() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type denorm_min() noexcept
+  _CCCL_API static constexpr _Tp denorm_min() noexcept
   {
-    return type{};
+    return _Tp{};
   }
 
   static constexpr bool is_iec559  = false;
@@ -418,11 +418,11 @@ public:
 // nvfp6_e2m3
 
 #if _CCCL_HAS_NVFP6_E2M3()
-template <>
-class __numeric_limits_impl<__nv_fp6_e2m3, __numeric_limits_type::__floating_point>
+template <class _Tp>
+class __numeric_limits_impl<__nv_fp6_e2m3, __numeric_limits_type::__floating_point, _Tp>
 {
 public:
-  using type = __nv_fp6_e2m3;
+  using type = _Tp;
 
   static constexpr bool is_specialized = true;
 
@@ -430,29 +430,29 @@ public:
   static constexpr int digits       = 4;
   static constexpr int digits10     = 0;
   static constexpr int max_digits10 = 3;
-  _CCCL_API static constexpr type min() noexcept
+  _CCCL_API static constexpr _Tp min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e2m3>(uint8_t(0x08u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x08u));
   }
-  _CCCL_API static constexpr type max() noexcept
+  _CCCL_API static constexpr _Tp max() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e2m3>(uint8_t(0x1fu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x1fu));
   }
-  _CCCL_API static constexpr type lowest() noexcept
+  _CCCL_API static constexpr _Tp lowest() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e2m3>(uint8_t(0x3fu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x3fu));
   }
 
   static constexpr bool is_integer = false;
   static constexpr bool is_exact   = false;
   static constexpr int radix       = FLT_RADIX;
-  _CCCL_API static constexpr type epsilon() noexcept
+  _CCCL_API static constexpr _Tp epsilon() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e2m3>(uint8_t(0x01u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x01u));
   }
-  _CCCL_API static constexpr type round_error() noexcept
+  _CCCL_API static constexpr _Tp round_error() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e2m3>(uint8_t(0x04u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x04u));
   }
 
   static constexpr int min_exponent   = 0;
@@ -465,21 +465,21 @@ public:
   static constexpr bool has_signaling_NaN                                  = false;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
-  _CCCL_API static constexpr type infinity() noexcept
+  _CCCL_API static constexpr _Tp infinity() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type quiet_NaN() noexcept
+  _CCCL_API static constexpr _Tp quiet_NaN() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type signaling_NaN() noexcept
+  _CCCL_API static constexpr _Tp signaling_NaN() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type denorm_min() noexcept
+  _CCCL_API static constexpr _Tp denorm_min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e2m3>(uint8_t(0x01u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x01u));
   }
 
   static constexpr bool is_iec559  = false;
@@ -495,11 +495,11 @@ public:
 // nvfp6_e3m2
 
 #if _CCCL_HAS_NVFP6_E3M2()
-template <>
-class __numeric_limits_impl<__nv_fp6_e3m2, __numeric_limits_type::__floating_point>
+template <class _Tp>
+class __numeric_limits_impl<__nv_fp6_e3m2, __numeric_limits_type::__floating_point, _Tp>
 {
 public:
-  using type = __nv_fp6_e3m2;
+  using type = _Tp;
 
   static constexpr bool is_specialized = true;
 
@@ -507,29 +507,29 @@ public:
   static constexpr int digits       = 3;
   static constexpr int digits10     = 0;
   static constexpr int max_digits10 = 2;
-  _CCCL_API static constexpr type min() noexcept
+  _CCCL_API static constexpr _Tp min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e3m2>(uint8_t(0x04u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x04u));
   }
-  _CCCL_API static constexpr type max() noexcept
+  _CCCL_API static constexpr _Tp max() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e3m2>(uint8_t(0x1fu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x1fu));
   }
-  _CCCL_API static constexpr type lowest() noexcept
+  _CCCL_API static constexpr _Tp lowest() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e3m2>(uint8_t(0x3fu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x3fu));
   }
 
   static constexpr bool is_integer = false;
   static constexpr bool is_exact   = false;
   static constexpr int radix       = FLT_RADIX;
-  _CCCL_API static constexpr type epsilon() noexcept
+  _CCCL_API static constexpr _Tp epsilon() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e3m2>(uint8_t(0x04u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x04u));
   }
-  _CCCL_API static constexpr type round_error() noexcept
+  _CCCL_API static constexpr _Tp round_error() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e3m2>(uint8_t(0x08u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x08u));
   }
 
   static constexpr int min_exponent   = -2;
@@ -542,21 +542,21 @@ public:
   static constexpr bool has_signaling_NaN                                  = false;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
-  _CCCL_API static constexpr type infinity() noexcept
+  _CCCL_API static constexpr _Tp infinity() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type quiet_NaN() noexcept
+  _CCCL_API static constexpr _Tp quiet_NaN() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type signaling_NaN() noexcept
+  _CCCL_API static constexpr _Tp signaling_NaN() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type denorm_min() noexcept
+  _CCCL_API static constexpr _Tp denorm_min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp6_e3m2>(uint8_t(0x01u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x01u));
   }
 
   static constexpr bool is_iec559  = false;
@@ -572,11 +572,11 @@ public:
 // nvfp4_e2m1
 
 #if _CCCL_HAS_NVFP4_E2M1()
-template <>
-class __numeric_limits_impl<__nv_fp4_e2m1, __numeric_limits_type::__floating_point>
+template <class _Tp>
+class __numeric_limits_impl<__nv_fp4_e2m1, __numeric_limits_type::__floating_point, _Tp>
 {
 public:
-  using type = __nv_fp4_e2m1;
+  using type = _Tp;
 
   static constexpr bool is_specialized = true;
 
@@ -584,29 +584,29 @@ public:
   static constexpr int digits       = 2;
   static constexpr int digits10     = 0;
   static constexpr int max_digits10 = 2;
-  _CCCL_API static constexpr type min() noexcept
+  _CCCL_API static constexpr _Tp min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp4_e2m1>(uint8_t(0x2u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x2u));
   }
-  _CCCL_API static constexpr type max() noexcept
+  _CCCL_API static constexpr _Tp max() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp4_e2m1>(uint8_t(0x7u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x7u));
   }
-  _CCCL_API static constexpr type lowest() noexcept
+  _CCCL_API static constexpr _Tp lowest() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp4_e2m1>(uint8_t(0xfu));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0xfu));
   }
 
   static constexpr bool is_integer = false;
   static constexpr bool is_exact   = false;
   static constexpr int radix       = FLT_RADIX;
-  _CCCL_API static constexpr type epsilon() noexcept
+  _CCCL_API static constexpr _Tp epsilon() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp4_e2m1>(uint8_t(0x1u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x1u));
   }
-  _CCCL_API static constexpr type round_error() noexcept
+  _CCCL_API static constexpr _Tp round_error() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp4_e2m1>(uint8_t(0x1u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x1u));
   }
 
   static constexpr int min_exponent   = 0;
@@ -619,21 +619,21 @@ public:
   static constexpr bool has_signaling_NaN                                  = false;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr float_denorm_style has_denorm = denorm_present;
   _CCCL_DEPRECATED_IN_CXX23 static constexpr bool has_denorm_loss          = false;
-  _CCCL_API static constexpr type infinity() noexcept
+  _CCCL_API static constexpr _Tp infinity() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type quiet_NaN() noexcept
+  _CCCL_API static constexpr _Tp quiet_NaN() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type signaling_NaN() noexcept
+  _CCCL_API static constexpr _Tp signaling_NaN() noexcept
   {
-    return type{};
+    return _Tp{};
   }
-  _CCCL_API static constexpr type denorm_min() noexcept
+  _CCCL_API static constexpr _Tp denorm_min() noexcept
   {
-    return ::cuda::std::__fp_from_storage<__nv_fp4_e2m1>(uint8_t(0x1u));
+    return ::cuda::std::__fp_from_storage<_Tp>(uint8_t(0x1u));
   }
 
   static constexpr bool is_iec559  = false;

--- a/libcudacxx/include/cuda/std/numbers
+++ b/libcudacxx/include/cuda/std/numbers
@@ -20,6 +20,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/std/__floating_point/cuda_fp_types.h>
 #include <cuda/std/__floating_point/storage.h>
 #include <cuda/std/__type_traits/always_false.h>
 #include <cuda/std/version>

--- a/libcudacxx/test/libcudacxx/cuda/numeric/narrow/narrow.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/numeric/narrow/narrow.pass.cpp
@@ -12,6 +12,7 @@
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
+#include "cuda_fp_types.h"
 #include "test_macros.h"
 
 #define CHECK_NARROWING_ERROR(expr, throw_cond)                                                                    \

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/check_cuda_fp_include.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/check_cuda_fp_include.pass.cpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Test that <cuda/std/limits> don't include any of the CUDA fp headers.
+
+#include <cuda/std/limits>
+
+#if defined(__CUDA_FP16_H__) || defined(__CUDA_BF16_H__) || defined(__CUDA_FP8_H__) || defined(__CUDA_FP6_H__) \
+  || defined(__CUDA_FP4_H__)
+#  error "any of the nvfp headers was included by <cuda/std/limits>"
+#endif
+
+int main(int, char**)
+{
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/common.h
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/common.h
@@ -14,8 +14,10 @@
 #include <disable_nvfp_conversions_and_operators.h>
 // clang-format on
 
-#include <cuda/std/__bit/bit_cast.h>
+#include <cuda/std/bit>
 #include <cuda/std/limits>
+
+#include "cuda_fp_types.h"
 
 template <class T>
 __host__ __device__ bool float_eq(T x, T y)

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/denorm_min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/denorm_min.pass.cpp
@@ -19,6 +19,7 @@
 #include <cuda/std/limits>
 
 #include "common.h"
+#include "cuda_fp_types.h"
 #include "test_macros.h"
 
 template <class T>

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/epsilon.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/epsilon.pass.cpp
@@ -19,6 +19,7 @@
 #include <cuda/std/limits>
 
 #include "common.h"
+#include "cuda_fp_types.h"
 #include "test_macros.h"
 
 template <class T>

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/infinity.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/infinity.pass.cpp
@@ -22,6 +22,7 @@
 #endif // _CCCL_COMPILER(MSVC)
 
 #include "common.h"
+#include "cuda_fp_types.h"
 #include "test_macros.h"
 
 TEST_NV_DIAG_SUPPRESS(221);

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/lowest.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/lowest.pass.cpp
@@ -21,6 +21,7 @@
 #include <cuda/std/limits>
 
 #include "common.h"
+#include "cuda_fp_types.h"
 #include "test_macros.h"
 
 template <class T>

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/max.pass.cpp
@@ -21,6 +21,7 @@
 #include <cuda/std/limits>
 
 #include "common.h"
+#include "cuda_fp_types.h"
 #include "test_macros.h"
 
 template <class T>

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/min.pass.cpp
@@ -21,6 +21,7 @@
 #include <cuda/std/limits>
 
 #include "common.h"
+#include "cuda_fp_types.h"
 #include "test_macros.h"
 
 template <class T>

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/quiet_NaN.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/quiet_NaN.pass.cpp
@@ -19,6 +19,7 @@
 #include <cuda/std/type_traits>
 
 #include "common.h"
+#include "cuda_fp_types.h"
 #include "test_macros.h"
 
 template <class T>

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/round_error.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/round_error.pass.cpp
@@ -18,6 +18,7 @@
 #include <cuda/std/limits>
 
 #include "common.h"
+#include "cuda_fp_types.h"
 #include "test_macros.h"
 
 template <class T>

--- a/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/signaling_NaN.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/language.support/support.limits/limits/numeric.limits.members/signaling_NaN.pass.cpp
@@ -19,6 +19,7 @@
 #include <cuda/std/type_traits>
 
 #include "common.h"
+#include "cuda_fp_types.h"
 #include "test_macros.h"
 
 template <class T>

--- a/libcudacxx/test/support/cuda_fp_types.h
+++ b/libcudacxx/test/support/cuda_fp_types.h
@@ -1,0 +1,18 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// Includes all <cuda_(fp|bf)NN.h> headers.
+
+#ifndef SUPPORT_CUDA_FP_TYPES_H
+#define SUPPORT_CUDA_FP_TYPES_H
+
+#include <cuda/std/__floating_point/cuda_fp_types.h>
+
+#endif // SUPPORT_CUDA_FP_TYPES_H


### PR DESCRIPTION
This should improve compile times of `<cuda/std/limits>`, which is modified to work with forward declarations of nvfp types exclusively without the need to include the full `<cuda_fpXY.h>` headers.

The idea is to put construction of all nvfp instances into an unevaluated context which is instantiated only once the function is actually used. It shifts the responsibility of including the full `<cuda_fpXY.h>` headers to the header's client (other header, user, ...), however, since they are using the type, they should be including the header anyway.

This requires us to write a bit more complicated code, for example:
```cpp
// old
template <class T>
struct __some_trait;
template <>
struct __some_trait<__half> { ... };

// new
template <class T, class U = T>
struct __some_trait;
template <class T>
struct __some_trait<__half, T> { ... };
```
but the benefits of reduced include times when the nvfp types are not actually needed are more valuable to us.