### PR TITLE
Deprecate `cuda::std::rel_ops` in c++20

### DIFF
--- a/cudax/include/cuda/experimental/__execution/completion_behavior.cuh
+++ b/cudax/include/cuda/experimental/__execution/completion_behavior.cuh
@@ -50,24 +50,6 @@ enum class _CCCL_TYPE_VISIBILITY_DEFAULT completion_behavior : int
                     ///< `start()`.
 };
 
-#if _LIBCUDACXX_HAS_SPACESHIP_OPERATOR()
-[[nodiscard]] _CCCL_API constexpr auto operator<=>(completion_behavior __a, completion_behavior __b) noexcept
-  -> ::cuda::std::strong_ordering
-{
-  return static_cast<int>(__a) <=> static_cast<int>(__b);
-}
-#else
-[[nodiscard]] _CCCL_API constexpr auto operator<(completion_behavior __a, completion_behavior __b) noexcept -> bool
-{
-  return static_cast<int>(__a) < static_cast<int>(__b);
-}
-[[nodiscard]] _CCCL_API constexpr auto operator==(completion_behavior __a, completion_behavior __b) noexcept -> bool
-{
-  return static_cast<int>(__a) == static_cast<int>(__b);
-}
-using namespace ::cuda::std::rel_ops;
-#endif
-
 template <completion_behavior _CB>
 using __constant_t = ::cuda::std::integral_constant<completion_behavior, _CB>;
 

--- a/libcudacxx/include/cuda/std/__utility/rel_ops.h
+++ b/libcudacxx/include/cuda/std/__utility/rel_ops.h
@@ -3,7 +3,7 @@
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -30,25 +30,25 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 namespace rel_ops
 {
 template <class _Tp>
-_CCCL_API inline bool operator!=(const _Tp& __x, const _Tp& __y)
+[[nodiscard]] _CCCL_DEPRECATED_IN_CXX20 _CCCL_API inline bool operator!=(const _Tp& __x, const _Tp& __y)
 {
   return !(__x == __y);
 }
 
 template <class _Tp>
-_CCCL_API inline bool operator>(const _Tp& __x, const _Tp& __y)
+[[nodiscard]] _CCCL_DEPRECATED_IN_CXX20 _CCCL_API inline bool operator>(const _Tp& __x, const _Tp& __y)
 {
   return __y < __x;
 }
 
 template <class _Tp>
-_CCCL_API inline bool operator<=(const _Tp& __x, const _Tp& __y)
+[[nodiscard]] _CCCL_DEPRECATED_IN_CXX20 _CCCL_API inline bool operator<=(const _Tp& __x, const _Tp& __y)
 {
   return !(__y < __x);
 }
 
 template <class _Tp>
-_CCCL_API inline bool operator>=(const _Tp& __x, const _Tp& __y)
+[[nodiscard]] _CCCL_DEPRECATED_IN_CXX20 _CCCL_API inline bool operator>=(const _Tp& __x, const _Tp& __y)
 {
   return !(__x < __y);
 }

--- a/libcudacxx/test/libcudacxx/std/utilities/utility/operators/rel_ops.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/utilities/utility/operators/rel_ops.pass.cpp
@@ -7,7 +7,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// test rel_ops
+// ADDITIONAL_COMPILE_DEFINITIONS: CCCL_IGNORE_DEPRECATED_API
+
+// test rel_ops, deprecated in c++20
 
 #include <cuda/std/cassert>
 #include <cuda/std/utility>


### PR DESCRIPTION
I accidently came across this