### PR TITLE
Add env-based decomposer overloads for DeviceRadixSort::SortPairs (po…

### DIFF
--- a/cub/cub/device/device_radix_sort.cuh
+++ b/cub/cub/device/device_radix_sort.cuh
@@ -611,6 +611,127 @@ public:
   //! @rst
   //! Sorts key-value pairs into ascending order using :math:`\approx 2N` auxiliary storage.
   //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The contents of the input data are not altered by the sorting operation.
+  //! - Pointers to contiguous memory must be used; iterators are not currently
+  //!   supported.
+  //! - A bit subrange ``[begin_bit, end_bit)`` is provided to specify which
+  //!   key bits are used for sorting.
+  //!
+  //! Snippet
+  //! --------------------------------------------------
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_radix_sort_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin radix-sort-pairs-decomposer-bits-env
+  //!     :end-before: example-end radix-sort-pairs-decomposer-bits-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyT
+  //!   **[inferred]** KeyT type
+  //!
+  //! @tparam ValueT
+  //!   **[inferred]** ValueT type
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam DecomposerT
+  //!   **[inferred]** Type of a callable object responsible for decomposing a
+  //!   ``KeyT`` into a tuple of references to its constituent arithmetic types
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type
+  //!
+  //! @param[in] d_keys_in
+  //!   Pointer to the input data of key data to sort
+  //!
+  //! @param[out] d_keys_out
+  //!   Pointer to the sorted output sequence of key data
+  //!
+  //! @param[in] d_values_in
+  //!   Pointer to the corresponding input sequence of associated value items
+  //!
+  //! @param[out] d_values_out
+  //!   Pointer to the correspondingly-reordered output sequence of associated
+  //!   value items
+  //!
+  //! @param[in] num_items
+  //!   Number of items to sort
+  //!
+  //! @param[in] decomposer
+  //!   Callable object responsible for decomposing a ``KeyT`` into a tuple of
+  //!   references to its constituent arithmetic types
+  //!
+  //! @param[in] begin_bit
+  //!   The least-significant bit index (inclusive) needed for key comparison
+  //!
+  //! @param[in] end_bit
+  //!   The most-significant bit index (exclusive) needed for key comparison
+  //!
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename KeyT,
+            typename ValueT,
+            typename NumItemsT,
+            typename DecomposerT,
+            typename EnvT = ::cuda::std::execution::env<>,
+            typename ::cuda::std::enable_if_t<!::cuda::std::is_convertible_v<DecomposerT, int>, int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortPairs(
+    const KeyT* d_keys_in,
+    KeyT* d_keys_out,
+    const ValueT* d_values_in,
+    ValueT* d_values_out,
+    NumItemsT num_items,
+    DecomposerT decomposer,
+    int begin_bit,
+    int end_bit,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE(GetName());
+
+    using offset_t           = detail::choose_offset_t<NumItemsT>;
+    using decomposer_check_t = detail::radix::decomposer_check_t<KeyT, DecomposerT>;
+
+    static_assert(decomposer_check_t::value,
+                  "DecomposerT must be a callable object returning a tuple of references to "
+                  "arithmetic types");
+
+    if constexpr (decomposer_check_t::value)
+    {
+      return detail::dispatch_with_env(
+        env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+          constexpr bool is_overwrite_okay = false;
+          DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
+          DoubleBuffer<ValueT> d_values(const_cast<ValueT*>(d_values_in), d_values_out);
+
+          return detail::radix_sort::dispatch<SortOrder::Ascending>(
+            storage,
+            bytes,
+            d_keys,
+            d_values,
+            static_cast<offset_t>(num_items),
+            begin_bit,
+            end_bit,
+            is_overwrite_okay,
+            stream,
+            decomposer);
+        });
+    }
+  }
+
+  //! @rst
+  //! Sorts key-value pairs into ascending order using :math:`\approx 2N` auxiliary storage.
+  //!
   //! .. versionadded:: 2.2.0
   //!    First appears in CUDA Toolkit 12.3.
   //!
@@ -746,6 +867,117 @@ public:
         static_cast<offset_t>(num_items),
         decomposer,
         stream);
+    }
+  }
+
+  //! @rst
+  //! Sorts key-value pairs into ascending order using :math:`\approx 2N` auxiliary storage.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The contents of the input data are not altered by the sorting operation.
+  //! - Pointers to contiguous memory must be used; iterators are not currently
+  //!   supported.
+  //!
+  //! Snippet
+  //! --------------------------------------------------
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_radix_sort_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin radix-sort-pairs-decomposer-env
+  //!     :end-before: example-end radix-sort-pairs-decomposer-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyT
+  //!   **[inferred]** KeyT type
+  //!
+  //! @tparam ValueT
+  //!   **[inferred]** ValueT type
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam DecomposerT
+  //!   **[inferred]** Type of a callable object responsible for decomposing a
+  //!   ``KeyT`` into a tuple of references to its constituent arithmetic types
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type
+  //!
+  //! @param[in] d_keys_in
+  //!   Pointer to the input data of key data to sort
+  //!
+  //! @param[out] d_keys_out
+  //!   Pointer to the sorted output sequence of key data
+  //!
+  //! @param[in] d_values_in
+  //!   Pointer to the corresponding input sequence of associated value items
+  //!
+  //! @param[out] d_values_out
+  //!   Pointer to the correspondingly-reordered output sequence of associated
+  //!   value items
+  //!
+  //! @param[in] num_items
+  //!   Number of items to sort
+  //!
+  //! @param[in] decomposer
+  //!   Callable object responsible for decomposing a ``KeyT`` into a tuple of
+  //!   references to its constituent arithmetic types
+  //!
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename KeyT,
+            typename ValueT,
+            typename NumItemsT,
+            typename DecomposerT,
+            typename EnvT = ::cuda::std::execution::env<>,
+            typename ::cuda::std::enable_if_t<!::cuda::std::is_convertible_v<DecomposerT, int>, int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortPairs(
+    const KeyT* d_keys_in,
+    KeyT* d_keys_out,
+    const ValueT* d_values_in,
+    ValueT* d_values_out,
+    NumItemsT num_items,
+    DecomposerT decomposer,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE(GetName());
+
+    using offset_t           = detail::choose_offset_t<NumItemsT>;
+    using decomposer_check_t = detail::radix::decomposer_check_t<KeyT, DecomposerT>;
+
+    static_assert(decomposer_check_t::value,
+                  "DecomposerT must be a callable object returning a tuple of references to "
+                  "arithmetic types");
+
+    if constexpr (decomposer_check_t::value)
+    {
+      return detail::dispatch_with_env(
+        env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+          constexpr bool is_overwrite_okay = false;
+          DoubleBuffer<KeyT> d_keys(const_cast<KeyT*>(d_keys_in), d_keys_out);
+          DoubleBuffer<ValueT> d_values(const_cast<ValueT*>(d_values_in), d_values_out);
+
+          return detail::radix_sort::dispatch<SortOrder::Ascending>(
+            storage,
+            bytes,
+            d_keys,
+            d_values,
+            static_cast<offset_t>(num_items),
+            0,
+            detail::radix::traits_t<KeyT>::default_end_bit(decomposer),
+            is_overwrite_okay,
+            stream,
+            decomposer);
+        });
     }
   }
 
@@ -1122,6 +1354,107 @@ public:
   //! @rst
   //! Sorts key-value pairs into ascending order using :math:`\approx N` auxiliary storage.
   //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The sorting operation is given a pair of key buffers and a corresponding
+  //!   pair of associated value buffers. Each pair is managed by a DoubleBuffer
+  //!   structure that indicates which of the two buffers is "current" (and thus
+  //!   contains the input data to be sorted).
+  //! - The contents of both buffers within each pair may be altered by the
+  //!   sorting operation.
+  //!
+  //! Snippet
+  //! --------------------------------------------------
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_radix_sort_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin radix-sort-pairs-db-decomposer-env
+  //!     :end-before: example-end radix-sort-pairs-db-decomposer-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyT
+  //!   **[inferred]** KeyT type
+  //!
+  //! @tparam ValueT
+  //!   **[inferred]** ValueT type
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam DecomposerT
+  //!   **[inferred]** Type of a callable object responsible for decomposing a
+  //!   ``KeyT`` into a tuple of references to its constituent arithmetic types
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type
+  //!
+  //! @param[in,out] d_keys
+  //!   Reference to the double-buffer of keys
+  //!
+  //! @param[in,out] d_values
+  //!   Double-buffer of values
+  //!
+  //! @param[in] num_items
+  //!   Number of items to sort
+  //!
+  //! @param[in] decomposer
+  //!   Callable object responsible for decomposing a ``KeyT`` into a tuple of
+  //!   references to its constituent arithmetic types
+  //!
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename KeyT,
+            typename ValueT,
+            typename NumItemsT,
+            typename DecomposerT,
+            typename EnvT = ::cuda::std::execution::env<>,
+            typename ::cuda::std::enable_if_t<!::cuda::std::is_convertible_v<DecomposerT, int>, int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortPairs(
+    DoubleBuffer<KeyT>& d_keys,
+    DoubleBuffer<ValueT>& d_values,
+    NumItemsT num_items,
+    DecomposerT decomposer,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE(GetName());
+
+    using offset_t           = detail::choose_offset_t<NumItemsT>;
+    using decomposer_check_t = detail::radix::decomposer_check_t<KeyT, DecomposerT>;
+
+    static_assert(decomposer_check_t::value,
+                  "DecomposerT must be a callable object returning a tuple of references to "
+                  "arithmetic types");
+
+    if constexpr (decomposer_check_t::value)
+    {
+      return detail::dispatch_with_env(
+        env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+          return detail::radix_sort::dispatch<SortOrder::Ascending>(
+            storage,
+            bytes,
+            d_keys,
+            d_values,
+            static_cast<offset_t>(num_items),
+            0,
+            detail::radix::traits_t<KeyT>::default_end_bit(decomposer),
+            true,
+            stream,
+            decomposer);
+        });
+    }
+  }
+
+  //! @rst
+  //! Sorts key-value pairs into ascending order using :math:`\approx N` auxiliary storage.
+  //!
   //! .. versionadded:: 2.2.0
   //!    First appears in CUDA Toolkit 12.3.
   //!
@@ -1267,6 +1600,116 @@ public:
         begin_bit,
         end_bit,
         stream);
+    }
+  }
+
+  //! @rst
+  //! Sorts key-value pairs into ascending order using :math:`\approx N` auxiliary storage.
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The sorting operation is given a pair of key buffers and a corresponding
+  //!   pair of associated value buffers. Each pair is managed by a DoubleBuffer
+  //!   structure.
+  //! - The contents of both buffers within each pair may be altered by the
+  //!   sorting operation.
+  //! - A bit subrange ``[begin_bit, end_bit)`` is provided to specify which
+  //!   key bits are used for sorting.
+  //!
+  //! Snippet
+  //! --------------------------------------------------
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_radix_sort_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin radix-sort-pairs-db-decomposer-bits-env
+  //!     :end-before: example-end radix-sort-pairs-db-decomposer-bits-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyT
+  //!   **[inferred]** KeyT type
+  //!
+  //! @tparam ValueT
+  //!   **[inferred]** ValueT type
+  //!
+  //! @tparam NumItemsT
+  //!   **[inferred]** Type of num_items
+  //!
+  //! @tparam DecomposerT
+  //!   **[inferred]** Type of a callable object responsible for decomposing a
+  //!   ``KeyT`` into a tuple of references to its constituent arithmetic types
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type
+  //!
+  //! @param[in,out] d_keys
+  //!   Reference to the double-buffer of keys
+  //!
+  //! @param[in,out] d_values
+  //!   Double-buffer of values
+  //!
+  //! @param[in] num_items
+  //!   Number of items to sort
+  //!
+  //! @param[in] decomposer
+  //!   Callable object responsible for decomposing a ``KeyT`` into a tuple of
+  //!   references to its constituent arithmetic types
+  //!
+  //! @param[in] begin_bit
+  //!   The least-significant bit index (inclusive) needed for key comparison
+  //!
+  //! @param[in] end_bit
+  //!   The most-significant bit index (exclusive) needed for key comparison
+  //!
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename KeyT,
+            typename ValueT,
+            typename NumItemsT,
+            typename DecomposerT,
+            typename EnvT = ::cuda::std::execution::env<>,
+            typename ::cuda::std::enable_if_t<!::cuda::std::is_convertible_v<DecomposerT, int>, int> = 0>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortPairs(
+    DoubleBuffer<KeyT>& d_keys,
+    DoubleBuffer<ValueT>& d_values,
+    NumItemsT num_items,
+    DecomposerT decomposer,
+    int begin_bit,
+    int end_bit,
+    EnvT env = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE(GetName());
+
+    using offset_t           = detail::choose_offset_t<NumItemsT>;
+    using decomposer_check_t = detail::radix::decomposer_check_t<KeyT, DecomposerT>;
+
+    static_assert(decomposer_check_t::value,
+                  "DecomposerT must be a callable object returning a tuple of references to "
+                  "arithmetic types");
+
+    if constexpr (decomposer_check_t::value)
+    {
+      return detail::dispatch_with_env(
+        env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+          return detail::radix_sort::dispatch<SortOrder::Ascending>(
+            storage,
+            bytes,
+            d_keys,
+            d_values,
+            static_cast<offset_t>(num_items),
+            begin_bit,
+            end_bit,
+            true,
+            stream,
+            decomposer);
+        });
     }
   }
 

--- a/cub/test/catch2_test_device_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_radix_sort_env.cu
@@ -11,6 +11,9 @@ struct stream_registry_factory_t;
 
 #include <thrust/device_vector.h>
 
+#include <cuda/devices>
+#include <cuda/stream>
+
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceRadixSort::SortPairs, device_radix_sort_pairs);
@@ -23,6 +26,20 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceRadixSort::SortKeysDescending, device_radix_so
 #include <c2h/catch2_test_helper.h>
 
 namespace stdexec = cuda::std::execution;
+
+struct custom_key_t
+{
+  int key;
+  int payload;
+};
+
+struct custom_decomposer_t
+{
+  __host__ __device__ auto operator()(custom_key_t& k) const -> ::cuda::std::tuple<int&>
+  {
+    return {k.key};
+  }
+};
 
 #if TEST_LAUNCH == 0
 
@@ -100,6 +117,62 @@ TEST_CASE("Device radix sort keys descending works with default environment", "[
   c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
 
   REQUIRE(keys_out == expected_keys);
+}
+
+TEST_CASE("Device radix sort pairs decomposer works with default environment", "[radix_sort][device]")
+{
+  auto keys_in    = c2h::device_vector<custom_key_t>{{3, 100}, {1, 200}, {2, 300}};
+  auto keys_out   = c2h::device_vector<custom_key_t>(3);
+  auto values_in  = c2h::device_vector<int>{0, 1, 2};
+  auto values_out = c2h::device_vector<int>(3);
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceRadixSort::SortPairs(
+      keys_in.data().get(),
+      keys_out.data().get(),
+      values_in.data().get(),
+      values_out.data().get(),
+      static_cast<int>(keys_in.size()),
+      custom_decomposer_t{}));
+
+  c2h::host_vector<custom_key_t> h_keys_out(keys_out);
+  REQUIRE(h_keys_out[0].key == 1);
+  REQUIRE(h_keys_out[1].key == 2);
+  REQUIRE(h_keys_out[2].key == 3);
+  c2h::host_vector<int> h_values_out(values_out);
+  REQUIRE(h_values_out[0] == 1);
+  REQUIRE(h_values_out[1] == 2);
+  REQUIRE(h_values_out[2] == 0);
+}
+
+TEST_CASE("Device radix sort pairs decomposer with bits works with default environment", "[radix_sort][device]")
+{
+  auto keys_in    = c2h::device_vector<custom_key_t>{{3, 100}, {1, 200}, {2, 300}};
+  auto keys_out   = c2h::device_vector<custom_key_t>(3);
+  auto values_in  = c2h::device_vector<int>{0, 1, 2};
+  auto values_out = c2h::device_vector<int>(3);
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceRadixSort::SortPairs(
+      keys_in.data().get(),
+      keys_out.data().get(),
+      values_in.data().get(),
+      values_out.data().get(),
+      static_cast<int>(keys_in.size()),
+      custom_decomposer_t{},
+      0,
+      sizeof(int) * 8));
+
+  c2h::host_vector<custom_key_t> h_keys_out(keys_out);
+  REQUIRE(h_keys_out[0].key == 1);
+  REQUIRE(h_keys_out[1].key == 2);
+  REQUIRE(h_keys_out[2].key == 3);
+  c2h::host_vector<int> h_values_out(values_out);
+  REQUIRE(h_values_out[0] == 1);
+  REQUIRE(h_values_out[1] == 2);
+  REQUIRE(h_values_out[2] == 0);
 }
 
 #endif
@@ -246,8 +319,7 @@ TEST_CASE("Device radix sort pairs uses custom stream", "[radix_sort][device]")
   auto values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = c2h::device_vector<int>(7);
 
-  cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -261,8 +333,8 @@ TEST_CASE("Device radix sort pairs uses custom stream", "[radix_sort][device]")
       values_out.data().get(),
       static_cast<int>(keys_in.size())));
 
-  auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
-  auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
+  cuda::stream_ref stream_ref{custom_stream};
+  auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
 
   device_radix_sort_pairs(
     keys_in.data().get(),
@@ -274,14 +346,13 @@ TEST_CASE("Device radix sort pairs uses custom stream", "[radix_sort][device]")
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  custom_stream.sync();
 
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   c2h::device_vector<int> expected_values{5, 4, 3, 1, 2, 0, 6};
 
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_sort][device]")
@@ -291,8 +362,7 @@ TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_sort]
   auto values_in  = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
   auto values_out = c2h::device_vector<int>(7);
 
-  cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -306,8 +376,8 @@ TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_sort]
       values_out.data().get(),
       static_cast<int>(keys_in.size())));
 
-  auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
-  auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
+  cuda::stream_ref stream_ref{custom_stream};
+  auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
 
   device_radix_sort_pairs_descending(
     keys_in.data().get(),
@@ -319,14 +389,13 @@ TEST_CASE("Device radix sort pairs descending uses custom stream", "[radix_sort]
     static_cast<int>(sizeof(int) * 8),
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  custom_stream.sync();
 
   c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
   c2h::device_vector<int> expected_values{6, 0, 2, 1, 3, 4, 5};
 
   REQUIRE(keys_out == expected_keys);
   REQUIRE(values_out == expected_values);
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]")
@@ -334,8 +403,7 @@ TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]")
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
 
-  cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -343,8 +411,8 @@ TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]")
     == cub::DeviceRadixSort::SortKeys(
       nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
-  auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
-  auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
+  cuda::stream_ref stream_ref{custom_stream};
+  auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
 
   device_radix_sort_keys(
     keys_in.data().get(),
@@ -354,10 +422,9 @@ TEST_CASE("Device radix sort keys uses custom stream", "[radix_sort][device]")
     static_cast<int>(static_cast<int>(sizeof(int) * 8)),
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  custom_stream.sync();
   c2h::device_vector<int> expected_keys{0, 3, 5, 6, 7, 8, 9};
   REQUIRE(keys_out == expected_keys);
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
 }
 
 TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_sort][device]")
@@ -365,8 +432,7 @@ TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_sort][
   auto keys_in  = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
   auto keys_out = c2h::device_vector<int>(7);
 
-  cudaStream_t custom_stream;
-  REQUIRE(cudaSuccess == cudaStreamCreate(&custom_stream));
+  cuda::stream custom_stream{cuda::devices[0]};
 
   size_t expected_bytes_allocated{};
   REQUIRE(
@@ -374,8 +440,8 @@ TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_sort][
     == cub::DeviceRadixSort::SortKeysDescending(
       nullptr, expected_bytes_allocated, keys_in.data().get(), keys_out.data().get(), static_cast<int>(keys_in.size())));
 
-  auto stream_prop = stdexec::prop{cuda::get_stream_t{}, cuda::stream_ref{custom_stream}};
-  auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
+  cuda::stream_ref stream_ref{custom_stream};
+  auto env = stdexec::env{stream_ref, expected_allocation_size(expected_bytes_allocated)};
 
   device_radix_sort_keys_descending(
     keys_in.data().get(),
@@ -385,8 +451,127 @@ TEST_CASE("Device radix sort keys descending uses custom stream", "[radix_sort][
     static_cast<int>(static_cast<int>(sizeof(int) * 8)),
     env);
 
-  REQUIRE(cudaSuccess == cudaStreamSynchronize(custom_stream));
+  custom_stream.sync();
   c2h::device_vector<int> expected_keys{9, 8, 7, 6, 5, 3, 0};
   REQUIRE(keys_out == expected_keys);
-  REQUIRE(cudaSuccess == cudaStreamDestroy(custom_stream));
+}
+
+TEST_CASE("Device radix sort pairs decomposer uses custom stream", "[radix_sort][device]")
+{
+  auto keys_in    = c2h::device_vector<custom_key_t>{{3, 100}, {1, 200}, {2, 300}};
+  auto keys_out   = c2h::device_vector<custom_key_t>(3);
+  auto values_in  = c2h::device_vector<int>{0, 1, 2};
+  auto values_out = c2h::device_vector<int>(3);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceRadixSort::SortPairs(
+      keys_in.data().get(),
+      keys_out.data().get(),
+      values_in.data().get(),
+      values_out.data().get(),
+      static_cast<int>(keys_in.size()),
+      custom_decomposer_t{},
+      stream_ref));
+
+  stream.sync();
+
+  c2h::host_vector<custom_key_t> h_keys_out(keys_out);
+  REQUIRE(h_keys_out[0].key == 1);
+  REQUIRE(h_keys_out[1].key == 2);
+  REQUIRE(h_keys_out[2].key == 3);
+  c2h::host_vector<int> h_values_out(values_out);
+  REQUIRE(h_values_out[0] == 1);
+  REQUIRE(h_values_out[1] == 2);
+  REQUIRE(h_values_out[2] == 0);
+}
+
+#if TEST_LAUNCH == 0
+
+TEST_CASE("Device radix sort pairs DB decomposer works with default environment", "[radix_sort][device]")
+{
+  c2h::device_vector<custom_key_t> keys_buf0{{3, 100}, {1, 200}, {2, 300}};
+  c2h::device_vector<custom_key_t> keys_buf1(3);
+  c2h::device_vector<int> values_buf0{0, 1, 2};
+  c2h::device_vector<int> values_buf1(3);
+
+  cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
+  cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceRadixSort::SortPairs(d_keys, d_values, static_cast<int>(keys_buf0.size()), custom_decomposer_t{}));
+
+  auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
+  c2h::host_vector<custom_key_t> h_keys(keys);
+  REQUIRE(h_keys[0].key == 1);
+  REQUIRE(h_keys[1].key == 2);
+  REQUIRE(h_keys[2].key == 3);
+  auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
+  c2h::host_vector<int> h_values(values);
+  REQUIRE(h_values[0] == 1);
+  REQUIRE(h_values[1] == 2);
+  REQUIRE(h_values[2] == 0);
+}
+
+TEST_CASE("Device radix sort pairs DB decomposer with bits works with default environment", "[radix_sort][device]")
+{
+  c2h::device_vector<custom_key_t> keys_buf0{{3, 100}, {1, 200}, {2, 300}};
+  c2h::device_vector<custom_key_t> keys_buf1(3);
+  c2h::device_vector<int> values_buf0{0, 1, 2};
+  c2h::device_vector<int> values_buf1(3);
+
+  cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
+  cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceRadixSort::SortPairs(
+            d_keys, d_values, static_cast<int>(keys_buf0.size()), custom_decomposer_t{}, 0, sizeof(int) * 8));
+
+  auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
+  c2h::host_vector<custom_key_t> h_keys(keys);
+  REQUIRE(h_keys[0].key == 1);
+  REQUIRE(h_keys[1].key == 2);
+  REQUIRE(h_keys[2].key == 3);
+  auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
+  c2h::host_vector<int> h_values(values);
+  REQUIRE(h_values[0] == 1);
+  REQUIRE(h_values[1] == 2);
+  REQUIRE(h_values[2] == 0);
+}
+
+#endif
+
+TEST_CASE("Device radix sort pairs DB decomposer uses custom stream", "[radix_sort][device]")
+{
+  c2h::device_vector<custom_key_t> keys_buf0{{3, 100}, {1, 200}, {2, 300}};
+  c2h::device_vector<custom_key_t> keys_buf1(3);
+  c2h::device_vector<int> values_buf0{0, 1, 2};
+  c2h::device_vector<int> values_buf1(3);
+
+  cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
+  cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceRadixSort::SortPairs(
+            d_keys, d_values, static_cast<int>(keys_buf0.size()), custom_decomposer_t{}, stream_ref));
+
+  stream.sync();
+
+  auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
+  c2h::host_vector<custom_key_t> h_keys(keys);
+  REQUIRE(h_keys[0].key == 1);
+  REQUIRE(h_keys[1].key == 2);
+  REQUIRE(h_keys[2].key == 3);
+  auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
+  c2h::host_vector<int> h_values(values);
+  REQUIRE(h_values[0] == 1);
+  REQUIRE(h_values[1] == 2);
+  REQUIRE(h_values[2] == 0);
 }

--- a/cub/test/catch2_test_device_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_radix_sort_env_api.cu
@@ -7,10 +7,28 @@
 #include <cub/device/device_radix_sort.cuh>
 
 #include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include <cuda/devices>
+#include <cuda/stream>
 
 #include <iostream>
 
 #include <c2h/catch2_test_helper.h>
+
+struct custom_key_t
+{
+  int key;
+  int payload;
+};
+
+struct custom_decomposer_t
+{
+  __host__ __device__ auto operator()(custom_key_t& k) const -> ::cuda::std::tuple<int&>
+  {
+    return {k.key};
+  }
+};
 
 C2H_TEST("cub::DeviceRadixSort::SortPairs env-based API", "[radix_sort][env]")
 {
@@ -156,4 +174,152 @@ C2H_TEST("cub::DeviceRadixSort::SortKeysDescending DoubleBuffer env-based API", 
   REQUIRE(error == cudaSuccess);
   auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
   REQUIRE(keys == expected_keys);
+}
+
+C2H_TEST("cub::DeviceRadixSort::SortPairs decomposer with bits env-based API", "[radix_sort][env]")
+{
+  // example-begin radix-sort-pairs-decomposer-bits-env
+  auto keys_in    = thrust::device_vector<custom_key_t>{{3, 100}, {1, 200}, {2, 300}};
+  auto keys_out   = thrust::device_vector<custom_key_t>(3);
+  auto values_in  = thrust::device_vector<int>{0, 1, 2};
+  auto values_out = thrust::device_vector<int>(3);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceRadixSort::SortPairs(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    custom_decomposer_t{},
+    0,
+    sizeof(int) * 8,
+    stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceRadixSort::SortPairs (decomposer+bits) failed with status: " << error << std::endl;
+  }
+  stream.sync();
+  // example-end radix-sort-pairs-decomposer-bits-env
+
+  REQUIRE(error == cudaSuccess);
+  thrust::host_vector<custom_key_t> h_keys_out(keys_out);
+  REQUIRE(h_keys_out[0].key == 1);
+  REQUIRE(h_keys_out[1].key == 2);
+  REQUIRE(h_keys_out[2].key == 3);
+  thrust::host_vector<int> h_values_out(values_out);
+  REQUIRE(h_values_out[0] == 1);
+  REQUIRE(h_values_out[1] == 2);
+  REQUIRE(h_values_out[2] == 0);
+}
+
+C2H_TEST("cub::DeviceRadixSort::SortPairs decomposer env-based API", "[radix_sort][env]")
+{
+  // example-begin radix-sort-pairs-decomposer-env
+  auto keys_in    = thrust::device_vector<custom_key_t>{{3, 100}, {1, 200}, {2, 300}};
+  auto keys_out   = thrust::device_vector<custom_key_t>(3);
+  auto values_in  = thrust::device_vector<int>{0, 1, 2};
+  auto values_out = thrust::device_vector<int>(3);
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceRadixSort::SortPairs(
+    keys_in.data().get(),
+    keys_out.data().get(),
+    values_in.data().get(),
+    values_out.data().get(),
+    static_cast<int>(keys_in.size()),
+    custom_decomposer_t{},
+    stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceRadixSort::SortPairs (decomposer) failed with status: " << error << std::endl;
+  }
+  stream.sync();
+  // example-end radix-sort-pairs-decomposer-env
+
+  REQUIRE(error == cudaSuccess);
+  thrust::host_vector<custom_key_t> h_keys_out(keys_out);
+  REQUIRE(h_keys_out[0].key == 1);
+  REQUIRE(h_keys_out[1].key == 2);
+  REQUIRE(h_keys_out[2].key == 3);
+  thrust::host_vector<int> h_values_out(values_out);
+  REQUIRE(h_values_out[0] == 1);
+  REQUIRE(h_values_out[1] == 2);
+  REQUIRE(h_values_out[2] == 0);
+}
+
+C2H_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer env-based API", "[radix_sort][env]")
+{
+  // example-begin radix-sort-pairs-db-decomposer-env
+  thrust::device_vector<custom_key_t> keys_buf0{{3, 100}, {1, 200}, {2, 300}};
+  thrust::device_vector<custom_key_t> keys_buf1(3);
+  thrust::device_vector<int> values_buf0{0, 1, 2};
+  thrust::device_vector<int> values_buf1(3);
+
+  cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
+  cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceRadixSort::SortPairs(
+    d_keys, d_values, static_cast<int>(keys_buf0.size()), custom_decomposer_t{}, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceRadixSort::SortPairs (DB decomposer) failed with status: " << error << std::endl;
+  }
+  stream.sync();
+  // example-end radix-sort-pairs-db-decomposer-env
+
+  REQUIRE(error == cudaSuccess);
+  auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
+  thrust::host_vector<custom_key_t> h_keys(keys);
+  REQUIRE(h_keys[0].key == 1);
+  REQUIRE(h_keys[1].key == 2);
+  REQUIRE(h_keys[2].key == 3);
+  auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
+  thrust::host_vector<int> h_values(values);
+  REQUIRE(h_values[0] == 1);
+  REQUIRE(h_values[1] == 2);
+  REQUIRE(h_values[2] == 0);
+}
+
+C2H_TEST("cub::DeviceRadixSort::SortPairs DoubleBuffer decomposer with bits env-based API", "[radix_sort][env]")
+{
+  // example-begin radix-sort-pairs-db-decomposer-bits-env
+  thrust::device_vector<custom_key_t> keys_buf0{{3, 100}, {1, 200}, {2, 300}};
+  thrust::device_vector<custom_key_t> keys_buf1(3);
+  thrust::device_vector<int> values_buf0{0, 1, 2};
+  thrust::device_vector<int> values_buf1(3);
+
+  cub::DoubleBuffer<custom_key_t> d_keys(keys_buf0.data().get(), keys_buf1.data().get());
+  cub::DoubleBuffer<int> d_values(values_buf0.data().get(), values_buf1.data().get());
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceRadixSort::SortPairs(
+    d_keys, d_values, static_cast<int>(keys_buf0.size()), custom_decomposer_t{}, 0, sizeof(int) * 8, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceRadixSort::SortPairs (DB decomposer+bits) failed with status: " << error << std::endl;
+  }
+  stream.sync();
+  // example-end radix-sort-pairs-db-decomposer-bits-env
+
+  REQUIRE(error == cudaSuccess);
+  auto& keys = d_keys.selector == 0 ? keys_buf0 : keys_buf1;
+  thrust::host_vector<custom_key_t> h_keys(keys);
+  REQUIRE(h_keys[0].key == 1);
+  REQUIRE(h_keys[1].key == 2);
+  REQUIRE(h_keys[2].key == 3);
+  auto& values = d_values.selector == 0 ? values_buf0 : values_buf1;
+  thrust::host_vector<int> h_values(values);
+  REQUIRE(h_values[0] == 1);
+  REQUIRE(h_values[1] == 2);
+  REQUIRE(h_values[2] == 0);
 }


### PR DESCRIPTION
works towards fixing https://github.com/NVIDIA/cccl/issues/7998

Adding the decomposer variants for `SortPairs`