### PR TITLE
[cudax] Add replicate and join for streams

### DIFF
--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -265,14 +265,14 @@ inline void __join_impl(const _ToRange& __to_streams, const _FromRange& __from_s
   auto __first                 = stream_ref(*__to_begin);
   auto __first_device          = __first.device();
   bool __use_per_stream_events = false;
-  cuda::event __event(__first_device);
+  cuda::event __local_event(__first_device);
   for (const auto& __from_stream : __from_streams)
   {
     auto __from = stream_ref(__from_stream);
 
     if (!__use_per_stream_events)
     {
-      auto __status = ::cuda::__driver::__eventRecordNoThrow(__event.get(), __from.get());
+      auto __status = ::cuda::__driver::__eventRecordNoThrow(__local_event.get(), __from.get());
       if (__status == cudaSuccess)
       {
         for (const auto& __to_stream : __to_streams)
@@ -280,7 +280,7 @@ inline void __join_impl(const _ToRange& __to_streams, const _FromRange& __from_s
           auto __to = stream_ref(__to_stream);
           if (__to != __from)
           {
-            __to.wait(__event);
+            __to.wait(__local_event);
           }
         }
         continue;

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -163,6 +163,21 @@ private:
   {}
 };
 
+template <size_t... _Idx>
+[[nodiscard]] inline auto __replicate_impl(logical_device __dev, ::cuda::std::index_sequence<_Idx...>)
+  -> ::cuda::std::array<stream, sizeof...(_Idx)>
+{
+  return ::cuda::std::array<stream, sizeof...(_Idx)>{((void) _Idx, stream(__dev))...};
+}
+
+template <size_t... _Idx>
+[[nodiscard]] inline auto
+__replicate_prepend_impl(stream&& __source, logical_device __dev, ::cuda::std::index_sequence<_Idx...>)
+  -> ::cuda::std::array<stream, sizeof...(_Idx) + 1>
+{
+  return ::cuda::std::array<stream, sizeof...(_Idx) + 1>{::cuda::std::move(__source), ((void) _Idx, stream(__dev))...};
+}
+
 template <size_t _Count>
 //! @brief Create a fixed-size group of streams on the same logical device as `__source`.
 //!
@@ -172,12 +187,7 @@ template <size_t _Count>
 [[nodiscard]] auto replicate(stream_ref __source) -> ::cuda::std::array<stream, _Count>
 {
   auto __dev = __source.logical_device();
-
-  auto __streams = [&]<size_t... _Idx>(::cuda::std::index_sequence<_Idx...>) {
-    return ::cuda::std::array<stream, _Count>{((void) _Idx, stream(__dev))...};
-  }(::cuda::std::make_index_sequence<_Count>{});
-
-  return __streams;
+  return __replicate_impl(__dev, ::cuda::std::make_index_sequence<_Count>{});
 }
 
 //! @brief Create a runtime-sized group of streams on the same logical device as `__source`.
@@ -228,12 +238,7 @@ template <size_t _Count>
 [[nodiscard]] inline auto replicate_prepend(stream&& __source) -> ::cuda::std::array<stream, _Count + 1>
 {
   auto __dev = __source.logical_device();
-
-  auto __streams = [&]<size_t... _Idx>(::cuda::std::index_sequence<_Idx...>) {
-    return ::cuda::std::array<stream, _Count + 1>{::cuda::std::move(__source), ((void) _Idx, stream(__dev))...};
-  }(::cuda::std::make_index_sequence<_Count>{});
-
-  return __streams;
+  return __replicate_prepend_impl(::cuda::std::move(__source), __dev, ::cuda::std::make_index_sequence<_Count>{});
 }
 
 template <class _Range>

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -27,16 +27,15 @@
 #include <cuda/__driver/driver_api.h>
 #include <cuda/__runtime/api_wrapper.h>
 #include <cuda/__stream/invalid_stream.h>
-
-#include <cuda/experimental/__device/logical_device.cuh>
-#include <cuda/experimental/__stream/stream_ref.cuh> // IWYU pragma: export
-#include <cuda/experimental/__utility/ensure_current_device.cuh>
-
 #include <cuda/std/__ranges/concepts.h>
 #include <cuda/std/array>
 #include <cuda/std/span>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
+
+#include <cuda/experimental/__device/logical_device.cuh>
+#include <cuda/experimental/__stream/stream_ref.cuh> // IWYU pragma: export
+#include <cuda/experimental/__utility/ensure_current_device.cuh>
 
 #include <vector>
 
@@ -168,10 +167,11 @@ template <size_t _Count>
 //! @brief Create a fixed-size group of streams on the same logical device as `__source`.
 //!
 //! @note This function only creates streams; it does not add synchronization dependencies.
-//! @note The streams are created with the default priority, which can be changed by the user. // TODO expose stream attributes?
+//! @note The streams are created with the default priority, which can be changed by the user. // TODO expose stream
+//! attributes?
 [[nodiscard]] auto replicate(stream_ref __source) -> ::cuda::std::array<stream, _Count>
 {
-  auto __dev      = __source.logical_device();
+  auto __dev = __source.logical_device();
 
   auto __streams = [&]<size_t... _Idx>(::cuda::std::index_sequence<_Idx...>) {
     return ::cuda::std::array<stream, _Count>{((void) _Idx, stream(__dev))...};
@@ -230,8 +230,7 @@ template <size_t _Count>
   auto __dev = __source.logical_device();
 
   auto __streams = [&]<size_t... _Idx>(::cuda::std::index_sequence<_Idx...>) {
-    return ::cuda::std::array<stream, _Count + 1>{
-      ::cuda::std::move(__source), ((void) _Idx, stream(__dev))...};
+    return ::cuda::std::array<stream, _Count + 1>{::cuda::std::move(__source), ((void) _Idx, stream(__dev))...};
   }(::cuda::std::make_index_sequence<_Count>{});
 
   return __streams;
@@ -242,8 +241,9 @@ _CCCL_CONCEPT __stream_join_range =
   ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream_ref>
   || ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream>;
 
-// TODO: consider accumulating all the dependencies in from range into a single stream in to_streams and then propagate that as a dependency to the other streams in to_streams
-// This has a drawback of introducing an extra dependency on that selected stream and other streams in to_streams, but results in less API calls overall.
+// TODO: consider accumulating all the dependencies in from range into a single stream in to_streams and then propagate
+// that as a dependency to the other streams in to_streams This has a drawback of introducing an extra dependency on
+// that selected stream and other streams in to_streams, but results in less API calls overall.
 //! @brief Internal implementation for joining two stream groups.
 //!
 //! For each stream in `__from_streams`, this function makes each non-identical stream
@@ -257,8 +257,8 @@ inline void __join_impl(const _ToRange& __to_streams, const _FromRange& __from_s
     return;
   }
 
-  auto __first                = stream_ref(*__to_begin);
-  auto __first_device         = __first.device();
+  auto __first                 = stream_ref(*__to_begin);
+  auto __first_device          = __first.device();
   bool __use_per_stream_events = false;
   cuda::event __event(__first_device);
   for (const auto& __from_stream : __from_streams)
@@ -317,9 +317,8 @@ inline void __join_impl(const _ToRange& __to_streams, const _FromRange& __from_s
 //! excluding identical stream pairs.
 _CCCL_TEMPLATE(class _ToRange, class _FromRange)
 _CCCL_REQUIRES(
-  ::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND
-  ::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __stream_join_range<_ToRange> _CCCL_AND
-  __stream_join_range<_FromRange>)
+  ::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND ::cuda::std::ranges::forward_range<const _FromRange&>
+    _CCCL_AND __stream_join_range<_ToRange> _CCCL_AND __stream_join_range<_FromRange>)
 inline void join(const _ToRange& __to_streams, const _FromRange& __from_streams)
 {
   __join_impl(__to_streams, __from_streams);

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -27,17 +27,13 @@
 #include <cuda/__driver/driver_api.h>
 #include <cuda/__runtime/api_wrapper.h>
 #include <cuda/__stream/invalid_stream.h>
-#include <cuda/std/__ranges/concepts.h>
-#include <cuda/std/array>
-#include <cuda/std/span>
-#include <cuda/std/type_traits>
-#include <cuda/std/utility>
+#include <cuda/std/__utility/exchange.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/__utility/swap.h>
 
 #include <cuda/experimental/__device/logical_device.cuh>
 #include <cuda/experimental/__stream/stream_ref.cuh> // IWYU pragma: export
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
-
-#include <vector>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -162,190 +158,6 @@ private:
       : stream_ref(__handle)
   {}
 };
-
-template <size_t... _Idx>
-[[nodiscard]] inline auto __replicate_impl(logical_device __dev, ::cuda::std::index_sequence<_Idx...>)
-  -> ::cuda::std::array<stream, sizeof...(_Idx)>
-{
-  return ::cuda::std::array<stream, sizeof...(_Idx)>{((void) _Idx, stream(__dev))...};
-}
-
-template <size_t... _Idx>
-[[nodiscard]] inline auto
-__replicate_prepend_impl(stream&& __source, logical_device __dev, ::cuda::std::index_sequence<_Idx...>)
-  -> ::cuda::std::array<stream, sizeof...(_Idx) + 1>
-{
-  return ::cuda::std::array<stream, sizeof...(_Idx) + 1>{::cuda::std::move(__source), ((void) _Idx, stream(__dev))...};
-}
-
-template <size_t _Count>
-//! @brief Create a fixed-size group of streams on the same logical device as `__source`.
-//!
-//! @note This function only creates streams; it does not add synchronization dependencies.
-//! @note The streams are created with the default priority, which can be changed by the user. // TODO expose stream
-//! attributes?
-[[nodiscard]] auto replicate(stream_ref __source) -> ::cuda::std::array<stream, _Count>
-{
-  auto __dev = __source.logical_device();
-  return __replicate_impl(__dev, ::cuda::std::make_index_sequence<_Count>{});
-}
-
-//! @brief Create a runtime-sized group of streams on the same logical device as `__source`.
-//!
-//! @note This function only creates streams; it does not add synchronization dependencies.
-[[nodiscard]] inline auto replicate(stream_ref __source, size_t __count) -> ::std::vector<stream>
-{
-  auto __dev = __source.logical_device();
-
-  ::std::vector<stream> __streams;
-  __streams.reserve(__count);
-
-  for (size_t __idx = 0; __idx < __count; ++__idx)
-  {
-    __streams.emplace_back(__dev);
-  }
-
-  return __streams;
-}
-
-//! @brief Create a runtime-sized group of streams on the same logical device as `__source` and prepend `__source` at
-//! index 0.
-//!
-//! @note This function only creates streams; it does not add synchronization dependencies.
-//! The returned vector has size `__count + 1` and owns all streams.
-[[nodiscard]] inline auto replicate_prepend(stream&& __source, size_t __count) -> ::std::vector<stream>
-{
-  auto __dev = __source.logical_device();
-
-  ::std::vector<stream> __streams;
-  __streams.reserve(__count + 1);
-  __streams.emplace_back(::cuda::std::move(__source));
-
-  for (size_t __idx = 0; __idx < __count; ++__idx)
-  {
-    __streams.emplace_back(__dev);
-  }
-
-  return __streams;
-}
-
-template <size_t _Count>
-//! @brief Create a fixed-size group of streams on the same logical device as `__source` and prepend `__source` at
-//! index 0.
-//!
-//! @note This function only creates streams; it does not add synchronization dependencies.
-//! The returned array has size `_Count + 1` and owns all streams.
-[[nodiscard]] inline auto replicate_prepend(stream&& __source) -> ::cuda::std::array<stream, _Count + 1>
-{
-  auto __dev = __source.logical_device();
-  return __replicate_prepend_impl(::cuda::std::move(__source), __dev, ::cuda::std::make_index_sequence<_Count>{});
-}
-
-template <class _Range>
-_CCCL_CONCEPT __stream_join_range =
-  ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream_ref>
-  || ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream>;
-
-// TODO: consider accumulating all the dependencies in from range into a single stream in to_streams and then propagate
-// that as a dependency to the other streams in to_streams This has a drawback of introducing an extra dependency on
-// that selected stream and other streams in to_streams, but results in less API calls overall.
-//! @brief Internal implementation for joining two stream groups.
-//!
-//! For each stream in `__from_streams`, this function makes each non-identical stream
-//! in `__to_streams` wait on it.
-template <class _ToRange, class _FromRange>
-inline void __join_impl(const _ToRange& __to_streams, const _FromRange& __from_streams)
-{
-  auto __to_begin = ::cuda::std::ranges::begin(__to_streams);
-  if (__to_begin == ::cuda::std::ranges::end(__to_streams))
-  {
-    return;
-  }
-
-  auto __first                 = stream_ref(*__to_begin);
-  auto __first_device          = __first.device();
-  bool __use_per_stream_events = false;
-  cuda::event __local_event(__first_device);
-  for (const auto& __from_stream : __from_streams)
-  {
-    auto __from = stream_ref(__from_stream);
-
-    if (!__use_per_stream_events)
-    {
-      auto __status = ::cuda::__driver::__eventRecordNoThrow(__local_event.get(), __from.get());
-      if (__status == cudaSuccess)
-      {
-        for (const auto& __to_stream : __to_streams)
-        {
-          auto __to = stream_ref(__to_stream);
-          if (__to != __from)
-          {
-            __to.wait(__local_event);
-          }
-        }
-        continue;
-      }
-
-      // If shared event record failed, detect cross-device mismatch and
-      // switch to per-source-stream events; otherwise propagate the failure.
-      if (__from.device() != __first_device)
-      {
-        __use_per_stream_events = true;
-      }
-      else
-      {
-        _CCCL_THROW(::cuda::cuda_error, __status, "Failed to record an event");
-      }
-    }
-
-    if (__use_per_stream_events)
-    {
-      // Some stream/device combinations cannot record into a shared event.
-      // Fall back to an event allocated for each source stream's device.
-      auto __from_event = cuda::event(__from);
-
-      for (const auto& __to_stream : __to_streams)
-      {
-        auto __to = stream_ref(__to_stream);
-        if (__to != __from)
-        {
-          __to.wait(__from_event);
-        }
-      }
-    }
-  }
-}
-
-//! @brief Synchronize one group of streams with another.
-//!
-//! Every stream in `__to_streams` waits on work from every stream in `__from_streams`,
-//! excluding identical stream pairs.
-_CCCL_TEMPLATE(class _ToRange, class _FromRange)
-_CCCL_REQUIRES(
-  ::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND ::cuda::std::ranges::forward_range<const _FromRange&>
-    _CCCL_AND __stream_join_range<_ToRange> _CCCL_AND __stream_join_range<_FromRange>)
-inline void join(const _ToRange& __to_streams, const _FromRange& __from_streams)
-{
-  __join_impl(__to_streams, __from_streams);
-}
-
-//! @brief Synchronize a single target stream with a source stream group.
-_CCCL_TEMPLATE(class _FromRange)
-_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __stream_join_range<_FromRange>)
-inline void join(stream_ref __to_stream, const _FromRange& __from_streams)
-{
-  __join_impl(::cuda::std::span<stream_ref>(&__to_stream, 1), __from_streams);
-}
-
-//! @brief Synchronize a target stream group with a single source stream.
-_CCCL_TEMPLATE(class _ToRange)
-_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND __stream_join_range<_ToRange>)
-inline void join(const _ToRange& __to_streams, stream_ref __from_stream)
-{
-  __join_impl(__to_streams, ::cuda::std::span<stream_ref>(&__from_stream, 1));
-}
-
-// TODO should there be join for single stream on both sides that lowers to stream1.wait(stream2)?
 } // namespace cuda::experimental
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/cudax/include/cuda/experimental/__stream/stream.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream.cuh
@@ -24,12 +24,21 @@
 #endif // no system header
 
 #include <cuda/__device/device_ref.h>
+#include <cuda/__driver/driver_api.h>
 #include <cuda/__runtime/api_wrapper.h>
 #include <cuda/__stream/invalid_stream.h>
 
 #include <cuda/experimental/__device/logical_device.cuh>
 #include <cuda/experimental/__stream/stream_ref.cuh> // IWYU pragma: export
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
+
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/array>
+#include <cuda/std/span>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
+
+#include <vector>
 
 #include <cuda/std/__cccl/prologue.h>
 
@@ -154,6 +163,185 @@ private:
       : stream_ref(__handle)
   {}
 };
+
+template <size_t _Count>
+//! @brief Create a fixed-size group of streams on the same logical device as `__source`.
+//!
+//! @note This function only creates streams; it does not add synchronization dependencies.
+//! @note The streams are created with the default priority, which can be changed by the user. // TODO expose stream attributes?
+[[nodiscard]] auto replicate(stream_ref __source) -> ::cuda::std::array<stream, _Count>
+{
+  auto __dev      = __source.logical_device();
+
+  auto __streams = [&]<size_t... _Idx>(::cuda::std::index_sequence<_Idx...>) {
+    return ::cuda::std::array<stream, _Count>{((void) _Idx, stream(__dev))...};
+  }(::cuda::std::make_index_sequence<_Count>{});
+
+  return __streams;
+}
+
+//! @brief Create a runtime-sized group of streams on the same logical device as `__source`.
+//!
+//! @note This function only creates streams; it does not add synchronization dependencies.
+[[nodiscard]] inline auto replicate(stream_ref __source, size_t __count) -> ::std::vector<stream>
+{
+  auto __dev = __source.logical_device();
+
+  ::std::vector<stream> __streams;
+  __streams.reserve(__count);
+
+  for (size_t __idx = 0; __idx < __count; ++__idx)
+  {
+    __streams.emplace_back(__dev);
+  }
+
+  return __streams;
+}
+
+//! @brief Create a runtime-sized group of streams on the same logical device as `__source` and prepend `__source` at
+//! index 0.
+//!
+//! @note This function only creates streams; it does not add synchronization dependencies.
+//! The returned vector has size `__count + 1` and owns all streams.
+[[nodiscard]] inline auto replicate_prepend(stream&& __source, size_t __count) -> ::std::vector<stream>
+{
+  auto __dev = __source.logical_device();
+
+  ::std::vector<stream> __streams;
+  __streams.reserve(__count + 1);
+  __streams.emplace_back(::cuda::std::move(__source));
+
+  for (size_t __idx = 0; __idx < __count; ++__idx)
+  {
+    __streams.emplace_back(__dev);
+  }
+
+  return __streams;
+}
+
+template <size_t _Count>
+//! @brief Create a fixed-size group of streams on the same logical device as `__source` and prepend `__source` at
+//! index 0.
+//!
+//! @note This function only creates streams; it does not add synchronization dependencies.
+//! The returned array has size `_Count + 1` and owns all streams.
+[[nodiscard]] inline auto replicate_prepend(stream&& __source) -> ::cuda::std::array<stream, _Count + 1>
+{
+  auto __dev = __source.logical_device();
+
+  auto __streams = [&]<size_t... _Idx>(::cuda::std::index_sequence<_Idx...>) {
+    return ::cuda::std::array<stream, _Count + 1>{
+      ::cuda::std::move(__source), ((void) _Idx, stream(__dev))...};
+  }(::cuda::std::make_index_sequence<_Count>{});
+
+  return __streams;
+}
+
+template <class _Range>
+_CCCL_CONCEPT __stream_join_range =
+  ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream_ref>
+  || ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream>;
+
+// TODO: consider accumulating all the dependencies in from range into a single stream in to_streams and then propagate that as a dependency to the other streams in to_streams
+// This has a drawback of introducing an extra dependency on that selected stream and other streams in to_streams, but results in less API calls overall.
+//! @brief Internal implementation for joining two stream groups.
+//!
+//! For each stream in `__from_streams`, this function makes each non-identical stream
+//! in `__to_streams` wait on it.
+template <class _ToRange, class _FromRange>
+inline void __join_impl(const _ToRange& __to_streams, const _FromRange& __from_streams)
+{
+  auto __to_begin = ::cuda::std::ranges::begin(__to_streams);
+  if (__to_begin == ::cuda::std::ranges::end(__to_streams))
+  {
+    return;
+  }
+
+  auto __first                = stream_ref(*__to_begin);
+  auto __first_device         = __first.device();
+  bool __use_per_stream_events = false;
+  cuda::event __event(__first_device);
+  for (const auto& __from_stream : __from_streams)
+  {
+    auto __from = stream_ref(__from_stream);
+
+    if (!__use_per_stream_events)
+    {
+      auto __status = ::cuda::__driver::__eventRecordNoThrow(__event.get(), __from.get());
+      if (__status == cudaSuccess)
+      {
+        for (const auto& __to_stream : __to_streams)
+        {
+          auto __to = stream_ref(__to_stream);
+          if (__to != __from)
+          {
+            __to.wait(__event);
+          }
+        }
+        continue;
+      }
+
+      // If shared event record failed, detect cross-device mismatch and
+      // switch to per-source-stream events; otherwise propagate the failure.
+      if (__from.device() != __first_device)
+      {
+        __use_per_stream_events = true;
+      }
+      else
+      {
+        _CCCL_THROW(::cuda::cuda_error, __status, "Failed to record an event");
+      }
+    }
+
+    if (__use_per_stream_events)
+    {
+      // Some stream/device combinations cannot record into a shared event.
+      // Fall back to an event allocated for each source stream's device.
+      auto __from_event = cuda::event(__from);
+
+      for (const auto& __to_stream : __to_streams)
+      {
+        auto __to = stream_ref(__to_stream);
+        if (__to != __from)
+        {
+          __to.wait(__from_event);
+        }
+      }
+    }
+  }
+}
+
+//! @brief Synchronize one group of streams with another.
+//!
+//! Every stream in `__to_streams` waits on work from every stream in `__from_streams`,
+//! excluding identical stream pairs.
+_CCCL_TEMPLATE(class _ToRange, class _FromRange)
+_CCCL_REQUIRES(
+  ::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND
+  ::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __stream_join_range<_ToRange> _CCCL_AND
+  __stream_join_range<_FromRange>)
+inline void join(const _ToRange& __to_streams, const _FromRange& __from_streams)
+{
+  __join_impl(__to_streams, __from_streams);
+}
+
+//! @brief Synchronize a single target stream with a source stream group.
+_CCCL_TEMPLATE(class _FromRange)
+_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __stream_join_range<_FromRange>)
+inline void join(stream_ref __to_stream, const _FromRange& __from_streams)
+{
+  __join_impl(::cuda::std::span<stream_ref>(&__to_stream, 1), __from_streams);
+}
+
+//! @brief Synchronize a target stream group with a single source stream.
+_CCCL_TEMPLATE(class _ToRange)
+_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND __stream_join_range<_ToRange>)
+inline void join(const _ToRange& __to_streams, stream_ref __from_stream)
+{
+  __join_impl(__to_streams, ::cuda::std::span<stream_ref>(&__from_stream, 1));
+}
+
+// TODO should there be join for single stream on both sides that lowers to stream1.wait(stream2)?
 } // namespace cuda::experimental
 
 #include <cuda/std/__cccl/epilogue.h>

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -163,29 +163,20 @@ struct stream_ref : ::cuda::stream_ref
   //! @note This function only creates streams; it does not add synchronization dependencies.
   //! @note The streams are created with the default priority, which can be changed by the user.
   template <::cuda::std::size_t _Count>
-  [[nodiscard]] _CCCL_HOST_API auto replicate() const
-  {
-    return __replicate_streams<_Count>(*this);
-  }
+  [[nodiscard]] _CCCL_HOST_API auto replicate() const -> ::cuda::std::array<stream, _Count>;
 
   //! @brief Create a runtime-sized group of streams on the same logical device as this stream.
   //!
   //! @note This function only creates streams; it does not add synchronization dependencies.
   //! @note The streams are created with the default priority, which can be changed by the user.
-  [[nodiscard]] _CCCL_HOST_API auto replicate(::cuda::std::size_t __count) const
-  {
-    return __replicate_streams(*this, __count);
-  }
+  [[nodiscard]] _CCCL_HOST_API auto replicate(::cuda::std::size_t __count) const -> ::std::vector<stream>;
 
   //! @brief Append a runtime-sized group of streams on the same logical device as this stream to `__out`.
   //!
   //! @note This function only creates streams; it does not add synchronization dependencies.
   //! @note The appended streams are created with the default priority, which can be changed by the user.
   template <class _Container>
-  _CCCL_HOST_API void replicate_into(_Container& __out, ::cuda::std::size_t __count) const
-  {
-    __replicate_streams_into(*this, __out, __count);
-  }
+  _CCCL_HOST_API void replicate_into(_Container& __out, ::cuda::std::size_t __count) const;
 };
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__stream/stream_ref.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_ref.cuh
@@ -21,14 +21,19 @@
 #endif // no system header
 
 #include <cuda/__device/all_devices.h>
+#include <cuda/__driver/driver_api.h>
 #include <cuda/__event/timed_event.h>
 #include <cuda/__runtime/api_wrapper.h>
 #include <cuda/__stream/stream_ref.h>
+#include <cuda/std/array>
+#include <cuda/std/span>
 
 #include <cuda/experimental/__device/logical_device.cuh>
 #include <cuda/experimental/__execution/completion_behavior.cuh>
 #include <cuda/experimental/__execution/fwd.cuh>
 #include <cuda/experimental/__utility/ensure_current_device.cuh>
+
+#include <vector>
 
 #include <cuda_runtime_api.h>
 
@@ -36,6 +41,21 @@
 
 namespace cuda::experimental
 {
+struct stream;
+struct stream_ref;
+
+template <class _ToRange, class _FromRange>
+_CCCL_HOST_API void __all_wait_all_impl(const _ToRange& __to_streams, const _FromRange& __from_streams);
+
+template <::cuda::std::size_t _Count>
+[[nodiscard]] _CCCL_HOST_API auto __replicate_streams(stream_ref __source) -> ::cuda::std::array<stream, _Count>;
+
+[[nodiscard]] _CCCL_HOST_API auto __replicate_streams(stream_ref __source, ::cuda::std::size_t __count)
+  -> ::std::vector<stream>;
+
+template <class _Container>
+_CCCL_HOST_API void __replicate_streams_into(stream_ref __source, _Container& __out, ::cuda::std::size_t __count);
+
 //! @brief A non-owning wrapper for cudaStream_t.
 //!
 //! @note It is undefined behavior to use a `stream_ref` object beyond the lifetime of the stream it was created from,
@@ -129,6 +149,43 @@ struct stream_ref : ::cuda::stream_ref
   [[nodiscard]] _CCCL_API constexpr auto
   query(const execution::get_completion_domain_t<execution::set_error_t>&, const _Env& __env) const noexcept
     -> __call_result_t<execution::get_domain_t, const _Env&>;
+
+  //! @brief Make this stream wait on all streams in `__from_streams`.
+  template <class _FromRange>
+  _CCCL_HOST_API void wait_all(const _FromRange& __from_streams) const
+  {
+    stream_ref __self = *this;
+    __all_wait_all_impl(::cuda::std::span<stream_ref>(&__self, 1), __from_streams);
+  }
+
+  //! @brief Create a fixed-size group of streams on the same logical device as this stream.
+  //!
+  //! @note This function only creates streams; it does not add synchronization dependencies.
+  //! @note The streams are created with the default priority, which can be changed by the user.
+  template <::cuda::std::size_t _Count>
+  [[nodiscard]] _CCCL_HOST_API auto replicate() const
+  {
+    return __replicate_streams<_Count>(*this);
+  }
+
+  //! @brief Create a runtime-sized group of streams on the same logical device as this stream.
+  //!
+  //! @note This function only creates streams; it does not add synchronization dependencies.
+  //! @note The streams are created with the default priority, which can be changed by the user.
+  [[nodiscard]] _CCCL_HOST_API auto replicate(::cuda::std::size_t __count) const
+  {
+    return __replicate_streams(*this, __count);
+  }
+
+  //! @brief Append a runtime-sized group of streams on the same logical device as this stream to `__out`.
+  //!
+  //! @note This function only creates streams; it does not add synchronization dependencies.
+  //! @note The appended streams are created with the default priority, which can be changed by the user.
+  template <class _Container>
+  _CCCL_HOST_API void replicate_into(_Container& __out, ::cuda::std::size_t __count) const
+  {
+    __replicate_streams_into(*this, __out, __count);
+  }
 };
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__stream/stream_utils.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_utils.cuh
@@ -126,14 +126,14 @@ _CCCL_CONCEPT __stream_join_range =
 
 //! @brief Make each target stream wait on `__event`, skipping the source stream itself.
 template <class _ToRange, class _Event>
-_CCCL_HOST_API void __wait_all_targets_on_event(const _ToRange& __to_streams, stream_ref __from, const _Event& __event)
+_CCCL_HOST_API void __wait_all_targets_on_event(const _ToRange& __to_streams, stream_ref __from, const _Event& __local_event)
 {
   for (const auto& __to_stream : __to_streams)
   {
     auto __to = stream_ref(__to_stream);
     if (__to != __from)
     {
-      __to.wait(__event);
+      __to.wait(__local_event);
     }
   }
 }

--- a/cudax/include/cuda/experimental/__stream/stream_utils.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_utils.cuh
@@ -1,0 +1,231 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__STREAM_STREAM_UTILS_CUH
+#define _CUDAX__STREAM_STREAM_UTILS_CUH
+
+#include <cuda/std/detail/__config>
+
+#include <cuda_runtime_api.h>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__driver/driver_api.h>
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__utility/integer_sequence.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/array>
+#include <cuda/std/span>
+
+#include <cuda/experimental/__stream/stream.cuh>
+
+#include <vector>
+
+#include <cuda/std/__cccl/prologue.h>
+
+namespace cuda::experimental
+{
+template <::cuda::std::size_t... _Idx>
+[[nodiscard]] _CCCL_HOST_API auto __replicate_impl(logical_device __dev, ::cuda::std::index_sequence<_Idx...>)
+  -> ::cuda::std::array<stream, sizeof...(_Idx)>
+{
+  return ::cuda::std::array<stream, sizeof...(_Idx)>{((void) _Idx, stream(__dev))...};
+}
+
+template <::cuda::std::size_t... _Idx>
+[[nodiscard]] _CCCL_HOST_API auto
+__replicate_prepend_impl(stream&& __source, logical_device __dev, ::cuda::std::index_sequence<_Idx...>)
+  -> ::cuda::std::array<stream, sizeof...(_Idx) + 1>
+{
+  return ::cuda::std::array<stream, sizeof...(_Idx) + 1>{::cuda::std::move(__source), ((void) _Idx, stream(__dev))...};
+}
+
+//! @brief Create a fixed-size group of streams on the same logical device as `__source`.
+//!
+//! @note This function only creates streams; it does not add synchronization dependencies.
+//! @note The streams are created with the default priority, which can be changed by the user. // TODO expose stream
+//! attributes?
+template <::cuda::std::size_t _Count>
+[[nodiscard]] _CCCL_HOST_API auto replicate(stream_ref __source) -> ::cuda::std::array<stream, _Count>
+{
+  auto __dev = __source.logical_device();
+  return __replicate_impl(__dev, ::cuda::std::make_index_sequence<_Count>{});
+}
+
+//! @brief Create a runtime-sized group of streams on the same logical device as `__source`.
+//!
+//! @note This function only creates streams; it does not add synchronization dependencies.
+[[nodiscard]] _CCCL_HOST_API inline auto replicate(stream_ref __source, ::cuda::std::size_t __count)
+  -> ::std::vector<stream>
+{
+  auto __dev = __source.logical_device();
+
+  ::std::vector<stream> __streams;
+  __streams.reserve(__count);
+
+  for (::cuda::std::size_t __idx = 0; __idx < __count; ++__idx)
+  {
+    __streams.emplace_back(__dev);
+  }
+
+  return __streams;
+}
+
+//! @brief Create a runtime-sized group of streams on the same logical device as `__source` and prepend `__source` at
+//! index 0.
+//!
+//! @note This function only creates streams; it does not add synchronization dependencies.
+//! The returned vector has size `__count + 1` and owns all streams.
+[[nodiscard]] _CCCL_HOST_API inline auto replicate_prepend(stream&& __source, ::cuda::std::size_t __count)
+  -> ::std::vector<stream>
+{
+  auto __dev = __source.logical_device();
+
+  ::std::vector<stream> __streams;
+  __streams.reserve(__count + 1);
+  __streams.emplace_back(::cuda::std::move(__source));
+
+  for (::cuda::std::size_t __idx = 0; __idx < __count; ++__idx)
+  {
+    __streams.emplace_back(__dev);
+  }
+
+  return __streams;
+}
+
+//! @brief Create a fixed-size group of streams on the same logical device as `__source` and prepend `__source` at
+//! index 0.
+//!
+//! @note This function only creates streams; it does not add synchronization dependencies.
+//! The returned array has size `_Count + 1` and owns all streams.
+template <::cuda::std::size_t _Count>
+[[nodiscard]] _CCCL_HOST_API inline auto replicate_prepend(stream&& __source) -> ::cuda::std::array<stream, _Count + 1>
+{
+  auto __dev = __source.logical_device();
+  return __replicate_prepend_impl(::cuda::std::move(__source), __dev, ::cuda::std::make_index_sequence<_Count>{});
+}
+
+template <class _Range>
+_CCCL_CONCEPT __stream_join_range =
+  ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream_ref>
+  || ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream>;
+
+// TODO: consider accumulating all the dependencies in from range into a single stream in to_streams and then propagate
+// that as a dependency to the other streams in to_streams This has a drawback of introducing an extra dependency on
+// that selected stream and other streams in to_streams, but results in less API calls overall.
+//! @brief Internal implementation for joining two stream groups.
+//!
+//! For each stream in `__from_streams`, this function makes each non-identical stream
+//! in `__to_streams` wait on it.
+template <class _ToRange, class _FromRange>
+_CCCL_HOST_API void __join_impl(const _ToRange& __to_streams, const _FromRange& __from_streams)
+{
+  auto __to_begin = ::cuda::std::ranges::begin(__to_streams);
+  if (__to_begin == ::cuda::std::ranges::end(__to_streams))
+  {
+    return;
+  }
+
+  auto __first                 = stream_ref(*__to_begin);
+  auto __first_device          = __first.device();
+  bool __use_per_stream_events = false;
+  cuda::event __local_event(__first_device);
+  for (const auto& __from_stream : __from_streams)
+  {
+    auto __from = stream_ref(__from_stream);
+
+    if (!__use_per_stream_events)
+    {
+      auto __status = ::cuda::__driver::__eventRecordNoThrow(__local_event.get(), __from.get());
+      if (__status == cudaSuccess)
+      {
+        for (const auto& __to_stream : __to_streams)
+        {
+          auto __to = stream_ref(__to_stream);
+          if (__to != __from)
+          {
+            __to.wait(__local_event);
+          }
+        }
+        continue;
+      }
+
+      // If shared event record failed, detect cross-device mismatch and
+      // switch to per-source-stream events; otherwise propagate the failure.
+      if (__from.device() != __first_device)
+      {
+        __use_per_stream_events = true;
+      }
+      else
+      {
+        _CCCL_THROW(::cuda::cuda_error, __status, "Failed to record an event");
+      }
+    }
+
+    if (__use_per_stream_events)
+    {
+      // Some stream/device combinations cannot record into a shared event.
+      // Fall back to an event allocated for each source stream's device.
+      auto __from_event = cuda::event(__from);
+
+      for (const auto& __to_stream : __to_streams)
+      {
+        auto __to = stream_ref(__to_stream);
+        if (__to != __from)
+        {
+          __to.wait(__from_event);
+        }
+      }
+    }
+  }
+}
+
+//! @brief Synchronize one group of streams with another.
+//!
+//! Every stream in `__to_streams` waits on work from every stream in `__from_streams`,
+//! excluding identical stream pairs.
+_CCCL_TEMPLATE(class _ToRange, class _FromRange)
+_CCCL_REQUIRES(
+  ::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND ::cuda::std::ranges::forward_range<const _FromRange&>
+    _CCCL_AND __stream_join_range<_ToRange> _CCCL_AND __stream_join_range<_FromRange>)
+_CCCL_HOST_API void join(const _ToRange& __to_streams, const _FromRange& __from_streams)
+{
+  __join_impl(__to_streams, __from_streams);
+}
+
+//! @brief Synchronize a single target stream with a source stream group.
+_CCCL_TEMPLATE(class _FromRange)
+_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __stream_join_range<_FromRange>)
+_CCCL_HOST_API void join(stream_ref __to_stream, const _FromRange& __from_streams)
+{
+  __join_impl(::cuda::std::span<stream_ref>(&__to_stream, 1), __from_streams);
+}
+
+//! @brief Synchronize a target stream group with a single source stream.
+_CCCL_TEMPLATE(class _ToRange)
+_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND __stream_join_range<_ToRange>)
+_CCCL_HOST_API void join(const _ToRange& __to_streams, stream_ref __from_stream)
+{
+  __join_impl(__to_streams, ::cuda::std::span<stream_ref>(&__from_stream, 1));
+}
+
+// TODO should there be join for single stream on both sides that lowers to stream1.wait(stream2)?
+} // namespace cuda::experimental
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDAX__STREAM_STREAM_UTILS_CUH

--- a/cudax/include/cuda/experimental/__stream/stream_utils.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_utils.cuh
@@ -124,6 +124,20 @@ _CCCL_CONCEPT __stream_join_range =
   ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream_ref>
   || ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream>;
 
+//! @brief Make each target stream wait on `__event`, skipping the source stream itself.
+template <class _ToRange, class _Event>
+_CCCL_HOST_API void __wait_all_targets_on_event(const _ToRange& __to_streams, stream_ref __from, const _Event& __event)
+{
+  for (const auto& __to_stream : __to_streams)
+  {
+    auto __to = stream_ref(__to_stream);
+    if (__to != __from)
+    {
+      __to.wait(__event);
+    }
+  }
+}
+
 // TODO: consider accumulating all the dependencies in from range into a single stream in to_streams and then propagate
 // that as a dependency to the other streams in to_streams This has a drawback of introducing an extra dependency on
 // that selected stream and other streams in to_streams, but results in less API calls overall.
@@ -153,14 +167,7 @@ _CCCL_HOST_API void __join_impl(const _ToRange& __to_streams, const _FromRange& 
       auto __status = ::cuda::__driver::__eventRecordNoThrow(__local_event.get(), __from.get());
       if (__status == cudaSuccess)
       {
-        for (const auto& __to_stream : __to_streams)
-        {
-          auto __to = stream_ref(__to_stream);
-          if (__to != __from)
-          {
-            __to.wait(__local_event);
-          }
-        }
+        __wait_all_targets_on_event(__to_streams, __from, __local_event);
         continue;
       }
 
@@ -181,15 +188,7 @@ _CCCL_HOST_API void __join_impl(const _ToRange& __to_streams, const _FromRange& 
       // Some stream/device combinations cannot record into a shared event.
       // Fall back to an event allocated for each source stream's device.
       auto __from_event = cuda::event(__from);
-
-      for (const auto& __to_stream : __to_streams)
-      {
-        auto __to = stream_ref(__to_stream);
-        if (__to != __from)
-        {
-          __to.wait(__from_event);
-        }
-      }
+      __wait_all_targets_on_event(__to_streams, __from, __from_event);
     }
   }
 }

--- a/cudax/include/cuda/experimental/__stream/stream_utils.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_utils.cuh
@@ -12,9 +12,6 @@
 #define _CUDAX__STREAM_STREAM_UTILS_CUH
 
 #include <cuda/std/detail/__config>
-
-#include <cuda_runtime_api.h>
-
 #if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
 #  pragma GCC system_header
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
@@ -23,20 +20,12 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__driver/driver_api.h>
 #include <cuda/std/__ranges/concepts.h>
-#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__utility/integer_sequence.h>
-#include <cuda/std/__utility/move.h>
 #include <cuda/std/array>
-#include <cuda/std/span>
-
-#include <cuda/experimental/__detail/type_traits.cuh>
-#include <cuda/experimental/__stream/stream.cuh>
 
 #include <vector>
-
-#include <cuda/std/__cccl/prologue.h>
 
 namespace cuda::experimental
 {
@@ -47,82 +36,39 @@ template <::cuda::std::size_t... _Idx>
   return ::cuda::std::array<stream, sizeof...(_Idx)>{((void) _Idx, stream(__dev))...};
 }
 
-template <::cuda::std::size_t... _Idx>
-[[nodiscard]] _CCCL_HOST_API auto
-__replicate_prepend_impl(stream&& __source, logical_device __dev, ::cuda::std::index_sequence<_Idx...>)
-  -> ::cuda::std::array<stream, sizeof...(_Idx) + 1>
-{
-  return ::cuda::std::array<stream, sizeof...(_Idx) + 1>{::cuda::std::move(__source), ((void) _Idx, stream(__dev))...};
-}
-
-//! @brief Create a fixed-size group of streams on the same logical device as `__source`.
-//!
-//! @note This function only creates streams; it does not add synchronization dependencies.
-//! @note The streams are created with the default priority, which can be changed by the user. // TODO expose stream
-//! attributes?
 template <::cuda::std::size_t _Count>
-[[nodiscard]] _CCCL_HOST_API auto replicate(stream_ref __source) -> ::cuda::std::array<stream, _Count>
+[[nodiscard]] _CCCL_HOST_API auto __replicate_streams(stream_ref __source) -> ::cuda::std::array<stream, _Count>
 {
   auto __dev = __source.logical_device();
   return __replicate_impl(__dev, ::cuda::std::make_index_sequence<_Count>{});
 }
 
-//! @brief Create a runtime-sized group of streams on the same logical device as `__source`.
-//!
-//! @note This function only creates streams; it does not add synchronization dependencies.
-[[nodiscard]] _CCCL_HOST_API inline auto replicate(stream_ref __source, ::cuda::std::size_t __count)
+[[nodiscard]] _CCCL_HOST_API inline auto __replicate_streams(stream_ref __source, ::cuda::std::size_t __count)
   -> ::std::vector<stream>
 {
   auto __dev = __source.logical_device();
-
   ::std::vector<stream> __streams;
   __streams.reserve(__count);
-
   for (::cuda::std::size_t __idx = 0; __idx < __count; ++__idx)
   {
     __streams.emplace_back(__dev);
   }
-
   return __streams;
 }
 
-//! @brief Create a runtime-sized group of streams on the same logical device as `__source` and prepend `__source` at
-//! index 0.
-//!
-//! @note This function only creates streams; it does not add synchronization dependencies.
-//! The returned vector has size `__count + 1` and owns all streams.
-[[nodiscard]] _CCCL_HOST_API inline auto replicate_prepend(stream&& __source, ::cuda::std::size_t __count)
-  -> ::std::vector<stream>
+template <class _Container>
+_CCCL_HOST_API void __replicate_streams_into(stream_ref __source, _Container& __out, ::cuda::std::size_t __count)
 {
   auto __dev = __source.logical_device();
-
-  ::std::vector<stream> __streams;
-  __streams.reserve(__count + 1);
-  __streams.emplace_back(::cuda::std::move(__source));
-
   for (::cuda::std::size_t __idx = 0; __idx < __count; ++__idx)
   {
-    __streams.emplace_back(__dev);
+    __out.emplace_back(__dev);
   }
-
-  return __streams;
-}
-
-//! @brief Create a fixed-size group of streams on the same logical device as `__source` and prepend `__source` at
-//! index 0.
-//!
-//! @note This function only creates streams; it does not add synchronization dependencies.
-//! The returned array has size `_Count + 1` and owns all streams.
-template <::cuda::std::size_t _Count>
-[[nodiscard]] _CCCL_HOST_API inline auto replicate_prepend(stream&& __source) -> ::cuda::std::array<stream, _Count + 1>
-{
-  auto __dev = __source.logical_device();
-  return __replicate_prepend_impl(::cuda::std::move(__source), __dev, ::cuda::std::make_index_sequence<_Count>{});
 }
 
 template <class _Range>
-_CCCL_CONCEPT __stream_join_range =
-  cuda::experimental::__one_of<::cuda::std::ranges::range_value_t<const _Range&>, stream_ref, stream>;
+_CCCL_CONCEPT __stream_wait_range =
+  ::cuda::std::is_constructible_v<stream_ref, ::cuda::std::ranges::range_value_t<const _Range&>>;
 
 //! @brief Make each target stream wait on `__event`, skipping the source stream itself.
 template <class _ToRange, class _Event>
@@ -139,15 +85,9 @@ __wait_all_targets_on_event(const _ToRange& __to_streams, stream_ref __from, con
   }
 }
 
-// TODO: consider accumulating all the dependencies in from range into a single stream in to_streams and then propagate
-// that as a dependency to the other streams in to_streams This has a drawback of introducing an extra dependency on
-// that selected stream and other streams in to_streams, but results in less API calls overall.
-//! @brief Internal implementation for joining two stream groups.
-//!
-//! For each stream in `__from_streams`, this function makes each non-identical stream
-//! in `__to_streams` wait on it.
+//! @brief Internal implementation for all-to-all stream waiting between two groups.
 template <class _ToRange, class _FromRange>
-_CCCL_HOST_API void __join_impl(const _ToRange& __to_streams, const _FromRange& __from_streams)
+_CCCL_HOST_API void __all_wait_all_impl(const _ToRange& __to_streams, const _FromRange& __from_streams)
 {
   auto __to_begin = ::cuda::std::ranges::begin(__to_streams);
   if (__to_begin == ::cuda::std::ranges::end(__to_streams))
@@ -172,8 +112,6 @@ _CCCL_HOST_API void __join_impl(const _ToRange& __to_streams, const _FromRange& 
         continue;
       }
 
-      // If shared event record failed, detect cross-device mismatch and
-      // switch to per-source-stream events; otherwise propagate the failure.
       if (__from.device() != __first_device)
       {
         __use_per_stream_events = true;
@@ -186,46 +124,39 @@ _CCCL_HOST_API void __join_impl(const _ToRange& __to_streams, const _FromRange& 
 
     if (__use_per_stream_events)
     {
-      // Some stream/device combinations cannot record into a shared event.
-      // Fall back to an event allocated for each source stream's device.
       auto __from_event = cuda::event{__from};
       __wait_all_targets_on_event(__to_streams, __from, __from_event);
     }
   }
 }
 
-//! @brief Synchronize one group of streams with another.
-//!
-//! Every stream in `__to_streams` waits on work from every stream in `__from_streams`,
-//! excluding identical stream pairs.
+// TODO: consider accumulating all sources into one target stream first and then
+// propagating that dependency to other targets to reduce API calls.
+//! @brief Make all streams in `__to_streams` wait on all streams in `__from_streams`.
 _CCCL_TEMPLATE(class _ToRange, class _FromRange)
 _CCCL_REQUIRES(
   ::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND ::cuda::std::ranges::forward_range<const _FromRange&>
-    _CCCL_AND __stream_join_range<_ToRange> _CCCL_AND __stream_join_range<_FromRange>)
-_CCCL_HOST_API void join(const _ToRange& __to_streams, const _FromRange& __from_streams)
+    _CCCL_AND __stream_wait_range<_ToRange> _CCCL_AND __stream_wait_range<_FromRange>)
+_CCCL_HOST_API void all_wait_all(const _ToRange& __to_streams, const _FromRange& __from_streams)
 {
-  __join_impl(__to_streams, __from_streams);
+  __all_wait_all_impl(__to_streams, __from_streams);
 }
 
-//! @brief Synchronize a single target stream with a source stream group.
+//! @brief Make a single target stream wait on all streams in `__from_streams`.
 _CCCL_TEMPLATE(class _FromRange)
-_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __stream_join_range<_FromRange>)
-_CCCL_HOST_API void join(stream_ref __to_stream, const _FromRange& __from_streams)
+_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __stream_wait_range<_FromRange>)
+_CCCL_HOST_API void all_wait_all(stream_ref __to_stream, const _FromRange& __from_streams)
 {
-  __join_impl(::cuda::std::span<stream_ref>(&__to_stream, 1), __from_streams);
+  __all_wait_all_impl(::cuda::std::span<stream_ref>(&__to_stream, 1), __from_streams);
 }
 
-//! @brief Synchronize a target stream group with a single source stream.
+//! @brief Make all streams in `__to_streams` wait on a single source stream.
 _CCCL_TEMPLATE(class _ToRange)
-_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND __stream_join_range<_ToRange>)
-_CCCL_HOST_API void join(const _ToRange& __to_streams, stream_ref __from_stream)
+_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _ToRange&> _CCCL_AND __stream_wait_range<_ToRange>)
+_CCCL_HOST_API void all_wait_all(const _ToRange& __to_streams, stream_ref __from_stream)
 {
-  __join_impl(__to_streams, ::cuda::std::span<stream_ref>(&__from_stream, 1));
+  __all_wait_all_impl(__to_streams, ::cuda::std::span<stream_ref>(&__from_stream, 1));
 }
-
-// TODO should there be join for single stream on both sides that lowers to stream1.wait(stream2)?
 } // namespace cuda::experimental
-
-#include <cuda/std/__cccl/epilogue.h>
 
 #endif // _CUDAX__STREAM_STREAM_UTILS_CUH

--- a/cudax/include/cuda/experimental/__stream/stream_utils.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_utils.cuh
@@ -31,6 +31,7 @@
 #include <cuda/std/array>
 #include <cuda/std/span>
 
+#include <cuda/experimental/__detail/type_traits.cuh>
 #include <cuda/experimental/__stream/stream.cuh>
 
 #include <vector>
@@ -121,16 +122,16 @@ template <::cuda::std::size_t _Count>
 
 template <class _Range>
 _CCCL_CONCEPT __stream_join_range =
-  ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream_ref>
-  || ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, stream>;
+  cuda::experimental::__one_of<::cuda::std::ranges::range_value_t<const _Range&>, stream_ref, stream>;
 
 //! @brief Make each target stream wait on `__event`, skipping the source stream itself.
 template <class _ToRange, class _Event>
-_CCCL_HOST_API void __wait_all_targets_on_event(const _ToRange& __to_streams, stream_ref __from, const _Event& __local_event)
+_CCCL_HOST_API void
+__wait_all_targets_on_event(const _ToRange& __to_streams, stream_ref __from, const _Event& __local_event)
 {
   for (const auto& __to_stream : __to_streams)
   {
-    auto __to = stream_ref(__to_stream);
+    auto __to = stream_ref{__to_stream};
     if (__to != __from)
     {
       __to.wait(__local_event);
@@ -154,13 +155,13 @@ _CCCL_HOST_API void __join_impl(const _ToRange& __to_streams, const _FromRange& 
     return;
   }
 
-  auto __first                 = stream_ref(*__to_begin);
+  auto __first                 = stream_ref{*__to_begin};
   auto __first_device          = __first.device();
   bool __use_per_stream_events = false;
   cuda::event __local_event(__first_device);
   for (const auto& __from_stream : __from_streams)
   {
-    auto __from = stream_ref(__from_stream);
+    auto __from = stream_ref{__from_stream};
 
     if (!__use_per_stream_events)
     {
@@ -187,7 +188,7 @@ _CCCL_HOST_API void __join_impl(const _ToRange& __to_streams, const _FromRange& 
     {
       // Some stream/device combinations cannot record into a shared event.
       // Fall back to an event allocated for each source stream's device.
-      auto __from_event = cuda::event(__from);
+      auto __from_event = cuda::event{__from};
       __wait_all_targets_on_event(__to_streams, __from, __from_event);
     }
   }

--- a/cudax/include/cuda/experimental/__stream/stream_utils.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_utils.cuh
@@ -60,12 +60,12 @@ template <::cuda::std::size_t _Count>
 }
 
 template <class _Container>
-_CCCL_HOST_API void __replicate_streams_into(stream_ref __source, _Container& __out, ::cuda::std::size_t __count)
+_CCCL_HOST_API void __replicate_streams_into(stream_ref __source, _Container& __container, ::cuda::std::size_t __count)
 {
   auto __dev = __source.logical_device();
   for (::cuda::std::size_t __idx = 0; __idx < __count; ++__idx)
   {
-    __out.emplace_back(__dev);
+    __container.emplace_back(__dev);
   }
 }
 
@@ -82,9 +82,9 @@ template <::cuda::std::size_t _Count>
 }
 
 template <class _Container>
-_CCCL_HOST_API void stream_ref::replicate_into(_Container& __out, ::cuda::std::size_t __count) const
+_CCCL_HOST_API void stream_ref::replicate_into(_Container& __container, ::cuda::std::size_t __count) const
 {
-  __replicate_streams_into(*this, __out, __count);
+  __replicate_streams_into(*this, __container, __count);
 }
 
 template <class _Range>

--- a/cudax/include/cuda/experimental/__stream/stream_utils.cuh
+++ b/cudax/include/cuda/experimental/__stream/stream_utils.cuh
@@ -24,6 +24,9 @@
 #include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__utility/integer_sequence.h>
 #include <cuda/std/array>
+#include <cuda/std/span>
+
+#include <cuda/experimental/__stream/stream.cuh>
 
 #include <vector>
 
@@ -64,6 +67,24 @@ _CCCL_HOST_API void __replicate_streams_into(stream_ref __source, _Container& __
   {
     __out.emplace_back(__dev);
   }
+}
+
+template <::cuda::std::size_t _Count>
+[[nodiscard]] _CCCL_HOST_API auto stream_ref::replicate() const -> ::cuda::std::array<stream, _Count>
+{
+  return __replicate_streams<_Count>(*this);
+}
+
+[[nodiscard]] _CCCL_HOST_API inline auto stream_ref::replicate(::cuda::std::size_t __count) const
+  -> ::std::vector<stream>
+{
+  return __replicate_streams(*this, __count);
+}
+
+template <class _Container>
+_CCCL_HOST_API void stream_ref::replicate_into(_Container& __out, ::cuda::std::size_t __count) const
+{
+  __replicate_streams_into(*this, __out, __count);
 }
 
 template <class _Range>

--- a/cudax/include/cuda/experimental/stream.cuh
+++ b/cudax/include/cuda/experimental/stream.cuh
@@ -13,5 +13,6 @@
 
 #include <cuda/experimental/__execution/stream/scheduler.cuh>
 #include <cuda/experimental/__stream/stream.cuh>
+#include <cuda/experimental/__stream/stream_utils.cuh>
 
 #endif // __CUDAX_STREAM__

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -10,6 +10,7 @@
 
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
+#include <cuda/std/array>
 
 #include <cuda/experimental/launch.cuh>
 #include <cuda/experimental/stream.cuh>
@@ -181,4 +182,173 @@ C2H_CCCLRT_TEST("Stream ID", "[stream]")
     CUDAX_REQUIRE(ref2.id() == id1);
 #endif // ^^^ !_CCCL_COMPILER(NVHPC, <, 25, 11) ^^^
   }
+}
+
+C2H_CCCLRT_TEST("Replicate only creates streams", "[stream]")
+{
+  cudax::stream source{cuda::device_ref{0}};
+
+  ::test::pinned<int> gate(0);
+  ::test::pinned<int> out(0);
+  ::cuda::atomic_ref atomic_gate(*gate);
+
+  cudax::launch(source, ::test::one_thread_dims, ::test::spin_until_80{}, gate.get());
+  auto [left] = cudax::replicate<1>(source);
+  cudax::launch(left, ::test::one_thread_dims, ::test::assign_42{}, out.get());
+
+  left.sync();
+  CUDAX_REQUIRE(*out == 42);
+  CUDAX_REQUIRE(!source.is_done());
+
+  atomic_gate.store(80);
+  source.sync();
+
+  CUDAX_REQUIRE(source.device() == left.device());
+}
+
+C2H_CCCLRT_TEST("Replicate supports dynamic stream counts", "[stream]")
+{
+  cudax::stream source{cuda::device_ref{0}};
+  constexpr size_t count = 3;
+  auto streams           = cudax::replicate(source, count);
+
+  CUDAX_REQUIRE(streams.size() == count);
+  for (size_t idx = 0; idx < count; ++idx)
+  {
+    CUDAX_REQUIRE(streams[idx] != source);
+    CUDAX_REQUIRE(streams[idx].device() == source.device());
+  }
+}
+
+C2H_CCCLRT_TEST("Replicate prepend keeps moved stream at index zero", "[stream]")
+{
+  cudax::stream source{cuda::device_ref{0}};
+  auto source_id = source.id();
+  constexpr size_t count = 2;
+
+  auto streams = cudax::replicate_prepend(::cuda::std::move(source), count);
+
+  CUDAX_REQUIRE(streams.size() == count + 1);
+  CUDAX_REQUIRE(streams.front().id() == source_id);
+  for (size_t idx = 1; idx < streams.size(); ++idx)
+  {
+    CUDAX_REQUIRE(streams[idx].device() == streams.front().device());
+  }
+}
+
+C2H_CCCLRT_TEST("Replicate prepend static keeps moved stream at index zero", "[stream]")
+{
+  cudax::stream source{cuda::device_ref{0}};
+  auto source_id = source.id();
+
+  auto streams = cudax::replicate_prepend<2>(::cuda::std::move(source));
+
+  CUDAX_REQUIRE(streams.size() == 3);
+  CUDAX_REQUIRE(streams[0].id() == source_id);
+  CUDAX_REQUIRE(streams[1].device() == streams[0].device());
+  CUDAX_REQUIRE(streams[2].device() == streams[0].device());
+}
+
+C2H_CCCLRT_TEST("Join synchronizes stream groups", "[stream]")
+{
+  cudax::stream target1{cuda::device_ref{0}};
+  cudax::stream target2{cuda::device_ref{0}};
+  cudax::stream source{cuda::device_ref{0}};
+  ::test::pinned<int> i(0);
+  ::cuda::atomic_ref atomic_i(*i);
+
+  cudax::launch(source, ::test::one_thread_dims, ::test::spin_until_80{}, i.get());
+  cudax::launch(source, ::test::one_thread_dims, ::test::assign_42{}, i.get());
+
+  auto targets = ::cuda::std::array<cudax::stream_ref, 2>{target1, target2};
+  cudax::join(targets, cudax::stream_ref{source});
+
+  cudax::launch(target1, ::test::one_thread_dims, ::test::verify_42{}, i.get());
+  cudax::launch(target2, ::test::one_thread_dims, ::test::verify_42{}, i.get());
+  CUDAX_REQUIRE(atomic_i.load() != 42);
+  CUDAX_REQUIRE(!target1.is_done());
+  CUDAX_REQUIRE(!target2.is_done());
+
+  atomic_i.store(80);
+  target1.sync();
+  target2.sync();
+  source.sync();
+}
+
+C2H_CCCLRT_TEST("Join overload accepts stream_ref single target", "[stream]")
+{
+  cudax::stream target{cuda::device_ref{0}};
+  cudax::stream source1{cuda::device_ref{0}};
+  cudax::stream source2{cuda::device_ref{0}};
+  ::test::pinned<int> i(0);
+  ::cuda::atomic_ref atomic_i(*i);
+
+  cudax::launch(source2, ::test::one_thread_dims, ::test::spin_until_80{}, i.get());
+  cudax::launch(source2, ::test::one_thread_dims, ::test::assign_42{}, i.get());
+
+  auto sources = ::cuda::std::array<cudax::stream_ref, 2>{source1, source2};
+  cudax::join(cudax::stream_ref{target}, sources);
+
+  cudax::launch(target, ::test::one_thread_dims, ::test::verify_42{}, i.get());
+  CUDAX_REQUIRE(atomic_i.load() != 42);
+  CUDAX_REQUIRE(!target.is_done());
+
+  atomic_i.store(80);
+  target.sync();
+  source1.sync();
+  source2.sync();
+}
+
+C2H_CCCLRT_TEST("Join supports streams from multiple devices", "[stream]")
+{
+  if (cuda::devices.size() < 2)
+  {
+    return;
+  }
+
+  cudax::stream target{cuda::device_ref{0}};
+  cudax::stream source0{cuda::device_ref{0}};
+  cudax::stream source1{cuda::device_ref{static_cast<int>(cuda::devices.size() - 1)}};
+  ::test::pinned<int> i(0);
+  ::cuda::atomic_ref atomic_i(*i);
+
+  cudax::launch(source0, ::test::one_thread_dims, ::test::spin_until_80{}, i.get());
+  cudax::launch(source0, ::test::one_thread_dims, ::test::assign_42{}, i.get());
+  cudax::launch(source1, ::test::one_thread_dims, ::test::spin_until_80{}, i.get());
+
+  auto targets = ::cuda::std::array<cudax::stream_ref, 1>{target};
+  auto sources = ::cuda::std::array<cudax::stream_ref, 2>{source0, source1};
+  cudax::join(targets, sources);
+
+  cudax::launch(target, ::test::one_thread_dims, ::test::verify_42{}, i.get());
+  CUDAX_REQUIRE(atomic_i.load() != 42);
+  CUDAX_REQUIRE(!target.is_done());
+
+  atomic_i.store(80);
+  target.sync();
+  source0.sync();
+  source1.sync();
+}
+
+C2H_CCCLRT_TEST("Join handles a stream present in both groups", "[stream]")
+{
+  cudax::stream shared{cuda::device_ref{0}};
+  cudax::stream target{cuda::device_ref{0}};
+  ::test::pinned<int> i(0);
+  ::cuda::atomic_ref atomic_i(*i);
+
+  cudax::launch(shared, ::test::one_thread_dims, ::test::spin_until_80{}, i.get());
+  cudax::launch(shared, ::test::one_thread_dims, ::test::assign_42{}, i.get());
+
+  auto to_streams   = ::cuda::std::array<cudax::stream_ref, 2>{shared, target};
+  auto from_streams = ::cuda::std::array<cudax::stream_ref, 1>{shared};
+  cudax::join(to_streams, from_streams);
+
+  cudax::launch(target, ::test::one_thread_dims, ::test::verify_42{}, i.get());
+  CUDAX_REQUIRE(atomic_i.load() != 42);
+  CUDAX_REQUIRE(!target.is_done());
+
+  atomic_i.store(80);
+  target.sync();
+  shared.sync();
 }

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -8,9 +8,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/std/array>
 #include <cuda/std/type_traits>
 #include <cuda/std/utility>
-#include <cuda/std/array>
 
 #include <cuda/experimental/launch.cuh>
 #include <cuda/experimental/stream.cuh>
@@ -223,7 +223,7 @@ C2H_CCCLRT_TEST("Replicate supports dynamic stream counts", "[stream]")
 C2H_CCCLRT_TEST("Replicate prepend keeps moved stream at index zero", "[stream]")
 {
   cudax::stream source{cuda::device_ref{0}};
-  auto source_id = source.id();
+  auto source_id         = source.id();
   constexpr size_t count = 2;
 
   auto streams = cudax::replicate_prepend(::cuda::std::move(source), count);

--- a/cudax/test/stream/stream_smoke.cu
+++ b/cudax/test/stream/stream_smoke.cu
@@ -15,6 +15,8 @@
 #include <cuda/experimental/launch.cuh>
 #include <cuda/experimental/stream.cuh>
 
+#include <vector>
+
 #include <testing.cuh>
 #include <utility.cuh>
 
@@ -193,7 +195,7 @@ C2H_CCCLRT_TEST("Replicate only creates streams", "[stream]")
   ::cuda::atomic_ref atomic_gate(*gate);
 
   cudax::launch(source, ::test::one_thread_dims, ::test::spin_until_80{}, gate.get());
-  auto [left] = cudax::replicate<1>(source);
+  auto [left] = source.replicate<1>();
   cudax::launch(left, ::test::one_thread_dims, ::test::assign_42{}, out.get());
 
   left.sync();
@@ -210,7 +212,7 @@ C2H_CCCLRT_TEST("Replicate supports dynamic stream counts", "[stream]")
 {
   cudax::stream source{cuda::device_ref{0}};
   constexpr size_t count = 3;
-  auto streams           = cudax::replicate(source, count);
+  auto streams           = source.replicate(count);
 
   CUDAX_REQUIRE(streams.size() == count);
   for (size_t idx = 0; idx < count; ++idx)
@@ -220,13 +222,16 @@ C2H_CCCLRT_TEST("Replicate supports dynamic stream counts", "[stream]")
   }
 }
 
-C2H_CCCLRT_TEST("Replicate prepend keeps moved stream at index zero", "[stream]")
+C2H_CCCLRT_TEST("Replicate into appends streams to an existing container", "[stream]")
 {
   cudax::stream source{cuda::device_ref{0}};
   auto source_id         = source.id();
   constexpr size_t count = 2;
 
-  auto streams = cudax::replicate_prepend(::cuda::std::move(source), count);
+  ::std::vector<cudax::stream> streams;
+  streams.reserve(count + 1);
+  streams.emplace_back(::cuda::std::move(source));
+  streams.front().replicate_into(streams, count);
 
   CUDAX_REQUIRE(streams.size() == count + 1);
   CUDAX_REQUIRE(streams.front().id() == source_id);
@@ -236,12 +241,16 @@ C2H_CCCLRT_TEST("Replicate prepend keeps moved stream at index zero", "[stream]"
   }
 }
 
-C2H_CCCLRT_TEST("Replicate prepend static keeps moved stream at index zero", "[stream]")
+C2H_CCCLRT_TEST("Replicate into appends streams with runtime count", "[stream]")
 {
   cudax::stream source{cuda::device_ref{0}};
-  auto source_id = source.id();
+  auto source_id         = source.id();
+  constexpr size_t count = 2;
 
-  auto streams = cudax::replicate_prepend<2>(::cuda::std::move(source));
+  ::std::vector<cudax::stream> streams;
+  streams.reserve(3);
+  streams.emplace_back(::cuda::std::move(source));
+  streams.front().replicate_into(streams, count);
 
   CUDAX_REQUIRE(streams.size() == 3);
   CUDAX_REQUIRE(streams[0].id() == source_id);
@@ -249,7 +258,7 @@ C2H_CCCLRT_TEST("Replicate prepend static keeps moved stream at index zero", "[s
   CUDAX_REQUIRE(streams[2].device() == streams[0].device());
 }
 
-C2H_CCCLRT_TEST("Join synchronizes stream groups", "[stream]")
+C2H_CCCLRT_TEST("all_wait_all synchronizes stream groups", "[stream]")
 {
   cudax::stream target1{cuda::device_ref{0}};
   cudax::stream target2{cuda::device_ref{0}};
@@ -261,7 +270,7 @@ C2H_CCCLRT_TEST("Join synchronizes stream groups", "[stream]")
   cudax::launch(source, ::test::one_thread_dims, ::test::assign_42{}, i.get());
 
   auto targets = ::cuda::std::array<cudax::stream_ref, 2>{target1, target2};
-  cudax::join(targets, cudax::stream_ref{source});
+  cudax::all_wait_all(targets, cudax::stream_ref{source});
 
   cudax::launch(target1, ::test::one_thread_dims, ::test::verify_42{}, i.get());
   cudax::launch(target2, ::test::one_thread_dims, ::test::verify_42{}, i.get());
@@ -275,7 +284,7 @@ C2H_CCCLRT_TEST("Join synchronizes stream groups", "[stream]")
   source.sync();
 }
 
-C2H_CCCLRT_TEST("Join overload accepts stream_ref single target", "[stream]")
+C2H_CCCLRT_TEST("stream.wait_all accepts stream group", "[stream]")
 {
   cudax::stream target{cuda::device_ref{0}};
   cudax::stream source1{cuda::device_ref{0}};
@@ -287,7 +296,7 @@ C2H_CCCLRT_TEST("Join overload accepts stream_ref single target", "[stream]")
   cudax::launch(source2, ::test::one_thread_dims, ::test::assign_42{}, i.get());
 
   auto sources = ::cuda::std::array<cudax::stream_ref, 2>{source1, source2};
-  cudax::join(cudax::stream_ref{target}, sources);
+  target.wait_all(sources);
 
   cudax::launch(target, ::test::one_thread_dims, ::test::verify_42{}, i.get());
   CUDAX_REQUIRE(atomic_i.load() != 42);
@@ -299,7 +308,7 @@ C2H_CCCLRT_TEST("Join overload accepts stream_ref single target", "[stream]")
   source2.sync();
 }
 
-C2H_CCCLRT_TEST("Join supports streams from multiple devices", "[stream]")
+C2H_CCCLRT_TEST("all_wait_all supports streams from multiple devices", "[stream]")
 {
   if (cuda::devices.size() < 2)
   {
@@ -318,7 +327,7 @@ C2H_CCCLRT_TEST("Join supports streams from multiple devices", "[stream]")
 
   auto targets = ::cuda::std::array<cudax::stream_ref, 1>{target};
   auto sources = ::cuda::std::array<cudax::stream_ref, 2>{source0, source1};
-  cudax::join(targets, sources);
+  cudax::all_wait_all(targets, sources);
 
   cudax::launch(target, ::test::one_thread_dims, ::test::verify_42{}, i.get());
   CUDAX_REQUIRE(atomic_i.load() != 42);
@@ -330,7 +339,7 @@ C2H_CCCLRT_TEST("Join supports streams from multiple devices", "[stream]")
   source1.sync();
 }
 
-C2H_CCCLRT_TEST("Join handles a stream present in both groups", "[stream]")
+C2H_CCCLRT_TEST("all_wait_all handles stream present in both groups", "[stream]")
 {
   cudax::stream shared{cuda::device_ref{0}};
   cudax::stream target{cuda::device_ref{0}};
@@ -340,9 +349,8 @@ C2H_CCCLRT_TEST("Join handles a stream present in both groups", "[stream]")
   cudax::launch(shared, ::test::one_thread_dims, ::test::spin_until_80{}, i.get());
   cudax::launch(shared, ::test::one_thread_dims, ::test::assign_42{}, i.get());
 
-  auto to_streams   = ::cuda::std::array<cudax::stream_ref, 2>{shared, target};
-  auto from_streams = ::cuda::std::array<cudax::stream_ref, 1>{shared};
-  cudax::join(to_streams, from_streams);
+  auto to_streams = ::cuda::std::array<cudax::stream_ref, 2>{shared, target};
+  cudax::all_wait_all(to_streams, shared);
 
   cudax::launch(target, ::test::one_thread_dims, ::test::verify_42{}, i.get());
   CUDAX_REQUIRE(atomic_i.load() != 42);

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -713,10 +713,19 @@ _CCCL_HOST_API inline void __streamWaitEvent(::CUstream __stream, ::CUevent __ev
   return static_cast<::cudaError_t>(__driver_fn(__evnt));
 }
 
-_CCCL_HOST_API inline void __eventRecord(::CUevent __evnt, ::CUstream __stream)
+[[nodiscard]] _CCCL_HOST_API inline ::cudaError_t __eventRecordNoThrow(::CUevent __evnt, ::CUstream __stream)
 {
   static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuEventRecord);
-  ::cuda::__driver::__call_driver_fn(__driver_fn, "Failed to record an event", __evnt, __stream);
+  return static_cast<::cudaError_t>(__driver_fn(__evnt, __stream));
+}
+
+_CCCL_HOST_API inline void __eventRecord(::CUevent __evnt, ::CUstream __stream)
+{
+  auto __status = __eventRecordNoThrow(__evnt, __stream);
+  if (__status != cudaSuccess)
+  {
+    _CCCL_THROW(::cuda::cuda_error, __status, "Failed to record an event");
+  }
 }
 
 _CCCL_HOST_API inline void __eventSynchronize(::CUevent __evnt)


### PR DESCRIPTION
This PR adds two APIs operating on streams: `replicate` and `join`.

`replicate` takes a stream and creates a specified number of new streams that target the same logical device as the input stream. It's a useful API to create side streams from a given stream that will target the same device along with the same green context restrictions. There is a static version that returns an array that can be easily unpacked with structured bindings and a dynamic version that returns a vector. In case user wants to keep the created streams in the same object as the input stream, there is also `replicate_prepend`, that takes the input stream as an rvalue and includes it in the output at index 0.

`join` is an API that establishes dependencies across two ranges of streams (`from_range` and `to_range`). It ensures all streams in `to_range` will depend on all work already scheduled in `from_range`. There are also two `join` overloads that take a single `stream_ref` as `from` or `to`.
The implementation is a naive for loop that inserts all pairs of event dependencies inside. There is a way to do it smarter where all dependencies are reduced into one stream first and then propagated among streams in `to` range, but that introduces an extra dependency on the stream used for the reduction. The naive implementation was selected, because the user can still opt-in to the smarter behavior by calling `join` twice:
```
cudax::join(to_set, from_set[0]);
cudax::join(from_set[0], from_set);
```
We can decide to change the implementation to that later or request a accumulating event record from CUDA to implement the smart version that does not introduce the extra dependency.

Unfortunately event in CUDA is bound to a specific context, while join should work with set of streams across context. There is a special handling of that in `join`, where first time it is detected that `to` set contains streams from different devices an event is allocated for every stream, instead of reusing one across all streams. There could be a way to optimize it better in the future if needed