### PR TITLE
Fix detection from CTK header version to compiler

### DIFF
--- a/libcudacxx/include/cuda/std/__type_traits/type_list.h
+++ b/libcudacxx/include/cuda/std/__type_traits/type_list.h
@@ -332,7 +332,7 @@ using __type_push_back = __type_call<_List, __type_quote<__type_list>, _Ts...>;
 template <class _List, class... _Ts>
 using __type_push_front = __type_call1<_List, __type_bind_front_quote<__type_list, _Ts...>>;
 
-#  if _CCCL_CTK_BELOW(12, 9)
+#  if _CCCL_CUDA_COMPILER(NVCC, <, 12, 9)
 
 namespace __detail
 {
@@ -361,7 +361,7 @@ _CCCL_API inline auto __as_type_list_fn(__undefined<_Ret(_Args...)>*) //
 template <class _List>
 using __as_type_list = decltype(__detail::__as_type_list_fn(static_cast<__undefined<_List>*>(nullptr)));
 
-#  else // ^^^ _ CCCl_CTK_BELOW(12, 9) / vvv _CCCL_CTK_AT_LEAST(12, 9) vvv
+#  else // ^^^ if _CCCL_CUDA_COMPILER(NVCC, <, 12, 9) / vvv if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9) vvv
 
 namespace __detail
 {
@@ -393,7 +393,7 @@ extern __fn_ptr_t<__type_list<_Ret, _Args...>> __as_type_list_v<_Ret(_Args...)>;
 template <class _List>
 using __as_type_list = decltype(__detail::__as_type_list_v<_List>());
 
-#  endif // _CCCL_CTK_AT_LEAST(12, 9)
+#  endif // if _CCCL_CUDA_COMPILER(NVCC, >=, 12, 9)
 
 //! \brief Given a type that can be interpreted as a type list and a
 //! meta-callable, invoke the meta-callable with the types in the list.


### PR DESCRIPTION
We want to check for the compiler version not the CTK header version