### PR TITLE
Implement `static_count` hierarchy query

### DIFF
--- a/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
@@ -170,6 +170,13 @@ struct hierarchy_level_base
 
   _CCCL_TEMPLATE(class _InLevel, class _Hierarchy)
   _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel> _CCCL_AND __is_or_has_hierarchy_member_v<_Hierarchy>)
+  [[nodiscard]] _CCCL_API static constexpr auto static_count(const _InLevel& __level, const _Hierarchy& __hier) noexcept
+  {
+    return __static_count_impl(__level, ::cuda::__unpack_hierarchy_if_needed(__hier));
+  }
+
+  _CCCL_TEMPLATE(class _InLevel, class _Hierarchy)
+  _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel> _CCCL_AND __is_or_has_hierarchy_member_v<_Hierarchy>)
   [[nodiscard]] _CCCL_API static constexpr ::cuda::std::size_t
   count(const _InLevel& __level, const _Hierarchy& __hier) noexcept
   {
@@ -417,6 +424,26 @@ private:
       __ret[__i] = _Exts::static_extent(__i);
     }
     return __ret;
+  }
+
+  template <class... _Args>
+  [[nodiscard]] _CCCL_API static constexpr auto __static_count_impl(const _Args&... __args) noexcept
+  {
+    using _Exts = decltype(_Level::extents(__args...));
+
+    if constexpr (_Exts::rank_dynamic() == 0)
+    {
+      ::cuda::std::size_t __ret{1};
+      for (::cuda::std::size_t __i = 0; __i < _Exts::rank(); ++__i)
+      {
+        __ret *= _Exts::static_extent(__i);
+      }
+      return __ret;
+    }
+    else
+    {
+      return ::cuda::std::dynamic_extent;
+    }
   }
 
   _CCCL_EXEC_CHECK_DISABLE

--- a/libcudacxx/include/cuda/__hierarchy/native_hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/native_hierarchy_level_base.h
@@ -60,6 +60,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __native_hierarchy_level_base : hierarchy_leve
   using __base_type::dims_as;
   using __base_type::extents;
   using __base_type::extents_as;
+  using __base_type::static_count;
   using __base_type::static_dims;
 
 #  if _CCCL_CUDA_COMPILATION()
@@ -87,6 +88,13 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __native_hierarchy_level_base : hierarchy_leve
   [[nodiscard]] _CCCL_DEVICE_API static auto extents(const _InLevel& __level) noexcept
   {
     return _Level::template extents_as<__default_md_query_type<_InLevel>>(__level);
+  }
+
+  _CCCL_TEMPLATE(class _InLevel)
+  _CCCL_REQUIRES(__is_native_hierarchy_level_v<_InLevel>)
+  [[nodiscard]] _CCCL_DEVICE_API static constexpr auto static_count(const _InLevel& __level) noexcept
+  {
+    return __base_type::__static_count_impl(__level);
   }
 
   _CCCL_TEMPLATE(class _InLevel)

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/hierarchy_queries.pass.cpp
@@ -70,7 +70,14 @@ __device__ void test_block(
     test_extents(exp, cuda::block, cuda::grid, hier);
   }
 
-  // 4. Test cuda::block.count(x, hier)
+  // 4. Test cuda::block.static_count(x, hier)
+  if constexpr (Hierarchy::has_level(cuda::cluster))
+  {
+    test_static_count(cuda::block, cuda::cluster, hier);
+  }
+  test_static_count(cuda::block, cuda::grid, hier);
+
+  // 5. Test cuda::block.count(x, hier)
   if constexpr (Hierarchy::has_level(cuda::cluster))
   {
     cuda::std::size_t exp = 1;
@@ -83,7 +90,7 @@ __device__ void test_block(
   }
   test_count(cuda::std::size_t{gridDim.z} * gridDim.y * gridDim.x, cuda::block, cuda::grid, hier);
 
-  // 5. test cuda::block.index(x, hier)
+  // 6. test cuda::block.index(x, hier)
   if constexpr (Hierarchy::has_level(cuda::cluster))
   {
     uint3 exp{0, 0, 0};
@@ -92,7 +99,7 @@ __device__ void test_block(
   }
   test_index(blockIdx, cuda::block, cuda::grid, hier);
 
-  // 6. Test cuda::block.rank(x, hier)
+  // 7. Test cuda::block.rank(x, hier)
   if constexpr (Hierarchy::has_level(cuda::cluster))
   {
     cuda::std::size_t exp = 0;

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/hierarchy_query_signatures.compile.pass.cpp
@@ -34,16 +34,20 @@ __device__ void test_query_signatures(const Level& level, const Hierarchy& hier)
   static_assert(cuda::std::is_same_v<unsigned, typename ExtentsResult::index_type>);
   static_assert(noexcept(cuda::block_level::extents(level, hier)));
 
-  // 4. Test cuda::block_level::count(x, hier) signature.
+  // 4. Test cuda::block_level::static_count(x, hier) signature.
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::block_level::static_count(level, hier))>);
+  static_assert(noexcept(cuda::block_level::static_count(level, hier)));
+
+  // 5. Test cuda::block_level::count(x, hier) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::block_level::count(level, hier))>);
   static_assert(noexcept(cuda::block_level::count(level, hier)));
 
-  // 5. Test cuda::block_level::index(x, hier) signature.
+  // 6. Test cuda::block_level::index(x, hier) signature.
   static_assert(
     cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::block_level::index(level, hier))>);
   static_assert(noexcept(cuda::block_level::index(level, hier)));
 
-  // 6. Test cuda::block_level::rank(x, hier) signature.
+  // 7. Test cuda::block_level::rank(x, hier) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::block_level::rank(level, hier))>);
   static_assert(noexcept(cuda::block_level::rank(level, hier)));
 }

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/native_hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/native_hierarchy_queries.pass.cpp
@@ -42,7 +42,11 @@ __device__ void test_block()
   }
   test_extents(cuda::std::dims<3, unsigned>{gridDim.x, gridDim.y, gridDim.z}, cuda::block, cuda::grid);
 
-  // 4. Test cuda::block.count(x)
+  // 4. Test cuda::block.static_count(x)
+  test_static_count(cuda::block, cuda::cluster);
+  test_static_count(cuda::block, cuda::grid);
+
+  // 5. Test cuda::block.count(x)
   {
     cuda::std::size_t exp = 1;
     NV_IF_TARGET(NV_PROVIDES_SM_90, ({
@@ -54,7 +58,7 @@ __device__ void test_block()
   }
   test_count(cuda::std::size_t{gridDim.z} * gridDim.y * gridDim.x, cuda::block, cuda::grid);
 
-  // 5. test cuda::block.index(x)
+  // 6. test cuda::block.index(x)
   {
     uint3 exp{0, 0, 0};
     NV_IF_TARGET(NV_PROVIDES_SM_90, (exp = __clusterRelativeBlockIdx();))
@@ -62,7 +66,7 @@ __device__ void test_block()
   }
   test_index(blockIdx, cuda::block, cuda::grid);
 
-  // 6. Test cuda::block.rank(x)
+  // 7. Test cuda::block.rank(x)
   {
     cuda::std::size_t exp = 0;
     NV_IF_TARGET(NV_PROVIDES_SM_90, ({

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/native_hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/native_hierarchy_query_signatures.compile.pass.cpp
@@ -31,16 +31,20 @@ __device__ void test_query_signatures(const Level& level)
   static_assert(cuda::std::is_same_v<cuda::std::dims<3, unsigned>, decltype(cuda::block_level::extents(level))>);
   static_assert(noexcept(cuda::block_level::extents(level)));
 
-  // 4. Test cuda::block_level::count(x) signature.
+  // 4. Test cuda::block_level::static_count(x) signature.
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::block_level::static_count(level))>);
+  static_assert(noexcept(cuda::block_level::static_count(level)));
+
+  // 5. Test cuda::block_level::count(x) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::block_level::count(level))>);
   static_assert(noexcept(cuda::block_level::count(level)));
 
-  // 5. Test cuda::block_level::index(x) signature.
+  // 6. Test cuda::block_level::index(x) signature.
   static_assert(
     cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::block_level::index(level))>);
   static_assert(noexcept(cuda::block_level::index(level)));
 
-  // 6. Test cuda::block_level::rank(x) signature.
+  // 7. Test cuda::block_level::rank(x) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::block_level::rank(level))>);
   static_assert(noexcept(cuda::block_level::rank(level)));
 }

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/hierarchy_queries.pass.cpp
@@ -47,13 +47,16 @@ __device__ void test_cluster(const Hierarchy& hier, const GridExts& grid_exts, c
     test_extents(exp, cuda::cluster, cuda::grid, hier);
   }
 
-  // 4. Test cuda::cluster.count(x, hier)
+  // 4. Test cuda::cluster.static_count(x, hier)
+  test_static_count(cuda::cluster, cuda::grid, hier);
+
+  // 5. Test cuda::cluster.count(x, hier)
   test_count(cuda::std::size_t{dims.z} * dims.y * dims.x, cuda::cluster, cuda::grid, hier);
 
-  // 5. test cuda::cluster.index(x, hier)
+  // 6. test cuda::cluster.index(x, hier)
   test_index(index, cuda::cluster, cuda::grid, hier);
 
-  // 6. Test cuda::cluster.rank(x, hier)
+  // 7. Test cuda::cluster.rank(x, hier)
   {
     const cuda::std::size_t exp = (index.z * dims.y + index.y) * dims.x + index.x;
     test_rank(exp, cuda::cluster, cuda::grid, hier);

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/hierarchy_query_signatures.compile.pass.cpp
@@ -34,16 +34,20 @@ __device__ void test_query_signatures(const Level& level, const Hierarchy& hier)
   static_assert(cuda::std::is_same_v<unsigned, typename ExtentsResult::index_type>);
   static_assert(noexcept(cuda::cluster_level::extents(level, hier)));
 
-  // 4. Test cuda::cluster_level::count(x, hier) signature.
+  // 4. Test cuda::cluster_level::static_count(x, hier) signature.
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::cluster_level::static_count(level, hier))>);
+  static_assert(noexcept(cuda::cluster_level::static_count(level, hier)));
+
+  // 5. Test cuda::cluster_level::count(x, hier) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::cluster_level::count(level, hier))>);
   static_assert(noexcept(cuda::cluster_level::count(level, hier)));
 
-  // 5. Test cuda::cluster_level::index(x, hier) signature.
+  // 6. Test cuda::cluster_level::index(x, hier) signature.
   static_assert(
     cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::cluster_level::index(level, hier))>);
   static_assert(noexcept(cuda::cluster_level::index(level, hier)));
 
-  // 6. Test cuda::cluster_level::rank(x, hier) signature.
+  // 7. Test cuda::cluster_level::rank(x, hier) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::cluster_level::rank(level, hier))>);
   static_assert(noexcept(cuda::cluster_level::rank(level, hier)));
 }

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/native_hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/native_hierarchy_queries.pass.cpp
@@ -37,13 +37,16 @@ __device__ void test_cluster()
   // 3. Test cuda::cluster.extents(x)
   test_extents(cuda::std::dims<3, unsigned>{dims.x, dims.y, dims.z}, cuda::cluster, cuda::grid);
 
-  // 4. Test cuda::cluster.count(x)
+  // 4. Test cuda::cluster.static_count(x)
+  test_static_count(cuda::cluster, cuda::grid);
+
+  // 5. Test cuda::cluster.count(x)
   test_count(cuda::std::size_t{dims.z} * dims.y * dims.x, cuda::cluster, cuda::grid);
 
-  // 5. test cuda::cluster.index(x)
+  // 6. test cuda::cluster.index(x)
   test_index(index, cuda::cluster, cuda::grid);
 
-  // 6. Test cuda::cluster.rank(x)
+  // 7. Test cuda::cluster.rank(x)
   {
     const cuda::std::size_t exp = (index.z * dims.y + index.y) * dims.x + index.x;
     test_rank(exp, cuda::cluster, cuda::grid);

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/native_hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/native_hierarchy_query_signatures.compile.pass.cpp
@@ -31,16 +31,20 @@ __device__ void test_query_signatures(const Level& level)
   static_assert(cuda::std::is_same_v<cuda::std::dims<3, unsigned>, decltype(cuda::cluster_level::extents(level))>);
   static_assert(noexcept(cuda::cluster_level::extents(level)));
 
-  // 4. Test cuda::cluster_level::count(x) signature.
+  // 4. Test cuda::cluster_level::static_count(x) signature.
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::cluster_level::static_count(level))>);
+  static_assert(noexcept(cuda::cluster_level::static_count(level)));
+
+  // 5. Test cuda::cluster_level::count(x) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::cluster_level::count(level))>);
   static_assert(noexcept(cuda::cluster_level::count(level)));
 
-  // 5. Test cuda::cluster_level::index(x) signature.
+  // 6. Test cuda::cluster_level::index(x) signature.
   static_assert(
     cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::cluster_level::index(level))>);
   static_assert(noexcept(cuda::cluster_level::index(level)));
 
-  // 6. Test cuda::cluster_level::rank(x) signature.
+  // 7. Test cuda::cluster_level::rank(x) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::cluster_level::rank(level))>);
   static_assert(noexcept(cuda::cluster_level::rank(level)));
 }

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_queries.pass.cpp
@@ -91,7 +91,15 @@ __device__ void test_thread(
     test_extents(exp, cuda::gpu_thread, cuda::grid, hier);
   }
 
-  // 4. Test cuda::gpu_thread.count(x, hier)
+  // 4. Test cuda::gpu_thread.static_count(x, hier)
+  test_static_count(cuda::gpu_thread, cuda::block, hier);
+  if constexpr (Hierarchy::has_level(cuda::cluster))
+  {
+    test_static_count(cuda::gpu_thread, cuda::cluster, hier);
+  }
+  test_static_count(cuda::gpu_thread, cuda::grid, hier);
+
+  // 5. Test cuda::gpu_thread.count(x, hier)
   test_count(cuda::std::size_t{blockDim.z} * blockDim.y * blockDim.x, cuda::gpu_thread, cuda::block, hier);
   if constexpr (Hierarchy::has_level(cuda::cluster))
   {
@@ -108,7 +116,7 @@ __device__ void test_thread(
     test_count(cuda::std::size_t{exp.z} * exp.y * exp.x, cuda::gpu_thread, cuda::grid, hier);
   }
 
-  // 5. test cuda::gpu_thread.index(x, hier)
+  // 6. test cuda::gpu_thread.index(x, hier)
   test_index(threadIdx, cuda::gpu_thread, cuda::block, hier);
   if constexpr (Hierarchy::has_level(cuda::cluster))
   {
@@ -129,7 +137,7 @@ __device__ void test_thread(
     test_index(exp, cuda::gpu_thread, cuda::grid, hier);
   }
 
-  // 6. Test cuda::gpu_thread.rank(x, hier)
+  // 7. Test cuda::gpu_thread.rank(x, hier)
   test_rank((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x, cuda::gpu_thread, cuda::block, hier);
   if constexpr (Hierarchy::has_level(cuda::cluster))
   {

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_query_signatures.compile.pass.cpp
@@ -34,16 +34,20 @@ __device__ void test_query_signatures(const Level& level, const Hierarchy& hier)
   static_assert(cuda::std::is_same_v<unsigned, typename ExtentsResult::index_type>);
   static_assert(noexcept(cuda::thread_level::extents(level, hier)));
 
-  // 4. Test cuda::thread_level::count(x, hier) signature.
+  // 5. Test cuda::thread_level::static_count(x, hier) signature.
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::static_count(level, hier))>);
+  static_assert(noexcept(cuda::thread_level::static_count(level, hier)));
+
+  // 5. Test cuda::thread_level::count(x, hier) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::count(level, hier))>);
   static_assert(noexcept(cuda::thread_level::count(level, hier)));
 
-  // 5. Test cuda::thread_level::index(x, hier) signature.
+  // 6. Test cuda::thread_level::index(x, hier) signature.
   static_assert(
     cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::thread_level::index(level, hier))>);
   static_assert(noexcept(cuda::thread_level::index(level, hier)));
 
-  // 6. Test cuda::thread_level::rank(x, hier) signature.
+  // 7. Test cuda::thread_level::rank(x, hier) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::rank(level, hier))>);
   static_assert(noexcept(cuda::thread_level::rank(level, hier)));
 }

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_queries.pass.cpp
@@ -59,7 +59,13 @@ __device__ void test_thread()
     test_extents(cuda::std::dims<3, unsigned>{exp.x, exp.y, exp.z}, cuda::gpu_thread, cuda::grid);
   }
 
-  // 4. Test cuda::gpu_thread.count(x)
+  // 4. Test cuda::gpu_thread.static_count(x)
+  test_static_count(cuda::gpu_thread, cuda::warp);
+  test_static_count(cuda::gpu_thread, cuda::block);
+  test_static_count(cuda::gpu_thread, cuda::cluster);
+  test_static_count(cuda::gpu_thread, cuda::grid);
+
+  // 5. Test cuda::gpu_thread.count(x)
   test_count(32, cuda::gpu_thread, cuda::warp);
   test_count(cuda::std::size_t{blockDim.z} * blockDim.y * blockDim.x, cuda::gpu_thread, cuda::block);
   {
@@ -76,7 +82,7 @@ __device__ void test_thread()
     test_count(cuda::std::size_t{exp.z} * exp.y * exp.x, cuda::gpu_thread, cuda::grid);
   }
 
-  // 5. test cuda::gpu_thread.index(x)
+  // 6. test cuda::gpu_thread.index(x)
   test_index(uint3{cuda::ptx::get_sreg_laneid(), 0, 0}, cuda::gpu_thread, cuda::warp);
   test_index(threadIdx, cuda::gpu_thread, cuda::block);
   {
@@ -97,7 +103,7 @@ __device__ void test_thread()
     test_index(exp, cuda::gpu_thread, cuda::grid);
   }
 
-  // 6. Test cuda::gpu_thread.rank(x)
+  // 7. Test cuda::gpu_thread.rank(x)
   test_rank(cuda::ptx::get_sreg_laneid(), cuda::gpu_thread, cuda::warp);
   test_rank((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x, cuda::gpu_thread, cuda::block);
   {

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/native_hierarchy_query_signatures.compile.pass.cpp
@@ -35,16 +35,20 @@ __device__ void test_query_signatures(const Level& level)
   static_assert(cuda::std::is_same_v<ExtentsRet, decltype(cuda::thread_level::extents(level))>);
   static_assert(noexcept(cuda::thread_level::extents(level)));
 
-  // 4. Test cuda::thread_level::count(x) signature.
+  // 4. Test cuda::thread_level::static_count(x) signature.
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::static_count(level))>);
+  static_assert(noexcept(cuda::thread_level::static_count(level)));
+
+  // 5. Test cuda::thread_level::count(x) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::count(level))>);
   static_assert(noexcept(cuda::thread_level::count(level)));
 
-  // 5. Test cuda::thread_level::index(x) signature.
+  // 6. Test cuda::thread_level::index(x) signature.
   static_assert(
     cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::thread_level::index(level))>);
   static_assert(noexcept(cuda::thread_level::index(level)));
 
-  // 6. Test cuda::thread_level::rank(x) signature.
+  // 7. Test cuda::thread_level::rank(x) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::rank(level))>);
   static_assert(noexcept(cuda::thread_level::rank(level)));
 }

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/native_hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/native_hierarchy_queries.pass.cpp
@@ -61,7 +61,12 @@ __device__ void test_warp()
     test_extents(cuda::std::dims<3, unsigned>{exp.x, exp.y, exp.z}, cuda::warp, cuda::grid);
   }
 
-  // 4. Test cuda::warp.count(x)
+  // 4. Test cuda::warp.static_count(x)
+  test_static_count(cuda::warp, cuda::block);
+  test_static_count(cuda::warp, cuda::cluster);
+  test_static_count(cuda::warp, cuda::grid);
+
+  // 5. Test cuda::warp.count(x)
   test_count(count_in_block, cuda::warp, cuda::block);
   {
     uint3 exp = dims_in_block;
@@ -77,7 +82,7 @@ __device__ void test_warp()
     test_count(cuda::std::size_t{exp.z} * exp.y * exp.x, cuda::warp, cuda::grid);
   }
 
-  // 5. test cuda::warp.index(x)
+  // 6. test cuda::warp.index(x)
   test_index(index_in_block, cuda::warp, cuda::block);
   {
     uint3 exp = index_in_block;
@@ -97,7 +102,7 @@ __device__ void test_warp()
     test_index(exp, cuda::warp, cuda::grid);
   }
 
-  // 6. Test cuda::warp.rank(x)
+  // 7. Test cuda::warp.rank(x)
   test_rank(rank_in_block, cuda::warp, cuda::block);
   {
     cuda::std::size_t exp = 0;

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/native_hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/native_hierarchy_query_signatures.compile.pass.cpp
@@ -32,15 +32,19 @@ __device__ void test_query_signatures(const Level& level)
   static_assert(cuda::std::is_same_v<ExtentsRet, decltype(cuda::warp_level::extents(level))>);
   static_assert(noexcept(cuda::warp_level::extents(level)));
 
-  // 4. Test cuda::warp_level::count(x) signature.
+  // 4. Test cuda::warp_level::static_count(x) signature.
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::warp_level::static_count(level))>);
+  static_assert(noexcept(cuda::warp_level::static_count(level)));
+
+  // 5. Test cuda::warp_level::count(x) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::warp_level::count(level))>);
   static_assert(noexcept(cuda::warp_level::count(level)));
 
-  // 5. Test cuda::warp_level::index(x) signature.
+  // 6. Test cuda::warp_level::index(x) signature.
   static_assert(cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::warp_level::index(level))>);
   static_assert(noexcept(cuda::warp_level::index(level)));
 
-  // 6. Test cuda::warp_level::rank(x) signature.
+  // 7. Test cuda::warp_level::rank(x) signature.
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::warp_level::rank(level))>);
   static_assert(noexcept(cuda::warp_level::rank(level)));
 }

--- a/libcudacxx/test/support/hierarchy_queries.h
+++ b/libcudacxx/test/support/hierarchy_queries.h
@@ -64,6 +64,21 @@ __device__ void test_extents(const Exp exp, const Level& level, Args... args)
 }
 
 template <class Level, class... Args>
+__device__ void test_static_count(Level level, Args... args)
+{
+  constexpr auto static_dims = level.static_dims(args...);
+  if constexpr (static_dims.x != cuda::std::dynamic_extent && static_dims.y != cuda::std::dynamic_extent
+                && static_dims.z != cuda::std::dynamic_extent)
+  {
+    static_assert(level.static_count(args...) == static_dims.x * static_dims.y * static_dims.z);
+  }
+  else
+  {
+    static_assert(level.static_count(args...) == cuda::std::dynamic_extent);
+  }
+}
+
+template <class Level, class... Args>
 __device__ void test_count(const cuda::std::size_t exp, const Level& level, Args... args)
 {
   assert(level.count(args...) == exp);


### PR DESCRIPTION
Currently, we only have `unit.count(level, hierarchy)`, which works in constexpr context, but only if all of the touched hierarchy levels have static extents. Otherwise the compilation fails. But in many places it would be extremely useful to just query the number of units and get `cuda::std::dynamic_extents` in case of some dimensions are being defined dynamically.