### PR TITLE
Fix allocator traits rebind deprecation warning

### DIFF
--- a/libcudacxx/include/cuda/std/__memory/allocator_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_traits.h
@@ -179,12 +179,14 @@ struct __is_always_equal<_Alloc, true>
 
 _CCCL_SUPPRESS_DEPRECATED_POP
 
+// Allocator::rebind is deprecated since C++17
+_CCCL_SUPPRESS_DEPRECATED_PUSH
+
 // __allocator_traits_rebind
 template <class _Tp, class _Up>
 _CCCL_CONCEPT __has_member_rebind_other =
   _CCCL_REQUIRES_EXPR((_Tp, _Up))(typename(typename _Tp::template rebind<_Up>::other));
 
-_CCCL_SUPPRESS_DEPRECATED_PUSH
 template <class _Tp, class _Up, bool = __has_member_rebind_other<_Tp, _Up>>
 struct __allocator_traits_rebind
 {


### PR DESCRIPTION
## Description

Fix
```sh
/cccl/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/__memory/allocator_traits.h:185:67: error: 'rebind<bool>' is deprecated [-Werror,-Wdeprecated-declarations]
  185 |   _CCCL_REQUIRES_EXPR((_Tp, _Up))(typename(typename _Tp::template rebind<_Up>::other));
      |                                                                   ^
/cccl/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/__concepts/concept_macros.h:311:41: note: expanded from macro '_CCCL_REQUIRES_EXPR'
  311 | #  define _CCCL_REQUIRES_EXPR(_TY, ...) _CCCL_REQUIRES_EXPR_IMPL(_TY, _CCCL_REQUIRES_EXPR_ID(_TY), __VA_ARGS__)
      |                                         ^
/cccl/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/__concepts/concept_macros.h:320:68: note: expanded from macro '_CCCL_REQUIRES_EXPR_IMPL'
  320 |       _CCCL_API inline static auto __cccl_well_formed(__VA_ARGS__) _CCCL_REQUIRES_EXPR_REQUIREMENTS_
      |                                                                    ^
/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1/__memory/allocator.h:132:10: note: 'rebind<bool>' has been explicitly marked deprecated here
  132 |   struct _LIBCPP_DEPRECATED_IN_CXX17 rebind {
      |          ^
```

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
