### PR TITLE
Drop main in libcu++ header test file

### DIFF
--- a/libcudacxx/cmake/header_test.cpp.in
+++ b/libcudacxx/cmake/header_test.cpp.in
@@ -21,5 +21,3 @@
 
 // This file tests that the respective header is includable on its own with a cuda compiler
 #include <@header@>
-
-int main(int, char**) { return 0; }


### PR DESCRIPTION
With the refactoring to the global CCCL header testing we already link to a library that contains main
