### PR TITLE
[cudax] Implement replicate and join for path_builder

### DIFF
--- a/cudax/include/cuda/experimental/__graph/graph_utils.cuh
+++ b/cudax/include/cuda/experimental/__graph/graph_utils.cuh
@@ -37,8 +37,7 @@
 namespace cuda::experimental
 {
 template <::cuda::std::size_t _Count, ::cuda::std::size_t... _Idx>
-[[nodiscard]] _CCCL_HOST_API auto
-__replicate_impl(const path_builder& __source, ::cuda::std::index_sequence<_Idx...>)
+[[nodiscard]] _CCCL_HOST_API auto __replicate_impl(const path_builder& __source, ::cuda::std::index_sequence<_Idx...>)
   -> ::cuda::std::array<path_builder, _Count>
 {
   const auto __dev   = __source.get_device();
@@ -58,8 +57,7 @@ template <::cuda::std::size_t _Count, ::cuda::std::size_t... _Idx>
 //! @brief Create a fixed-size group of peer path builders with the same graph/device as `__source`.
 //! @note This function only creates path builders; it does not add synchronization dependencies.
 template <::cuda::std::size_t _Count>
-[[nodiscard]] _CCCL_HOST_API auto replicate(const path_builder& __source)
-  -> ::cuda::std::array<path_builder, _Count>
+[[nodiscard]] _CCCL_HOST_API auto replicate(const path_builder& __source) -> ::cuda::std::array<path_builder, _Count>
 {
   return __replicate_impl<_Count>(__source, ::cuda::std::make_index_sequence<_Count>{});
 }
@@ -132,7 +130,7 @@ _CCCL_HOST_API void __join_impl(_ToRange& __to_builders, const _FromRange& __fro
 _CCCL_TEMPLATE(class _ToRange, class _FromRange)
 _CCCL_REQUIRES(
   ::cuda::std::ranges::forward_range<_ToRange&> _CCCL_AND ::cuda::std::ranges::forward_range<const _FromRange&>
-  _CCCL_AND __path_builder_join_range<_ToRange> _CCCL_AND __path_builder_join_range<_FromRange>)
+    _CCCL_AND __path_builder_join_range<_ToRange> _CCCL_AND __path_builder_join_range<_FromRange>)
 _CCCL_HOST_API void join(_ToRange& __to_builders, const _FromRange& __from_builders)
 {
   __join_impl(__to_builders, __from_builders);
@@ -140,8 +138,7 @@ _CCCL_HOST_API void join(_ToRange& __to_builders, const _FromRange& __from_build
 
 //! @brief Synchronize a single target path builder with a group of source path builders.
 _CCCL_TEMPLATE(class _FromRange)
-_CCCL_REQUIRES(
-  ::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __path_builder_join_range<_FromRange>)
+_CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __path_builder_join_range<_FromRange>)
 _CCCL_HOST_API void join(path_builder& __to_builder, const _FromRange& __from_builders)
 {
   auto __to_span = ::cuda::std::span<path_builder>(&__to_builder, 1);

--- a/cudax/include/cuda/experimental/__graph/graph_utils.cuh
+++ b/cudax/include/cuda/experimental/__graph/graph_utils.cuh
@@ -1,0 +1,162 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDAX__GRAPH_GRAPH_UTILS_CUH
+#define _CUDAX__GRAPH_GRAPH_UTILS_CUH
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__type_traits/is_same.h>
+#include <cuda/std/__utility/integer_sequence.h>
+#include <cuda/std/__utility/move.h>
+#include <cuda/std/array>
+#include <cuda/std/span>
+
+#include <cuda/experimental/__graph/path_builder.cuh>
+
+#include <vector>
+
+#include <cuda/std/__cccl/prologue.h>
+
+namespace cuda::experimental
+{
+template <::cuda::std::size_t _Count, ::cuda::std::size_t... _Idx>
+[[nodiscard]] _CCCL_HOST_API auto
+__replicate_impl(const path_builder& __source, ::cuda::std::index_sequence<_Idx...>)
+  -> ::cuda::std::array<path_builder, _Count>
+{
+  const auto __dev   = __source.get_device();
+  const auto __graph = __source.get_native_graph_handle();
+  return ::cuda::std::array<path_builder, _Count>{((void) _Idx, path_builder(__dev, __graph))...};
+}
+
+template <::cuda::std::size_t _Count, ::cuda::std::size_t... _Idx>
+[[nodiscard]] _CCCL_HOST_API auto __replicate_prepend_impl(
+  path_builder&& __source, device_ref __dev, cudaGraph_t __graph, ::cuda::std::index_sequence<_Idx...>)
+  -> ::cuda::std::array<path_builder, _Count + 1>
+{
+  return ::cuda::std::array<path_builder, _Count + 1>{
+    ::cuda::std::move(__source), ((void) _Idx, path_builder(__dev, __graph))...};
+}
+
+//! @brief Create a fixed-size group of peer path builders with the same graph/device as `__source`.
+//! @note This function only creates path builders; it does not add synchronization dependencies.
+template <::cuda::std::size_t _Count>
+[[nodiscard]] _CCCL_HOST_API auto replicate(const path_builder& __source)
+  -> ::cuda::std::array<path_builder, _Count>
+{
+  return __replicate_impl<_Count>(__source, ::cuda::std::make_index_sequence<_Count>{});
+}
+
+//! @brief Create a runtime-sized group of peer path builders with the same graph/device as `__source`.
+//! @note This function only creates path builders; it does not add synchronization dependencies.
+[[nodiscard]] _CCCL_HOST_API inline auto replicate(const path_builder& __source, ::cuda::std::size_t __count)
+  -> ::std::vector<path_builder>
+{
+  const auto __dev   = __source.get_device();
+  const auto __graph = __source.get_native_graph_handle();
+  ::std::vector<path_builder> __replicas;
+  __replicas.reserve(__count);
+  for (::cuda::std::size_t __idx = 0; __idx < __count; ++__idx)
+  {
+    __replicas.emplace_back(__dev, __graph);
+  }
+  return __replicas;
+}
+
+//! @brief Create a runtime-sized group of peer path builders with the same graph/device as `__source` and prepend
+//! `__source` at index 0.
+//! @note This function only creates path builders; it does not add synchronization dependencies.
+[[nodiscard]] _CCCL_HOST_API inline auto replicate_prepend(path_builder&& __source, ::cuda::std::size_t __count)
+  -> ::std::vector<path_builder>
+{
+  const auto __dev   = __source.get_device();
+  const auto __graph = __source.get_native_graph_handle();
+  ::std::vector<path_builder> __replicas;
+  __replicas.reserve(__count + 1);
+  __replicas.emplace_back(::cuda::std::move(__source));
+  for (::cuda::std::size_t __idx = 0; __idx < __count; ++__idx)
+  {
+    __replicas.emplace_back(__dev, __graph);
+  }
+  return __replicas;
+}
+
+template <::cuda::std::size_t _Count>
+//! @brief Create a fixed-size group of peer path builders with the same graph/device as `__source` and prepend
+//! `__source` at index 0.
+//! @note This function only creates path builders; it does not add synchronization dependencies.
+[[nodiscard]] _CCCL_HOST_API auto replicate_prepend(path_builder&& __source)
+  -> ::cuda::std::array<path_builder, _Count + 1>
+{
+  const auto __dev   = __source.get_device();
+  const auto __graph = __source.get_native_graph_handle();
+  return __replicate_prepend_impl<_Count>(
+    ::cuda::std::move(__source), __dev, __graph, ::cuda::std::make_index_sequence<_Count>{});
+}
+
+template <class _Range>
+_CCCL_CONCEPT __path_builder_join_range =
+  ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, path_builder>;
+
+template <class _ToRange, class _FromRange>
+_CCCL_HOST_API void __join_impl(_ToRange& __to_builders, const _FromRange& __from_builders)
+{
+  // TODO: Consider adding dependency deduplication in join to avoid duplicate graph edges.
+  for (auto& __to : __to_builders)
+  {
+    for (const auto& __from : __from_builders)
+    {
+      __to.depends_on(__from.get_dependencies());
+    }
+  }
+}
+
+//! @brief Synchronize one group of path builders with another by adding dependencies from all `from` into all `to`.
+_CCCL_TEMPLATE(class _ToRange, class _FromRange)
+_CCCL_REQUIRES(
+  ::cuda::std::ranges::forward_range<_ToRange&> _CCCL_AND ::cuda::std::ranges::forward_range<const _FromRange&>
+  _CCCL_AND __path_builder_join_range<_ToRange> _CCCL_AND __path_builder_join_range<_FromRange>)
+_CCCL_HOST_API void join(_ToRange& __to_builders, const _FromRange& __from_builders)
+{
+  __join_impl(__to_builders, __from_builders);
+}
+
+//! @brief Synchronize a single target path builder with a group of source path builders.
+_CCCL_TEMPLATE(class _FromRange)
+_CCCL_REQUIRES(
+  ::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __path_builder_join_range<_FromRange>)
+_CCCL_HOST_API void join(path_builder& __to_builder, const _FromRange& __from_builders)
+{
+  auto __to_span = ::cuda::std::span<path_builder>(&__to_builder, 1);
+  __join_impl(__to_span, __from_builders);
+}
+
+//! @brief Synchronize a group of target path builders with a single source path builder.
+_CCCL_TEMPLATE(class _ToRange)
+_CCCL_REQUIRES(::cuda::std::ranges::forward_range<_ToRange&> _CCCL_AND __path_builder_join_range<_ToRange>)
+_CCCL_HOST_API void join(_ToRange& __to_builders, const path_builder& __from_builder)
+{
+  __join_impl(__to_builders, ::cuda::std::span<const path_builder>(&__from_builder, 1));
+}
+} // namespace cuda::experimental
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDAX__GRAPH_GRAPH_UTILS_CUH

--- a/cudax/include/cuda/experimental/__graph/graph_utils.cuh
+++ b/cudax/include/cuda/experimental/__graph/graph_utils.cuh
@@ -68,13 +68,13 @@ template <::cuda::std::size_t _Count>
 
 template <class _Container>
 _CCCL_HOST_API void
-__replicate_builders_into(const path_builder& __source, _Container& __out, ::cuda::std::size_t __count)
+__replicate_builders_into(const path_builder& __source, _Container& __dest, ::cuda::std::size_t __count)
 {
   const auto __dev   = __source.get_device();
   const auto __graph = __source.get_native_graph_handle();
   for (::cuda::std::size_t __idx = 0; __idx < __count; ++__idx)
   {
-    __out.emplace_back(__dev, __graph);
+    __dest.emplace_back(__dev, __graph);
   }
 }
 

--- a/cudax/include/cuda/experimental/__graph/graph_utils.cuh
+++ b/cudax/include/cuda/experimental/__graph/graph_utils.cuh
@@ -24,7 +24,6 @@
 #include <cuda/std/__ranges/concepts.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/__utility/integer_sequence.h>
-#include <cuda/std/__utility/move.h>
 #include <cuda/std/array>
 #include <cuda/std/span>
 
@@ -36,35 +35,24 @@
 
 namespace cuda::experimental
 {
-template <::cuda::std::size_t _Count, ::cuda::std::size_t... _Idx>
-[[nodiscard]] _CCCL_HOST_API auto __replicate_impl(const path_builder& __source, ::cuda::std::index_sequence<_Idx...>)
+template <::cuda::std::size_t... _Idx>
+[[nodiscard]] _CCCL_HOST_API auto
+__replicate_impl(device_ref __dev, cudaGraph_t __graph, ::cuda::std::index_sequence<_Idx...>)
+  -> ::cuda::std::array<path_builder, sizeof...(_Idx)>
+{
+  return ::cuda::std::array<path_builder, sizeof...(_Idx)>{((void) _Idx, path_builder(__dev, __graph))...};
+}
+
+template <::cuda::std::size_t _Count>
+[[nodiscard]] _CCCL_HOST_API auto __replicate_builders(const path_builder& __source)
   -> ::cuda::std::array<path_builder, _Count>
 {
   const auto __dev   = __source.get_device();
   const auto __graph = __source.get_native_graph_handle();
-  return ::cuda::std::array<path_builder, _Count>{((void) _Idx, path_builder(__dev, __graph))...};
+  return __replicate_impl(__dev, __graph, ::cuda::std::make_index_sequence<_Count>{});
 }
 
-template <::cuda::std::size_t _Count, ::cuda::std::size_t... _Idx>
-[[nodiscard]] _CCCL_HOST_API auto __replicate_prepend_impl(
-  path_builder&& __source, device_ref __dev, cudaGraph_t __graph, ::cuda::std::index_sequence<_Idx...>)
-  -> ::cuda::std::array<path_builder, _Count + 1>
-{
-  return ::cuda::std::array<path_builder, _Count + 1>{
-    ::cuda::std::move(__source), ((void) _Idx, path_builder(__dev, __graph))...};
-}
-
-//! @brief Create a fixed-size group of peer path builders with the same graph/device as `__source`.
-//! @note This function only creates path builders; it does not add synchronization dependencies.
-template <::cuda::std::size_t _Count>
-[[nodiscard]] _CCCL_HOST_API auto replicate(const path_builder& __source) -> ::cuda::std::array<path_builder, _Count>
-{
-  return __replicate_impl<_Count>(__source, ::cuda::std::make_index_sequence<_Count>{});
-}
-
-//! @brief Create a runtime-sized group of peer path builders with the same graph/device as `__source`.
-//! @note This function only creates path builders; it does not add synchronization dependencies.
-[[nodiscard]] _CCCL_HOST_API inline auto replicate(const path_builder& __source, ::cuda::std::size_t __count)
+[[nodiscard]] _CCCL_HOST_API inline auto __replicate_builders(const path_builder& __source, ::cuda::std::size_t __count)
   -> ::std::vector<path_builder>
 {
   const auto __dev   = __source.get_device();
@@ -78,35 +66,16 @@ template <::cuda::std::size_t _Count>
   return __replicas;
 }
 
-//! @brief Create a runtime-sized group of peer path builders with the same graph/device as `__source` and prepend
-//! `__source` at index 0.
-//! @note This function only creates path builders; it does not add synchronization dependencies.
-[[nodiscard]] _CCCL_HOST_API inline auto replicate_prepend(path_builder&& __source, ::cuda::std::size_t __count)
-  -> ::std::vector<path_builder>
+template <class _Container>
+_CCCL_HOST_API void
+__replicate_builders_into(const path_builder& __source, _Container& __out, ::cuda::std::size_t __count)
 {
   const auto __dev   = __source.get_device();
   const auto __graph = __source.get_native_graph_handle();
-  ::std::vector<path_builder> __replicas;
-  __replicas.reserve(__count + 1);
-  __replicas.emplace_back(::cuda::std::move(__source));
   for (::cuda::std::size_t __idx = 0; __idx < __count; ++__idx)
   {
-    __replicas.emplace_back(__dev, __graph);
+    __out.emplace_back(__dev, __graph);
   }
-  return __replicas;
-}
-
-template <::cuda::std::size_t _Count>
-//! @brief Create a fixed-size group of peer path builders with the same graph/device as `__source` and prepend
-//! `__source` at index 0.
-//! @note This function only creates path builders; it does not add synchronization dependencies.
-[[nodiscard]] _CCCL_HOST_API auto replicate_prepend(path_builder&& __source)
-  -> ::cuda::std::array<path_builder, _Count + 1>
-{
-  const auto __dev   = __source.get_device();
-  const auto __graph = __source.get_native_graph_handle();
-  return __replicate_prepend_impl<_Count>(
-    ::cuda::std::move(__source), __dev, __graph, ::cuda::std::make_index_sequence<_Count>{});
 }
 
 template <class _Range>

--- a/cudax/include/cuda/experimental/__graph/path_builder.cuh
+++ b/cudax/include/cuda/experimental/__graph/path_builder.cuh
@@ -16,10 +16,8 @@
 #include <cuda/__runtime/api_wrapper.h>
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/__exception/exception_macros.h>
-#include <cuda/std/__ranges/concepts.h>
 #include <cuda/std/span>
 #include <cuda/std/type_traits>
-#include <cuda/std/utility>
 
 #include <cuda/experimental/__graph/concepts.cuh>
 #include <cuda/experimental/__graph/graph_builder.cuh>
@@ -178,8 +176,11 @@ struct path_builder
 
   //! \brief Add a range of dependency nodes to this path builder.
   //! \param __deps The dependency node range to add.
-  template <size_t _Extent>
-  _CCCL_HOST_API void depends_on(::cuda::std::span<const cudaGraphNode_t, _Extent> __deps)
+  _CCCL_TEMPLATE(class _Range)
+  _CCCL_REQUIRES(
+    ::cuda::std::ranges::forward_range<const _Range&>
+    _CCCL_AND ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, cudaGraphNode_t>)
+  _CCCL_HOST_API void depends_on(const _Range& __deps)
   {
     __nodes_.insert(__nodes_.end(), __deps.begin(), __deps.end());
   }
@@ -238,120 +239,6 @@ template <typename _FirstNode, typename... _Nodes>
   path_builder __pb(__dev, __first_node.get_native_graph_handle());
   __pb.depends_on(__first_node, __nodes...);
   return __pb;
-}
-
-template <size_t _Count, size_t... _Idx>
-[[nodiscard]] inline auto __replicate_impl(const path_builder& __source, ::cuda::std::index_sequence<_Idx...>)
-  -> ::cuda::std::array<path_builder, _Count>
-{
-  const auto __dev    = __source.get_device();
-  const auto __graph  = __source.get_native_graph_handle();
-  return ::cuda::std::array<path_builder, _Count>{((void) _Idx, path_builder(__dev, __graph))...};
-}
-
-template <size_t _Count, size_t... _Idx>
-[[nodiscard]] inline auto __replicate_prepend_impl(
-  path_builder&& __source, device_ref __dev, cudaGraph_t __graph, ::cuda::std::index_sequence<_Idx...>)
-  -> ::cuda::std::array<path_builder, _Count + 1>
-{
-  return ::cuda::std::array<path_builder, _Count + 1>{
-    ::cuda::std::move(__source), ((void) _Idx, path_builder(__dev, __graph))...};
-}
-
-//! @brief Create a fixed-size group of peer path builders with the same graph/device as `__source`.
-//! @note This function only creates path builders; it does not add synchronization dependencies.
-template <size_t _Count>
-[[nodiscard]] inline auto replicate(const path_builder& __source) -> ::cuda::std::array<path_builder, _Count>
-{
-  return __replicate_impl<_Count>(__source, ::cuda::std::make_index_sequence<_Count>{});
-}
-
-//! @brief Create a runtime-sized group of peer path builders with the same graph/device as `__source`.
-//! @note This function only creates path builders; it does not add synchronization dependencies.
-[[nodiscard]] inline auto replicate(const path_builder& __source, size_t __count) -> ::std::vector<path_builder>
-{
-  const auto __dev   = __source.get_device();
-  const auto __graph = __source.get_native_graph_handle();
-  ::std::vector<path_builder> __replicas;
-  __replicas.reserve(__count);
-  for (size_t __idx = 0; __idx < __count; ++__idx)
-  {
-    __replicas.emplace_back(__dev, __graph);
-  }
-  return __replicas;
-}
-
-//! @brief Create a runtime-sized group of peer path builders with the same graph/device as `__source` and prepend
-//! `__source` at index 0.
-//! @note This function only creates path builders; it does not add synchronization dependencies.
-[[nodiscard]] inline auto replicate_prepend(path_builder&& __source, size_t __count) -> ::std::vector<path_builder>
-{
-  const auto __dev   = __source.get_device();
-  const auto __graph = __source.get_native_graph_handle();
-  ::std::vector<path_builder> __replicas;
-  __replicas.reserve(__count + 1);
-  __replicas.emplace_back(::cuda::std::move(__source));
-  for (size_t __idx = 0; __idx < __count; ++__idx)
-  {
-    __replicas.emplace_back(__dev, __graph);
-  }
-  return __replicas;
-}
-
-template <size_t _Count>
-//! @brief Create a fixed-size group of peer path builders with the same graph/device as `__source` and prepend
-//! `__source` at index 0.
-//! @note This function only creates path builders; it does not add synchronization dependencies.
-[[nodiscard]] inline auto replicate_prepend(path_builder&& __source) -> ::cuda::std::array<path_builder, _Count + 1>
-{
-  const auto __dev   = __source.get_device();
-  const auto __graph = __source.get_native_graph_handle();
-  return __replicate_prepend_impl<_Count>(::cuda::std::move(__source), __dev, __graph, ::cuda::std::make_index_sequence<_Count>{});
-}
-
-template <class _Range>
-_CCCL_CONCEPT __path_builder_join_range =
-  ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, path_builder>;
-
-template <class _ToRange, class _FromRange>
-inline void __join_impl(_ToRange& __to_builders, const _FromRange& __from_builders)
-{
-  // TODO: Consider adding dependency deduplication in join to avoid duplicate graph edges.
-  for (auto& __to : __to_builders)
-  {
-    for (const auto& __from : __from_builders)
-    {
-      __to.depends_on(__from.get_dependencies());
-    }
-  }
-}
-
-//! @brief Synchronize one group of path builders with another by adding dependencies from all `from` into all `to`.
-_CCCL_TEMPLATE(class _ToRange, class _FromRange)
-_CCCL_REQUIRES(
-  ::cuda::std::ranges::forward_range<_ToRange&> _CCCL_AND ::cuda::std::ranges::forward_range<const _FromRange&>
-  _CCCL_AND __path_builder_join_range<_ToRange> _CCCL_AND __path_builder_join_range<_FromRange>)
-inline void join(_ToRange& __to_builders, const _FromRange& __from_builders)
-{
-  __join_impl(__to_builders, __from_builders);
-}
-
-//! @brief Synchronize a single target path builder with a group of source path builders.
-_CCCL_TEMPLATE(class _FromRange)
-_CCCL_REQUIRES(
-  ::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __path_builder_join_range<_FromRange>)
-inline void join(path_builder& __to_builder, const _FromRange& __from_builders)
-{
-  auto __to_span = ::cuda::std::span<path_builder>(&__to_builder, 1);
-  __join_impl(__to_span, __from_builders);
-}
-
-//! @brief Synchronize a group of target path builders with a single source path builder.
-_CCCL_TEMPLATE(class _ToRange)
-_CCCL_REQUIRES(::cuda::std::ranges::forward_range<_ToRange&> _CCCL_AND __path_builder_join_range<_ToRange>)
-inline void join(_ToRange& __to_builders, const path_builder& __from_builder)
-{
-  __join_impl(__to_builders, ::cuda::std::span<const path_builder>(&__from_builder, 1));
 }
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__graph/path_builder.cuh
+++ b/cudax/include/cuda/experimental/__graph/path_builder.cuh
@@ -16,6 +16,10 @@
 #include <cuda/__runtime/api_wrapper.h>
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/__exception/exception_macros.h>
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/span>
+#include <cuda/std/type_traits>
+#include <cuda/std/utility>
 
 #include <cuda/experimental/__graph/concepts.cuh>
 #include <cuda/experimental/__graph/graph_builder.cuh>
@@ -172,6 +176,14 @@ struct path_builder
       ...);
   }
 
+  //! \brief Add a range of dependency nodes to this path builder.
+  //! \param __deps The dependency node range to add.
+  template <size_t _Extent>
+  _CCCL_HOST_API void depends_on(::cuda::std::span<const cudaGraphNode_t, _Extent> __deps)
+  {
+    __nodes_.insert(__nodes_.end(), __deps.begin(), __deps.end());
+  }
+
   //! \brief Get the graph that the path builder is building.
   //! \return The graph that the path builder is building.
   [[nodiscard]] _CCCL_NODEBUG_HOST_API constexpr auto get_graph() const noexcept -> graph_builder_ref
@@ -226,6 +238,120 @@ template <typename _FirstNode, typename... _Nodes>
   path_builder __pb(__dev, __first_node.get_native_graph_handle());
   __pb.depends_on(__first_node, __nodes...);
   return __pb;
+}
+
+template <size_t _Count, size_t... _Idx>
+[[nodiscard]] inline auto __replicate_impl(const path_builder& __source, ::cuda::std::index_sequence<_Idx...>)
+  -> ::cuda::std::array<path_builder, _Count>
+{
+  const auto __dev    = __source.get_device();
+  const auto __graph  = __source.get_native_graph_handle();
+  return ::cuda::std::array<path_builder, _Count>{((void) _Idx, path_builder(__dev, __graph))...};
+}
+
+template <size_t _Count, size_t... _Idx>
+[[nodiscard]] inline auto __replicate_prepend_impl(
+  path_builder&& __source, device_ref __dev, cudaGraph_t __graph, ::cuda::std::index_sequence<_Idx...>)
+  -> ::cuda::std::array<path_builder, _Count + 1>
+{
+  return ::cuda::std::array<path_builder, _Count + 1>{
+    ::cuda::std::move(__source), ((void) _Idx, path_builder(__dev, __graph))...};
+}
+
+//! @brief Create a fixed-size group of peer path builders with the same graph/device as `__source`.
+//! @note This function only creates path builders; it does not add synchronization dependencies.
+template <size_t _Count>
+[[nodiscard]] inline auto replicate(const path_builder& __source) -> ::cuda::std::array<path_builder, _Count>
+{
+  return __replicate_impl<_Count>(__source, ::cuda::std::make_index_sequence<_Count>{});
+}
+
+//! @brief Create a runtime-sized group of peer path builders with the same graph/device as `__source`.
+//! @note This function only creates path builders; it does not add synchronization dependencies.
+[[nodiscard]] inline auto replicate(const path_builder& __source, size_t __count) -> ::std::vector<path_builder>
+{
+  const auto __dev   = __source.get_device();
+  const auto __graph = __source.get_native_graph_handle();
+  ::std::vector<path_builder> __replicas;
+  __replicas.reserve(__count);
+  for (size_t __idx = 0; __idx < __count; ++__idx)
+  {
+    __replicas.emplace_back(__dev, __graph);
+  }
+  return __replicas;
+}
+
+//! @brief Create a runtime-sized group of peer path builders with the same graph/device as `__source` and prepend
+//! `__source` at index 0.
+//! @note This function only creates path builders; it does not add synchronization dependencies.
+[[nodiscard]] inline auto replicate_prepend(path_builder&& __source, size_t __count) -> ::std::vector<path_builder>
+{
+  const auto __dev   = __source.get_device();
+  const auto __graph = __source.get_native_graph_handle();
+  ::std::vector<path_builder> __replicas;
+  __replicas.reserve(__count + 1);
+  __replicas.emplace_back(::cuda::std::move(__source));
+  for (size_t __idx = 0; __idx < __count; ++__idx)
+  {
+    __replicas.emplace_back(__dev, __graph);
+  }
+  return __replicas;
+}
+
+template <size_t _Count>
+//! @brief Create a fixed-size group of peer path builders with the same graph/device as `__source` and prepend
+//! `__source` at index 0.
+//! @note This function only creates path builders; it does not add synchronization dependencies.
+[[nodiscard]] inline auto replicate_prepend(path_builder&& __source) -> ::cuda::std::array<path_builder, _Count + 1>
+{
+  const auto __dev   = __source.get_device();
+  const auto __graph = __source.get_native_graph_handle();
+  return __replicate_prepend_impl<_Count>(::cuda::std::move(__source), __dev, __graph, ::cuda::std::make_index_sequence<_Count>{});
+}
+
+template <class _Range>
+_CCCL_CONCEPT __path_builder_join_range =
+  ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, path_builder>;
+
+template <class _ToRange, class _FromRange>
+inline void __join_impl(_ToRange& __to_builders, const _FromRange& __from_builders)
+{
+  // TODO: Consider adding dependency deduplication in join to avoid duplicate graph edges.
+  for (auto& __to : __to_builders)
+  {
+    for (const auto& __from : __from_builders)
+    {
+      __to.depends_on(__from.get_dependencies());
+    }
+  }
+}
+
+//! @brief Synchronize one group of path builders with another by adding dependencies from all `from` into all `to`.
+_CCCL_TEMPLATE(class _ToRange, class _FromRange)
+_CCCL_REQUIRES(
+  ::cuda::std::ranges::forward_range<_ToRange&> _CCCL_AND ::cuda::std::ranges::forward_range<const _FromRange&>
+  _CCCL_AND __path_builder_join_range<_ToRange> _CCCL_AND __path_builder_join_range<_FromRange>)
+inline void join(_ToRange& __to_builders, const _FromRange& __from_builders)
+{
+  __join_impl(__to_builders, __from_builders);
+}
+
+//! @brief Synchronize a single target path builder with a group of source path builders.
+_CCCL_TEMPLATE(class _FromRange)
+_CCCL_REQUIRES(
+  ::cuda::std::ranges::forward_range<const _FromRange&> _CCCL_AND __path_builder_join_range<_FromRange>)
+inline void join(path_builder& __to_builder, const _FromRange& __from_builders)
+{
+  auto __to_span = ::cuda::std::span<path_builder>(&__to_builder, 1);
+  __join_impl(__to_span, __from_builders);
+}
+
+//! @brief Synchronize a group of target path builders with a single source path builder.
+_CCCL_TEMPLATE(class _ToRange)
+_CCCL_REQUIRES(::cuda::std::ranges::forward_range<_ToRange&> _CCCL_AND __path_builder_join_range<_ToRange>)
+inline void join(_ToRange& __to_builders, const path_builder& __from_builder)
+{
+  __join_impl(__to_builders, ::cuda::std::span<const path_builder>(&__from_builder, 1));
 }
 } // namespace cuda::experimental
 

--- a/cudax/include/cuda/experimental/__graph/path_builder.cuh
+++ b/cudax/include/cuda/experimental/__graph/path_builder.cuh
@@ -177,9 +177,8 @@ struct path_builder
   //! \brief Add a range of dependency nodes to this path builder.
   //! \param __deps The dependency node range to add.
   _CCCL_TEMPLATE(class _Range)
-  _CCCL_REQUIRES(
-    ::cuda::std::ranges::forward_range<const _Range&>
-    _CCCL_AND ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, cudaGraphNode_t>)
+  _CCCL_REQUIRES(::cuda::std::ranges::forward_range<const _Range&>
+                   _CCCL_AND ::cuda::std::is_same_v<::cuda::std::ranges::range_value_t<const _Range&>, cudaGraphNode_t>)
   _CCCL_HOST_API void depends_on(const _Range& __deps)
   {
     __nodes_.insert(__nodes_.end(), __deps.begin(), __deps.end());

--- a/cudax/include/cuda/experimental/__graph/path_builder.cuh
+++ b/cudax/include/cuda/experimental/__graph/path_builder.cuh
@@ -50,7 +50,7 @@ template <::cuda::std::size_t _Count>
 
 template <class _Container>
 _CCCL_HOST_API void
-__replicate_builders_into(const path_builder& __source, _Container& __out, ::cuda::std::size_t __count);
+__replicate_builders_into(const path_builder& __source, _Container& __dest, ::cuda::std::size_t __count);
 
 //! \brief A builder for a path in a CUDA graph.
 //!
@@ -213,12 +213,12 @@ struct path_builder
     return __replicate_builders(*this, __count);
   }
 
-  //! @brief Append runtime-sized peer path builders with the same graph/device as this path builder to `__out`.
+  //! @brief Append runtime-sized peer path builders with the same graph/device as this path builder to `__dest`.
   //! @note This function only creates path builders; it does not add synchronization dependencies.
   template <class _Container>
-  _CCCL_HOST_API void replicate_into(_Container& __out, ::cuda::std::size_t __count) const
+  _CCCL_HOST_API void replicate_into(_Container& __dest, ::cuda::std::size_t __count) const
   {
-    __replicate_builders_into(*this, __out, __count);
+    __replicate_builders_into(*this, __dest, __count);
   }
 
   //! \brief Get the graph that the path builder is building.

--- a/cudax/include/cuda/experimental/__graph/path_builder.cuh
+++ b/cudax/include/cuda/experimental/__graph/path_builder.cuh
@@ -16,6 +16,7 @@
 #include <cuda/__runtime/api_wrapper.h>
 #include <cuda/std/__exception/cuda_error.h>
 #include <cuda/std/__exception/exception_macros.h>
+#include <cuda/std/array>
 #include <cuda/std/span>
 #include <cuda/std/type_traits>
 
@@ -38,6 +39,19 @@
 
 namespace cuda::experimental
 {
+struct path_builder;
+
+template <::cuda::std::size_t _Count>
+[[nodiscard]] _CCCL_HOST_API auto __replicate_builders(const path_builder& __source)
+  -> ::cuda::std::array<path_builder, _Count>;
+
+[[nodiscard]] _CCCL_HOST_API auto __replicate_builders(const path_builder& __source, ::cuda::std::size_t __count)
+  -> ::std::vector<path_builder>;
+
+template <class _Container>
+_CCCL_HOST_API void
+__replicate_builders_into(const path_builder& __source, _Container& __out, ::cuda::std::size_t __count);
+
 //! \brief A builder for a path in a CUDA graph.
 //!
 //! This class allows for the creation of a path in a CUDA graph, which is a sequence of nodes that are executed in
@@ -182,6 +196,29 @@ struct path_builder
   _CCCL_HOST_API void depends_on(const _Range& __deps)
   {
     __nodes_.insert(__nodes_.end(), __deps.begin(), __deps.end());
+  }
+
+  //! @brief Create a fixed-size group of peer path builders with the same graph/device as this path builder.
+  //! @note This function only creates path builders; it does not add synchronization dependencies.
+  template <::cuda::std::size_t _Count>
+  [[nodiscard]] _CCCL_HOST_API auto replicate() const -> ::cuda::std::array<path_builder, _Count>
+  {
+    return __replicate_builders<_Count>(*this);
+  }
+
+  //! @brief Create a runtime-sized group of peer path builders with the same graph/device as this path builder.
+  //! @note This function only creates path builders; it does not add synchronization dependencies.
+  [[nodiscard]] _CCCL_HOST_API auto replicate(::cuda::std::size_t __count) const -> ::std::vector<path_builder>
+  {
+    return __replicate_builders(*this, __count);
+  }
+
+  //! @brief Append runtime-sized peer path builders with the same graph/device as this path builder to `__out`.
+  //! @note This function only creates path builders; it does not add synchronization dependencies.
+  template <class _Container>
+  _CCCL_HOST_API void replicate_into(_Container& __out, ::cuda::std::size_t __count) const
+  {
+    __replicate_builders_into(*this, __out, __count);
   }
 
   //! \brief Get the graph that the path builder is building.

--- a/cudax/include/cuda/experimental/graph.cuh
+++ b/cudax/include/cuda/experimental/graph.cuh
@@ -18,8 +18,8 @@
 #include <cuda/experimental/__graph/graph_builder.cuh>
 #include <cuda/experimental/__graph/graph_node_ref.cuh>
 #include <cuda/experimental/__graph/graph_node_type.cuh>
-#include <cuda/experimental/__graph/path_builder.cuh>
 #include <cuda/experimental/__graph/graph_utils.cuh>
+#include <cuda/experimental/__graph/path_builder.cuh>
 // IWYU pragma: end_exports
 
 #endif // __CUDAX_GRAPH_CUH

--- a/cudax/include/cuda/experimental/graph.cuh
+++ b/cudax/include/cuda/experimental/graph.cuh
@@ -19,6 +19,7 @@
 #include <cuda/experimental/__graph/graph_node_ref.cuh>
 #include <cuda/experimental/__graph/graph_node_type.cuh>
 #include <cuda/experimental/__graph/path_builder.cuh>
+#include <cuda/experimental/__graph/graph_utils.cuh>
 // IWYU pragma: end_exports
 
 #endif // __CUDAX_GRAPH_CUH

--- a/cudax/test/graph/graph_smoke.cu
+++ b/cudax/test/graph/graph_smoke.cu
@@ -13,6 +13,8 @@
 #include <cuda/experimental/memory_resource.cuh>
 #include <cuda/experimental/stream.cuh>
 
+#include <cuda/std/array>
+
 #include <testing.cuh>
 #include <utility.cuh>
 
@@ -243,6 +245,129 @@ C2H_TEST("Path builder with kernel nodes", "[graph]")
     CUDAX_REQUIRE(*ptr == 54);
   }
 
+  SECTION("path_builder replicate and join")
+  {
+    cudax::graph_builder g;
+    auto pb = cudax::start_path(g);
+    cudax::launch(pb, test::one_thread_dims, test::assign_42{}, ptr);
+
+    auto branches = cudax::replicate<2>(pb);
+    CUDAX_REQUIRE(branches[0].get_dependencies().size() == 0);
+    CUDAX_REQUIRE(branches[1].get_dependencies().size() == 0);
+
+    cudax::join(branches, pb);
+    CUDAX_REQUIRE(branches[0].get_dependencies().size() == 1);
+    CUDAX_REQUIRE(branches[1].get_dependencies().size() == 1);
+    CUDAX_REQUIRE(branches[0].get_dependencies()[0] == pb.get_dependencies()[0]);
+    CUDAX_REQUIRE(branches[1].get_dependencies()[0] == pb.get_dependencies()[0]);
+
+    cudax::launch(branches[0], test::one_thread_dims, test::atomic_add_one{}, ptr);
+    cudax::launch(branches[1], test::one_thread_dims, test::atomic_add_one{}, ptr);
+
+    auto sink = cudax::start_path(g);
+    cudax::join(sink, branches);
+    cudax::launch(sink, test::one_thread_dims, test::verify_n<44>{}, ptr);
+
+    auto exec = g.instantiate();
+    exec.launch(s);
+    s.sync();
+    CUDAX_REQUIRE(*ptr == 44);
+    *ptr = 0;
+  }
+
+  SECTION("path_builder join supports group-to-group")
+  {
+    cudax::graph_builder g;
+    auto root = cudax::start_path(g);
+    cudax::launch(root, test::one_thread_dims, test::assign_42{}, ptr);
+
+    auto source0 = cudax::start_path(g, root);
+    auto source1 = cudax::start_path(g, root);
+    cudax::launch(source0, test::one_thread_dims, test::atomic_add_one{}, ptr);
+    cudax::launch(source1, test::one_thread_dims, test::atomic_add_one{}, ptr);
+
+    auto target0 = cudax::start_path(g);
+    auto target1 = cudax::start_path(g);
+    auto targets = ::cuda::std::array<cudax::path_builder, 2>{target0, target1};
+    auto sources = ::cuda::std::array<cudax::path_builder, 2>{source0, source1};
+
+    cudax::join(targets, sources);
+    CUDAX_REQUIRE(targets[0].get_dependencies().size() == 2);
+    CUDAX_REQUIRE(targets[1].get_dependencies().size() == 2);
+
+    cudax::launch(targets[0], test::one_thread_dims, test::verify_n<44>{}, ptr);
+    auto exec = g.instantiate();
+    exec.launch(s);
+    s.sync();
+    CUDAX_REQUIRE(*ptr == 44);
+    *ptr = 0;
+  }
+
+  SECTION("path_builder join supports multi-node source fan-in")
+  {
+    cudax::graph_builder g;
+    auto root = cudax::start_path(g);
+    cudax::launch(root, test::one_thread_dims, test::assign_42{}, ptr);
+
+    auto p0 = cudax::start_path(g, root);
+    auto p1 = cudax::start_path(g, root);
+    auto p2 = cudax::start_path(g, root);
+    auto p3 = cudax::start_path(g, root);
+    auto n0 = cudax::launch(p0, test::one_thread_dims, test::atomic_add_one{}, ptr);
+    auto n1 = cudax::launch(p1, test::one_thread_dims, test::atomic_add_one{}, ptr);
+    auto n2 = cudax::launch(p2, test::one_thread_dims, test::atomic_add_one{}, ptr);
+    auto n3 = cudax::launch(p3, test::one_thread_dims, test::atomic_add_one{}, ptr);
+
+    auto source0 = cudax::start_path(g);
+    auto source1 = cudax::start_path(g);
+    source0.depends_on(n0, n1);
+    source1.depends_on(n2, n3);
+    CUDAX_REQUIRE(source0.get_dependencies().size() == 2);
+    CUDAX_REQUIRE(source1.get_dependencies().size() == 2);
+
+    auto target0 = cudax::start_path(g);
+    auto target1 = cudax::start_path(g);
+    auto targets = ::cuda::std::array<cudax::path_builder, 2>{target0, target1};
+    auto sources = ::cuda::std::array<cudax::path_builder, 2>{source0, source1};
+    cudax::join(targets, sources);
+    CUDAX_REQUIRE(targets[0].get_dependencies().size() == 4);
+    CUDAX_REQUIRE(targets[1].get_dependencies().size() == 4);
+
+    cudax::launch(targets[0], test::one_thread_dims, test::verify_n<46>{}, ptr);
+    auto exec = g.instantiate();
+    exec.launch(s);
+    s.sync();
+    CUDAX_REQUIRE(*ptr == 46);
+    *ptr = 0;
+  }
+
+  SECTION("path_builder replicate_prepend variants")
+  {
+    cudax::graph_builder g;
+
+    auto dynamic_seed = cudax::start_path(g);
+    cudax::launch(dynamic_seed, test::one_thread_dims, test::assign_42{}, ptr);
+    const auto dynamic_seed_dep = dynamic_seed.get_dependencies()[0];
+    auto dynamic_group          = cudax::replicate_prepend(std::move(dynamic_seed), 2);
+
+    CUDAX_REQUIRE(dynamic_group.size() == 3);
+    CUDAX_REQUIRE(dynamic_group[0].get_dependencies().size() == 1);
+    CUDAX_REQUIRE(dynamic_group[0].get_dependencies()[0] == dynamic_seed_dep);
+    CUDAX_REQUIRE(dynamic_group[1].get_dependencies().size() == 0);
+    CUDAX_REQUIRE(dynamic_group[2].get_dependencies().size() == 0);
+
+    auto static_seed = cudax::start_path(g);
+    cudax::launch(static_seed, test::one_thread_dims, test::assign_42{}, ptr);
+    const auto static_seed_dep = static_seed.get_dependencies()[0];
+    auto static_group          = cudax::replicate_prepend<2>(std::move(static_seed));
+
+    CUDAX_REQUIRE(static_group.size() == 3);
+    CUDAX_REQUIRE(static_group[0].get_dependencies().size() == 1);
+    CUDAX_REQUIRE(static_group[0].get_dependencies()[0] == static_seed_dep);
+    CUDAX_REQUIRE(static_group[1].get_dependencies().size() == 0);
+    CUDAX_REQUIRE(static_group[2].get_dependencies().size() == 0);
+  }
+
 #if _CCCL_CTK_AT_LEAST(12, 3)
   SECTION("legacy stream capture")
   {
@@ -271,6 +396,30 @@ C2H_TEST("Path builder with kernel nodes", "[graph]")
 
   if (cuda::devices.size() > 1)
   {
+    SECTION("Multi-device path_builder join")
+    {
+      cudax::graph_builder g(cuda::devices[0]);
+      auto root = cudax::start_path(g);
+      cudax::launch(root, test::one_thread_dims, test::assign_42{}, ptr);
+
+      auto dev0_source = cudax::start_path(cuda::devices[0], root);
+      auto dev1_source = cudax::start_path(cuda::devices[1], root);
+      cudax::launch(dev0_source, test::one_thread_dims, test::atomic_add_one{}, ptr);
+      cudax::launch(dev1_source, test::one_thread_dims, test::atomic_add_one{}, ptr);
+
+      auto target_group = cudax::replicate<1>(cudax::start_path(cuda::devices[0], root));
+      auto source_group = ::cuda::std::array<cudax::path_builder, 2>{dev0_source, dev1_source};
+      cudax::join(target_group, source_group);
+      CUDAX_REQUIRE(target_group[0].get_dependencies().size() >= 2);
+
+      cudax::launch(target_group[0], test::one_thread_dims, test::verify_n<44>{}, ptr);
+      auto exec = g.instantiate();
+      exec.launch(s);
+      s.sync();
+      CUDAX_REQUIRE(*ptr == 44);
+      *ptr = 0;
+    }
+
     SECTION("Multi-device graph")
     {
       cuda::device_memory_pool_ref dev0_mr = cuda::device_default_memory_pool(cuda::devices[0]);

--- a/cudax/test/graph/graph_smoke.cu
+++ b/cudax/test/graph/graph_smoke.cu
@@ -8,12 +8,12 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <cuda/std/array>
+
 #include <cuda/experimental/graph.cuh>
 #include <cuda/experimental/launch.cuh>
 #include <cuda/experimental/memory_resource.cuh>
 #include <cuda/experimental/stream.cuh>
-
-#include <cuda/std/array>
 
 #include <testing.cuh>
 #include <utility.cuh>

--- a/cudax/test/graph/graph_smoke.cu
+++ b/cudax/test/graph/graph_smoke.cu
@@ -15,6 +15,8 @@
 #include <cuda/experimental/memory_resource.cuh>
 #include <cuda/experimental/stream.cuh>
 
+#include <vector>
+
 #include <testing.cuh>
 #include <utility.cuh>
 
@@ -251,7 +253,7 @@ C2H_TEST("Path builder with kernel nodes", "[graph]")
     auto pb = cudax::start_path(g);
     cudax::launch(pb, test::one_thread_dims, test::assign_42{}, ptr);
 
-    auto branches = cudax::replicate<2>(pb);
+    auto branches = pb.replicate<2>();
     CUDAX_REQUIRE(branches[0].get_dependencies().size() == 0);
     CUDAX_REQUIRE(branches[1].get_dependencies().size() == 0);
 
@@ -341,14 +343,17 @@ C2H_TEST("Path builder with kernel nodes", "[graph]")
     *ptr = 0;
   }
 
-  SECTION("path_builder replicate_prepend variants")
+  SECTION("path_builder replicate_into appends peers")
   {
     cudax::graph_builder g;
 
     auto dynamic_seed = cudax::start_path(g);
     cudax::launch(dynamic_seed, test::one_thread_dims, test::assign_42{}, ptr);
     const auto dynamic_seed_dep = dynamic_seed.get_dependencies()[0];
-    auto dynamic_group          = cudax::replicate_prepend(std::move(dynamic_seed), 2);
+    ::std::vector<cudax::path_builder> dynamic_group;
+    dynamic_group.reserve(3);
+    dynamic_group.emplace_back(std::move(dynamic_seed));
+    dynamic_group.front().replicate_into(dynamic_group, 2);
 
     CUDAX_REQUIRE(dynamic_group.size() == 3);
     CUDAX_REQUIRE(dynamic_group[0].get_dependencies().size() == 1);
@@ -359,7 +364,10 @@ C2H_TEST("Path builder with kernel nodes", "[graph]")
     auto static_seed = cudax::start_path(g);
     cudax::launch(static_seed, test::one_thread_dims, test::assign_42{}, ptr);
     const auto static_seed_dep = static_seed.get_dependencies()[0];
-    auto static_group          = cudax::replicate_prepend<2>(std::move(static_seed));
+    ::std::vector<cudax::path_builder> static_group;
+    static_group.reserve(3);
+    static_group.emplace_back(std::move(static_seed));
+    static_group.front().replicate_into(static_group, 2);
 
     CUDAX_REQUIRE(static_group.size() == 3);
     CUDAX_REQUIRE(static_group[0].get_dependencies().size() == 1);
@@ -407,7 +415,7 @@ C2H_TEST("Path builder with kernel nodes", "[graph]")
       cudax::launch(dev0_source, test::one_thread_dims, test::atomic_add_one{}, ptr);
       cudax::launch(dev1_source, test::one_thread_dims, test::atomic_add_one{}, ptr);
 
-      auto target_group = cudax::replicate<1>(cudax::start_path(cuda::devices[0], root));
+      auto target_group = cudax::start_path(cuda::devices[0], root).replicate<1>();
       auto source_group = ::cuda::std::array<cudax::path_builder, 2>{dev0_source, dev1_source};
       cudax::join(target_group, source_group);
       CUDAX_REQUIRE(target_group[0].get_dependencies().size() >= 2);


### PR DESCRIPTION
PR https://github.com/NVIDIA/cccl/pull/8014 implements `replicate` and `join` for streams, this one does that for `path_builder`. The semantics is mostly the same as for streams, `replicate` creates a requested number of path builders in the same graph, `replicate_prepend` does the same but also add the input one to the output. `join` gathers all dependencies from one set of path builders and adds them to another set of path builders.
One observation was that we don't try to avoid duplicate dependencies in graph APIs and we possibly should take a look into that. `join` probably could use some duplicate dependency control, because the underlying driver API won't accept them. But that is a problem for another PR