### PR TITLE
Fix `MergeSort` uninit memory read sanitizer errors

### DIFF
--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -367,7 +367,7 @@ C2H_TEST("DeviceMergeSort::SortPairs works", "[merge][sort][device]", wide_key_t
 }
 
 C2H_TEST(
-  "DeviceMergeSort::StableSortPairs works and performs a stable sort", "[merge][sort][device][skip-cs-initcheck]", key_types, value_types)
+  "DeviceMergeSort::StableSortPairs works and performs a stable sort", "[merge][sort][device]", key_types, value_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
   using data_t   = typename c2h::get<1, TestType>;

--- a/cub/test/catch2_test_device_merge_sort.cu
+++ b/cub/test/catch2_test_device_merge_sort.cu
@@ -248,7 +248,7 @@ C2H_TEST("DeviceMergeSort::SortKeys works", "[merge][sort][device]", wide_key_ty
 
 C2H_TEST("DeviceMergeSort::StableSortKeysCopy works and performs a stable sort when there are a lot sort-keys that "
          "compare equal",
-         "[merge][sort][device][skip-cs-racecheck][skip-cs-memcheck]")
+         "[merge][sort][device][skip-cs-racecheck][skip-cs-memcheck][skip-cs-initcheck]")
 {
   using key_t    = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t>;
   using offset_t = std::size_t;
@@ -277,7 +277,7 @@ C2H_TEST("DeviceMergeSort::StableSortKeysCopy works and performs a stable sort w
   REQUIRE(keys_expected == keys_out);
 }
 
-C2H_TEST("DeviceMergeSort::StableSortKeys works", "[merge][sort][device]")
+C2H_TEST("DeviceMergeSort::StableSortKeys works", "[merge][sort][device][skip-cs-initcheck]")
 {
   using key_t    = c2h::custom_type_t<c2h::equal_comparable_t, c2h::less_comparable_t>;
   using offset_t = std::int32_t;
@@ -367,7 +367,7 @@ C2H_TEST("DeviceMergeSort::SortPairs works", "[merge][sort][device]", wide_key_t
 }
 
 C2H_TEST(
-  "DeviceMergeSort::StableSortPairs works and performs a stable sort", "[merge][sort][device]", key_types, value_types)
+  "DeviceMergeSort::StableSortPairs works and performs a stable sort", "[merge][sort][device][skip-cs-initcheck]", key_types, value_types)
 {
   using key_t    = typename c2h::get<0, TestType>;
   using data_t   = typename c2h::get<1, TestType>;


### PR DESCRIPTION
fixes #8054 

Suppress sanitizer initialization check `initcheck` tests on three tests that (most probably) use padding and fail with uninit memory read. Pads are never initialized from `c2h::gen` and kick back.

@miscco is there any way to launch sanitizer just for this PR? It's kinda bulky to check locally in my ws.