### PR TITLE
Implement parallel `cuda::std::is_sorted`

### DIFF
--- a/libcudacxx/benchmarks/bench/is_sorted/basic.cu
+++ b/libcudacxx/benchmarks/bench/is_sorted/basic.cu
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include <cuda/functional>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = ::cuda::std::clamp<std::size_t>(elements * common_prefix, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::sequence(dinput.begin(), dinput.end(), T{0});
+  dinput[mismatch_point] = T{-1};
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(cuda::std::is_sorted(cuda_policy(alloc, launch), dinput.begin(), dinput.end()));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});
+
+template <typename T>
+static void with_predicate(nvbench::state& state, nvbench::type_list<T>)
+{
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = ::cuda::std::clamp<std::size_t>(elements * common_prefix, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::sequence(dinput.begin(), dinput.end(), T{0});
+  dinput[mismatch_point] = T{-1};
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(
+                 cuda::std::is_sorted(cuda_policy(alloc, launch), dinput.begin(), dinput.end(), cuda::std::less<>{}));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});

--- a/libcudacxx/benchmarks/bench/is_sorted_until/basic.cu
+++ b/libcudacxx/benchmarks/bench/is_sorted_until/basic.cu
@@ -1,0 +1,76 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include <cuda/functional>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = ::cuda::std::clamp<std::size_t>(elements * common_prefix, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::sequence(dinput.begin(), dinput.end(), T{0});
+  dinput[mismatch_point] = T{-1};
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(cuda::std::is_sorted_until(cuda_policy(alloc, launch), dinput.begin(), dinput.end()));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});
+
+template <typename T>
+static void with_predicate(nvbench::state& state, nvbench::type_list<T>)
+{
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = ::cuda::std::clamp<std::size_t>(elements * common_prefix, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::sequence(dinput.begin(), dinput.end(), T{0});
+  dinput[mismatch_point] = T{-1};
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(
+    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      do_not_optimize(
+        cuda::std::is_sorted_until(cuda_policy(alloc, launch), dinput.begin(), dinput.end(), cuda::std::less<>{}));
+    });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});

--- a/libcudacxx/include/cuda/std/__pstl/is_sorted.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_sorted.h
@@ -1,0 +1,93 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_IS_SORTED_H
+#define _CUDA_STD___PSTL_IS_SORTED_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__iterator/zip_function.h>
+#  include <cuda/__iterator/zip_iterator.h>
+#  include <cuda/__nvtx/nvtx.h>
+#  include <cuda/std/__algorithm/is_sorted.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/find_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _BinaryPredicate = less<>)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+[[nodiscard]] _CCCL_HOST_API bool is_sorted(
+  [[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPredicate __pred = {})
+{
+  static_assert(indirect_binary_predicate<_BinaryPredicate, _InputIterator, _InputIterator>,
+                "cuda::std::is_sorted: BinaryPredicate must satisfy "
+                "indirect_binary_predicate<BinaryPredicate, InputIterator, InputIterator>");
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::std::is_sorted");
+
+    if (__first == __last)
+    {
+      return true;
+    }
+
+    // Note we compare __first + 1 and __first, so that we do not need to negate the predicate
+    auto __result = __dispatch(
+      __policy,
+      ::cuda::zip_iterator{__first + 1, __first},
+      ::cuda::zip_iterator{__last, __last},
+      ::cuda::zip_function{::cuda::std::move(__pred)});
+    return ::cuda::std::get<0>(__result.__iterators()) == __last;
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::is_sorted requires at least one selected backend");
+    return ::cuda::std::is_sorted(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_IS_SORTED_H

--- a/libcudacxx/include/cuda/std/__pstl/is_sorted_until.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_sorted_until.h
@@ -1,0 +1,95 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_IS_SORTED_UNTIL_H
+#define _CUDA_STD___PSTL_IS_SORTED_UNTIL_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__iterator/zip_function.h>
+#  include <cuda/__iterator/zip_iterator.h>
+#  include <cuda/__nvtx/nvtx.h>
+#  include <cuda/std/__algorithm/is_sorted_until.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/operations.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/find_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _BinaryPredicate = less<>)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+[[nodiscard]] _CCCL_HOST_API _InputIterator is_sorted_until(
+  [[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, _BinaryPredicate __pred = {})
+{
+  static_assert(indirect_binary_predicate<_BinaryPredicate, _InputIterator, _InputIterator>,
+                "cuda::std::is_sorted_until: BinaryPredicate must satisfy "
+                "indirect_binary_predicate<BinaryPredicate, InputIterator, InputIterator>");
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::std::is_sorted_until");
+
+    if (__first == __last)
+    {
+      return __first;
+    }
+
+    // Note we compare __first + 1 and __first, so that we do not need to negate the predicate
+    auto __result = __dispatch(
+      __policy,
+      ::cuda::zip_iterator{__first + 1, __first},
+      ::cuda::zip_iterator{__last, __last},
+      ::cuda::zip_function{::cuda::std::move(__pred)});
+    return ::cuda::std::get<0>(__result.__iterators());
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>,
+                  "Parallel cuda::std::is_sorted_until requires at least one selected backend");
+    return ::cuda::std::is_sorted_until(
+      ::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_IS_SORTED_UNTIL_H

--- a/libcudacxx/include/cuda/std/__pstl_algorithm
+++ b/libcudacxx/include/cuda/std/__pstl_algorithm
@@ -42,6 +42,8 @@
 #include <cuda/std/__pstl/generate.h>
 #include <cuda/std/__pstl/generate_n.h>
 #include <cuda/std/__pstl/inclusive_scan.h>
+#include <cuda/std/__pstl/is_sorted.h>
+#include <cuda/std/__pstl/is_sorted_until.h>
 #include <cuda/std/__pstl/merge.h>
 #include <cuda/std/__pstl/mismatch.h>
 #include <cuda/std/__pstl/none_of.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted.cu
@@ -1,0 +1,104 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, ForwardIterator Iter>
+// bool is_sorted(ExecutionPolicy&& policy, Iter first, Iter last);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/iterator>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 1000;
+
+struct turn_42_into_1337
+{
+  __device__ constexpr int operator()(const int val) const noexcept
+  {
+    return val == 42 ? 1337 : val;
+  }
+};
+
+template <class Policy>
+void test_is_sorted(const Policy& policy, thrust::device_vector<int>& input)
+{
+  { // empty should not access anything
+    const auto res = cuda::std::is_sorted(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr));
+    CHECK(res);
+  }
+
+  thrust::sequence(input.begin(), input.end(), 0);
+  { // sorted contiguous range
+    const auto res = cuda::std::is_sorted(policy, input.begin(), input.end());
+    CHECK(res);
+  }
+
+  { // sorted random access range
+    const auto res = cuda::std::is_sorted(policy, cuda::counting_iterator{0}, cuda::counting_iterator{size});
+    CHECK(res);
+  }
+
+  { // unsorted contiguous range
+    input[42]      = 1337;
+    const auto res = cuda::std::is_sorted(policy, input.begin(), input.end());
+    CHECK(!res);
+  }
+
+  { // unsorted random access range
+    const auto res = cuda::std::is_sorted(
+      policy,
+      cuda::transform_iterator{cuda::counting_iterator{0}, turn_42_into_1337{}},
+      cuda::transform_iterator{cuda::counting_iterator{size}, turn_42_into_1337{}});
+    CHECK(!res);
+  }
+}
+
+C2H_TEST("cuda::std::is_sorted(iter, iter)", "[parallel algorithm]")
+{
+  thrust::device_vector<int> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    test_is_sorted(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    test_is_sorted(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    test_is_sorted(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    test_is_sorted(policy, input);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_comp.cu
@@ -1,0 +1,110 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, ForwardIterator Iter, BinaryPredicate>
+// bool is_sorted(ExecutionPolicy&& policy, Iter first, Iter last, BinaryPredicate pred);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/iterator>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 1000;
+
+struct turn_42_into_1337
+{
+  __device__ constexpr int operator()(const int val) const noexcept
+  {
+    return val == 42 ? 1337 : val;
+  }
+};
+
+template <class Policy>
+void test_is_sorted(const Policy& policy, thrust::device_vector<int>& input)
+{
+  { // empty should not access anything
+    const auto res =
+      cuda::std::is_sorted(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::std::greater<>{});
+    CHECK(res);
+  }
+
+  thrust::sequence(input.begin(), input.end(), size, -1);
+  { // sorted contiguous range
+    const auto res = cuda::std::is_sorted(policy, input.begin(), input.end(), cuda::std::greater<>{});
+    CHECK(res);
+  }
+
+  { // sorted random access range
+    const auto res = cuda::std::is_sorted(
+      policy,
+      cuda::strided_iterator{cuda::counting_iterator{size}, -1},
+      cuda::strided_iterator{cuda::counting_iterator{0}, -1},
+      cuda::std::greater<>{});
+    CHECK(res);
+  }
+
+  { // unsorted contiguous range
+    input[42]      = 1337;
+    const auto res = cuda::std::is_sorted(policy, input.begin(), input.end(), cuda::std::greater<>{});
+    CHECK(!res);
+  }
+
+  { // unsorted random access range
+    const auto res = cuda::std::is_sorted(
+      policy,
+      cuda::transform_iterator{cuda::strided_iterator{cuda::counting_iterator{size}, -1}, turn_42_into_1337{}},
+      cuda::transform_iterator{cuda::strided_iterator{cuda::counting_iterator{0}, -1}, turn_42_into_1337{}},
+      cuda::std::greater<>{});
+    CHECK(!res);
+  }
+}
+
+C2H_TEST("cuda::std::is_sorted(iter, iter, pred)", "[parallel algorithm]")
+{
+  thrust::device_vector<int> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    test_is_sorted(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    test_is_sorted(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    test_is_sorted(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    test_is_sorted(policy, input);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until.cu
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, ForwardIterator Iter>
+// bool is_sorted_until(ExecutionPolicy&& policy, Iter first, Iter last);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/iterator>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 1000;
+
+struct turn_42_into_1337
+{
+  __device__ constexpr int operator()(const int val) const noexcept
+  {
+    return val == 42 ? 1337 : val;
+  }
+};
+
+template <class Policy>
+void test_is_sorted_until(const Policy& policy, thrust::device_vector<int>& input)
+{
+  { // empty should not access anything
+    const auto res = cuda::std::is_sorted_until(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr));
+    CHECK(res == nullptr);
+  }
+
+  thrust::sequence(input.begin(), input.end(), 0);
+  { // sorted contiguous range
+    const auto res = cuda::std::is_sorted_until(policy, input.begin(), input.end());
+    CHECK(res == input.end());
+  }
+
+  { // sorted random access range
+    const auto res = cuda::std::is_sorted_until(policy, cuda::counting_iterator{0}, cuda::counting_iterator{size});
+    CHECK(res == cuda::counting_iterator{size});
+  }
+
+  { // unsorted contiguous range
+    input[42]      = 1337;
+    const auto res = cuda::std::is_sorted_until(policy, input.begin(), input.end());
+    // 43 < 1337
+    CHECK(res == cuda::std::next(input.begin(), 43));
+    CHECK(cuda::std::is_sorted(policy, input.begin(), res));
+  }
+
+  { // unsorted random access range
+    auto iter      = cuda::transform_iterator{cuda::counting_iterator{0}, turn_42_into_1337{}};
+    const auto res = cuda::std::is_sorted_until(policy, iter, iter + size);
+    CHECK(cuda::std::is_sorted(policy, iter, res));
+    CHECK(res == cuda::std::next(iter, 43));
+  }
+}
+
+C2H_TEST("cuda::std::is_sorted_until(iter, iter)", "[parallel algorithm]")
+{
+  thrust::device_vector<int> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    test_is_sorted_until(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    test_is_sorted_until(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    test_is_sorted_until(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    test_is_sorted_until(policy, input);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until_comp.cu
@@ -1,0 +1,111 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, ForwardIterator Iter, BinaryPredicate>
+// bool is_sorted_until(ExecutionPolicy&& policy, Iter first, Iter last, BinaryPredicate pred);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/__pstl_algorithm>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/iterator>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 1000;
+
+struct turn_42_into_1337
+{
+  __device__ constexpr int operator()(const int val) const noexcept
+  {
+    return val == 42 ? 1337 : val;
+  }
+};
+
+template <class Policy>
+void test_is_sorted_until(const Policy& policy, thrust::device_vector<int>& input)
+{
+  { // empty should not access anything
+    const auto res = cuda::std::is_sorted_until(
+      policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), cuda::std::greater<>{});
+    CHECK(res == nullptr);
+  }
+
+  thrust::sequence(input.begin(), input.end(), size, -1);
+  { // sorted contiguous range
+    const auto res = cuda::std::is_sorted_until(policy, input.begin(), input.end(), cuda::std::greater<>{});
+    CHECK(res == input.end());
+  }
+
+  { // sorted random access range
+    const auto res = cuda::std::is_sorted_until(
+      policy,
+      cuda::strided_iterator{cuda::counting_iterator{size}, -1},
+      cuda::strided_iterator{cuda::counting_iterator{0}, -1},
+      cuda::std::greater<>{});
+    CHECK(res == cuda::strided_iterator{cuda::counting_iterator{0}, -1});
+  }
+
+  { // unsorted contiguous range
+    input[42]      = 1337;
+    const auto res = cuda::std::is_sorted_until(policy, input.begin(), input.end(), cuda::std::greater<>{});
+    // 969 < 1337
+    CHECK(res == cuda::std::next(input.begin(), 42));
+    CHECK(cuda::std::is_sorted(policy, input.begin(), res, cuda::std::greater<>{}));
+  }
+
+  { // unsorted random access range
+    auto iter =
+      cuda::transform_iterator{cuda::strided_iterator{cuda::counting_iterator{size}, -1}, turn_42_into_1337{}};
+    const auto res = cuda::std::is_sorted_until(policy, iter, iter + size, cuda::std::greater<>{});
+    CHECK(res == iter + (size - 42));
+    CHECK(cuda::std::is_sorted(policy, iter, res, cuda::std::greater<>{}));
+  }
+}
+
+C2H_TEST("cuda::std::is_sorted_until(iter, iter, pred)", "[parallel algorithm]")
+{
+  thrust::device_vector<int> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::__cub_par_unseq;
+    test_is_sorted_until(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    test_is_sorted_until(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    test_is_sorted_until(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    test_is_sorted_until(policy, input);
+  }
+}

--- a/thrust/benchmarks/bench/is_sorted/basic.cu
+++ b/thrust/benchmarks/bench/is_sorted/basic.cu
@@ -1,0 +1,74 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include <cuda/functional>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = ::cuda::std::clamp<std::size_t>(elements * common_prefix, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::sequence(dinput.begin(), dinput.end(), T{0});
+  dinput[mismatch_point] = T{-1};
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(thrust::is_sorted(policy(alloc, launch), dinput.begin(), dinput.end()));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});
+
+template <typename T>
+static void with_predicate(nvbench::state& state, nvbench::type_list<T>)
+{
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = ::cuda::std::clamp<std::size_t>(elements * common_prefix, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::sequence(dinput.begin(), dinput.end(), T{0});
+  dinput[mismatch_point] = T{-1};
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(
+    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      do_not_optimize(thrust::is_sorted(policy(alloc, launch), dinput.begin(), dinput.end(), cuda::std::less<>{}));
+    });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});

--- a/thrust/benchmarks/bench/is_sorted_until/basic.cu
+++ b/thrust/benchmarks/bench/is_sorted_until/basic.cu
@@ -1,0 +1,75 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include <cuda/functional>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = ::cuda::std::clamp<std::size_t>(elements * common_prefix, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::sequence(dinput.begin(), dinput.end(), T{0});
+  dinput[mismatch_point] = T{-1};
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(thrust::is_sorted_until(policy(alloc, launch), dinput.begin(), dinput.end()));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});
+
+template <typename T>
+static void with_predicate(nvbench::state& state, nvbench::type_list<T>)
+{
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = ::cuda::std::clamp<std::size_t>(elements * common_prefix, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::sequence(dinput.begin(), dinput.end(), T{0});
+  dinput[mismatch_point] = T{-1};
+
+  state.add_global_memory_reads<T>(mismatch_point + 1);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(
+                 thrust::is_sorted_until(policy(alloc, launch), dinput.begin(), dinput.end(), cuda::std::less<>{}));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});


### PR DESCRIPTION
This implements the `is_sorted` algorithms for the cuda backend.

* `std::is_sorted` see https://en.cppreference.com/w/cpp/algorithm/is_sorted.html
* `std::is_sorted_until` see https://en.cppreference.com/w/cpp/algorithm/is_sorted_until.html

It provides tests and benchmarks similar to Thrust and some boilerplate for libcu++

The functionality is publicly available yet and implemented in a private internal header

Fixes #7762
