### PR TITLE
[STF] Expose graph() and stage() on unified context class

### DIFF
--- a/cudax/include/cuda/experimental/__stf/internal/context.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/context.cuh
@@ -410,6 +410,22 @@ public:
     };
   }
 
+  cudaGraph_t graph() const
+  {
+    _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
+    return payload->*[&](auto& self) {
+      return self.graph();
+    };
+  }
+
+  size_t stage() const
+  {
+    _CCCL_ASSERT(payload.index() != ::std::variant_npos, "Context is not initialized");
+    return payload->*[&](auto& self) {
+      return self.stage();
+    };
+  }
+
   /**
    * @brief Returns the number of tasks created since the context was created or since the last fence (if any)
    */
@@ -963,6 +979,20 @@ UNITTEST("context is_graph_ctx")
 
   context ctx2 = graph_ctx();
   EXPECT(ctx2.is_graph_ctx());
+  ctx2.finalize();
+};
+
+UNITTEST("context graph and stage")
+{
+  // stream_ctx: graph() is nullptr, stage() is size_t(-1)
+  context ctx;
+  EXPECT(ctx.graph() == nullptr);
+  ctx.finalize();
+
+  // graph_ctx: graph() and stage() delegate to backend
+  context ctx2 = graph_ctx();
+  ctx2.logical_data(1); // ensure context has been used so graph may be created
+  EXPECT(ctx2.graph() != nullptr);
   ctx2.finalize();
 };
 


### PR DESCRIPTION
- Add context::graph() and context::stage() that delegate to the payload (stream_ctx or graph_ctx) so generic code can query the underlying graph and stage without knowing the backend.
- Add UNITTEST("context graph and stage") to verify stream_ctx returns nullptr graph and graph_ctx returns non-null graph.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
