### PR TITLE
Add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES.
+#                         All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+---
+Checks:
+  # enable everything first
+  - 'performance-*'
+  - 'modernize-*'
+  - 'readability-*'
+  - 'clang-analyzer-*'
+  - 'clang-diagnostic-*'
+  - 'bugprone-*'
+  - 'misc-*'
+  - 'core-*'
+  - 'mpi-*'
+  - 'cert-*'
+  - 'portability-*'
+  - 'google-*'
+  - 'cppcoreguidelines-*'
+  - 'concurrency-*'
+  # TODO: BEGIN REMOVE ME
+  - '-*'
+  - 'performance-implicit-conversion-in-loop'
+  # END REMOVE ME
+  # HICPP is 99% aliased to other checks (mostly modernize-* and bugprone-*). We don't
+  # want to also enable it because then we need to duplicate the NOLINT. The only 2 checks
+  # that aren't aliases are:
+  #
+  # - hicpp-multiway-paths-covered. This check is useful for detecting degenerate if-else
+  #   branches, but the switch cases are IMO better handled by -Wswitch. To make -Wswitch
+  #   even stronger, we should ban default: cases entirely,
+  #
+  # - hicpp-signed-bitwise. This check is also covered by
+  #   clang.llvm.org/extra/clang-tidy/checks/clang-analyzer/core.BitwiseShift.html
+  #
+  # - 'hicpp-*'
+  #
+  # LLVM checks are extremely specific to the LLVM project and aren't suitable for
+  # downstream users.
+  #
+  # - 'llvm-*'
+  #
+  # then disable the stuff we don't want
+  - '-cert-dcl21-cpp'  # returning non-const from operator-- or operator++
+  - '-cert-dcl50-cpp'  # allow c-style variadics
+  # No reserved identifiers, both of these are aliased to bugprone-reserved-identifier,
+  # which we do enable. Leaving these enabled however, leads to needing to specify all
+  # three (bugprone-reserved-identifier, cert-dcl51-cpp, and cert-dcl37-c) in NOLINT lines
+  # which is a hassle. Since bugprone-reserved-identifier is enabled, the check still
+  # fires.
+  - '-cert-dcl51-cpp,-cert-dcl37-c,-cert-oop54-cpp'
+  # Covered by bugprone-throwing-static-initialization
+  - '-cert-err58-cpp'
+  - '-modernize-use-trailing-return-type'
+  - '-readability-function-cognitive-complexity'
+  - '-readability-implicit-bool-conversion'
+  - '-readability-braces-around-statements'
+  - '-readability-qualified-auto'
+  - '-readability-isolate-declaration'
+  - '-modernize-avoid-c-arrays'
+  - '-cppcoreguidelines-avoid-c-arrays'
+  - '-readability-named-parameter'
+  - '-readability-identifier-length'
+  - '-misc-non-private-member-variables-in-classes'
+  - '-bugprone-easily-swappable-parameters'
+  - '-bugprone-implicit-widening-of-multiplication-result'
+  - '-misc-include-cleaner'
+  - '-misc-header-include-cycle'
+  - '-modernize-macro-to-enum'
+  - '-cppcoreguidelines-macro-to-enum'
+  - '-misc-no-recursion'
+  - '-bugprone-dynamic-static-initializers'
+  - '-portability-avoid-pragma-once'
+  # Generally speaking if something is static then it has an express reason to be. 99% of
+  # the candidates identified by this check were because they just so happened not to
+  # touch any member variables, not because they are logically static. So we disable the
+  # check.
+  - '-readability-convert-member-functions-to-static'
+  # When running in a conda env, ignore options that may have been added by conda but are unused
+  - '-clang-diagnostic-unused-command-line-argument'
+  # Given
+  #
+  # std::make_pair<some_type, some_other_type>(...)
+  #
+  # Results in: error: for C++11-compatibility, use pair directly. But we don't care about
+  # C++11, and so we don't care about this warning.
+  - '-google-build-explicit-make-pair'
+  # This check is incredibly expensive for absolutely no reason, and since we a) use
+  # modern google-test and b) don't have clang-tidy enabled on our testing code, we don't
+  # need to enable it!
+  - '-google-upgrade-googletest-case'
+  # This warning will warn if you have redundant default-initializers for class
+  # members. For example:
+  #
+  # class Foo
+  # {
+  #   int x_{}; // WARNING: redundant initializer here
+  #
+  # public:
+  #   Foo(int x) : x_{x} { }
+  # };
+  #
+  # Since Foo can only ever be constructed with an explicit value for x_ via its constructor,
+  # the default initializer is technically redundant. However, if we change the definition
+  # of Foo to now allow a default ctor, then the initializer becomes non-redundant
+  # again. It is easier to just follow the rule of "always explicitly default initialize
+  # members" than to remember to change 2 places at once.
+  - '-readability-redundant-member-init'
+  # Alias for readability-enum-initial-value, disable this one because the readability-
+  # name is easier to understand, and we don't want to silence 2 things for the same
+  # warning.
+  - '-cert-int09-c'
+  # This one is potentially controversial. This check warns when iterating over unordered
+  # containers of pointers:
+  #
+  # {
+  #   int a = 1, b = 2;
+  #   std::unordered_set<int *> set = {&a, &b};
+  #
+  #   for (auto *i : set) { // iteration order not deterministic
+  #     f(i);
+  #   }
+  # }
+  #
+  # On the one hand, this is a clear case of non-determinism. But on the other hand, I
+  # feel it is obvious that a user does not care about the order of iteration
+  # because... they are using unordered containers!
+  - '-bugprone-nondeterministic-pointer-iteration-order'
+  - '-cppcoreguidelines-pro-type-reinterpret-cast'
+  # We don't use GSL
+  - '-cppcoreguidelines-owning-memory'
+  # Covered by modernize-use-override already
+  - '-cppcoreguidelines-explicit-virtual-functions'
+  # Covered by readability-magic-numbers
+  - '-cppcoreguidelines-avoid-magic-numbers'
+  # This check does more harm than good, as it appears to be very rudimentary. For
+  # example, it emits warnings saying that:
+  #
+  # #define DEFINE_OPERATOR(op)                            \
+  #   _CCCL_HOST_DEVICE custom_numeric operator op() const \
+  #   {                                                    \
+  #     return custom_numeric(op value[0]);                \
+  #   }
+  #
+  # Should be replaced by a template function, but this is not possible. We instead rely
+  # on best judgment of reviewers to catch macros that can be functions.
+  - '-cppcoreguidelines-macro-usage'
+  # This check does not understand more complex macro usage where brackets are not allowed
+  #
+  # error: macro replacement list should be enclosed in parentheses [bugprone-macro-parentheses]
+  # 36 | #define __THRUST_HOST_SYSTEM_INCLUDE(filename) <__THRUST_HOST_SYSTEM_ROOT/filename>
+  #    |                                                                           ^
+  #    |                                                                           (       )
+  #
+  # So better left disabled.
+  - '-bugprone-macro-parentheses'
+  # TODO: ironically enough, enable this someday
+  - '-google-readability-todo'
+  # Covered by modernize-avoid-c-style-cast, and also is buggier. It seems to fire on
+  # `_v`-style constexpr bools as well sometimes.
+  - '-google-readability-casting'
+  # Covered by performance-noexcept-move-constructor
+  - '-cppcoreguidelines-noexcept-move-operations'
+  # REVIEW ME: This warns about any usage of operator[], suggesting usage of .at() instead. Could
+  - '-cppcoreguidelines-pro-bounds-avoid-unchecked-container-access'
+  # Covered by bugprone-narrowing-conversions
+  - '-cppcoreguidelines-narrowing-conversions'
+  # Covered by misc-unconventional-assign-operator
+  - '-cppcoreguidelines-c-copy-assignment-signature'
+  # Covered by performance-noexcept-swap
+  - '-cppcoreguidelines-noexcept-swap'
+  # Covered by modernize-use-default-member-init
+  - '-cppcoreguidelines-use-default-member-init'
+  # clang-tidy documentation says that for a given file, it matches the closest
+  # .clang-tidy up the directory stack and applies the configuration from it. However, by
+  # "it" `clang-tidy` means the closest `.clang-tidy` to the *source* file, not the file
+  # that was included by the source file.
+  #
+  # So `cuda/std/foo.h` included by `cccl/foo/bar/baz.cpp` will never "match" against
+  # `cccl/libcudacxx/.clang-tidy` because `clang-tidy` finds `cccl/.clang-tidy` instead.
+  #
+  # So we disable this for now. In the future we should add a custom check that bans
+  # reserved identifiers except symbols from libcu++.
+  - '-bugprone-reserved-identifier'
+WarningsAsErrors: '*'
+HeaderFileExtensions:
+  - ''
+  - h
+  - hh
+  - hpp
+  - hxx
+  - cuh
+  - inl
+  - ipp
+ImplementationFileExtensions:
+  - c
+  - cc
+  - cpp
+  - cxx
+  - cu
+SystemHeaders: false
+ExtraArgsBefore:
+  # To match _CCCL_DOXYGEN_INVOKED
+  - '-D_CCCL_CLANG_TIDY_INVOKED=1'
+  - '-ftemplate-backtrace-limit=0'
+  - '-fmacro-backtrace-limit=0'
+ExtraArgs:
+  # These must come in ExtraArgs not ExtraArgsBefore, because they are overriding the
+  # effects of -Wall and -Werror, where the last flag "wins".
+  - '-Wno-unknown-warning-option'
+  - '-Wno-unknown-cuda-version'
+  - '-Wno-error=unused-command-line-argument'
+CheckOptions:
+  cert-dcl16-c.NewSuffixes: 'L;LL;LU;LLU'
+  cert-err33-c.CheckedFunctions: '::aligned_alloc;::asctime_s;::at_quick_exit;::atexit;::bsearch;::bsearch_s;::btowc;::c16rtomb;::c32rtomb;::calloc;::clock;::cnd_broadcast;::cnd_init;::cnd_signal;::cnd_timedwait;::cnd_wait;::ctime_s;::fclose;::fflush;::fgetc;::fgetpos;::fgets;::fgetwc;::fopen;::fopen_s;::fprintf;::fprintf_s;::fputc;::fputs;::fputwc;::fputws;::fread;::freopen;::freopen_s;::fscanf;::fscanf_s;::fseek;::fsetpos;::ftell;::fwprintf;::fwprintf_s;::fwrite;::fwscanf;::fwscanf_s;::getc;::getchar;::getenv;::getenv_s;::gets_s;::getwc;::getwchar;::gmtime;::gmtime_s;::localtime;::localtime_s;::malloc;::mbrtoc16;::mbrtoc32;::mbsrtowcs;::mbsrtowcs_s;::mbstowcs;::mbstowcs_s;::memchr;::mktime;::mtx_init;::mtx_lock;::mtx_timedlock;::mtx_trylock;::mtx_unlock;::printf_s;::putc;::putwc;::raise;::realloc;::remove;::rename;::scanf;::scanf_s;::setlocale;::setvbuf;::signal;::snprintf;::snprintf_s;::sprintf;::sprintf_s;::sscanf;::sscanf_s;::strchr;::strerror_s;::strftime;::strpbrk;::strrchr;::strstr;::strtod;::strtof;::strtoimax;::strtok;::strtok_s;::strtol;::strtold;::strtoll;::strtoul;::strtoull;::strtoumax;::strxfrm;::swprintf;::swprintf_s;::swscanf;::swscanf_s;::thrd_create;::thrd_detach;::thrd_join;::thrd_sleep;::time;::timespec_get;::tmpfile;::tmpfile_s;::tmpnam;::tmpnam_s;::tss_create;::tss_get;::tss_set;::ungetc;::ungetwc;::vfprintf;::vfprintf_s;::vfscanf;::vfscanf_s;::vfwprintf;::vfwprintf_s;::vfwscanf;::vfwscanf_s;::vprintf_s;::vscanf;::vscanf_s;::vsnprintf;::vsnprintf_s;::vsprintf;::vsprintf_s;::vsscanf;::vsscanf_s;::vswprintf;::vswprintf_s;::vswscanf;::vswscanf_s;::vwprintf_s;::vwscanf;::vwscanf_s;::wcrtomb;::wcschr;::wcsftime;::wcspbrk;::wcsrchr;::wcsrtombs;::wcsrtombs_s;::wcsstr;::wcstod;::wcstof;::wcstoimax;::wcstok;::wcstok_s;::wcstol;::wcstold;::wcstoll;::wcstombs;::wcstombs_s;::wcstoul;::wcstoull;::wcstoumax;::wcsxfrm;::wctob;::wctrans;::wctype;::wmemchr;::wprintf_s;::wscanf;::wscanf_s;'
+  llvm-else-after-return.WarnOnUnfixable: 'false'
+  cert-str34-c.DiagnoseSignedUnsignedCharComparisons: 'false'
+  cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: 'true'
+  google-readability-braces-around-statements.ShortStatementLines: '1'
+  llvm-qualified-auto.AddConstToQualified: 'false'
+  llvm-else-after-return.WarnOnConditionVariables: 'false'
+  cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField: 'false'
+  performance-move-const-arg.CheckTriviallyCopyableMove: 'false'
+  performance-inefficient-string-concatenation.StrictMode: 'true'
+  readability-simplify-boolean-expr.ChainedConditionalReturn: 'true'
+  readability-simplify-boolean-expr.ChainedConditionalAssignment: 'true'
+  bugprone-dangling-handle.HandleClasses: '::cuda::std::span;::cuda::std::mdspan'
+  bugprone-misplaced-widening-cast.CheckImplicitCasts: 'true'
+  bugprone-unused-return-value.AllowCastToVoid: 'true'
+  readability-enum-initial-value.AllowExplicitZeroFirstInitialValue: 'false'
+  readability-enum-initial-value.AllowExplicitSequentialInitialValues: 'false'
+  readability-redundant-access-specifiers.CheckFirstDeclaration: 'true'
+  bugprone-lambda-function-name.IgnoreMacros: 'true'
+  # readability-identifier-naming.ClassCase: 'lower_case'
+  # readability-identifier-naming.UnionCase: 'lower_case'
+  # readability-identifier-naming.ClassConstantCase: 'UPPER_CASE'
+  # readability-identifier-naming.ClassIgnoredRegexp: 'tuple|has_.*|is_.*|as_.*|.*_tag|tag|.*_of'
+  # readability-identifier-naming.ConstantMemberCase: 'UPPER_CASE'
+  # readability-identifier-naming.ConstantMemberIgnoredRegexp: 'value'
+  # readability-identifier-naming.EnumCase: 'lower_case'
+  # readability-identifier-naming.EnumConstantCase: 'UPPER_CASE'
+  # readability-identifier-naming.FunctionCase: 'lower_case'
+  # readability-identifier-naming.GlobalConstantCase: 'UPPER_CASE'
+  # readability-identifier-naming.GlobalConstantIgnoredRegexp: '.*_v'
+  # readability-identifier-naming.LocalVariableCase: 'lower_case'
+  # # We want to allow constexpr auto MY_VAL1
+  # readability-identifier-naming.LocalVariableIgnoredRegexp: '[A-Z_0-9]+'
+  # readability-identifier-naming.MacroDefinitionCase: 'UPPER_CASE'
+  # # We want to allow MY_MACRO_PRIVATE_1_
+  # readability-identifier-naming.MacroDefinitionIgnoredRegexp: '[A-Z_0-9]+'
+  # readability-identifier-naming.NamespaceCase: 'lower_case'
+  # readability-identifier-naming.PrivateMemberCase: 'lower_case'
+  # readability-identifier-naming.PrivateMemberSuffix: '_'
+  # readability-identifier-naming.PrivateMethodCase: 'lower_case'
+  # readability-identifier-naming.PrivateMethodSuffix: '_'
+  # readability-identifier-naming.ProtectedMemberCase: 'lower_case'
+  # readability-identifier-naming.ProtectedMemberSuffix: '_'
+  # readability-identifier-naming.ProtectedMethodCase: 'lower_case'
+  # readability-identifier-naming.ProtectedMethodSuffix: '_'
+  # readability-identifier-naming.PublicMethodCase: 'lower_case'
+  # readability-identifier-naming.ScopedEnumCase: 'lower_case'
+  # readability-identifier-naming.ScopedEnumConstantCase: 'UPPER_CASE'
+  readability-magic-numbers.IgnoredIntegerValues: '0;1;2;3;4;5;6;7;8;9'
+  # There are some single-argument functions that we would not like to ignore
+  # (`to_string(bool provenance = false)` comes to mind), but setting this to false makes
+  # clang-tidy warn on a bunch of "obvious" calls, like `set_dim(1)` or
+  # `with_concurrent(true)`.
+  bugprone-argument-comment.IgnoreSingleArgument: true
+  bugprone-argument-comment.CommentBoolLiterals: true
+  bugprone-argument-comment.CommentIntegerLiterals: true
+  bugprone-argument-comment.CommentFloatLiterals: true
+  bugprone-argument-comment.CommentStringLiterals: true
+  bugprone-argument-comment.CommentCharacterLiterals: true
+  bugprone-argument-comment.CommentUserDefinedLiterals: true
+  bugprone-argument-comment.CommentNullPtrs: true
+  cppcoreguidelines-macro-usage.AllowedRegexp: '^DEBUG_.*|THRUST_PP_.*|_CCCL.*_PP_.*'
+  bugprone-reserved-identifier.AllowedIdentifiers: '^_CCCL.*'
+...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,17 @@ else()
   set(CCCL_ENABLE_CUDAX OFF)
 endif()
 
+option(CCCL_ENABLE_CLANG_TIDY "Enable clang-tidy" OFF)
+mark_as_advanced(CCCL_ENABLE_CLANG_TIDY)
+
+if (CCCL_TOPLEVEL_PROJECT)
+  include(cmake/CCCLAddTidyTarget.cmake)
+
+  if (CCCL_ENABLE_CLANG_TIDY)
+    cccl_tidy_init()
+  endif()
+endif()
+
 include(CTest)
 enable_testing()
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -106,6 +106,22 @@
       }
     },
     {
+      "name": "all-tidy",
+      "displayName": "clang-tidy",
+      "inherits": "all-dev-debug",
+      "cacheVariables": {
+        "CMAKE_CXX_STANDARD": "17",
+        "CMAKE_CUDA_STANDARD": "17",
+        "THRUST_MULTICONFIG_WORKLOAD": "MEDIUM",
+        "CCCL_ENABLE_BENCHMARKS": true,
+        "CCCL_ENABLE_CLANG_TIDY": true,
+        "CMAKE_C_COMPILER": "clang",
+        "CMAKE_CXX_COMPILER": "clang++",
+        "CMAKE_CUDA_FLAGS": "",
+        "CMAKE_CUDA_COMPILER": "clang++"
+      }
+    },
+    {
       "name": "libcudacxx-codegen",
       "displayName": "libcu++: codegen",
       "inherits": "base",
@@ -468,6 +484,13 @@
     {
       "name": "all-dev-debug",
       "configurePreset": "all-dev-debug"
+    },
+    {
+      "name": "all-tidy",
+      "configurePreset": "all-tidy",
+      "targets": [
+        "cccl.tidy"
+      ]
     },
     {
       "name": "install",

--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -337,6 +337,8 @@ function build_preset() {
     local green="1;32"
     local red="1;31"
     local GROUP_NAME="🏗️  Build ${BUILD_NAME}"
+    shift 2
+    local BUILD_COMMANDS=("$@")
 
     symlink_latest_preset "$PRESET"
 
@@ -362,7 +364,7 @@ function build_preset() {
 
     pushd .. > /dev/null
     status=0
-    run_ci_timed_command "$GROUP_NAME" cmake --build --preset="$PRESET" -v || status=$?
+    run_ci_timed_command "$GROUP_NAME" cmake --build --preset="$PRESET" -v "${BUILD_COMMANDS[@]}" || status=$?
     popd > /dev/null
 
     if [[ -n "${GITHUB_ACTIONS:-}" || -n "${MEMMON:-}" ]]; then

--- a/ci/build_tidy.sh
+++ b/ci/build_tidy.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/build_common.sh"
+
+print_environment_details
+
+BUILD_NAME="clang-tidy"
+PRESET="all-tidy"
+CMAKE_OPTIONS=("-DCMAKE_CXX_STANDARD=${CXX_STANDARD}" "-DCMAKE_CUDA_STANDARD=${CXX_STANDARD}")
+# Clang does not understand -G, passed by all-dev-debug which all-tidy derives from
+CMAKE_OPTIONS+=("-DCMAKE_CUDA_FLAGS=")
+# TODO(jfaibussowit)
+#
+# STF seems to trip clang-cuda up pretty heavily. It's unclear whether this is because STF
+# hasn't been compiled against clang-cuda before or whether it's an issue with clang-cuda
+# itself.
+CMAKE_OPTIONS+=("-Dcudax_ENABLE_CUDASTF=OFF")
+CMAKE_OPTIONS+=("-Dcudax_ENABLE_PLACES=OFF")
+
+# Cannot use configure_and_build_preset because that does not allow us to pass additional
+# arguments to the build command.
+configure_preset "${BUILD_NAME}" "${PRESET}" "${CMAKE_OPTIONS[@]}"
+# Keep going after errors, we want CI to unearth all clang-tidy errors in one go
+BUILD_OPTIONS=(-- -k 0)
+build_preset "${BUILD_NAME}" "${PRESET}" "${BUILD_OPTIONS[@]}"
+
+print_time_summary

--- a/ci/matrix.yaml
+++ b/ci/matrix.yaml
@@ -89,6 +89,16 @@ workflows:
     # libc++
     # - arm64 for now as it's closest to android.
     # - {jobs: ['build'], cpu: 'arm64', project: 'libcudacxx', std: 'all', cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', cmake_options: '-DCCCL_USE_LIBCXX=ON', sm: '75;80;90;100'}
+    # clang-tidy
+    #
+    # The precise value of sm is not important, but it is required for cmake to identify
+    # clang as a CUDA compiler (see
+    # https://discourse.cmake.org/t/cmake-cuda-clang-fails/8657/5).
+    #
+    # Standard being exactly "min" is required. clang-tidy may emit additional diagnostics
+    # for later C++ versions (for example, warning that you should use designated
+    # initializers in C++20 or higher).
+    - { jobs: ['build'], project: 'tidy', std: 'min', cxx: ['clang'], cudacxx: ['clang'], ctk: 'clang-cuda', sm: '75' }
 
   # Used when an upstream project changes to reduce time spent smoke testing dependencies.
   pull_request_lite:
@@ -209,6 +219,8 @@ workflows:
     - {jobs: ['build'], cxx: 'nvhpc',      ctk: 'nvhpc',      std: 'all', project: ['libcudacxx', 'cub', 'thrust', 'cudax', 'stdpar'], cpu: ['amd64', 'arm64']}
     # clang-cuda
     - {jobs: ['build'], cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', std: 'all', sm: '75;80;90;100'}
+    # clang-tidy
+    - { jobs: ['build'], project: 'tidy', std: 'min', cxx: ['clang'], cudacxx: ['clang'], ctk: 'clang-cuda', sm: '75' }
 
   weekly:
     # CTK 12.0 full matrix build: default projects
@@ -298,6 +310,8 @@ workflows:
     - {jobs: ['build'], cudacxx: 'clang', ctk: 'clang-cuda', cxx: 'clang-cuda', std: 'all', sm: '75;80;90;100'}
     # compute-sanitizer
     - {jobs: ['compute_sanitizer'], project: 'cub', std: 'max', gpu: 'rtxa6000', sm: 'gpu', cmake_options: '-DCMAKE_CUDA_FLAGS=-lineinfo'}
+    # clang-tidy
+    - { jobs: ['build'], project: 'tidy', std: 'min', cxx: ['clang'], cudacxx: ['clang'], ctk: 'clang-cuda', sm: '75' }
 
   python-wheels:
     - {jobs: ['test'], project: 'python', ctk: ['12.X', '13.0', '13.X'], py_version: ['3.10', '3.11', '3.12', '3.13'], gpu: 'l4', cxx: ['gcc13', 'msvc']}
@@ -562,6 +576,9 @@ projects:
   bisect:
     name: 'Bisect'
     stds: [17, 20]
+  tidy:
+    name: 'clang-tidy'
+    stds: [17]
 
 # testing -> Runner with GPU is in a nv-gh-runners testing pool
 gpus:

--- a/ci/project_files_and_dependencies.yaml
+++ b/ci/project_files_and_dependencies.yaml
@@ -180,12 +180,40 @@ projects:
     full_dependencies: []
     include_regexes: ["nvrtcc/"]
 
+  # This is a dummy project, and only really serves to encode dependencies. Any time any
+  # of the C/C++ projects are modified, we want to launch one (and only one) clang-tidy
+  # job for the whole of CCCL.
+  tidy:
+    name: "clang-tidy"
+    matrix_project: "tidy"
+    full_dependencies:
+      - libcudacxx_public
+      - libcudacxx_internal
+      - cub_public
+      - cub_internal
+      - thrust_public
+      - thrust_internal
+      - cudax_public
+      - cudax_internal
+      - cccl_c_parallel_public
+      - cccl_c_parallel_internal
+      - cccl_c_stf
+      - stdpar
+      - c2h
+      - nvrtcc
+    include_regexes: [".clang-tidy"]
+
 # Files matching any of these regexes will be ignored globally.
 ignore_regexes:
   - '.+\.md$'
   - '\.branch_notes/'
   - '\.clang-format'
   - '\.clangd'
+  # Do not add .clang-tidy to this list. If we modify .clang-tidy to either add or remove
+  # a check we still want CI to run the clang-tidy job even if it results in no C/C++ code
+  # changes.
+  #
+  # - '\.clang-tidy'
   - '\.devcontainer/img'
   - '\.git-blame-ignore-revs'
   - '\.github/actions/docs-build'

--- a/ci/test/inspect_changes/c2h_dependency.output
+++ b/ci/test/inspect_changes/c2h_dependency.output
@@ -1,2 +1,2 @@
-FULL_BUILD=
+FULL_BUILD=tidy
 LITE_BUILD=libcudacxx cub cudax cccl_c_parallel cccl_c_stf packaging

--- a/ci/test/inspect_changes/core_dirty.output
+++ b/ci/test/inspect_changes/core_dirty.output
@@ -1,2 +1,2 @@
-FULL_BUILD=libcudacxx cub thrust cudax cccl_c_parallel cccl_c_stf python packaging stdpar nvbench_helper nvrtcc
+FULL_BUILD=libcudacxx cub thrust cudax cccl_c_parallel cccl_c_stf python packaging stdpar nvbench_helper nvrtcc tidy
 LITE_BUILD=

--- a/ci/test/inspect_changes/libcudacxx_both.output
+++ b/ci/test/inspect_changes/libcudacxx_both.output
@@ -1,2 +1,2 @@
-FULL_BUILD=libcudacxx
+FULL_BUILD=libcudacxx tidy
 LITE_BUILD=cub thrust cudax cccl_c_parallel cccl_c_stf python packaging stdpar nvbench_helper

--- a/ci/test/inspect_changes/libcudacxx_internal_only.output
+++ b/ci/test/inspect_changes/libcudacxx_internal_only.output
@@ -1,2 +1,2 @@
-FULL_BUILD=libcudacxx
+FULL_BUILD=libcudacxx tidy
 LITE_BUILD=packaging

--- a/ci/test/inspect_changes/libcudacxx_public_only.output
+++ b/ci/test/inspect_changes/libcudacxx_public_only.output
@@ -1,2 +1,2 @@
-FULL_BUILD=libcudacxx
+FULL_BUILD=libcudacxx tidy
 LITE_BUILD=cub thrust cudax cccl_c_parallel cccl_c_stf python packaging stdpar nvbench_helper

--- a/ci/test/inspect_changes/libcudacxx_thrust.output
+++ b/ci/test/inspect_changes/libcudacxx_thrust.output
@@ -1,2 +1,2 @@
-FULL_BUILD=libcudacxx thrust
+FULL_BUILD=libcudacxx thrust tidy
 LITE_BUILD=cub cudax cccl_c_parallel cccl_c_stf python packaging stdpar nvbench_helper

--- a/cmake/CCCLAddExecutable.cmake
+++ b/cmake/CCCLAddExecutable.cmake
@@ -7,7 +7,7 @@
 # If ADD_CTEST is specified, a CTest test is added with the same name as the target,
 # which runs the executable with no arguments.
 function(cccl_add_executable target_name)
-  set(options ADD_CTEST NO_METATARGETS)
+  set(options ADD_CTEST NO_METATARGETS NO_CLANG_TIDY)
   set(oneValueArgs METATARGET_PATH DIALECT)
   set(multiValueArgs SOURCES)
   cmake_parse_arguments(
@@ -45,5 +45,9 @@ function(cccl_add_executable target_name)
       set(metatarget_path ${_cccl_METATARGET_PATH})
     endif()
     cccl_ensure_metatargets(${target_name} METATARGET_PATH ${metatarget_path})
+  endif()
+
+  if (NOT _cccl_NO_CLANG_TIDY)
+    cccl_tidy_add_target(SOURCES ${_cccl_SOURCES})
   endif()
 endfunction()

--- a/cmake/CCCLAddTidyTarget.cmake
+++ b/cmake/CCCLAddTidyTarget.cmake
@@ -1,0 +1,172 @@
+include_guard(GLOBAL)
+
+#[=======================================================================[.rst:
+cccl_tidy_init
+--------------
+
+Initialize ``clang-tidy`` support and define the global ``cccl.tidy`` target. It must be
+called before adding any CCCL ``clang-tidy`` targets.
+
+Subsequent calls to this functions are no-ops.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+  ``CCCL_TIDY_INITIALIZED`` set to true in the parent scope.
+
+#]=======================================================================]
+function(cccl_tidy_init)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "tidy_init")
+
+  if (CCCL_TIDY_INITIALIZED)
+    return()
+  endif()
+
+  find_program(CCCL_CLANG_TIDY clang-tidy REQUIRED)
+
+  add_custom_target(cccl.tidy COMMENT "clang-tidy CCCL")
+
+  # Do not set to cache; multiple separate instances of CCCL in a build should not
+  # conflict.
+  set(CCCL_TIDY_INITIALIZED TRUE)
+  set(CCCL_TIDY_INITIALIZED TRUE PARENT_SCOPE)
+endfunction()
+
+#[=======================================================================[.rst:
+cccl_tidy_make_subproject_target
+--------------------------------
+
+Create a meta target per sub-project that depends on all the targets for that
+subproject. It itself will depend on the ``cccl.tidy target``. For example, this will
+create:
+
+- cub.tidy
+- libcudacxx.tidy
+- thrust.tidy
+
+etc. This allows running clang-tidy over just a subset of the repository.
+
+The generated target name depends on the current value of ``PROJECT_NAME``.
+
+Arguments
+^^^^^^^^^
+
+``result_var``
+  The variable in which to store the created target name.
+
+#]=======================================================================]
+function(cccl_tidy_make_subproject_target result_var)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "tidy_make_subproject_target")
+
+  if (NOT CCCL_TIDY_INITIALIZED)
+    # For the cccl.tidy target
+    message(FATAL_ERROR "Must call cccl_tidy_init() first")
+  endif()
+
+  string(TOLOWER "${PROJECT_NAME}.tidy" target_name)
+
+  if (NOT TARGET "${target_name}")
+    add_custom_target("${target_name}" COMMENT "clang-tidy ${PROJECT_NAME}")
+    add_dependencies(cccl.tidy "${target_name}")
+  endif()
+  set(${result_var} "${target_name}" PARENT_SCOPE)
+endfunction()
+
+#[=======================================================================[.rst:
+cccl_tidy_add_target
+--------------------
+
+Create per-source ``clang-tidy`` targets and attach them to both the global ``cccl.tidy``
+target and per sub-project target (e.g. ``cub.tidy``)
+
+.. note::
+
+  :command:`cccl_tidy_init` must be called before using this function to establish the
+  global ``cccl.tidy`` target.
+
+If ``CCCL_ENABLE_CLANG_TIDY`` is false, this does nothing (except error-check the function
+call signature).
+
+Passing the same source file multiple times is allowed. A target is created for it only
+once.
+
+If ``SOURCES`` is empty, this function does nothing.
+
+Arguments
+^^^^^^^^^
+
+``SOURCES``
+  List of source files to analyze. Paths may be absolute or relative. Relative paths are
+  resolved against ``CMAKE_CURRENT_SOURCE_DIR``.
+
+#]=======================================================================]
+function(cccl_tidy_add_target)
+  list(APPEND CMAKE_MESSAGE_CONTEXT "tidy_add_target")
+
+  set(options)
+  set(one_value_args)
+  set(multi_value_args SOURCES)
+
+  cmake_parse_arguments(
+    _cccl
+    "${options}"
+    "${one_value_args}"
+    "${multi_value_args}"
+    ${ARGN}
+  )
+
+  if (_cccl_UNPARSED_ARGUMENTS)
+    message(FATAL_ERROR "Unrecognized arguments: ${_cccl_UNPARSED_ARGUMENTS}")
+  endif()
+
+  # It is still possible to call this function even if clang-tidy has not been
+  # disabled. We handle this gracefully to avoid complicating the callsite.
+  #
+  # This must come before the CCCL_TIDY_INITIALIZED check because that is only called when
+  # CCCL_ENABLE_CLANG_TIDY is true.
+  if (NOT CCCL_ENABLE_CLANG_TIDY)
+    return()
+  endif()
+
+  if (NOT CCCL_TIDY_INITIALIZED)
+    message(FATAL_ERROR "Must call cccl_tidy_init() first")
+  endif()
+
+  cccl_tidy_make_subproject_target(subproject_target)
+
+  foreach (src IN LISTS _cccl_SOURCES)
+    cmake_path(SET src NORMALIZE "${src}")
+    if (NOT IS_ABSOLUTE "${src}")
+      cmake_path(SET src NORMALIZE "${CMAKE_CURRENT_SOURCE_DIR}/${src}")
+    endif()
+
+    cmake_path(
+      RELATIVE_PATH src
+      BASE_DIRECTORY "${CCCL_SOURCE_DIR}"
+      OUTPUT_VARIABLE rel_src
+    )
+    string(MAKE_C_IDENTIFIER "${rel_src}" tidy_target)
+    set(tidy_target "${tidy_target}.tidy")
+
+    if (TARGET "${tidy_target}")
+      # We have seen this file before
+      return()
+    endif()
+
+    add_custom_target(
+      "${tidy_target}"
+      DEPENDS "${src}"
+      COMMAND
+        ${CCCL_CLANG_TIDY} #
+        --use-color #
+        --quiet #
+        --extra-arg=-Wno-error=unused-command-line-argument #
+        --extra-arg=-D_CCCL_CLANG_TIDY_INVOKED=1 #
+        -p "${CMAKE_BINARY_DIR}" #
+        "${src}"
+      COMMENT "clang-tidy ${rel_src}"
+    )
+
+    add_dependencies("${subproject_target}" "${tidy_target}")
+  endforeach()
+endfunction()

--- a/cub/.clang-tidy
+++ b/cub/.clang-tidy
@@ -1,9 +1,13 @@
 ---
 Checks:
-      'modernize-*,
-       -modernize-use-equals-default,
-       -modernize-concat-nested-namespaces,
-       -modernize-use-trailing-return-type'
+  # TODO: BEGIN REMOVE ME
+  - '-*'
+  - 'performance-implicit-conversion-in-loop'
+  # END REMOVE ME
+      # 'modernize-*,
+      #  -modernize-use-equals-default,
+      #  -modernize-concat-nested-namespaces,
+      #  -modernize-use-trailing-return-type'
 
       # -modernize-use-equals-default        # auto-fix is broken (doesn't insert =default correctly)
       # -modernize-concat-nested-namespaces  # auto-fix is broken (can delete code)

--- a/cub/benchmarks/CMakeLists.txt
+++ b/cub/benchmarks/CMakeLists.txt
@@ -5,7 +5,19 @@ cccl_get_nvbench_helper()
 set(benches_root "${CMAKE_CURRENT_LIST_DIR}")
 
 if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
-  message(FATAL_ERROR "CUB benchmarks must be built in release mode.")
+  set(message_type FATAL_ERROR)
+  if (CCCL_ENABLE_CLANG_TIDY)
+    # We are here because CI has force-enabled clang-tidy. We must use a debug build for
+    # this because certain clang-tidy checks (such as out of bounds or clang static
+    # analyzer) work better when they see assert()'s. In this case we don't actually
+    # intend to run any of the benchmarks, we just need them to be compilable, so a simple
+    # warning is enough.
+    #
+    # We don't ignore this outright (by making it say, DEBUG or VERBOSE), because it's
+    # possible that a user may accidentally stumble into enabling the option.
+    set(message_type WARNING)
+  endif()
+  message(${message_type} "CUB benchmarks must be built in release mode.")
 endif()
 
 if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -200,7 +200,12 @@ function(
     _cub_is_fail_test(is_fail_test "${test_src}")
 
     if (is_fail_test)
-      cccl_add_executable(${test_target} SOURCES "${test_src}" NO_METATARGETS)
+      cccl_add_executable(
+        ${test_target}
+        SOURCES "${test_src}"
+        NO_CLANG_TIDY
+        NO_METATARGETS
+      )
     else()
       cccl_add_executable(
         ${test_target}

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -512,7 +512,21 @@ void launch(ActionT action, Args... args)
 template <class ActionT, class... Args>
 __global__ void device_side_api_launch_kernel(cudaError_t* d_error, ActionT action, Args... args)
 {
+  // The clang-tidy job uses clang-20 but clang does not support CUDA dynamic parallelism until
+  // clang-22. Since we are inside clang-tidy we don't actually care whether the kernel is
+  // invoked so do what we must to silence any compiler errors (though if we ever do use
+  // clang-22+ then invoke the kernel anyways to have clang-tidy check it).
+#  ifdef _CCCL_CLANG_TIDY_INVOKED
+#    if _CCCL_HAS_CDP()
   *d_error = action(args...);
+#    else // ^^^  _CCCL_HAS_CDP() ^^^ / vvv ! _CCCL_HAS_CDP() vvv
+  static_cast<void>(action);
+  (static_cast<void>(args), ...);
+  *d_error = cudaSuccess;
+#    endif // ! _CCCL_HAS_CDP()
+#  else // ^^^ _CCCL_CLANG_TIDY_INVOKED ^^^ / vvv !_CCCL_CLANG_TIDY_INVOKED vvv
+  *d_error = action(args...);
+#  endif // !_CCCL_CLANG_TIDY_INVOKED
 }
 
 template <class ActionT, class... Args>

--- a/cub/test/catch2_test_launch_helper.h
+++ b/cub/test/catch2_test_launch_helper.h
@@ -126,7 +126,23 @@ template <class ActionT, class... Args>
 __global__ void device_side_api_launch_kernel(
   std::uint8_t* d_temp_storage, std::size_t* temp_storage_bytes, cudaError_t* d_error, ActionT action, Args... args)
 {
+  // The clang-tidy job uses clang-20 but clang does not support CUDA dynamic parallelism until
+  // clang-22. Since we are inside clang-tidy we don't actually care whether the kernel is
+  // invoked so do what we must to silence any compiler errors (though if we ever do use
+  // clang-22+ then invoke the kernel anyways to have clang-tidy check it).
+#  ifdef _CCCL_CLANG_TIDY_INVOKED
+#    if _CCCL_HAS_CDP()
   *d_error = action(d_temp_storage, *temp_storage_bytes, args...);
+#    else // ^^^  _CCCL_HAS_CDP() ^^^ / vvv ! _CCCL_HAS_CDP() vvv
+  static_cast<void>(d_temp_storage);
+  static_cast<void>(temp_storage_bytes);
+  static_cast<void>(action);
+  (static_cast<void>(args), ...);
+  *d_error = cudaSuccess;
+#    endif // ! _CCCL_HAS_CDP()
+#  else // ^^^ _CCCL_CLANG_TIDY_INVOKED ^^^ / vvv !_CCCL_CLANG_TIDY_INVOKED vvv
+  *d_error = action(d_temp_storage, *temp_storage_bytes, args...);
+#  endif // !_CCCL_CLANG_TIDY_INVOKED
 }
 
 // We should assign 0 to stream argument when launching on device side, because host stream is not valid there.

--- a/cub/test/internal/catch2_test_integer_utils.cu
+++ b/cub/test/internal/catch2_test_integer_utils.cu
@@ -25,11 +25,13 @@ using integral_types =
 using floating_point_types =
   c2h::type_list<float,
                  double
-#if TEST_HALF_T()
+// TODO(jfaibussowit): re-enable these, clang-tidy seems to choke on operator==() between
+// __half, __nv_bfloat16, and short below
+#if TEST_HALF_T() && !defined(_CCCL_CLANG_TIDY_INVOKED)
                  ,
                  __half
 #endif
-#if TEST_BF_T()
+#if TEST_BF_T() && !defined(_CCCL_CLANG_TIDY_INVOKED)
                  ,
                  __nv_bfloat16
 #endif

--- a/cudax/include/cuda/experimental/__cuco/hyperloglog_ref.cuh
+++ b/cudax/include/cuda/experimental/__cuco/hyperloglog_ref.cuh
@@ -22,6 +22,8 @@
 #endif // no system header
 
 #include <cuda/std/__cstddef/types.h>
+#include <cuda/std/__type_traits/enable_if.h>
+#include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/span>
 #include <cuda/stream>
 
@@ -105,8 +107,38 @@ public:
   //!
   //! @param __group CUDA Cooperative group this operation is executed in
   template <class _CG>
-  _CCCL_DEVICE constexpr void clear(_CG __group) noexcept
+  _CCCL_DEVICE constexpr ::cuda::std::enable_if_t<!::cuda::std::is_convertible_v<_CG, ::cuda::stream_ref>>
+  clear(_CG __group) noexcept
   {
+    // The enable_if above is to work around an incompatibility between host and device
+    // overload preference for clang and NVCC. See
+    // https://llvm.org/docs/CompileCudaWithLLVM.html#overloading-based-on-host-and-device-attributes
+    // for further reading, but the bottom line is when:
+    //
+    // 1. Compiling in device mode (and clang compiles CUDA in a "hybrid" host-device mode,
+    //    also explained by the link above).
+    // 2. And the current function is __host__ __device__.
+    // 3. And the function whose overload needs to be resolved has both a __host__ __device__,
+    //    and __device__ (and/or __host__) overload.
+    //
+    // Then clang will prefer these overloads (assuming they have equal priority under C++
+    // rules) in the following order:
+    //
+    // 1. __host__ __device__
+    // 2. __device__
+    // 3. __host__
+    //
+    // In this particular case, `clear(_CG)` conflicts with `clear(::cuda::stream_ref)` when called
+    // from `hyperloglog::clear(::cuda::stream_ref)`. `hyperloglog::clear(::cuda::stream_ref)`
+    // is constexpr, and therefore implicitly __host__ __device__. Since
+    // `clear(::cuda::stream_ref)` on this class is only __host__, it will take lower priority
+    // that `clear(_CG)`, and we get:
+    //
+    // cudax/include/cuda/experimental/__cuco/__hyperloglog/hyperloglog_impl.cuh:131:28: error: no member named
+    // 'thread_rank' in 'cuda::stream_ref' [clang-diagnostic-error]
+    //
+    // 131 | for (int __i = __group.thread_rank(); __i < __sketch.size(); __i += __group.size())
+    //     |               ~~~~~~~ ^
     __impl.__clear(__group);
   }
 

--- a/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
+++ b/cudax/include/cuda/experimental/__execution/stream/adaptor.cuh
@@ -301,7 +301,11 @@ private:
 
     // without the following, the kernel in __host_start will fail to launch with
     // cudaErrorInvalidDeviceFunction.
+#ifndef _CCCL_CLANG_TIDY_INVOKED
+    // clang-tidy<22 errors when compiling this, complaining that we are taking a reference to
+    // __global__ function inside a __device__ function.
     ::__cccl_unused(&__completion_kernel<__block_threads, _Rcvr, __results_t>);
+#endif
     __state.__state_.__complete_inline_ = true;
     execution::start(__state.__opstate_);
   }

--- a/cudax/test/common/testing.cuh
+++ b/cudax/test/common/testing.cuh
@@ -13,6 +13,7 @@
 
 #include <cuda/__cccl_config>
 #include <cuda/__driver/driver_api.h>
+#include <cuda/std/__exception/terminate.h>
 
 #include <nv/target>
 
@@ -31,12 +32,19 @@ namespace cudax_async = cuda::experimental::execution; // NOLINT: misc-unused-al
 
 #define CUDART(call) REQUIRE((call) == cudaSuccess)
 
-__device__ inline void cudax_require_impl(
-  bool condition,
-  [[maybe_unused]] const char* condition_text,
-  [[maybe_unused]] const char* filename,
-  [[maybe_unused]] unsigned int linenum,
-  [[maybe_unused]] const char* funcname)
+// Unlike nvcc, when clang parses CUDA, both the host and device sections are present (see
+// https://llvm.org/docs/CompileCudaWithLLVM.html#compilation-models). The upshot here is that
+// certain calls of CUDAX_REQUIRE() from host code will try to use device calls because
+// NV_IS_DEVICE is true.
+#if _CCCL_CUDA_COMPILER(CLANG)
+__host__
+#endif
+  __device__ inline void
+  cudax_require_impl(bool condition,
+                     [[maybe_unused]] const char* condition_text,
+                     [[maybe_unused]] const char* filename,
+                     [[maybe_unused]] unsigned int linenum,
+                     [[maybe_unused]] const char* funcname)
 {
   if (!condition)
   {
@@ -54,7 +62,7 @@ __device__ inline void cudax_require_impl(
            threadIdx.z,
            condition_text);
 #endif
-    __trap();
+    ::cuda::std::terminate();
   }
 }
 

--- a/cudax/test/execution/test_let_value.cu
+++ b/cudax/test/execution/test_let_value.cu
@@ -467,8 +467,16 @@ C2H_TEST("let_value works when the function returns a dependent sender", "[adapt
 
 #endif // _CCCL_HOST_COMPILATION()
 
-#if !_CCCL_CUDA_COMPILER(NVCC)
-// This example causes nvcc to segfault
+#if !_CCCL_CUDA_COMPILER(NVCC) && !defined(_CCCL_CLANG_TIDY_INVOKED)
+// This example causes nvcc to segfault, and clang-tidy to error out with
+//
+// cudax/test/execution/test_let_value.cu:487:17: error: static assertion failed due to requirement
+// '::cuda::std::is_same_v<cuda::experimental::execution::default_domain, (anonymous
+// namespace)::let_value_test_domain2>' [clang-diagnostic-error]
+//
+// 487 |   static_assert(::cuda::std::is_same_v<decltype(result), let_value_test_domain2>);
+//     |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 struct let_value_test_domain2
 {};
 

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -7,16 +7,22 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
-#include <cuda/atomic>
-#include <cuda/memory>
 
-#include <cuda/experimental/graph.cuh>
-#include <cuda/experimental/kernel.cuh>
-#include <cuda/experimental/launch.cuh>
-#include <cuda/experimental/stream.cuh>
+// clang does not support __managed__ declarations, so clang-tidy produces spurious
+// errors. https://github.com/llvm/llvm-project/pull/149716 seemingly adds support for
+// __managed__ variables, but that PR seems to have stagnated.
+#ifndef _CCCL_CLANG_TIDY_INVOKED
 
-#include <cooperative_groups.h>
-#include <testing.cuh>
+#  include <cuda/atomic>
+#  include <cuda/memory>
+
+#  include <cuda/experimental/graph.cuh>
+#  include <cuda/experimental/kernel.cuh>
+#  include <cuda/experimental/launch.cuh>
+#  include <cuda/experimental/stream.cuh>
+
+#  include <cooperative_groups.h>
+#  include <testing.cuh>
 
 __managed__ bool kernel_run_proof = false;
 
@@ -185,7 +191,7 @@ void launch_smoke_test(StreamOrPathBuilder& dst)
       cudax::launch(dst, config, kernel_int_argument, 1U);
       check_kernel_run(dst);
 
-#if _CCCL_CTK_AT_LEAST(12, 1)
+#  if _CCCL_CTK_AT_LEAST(12, 1)
       cudax::launch(dst, config, cudax::kernel_ref{kernel_int_argument}, dummy);
       check_kernel_run(dst);
       cudax::launch(dst, config, cudax::kernel_ref{kernel_int_argument}, 1);
@@ -194,7 +200,7 @@ void launch_smoke_test(StreamOrPathBuilder& dst)
       check_kernel_run(dst);
       cudax::launch(dst, config, cudax::kernel_ref{kernel_int_argument}, 1U);
       check_kernel_run(dst);
-#endif // _CCCL_CTK_AT_LEAST(12, 1)
+#  endif // _CCCL_CTK_AT_LEAST(12, 1)
 
       cudax::launch(dst, config, functor_int_argument(), dummy);
       check_kernel_run(dst);
@@ -210,9 +216,9 @@ void launch_smoke_test(StreamOrPathBuilder& dst)
     {
       auto functor_instance = functor_taking_config<block_size>();
       auto kernel_instance  = kernel_taking_config<decltype(config), block_size>;
-#if _CCCL_CTK_AT_LEAST(12, 1)
+#  if _CCCL_CTK_AT_LEAST(12, 1)
       cudax::kernel_ref kernel_ref_instance = kernel_instance;
-#endif // _CCCL_CTK_AT_LEAST(12, 1)
+#  endif // _CCCL_CTK_AT_LEAST(12, 1)
 
       cudax::launch(dst, config, functor_instance, grid_size);
       check_kernel_run(dst);
@@ -232,7 +238,7 @@ void launch_smoke_test(StreamOrPathBuilder& dst)
       cudax::launch(dst, config, kernel_instance, static_cast<unsigned int>(grid_size));
       check_kernel_run(dst);
 
-#if _CCCL_CTK_AT_LEAST(12, 1)
+#  if _CCCL_CTK_AT_LEAST(12, 1)
       cudax::launch(dst, config, kernel_ref_instance, grid_size);
       check_kernel_run(dst);
       cudax::launch(dst, config, kernel_ref_instance, ::cuda::std::move(grid_size));
@@ -241,7 +247,7 @@ void launch_smoke_test(StreamOrPathBuilder& dst)
       check_kernel_run(dst);
       cudax::launch(dst, config, kernel_ref_instance, static_cast<unsigned int>(grid_size));
       check_kernel_run(dst);
-#endif // _CCCL_CTK_AT_LEAST(12, 1)
+#  endif // _CCCL_CTK_AT_LEAST(12, 1)
     }
   }
 
@@ -314,11 +320,11 @@ C2H_TEST("Launch smoke path builder", "[launch]")
   launch_smoke_test(pb);
 
   // In CUDA 12.0 we don't test kernel_ref launches, so the node count is lower
-#if _CCCL_CTK_BELOW(12, 1)
+#  if _CCCL_CTK_BELOW(12, 1)
   CUDAX_REQUIRE(g.node_count() == 48);
-#else // ^^^ _CCCL_CTK_BELOW(12, 1) ^^^ / vvv _CCCL_CTK_AT_LEAST(12, 1) vvv
+#  else // ^^^ _CCCL_CTK_BELOW(12, 1) ^^^ / vvv _CCCL_CTK_AT_LEAST(12, 1) vvv
   CUDAX_REQUIRE(g.node_count() == 64);
-#endif // _CCCL_CTK_BELOW(12, 1)
+#  endif // _CCCL_CTK_BELOW(12, 1)
 
   auto exec = g.instantiate();
   cudax::stream s{cuda::device_ref{0}};
@@ -386,3 +392,5 @@ C2H_TEST("Launch with default config", "")
 {
   test_default_config();
 }
+
+#endif // _CCCL_CLANG_TIDY_INVOKED

--- a/cudax/test/places/CMakeLists.txt
+++ b/cudax/test/places/CMakeLists.txt
@@ -110,7 +110,12 @@ function(cudax_add_places_fail_test target_name_var source)
 
   set(test_target cudax.test.places.error.${filename})
 
-  cccl_add_executable(${test_target} SOURCES ${source} NO_METATARGETS)
+  cccl_add_executable(
+    ${test_target}
+    SOURCES ${source}
+    NO_METATARGETS
+    NO_CLANG_TIDY
+  )
   cudax_places_configure_target(${test_target})
   target_link_libraries(${test_target} PRIVATE cudax.compiler_interface)
   cccl_add_xfail_compile_target_test(

--- a/libcudacxx/benchmarks/CMakeLists.txt
+++ b/libcudacxx/benchmarks/CMakeLists.txt
@@ -5,7 +5,19 @@ cccl_get_nvbench_helper()
 set(benches_root "${CMAKE_CURRENT_LIST_DIR}")
 
 if (NOT CMAKE_BUILD_TYPE STREQUAL "Release")
-  message(FATAL_ERROR "libcu++ benchmarks must be built in release mode.")
+  set(message_type FATAL_ERROR)
+  if (CCCL_ENABLE_CLANG_TIDY)
+    # We are here because CI has force-enabled clang-tidy. We must use a debug build for
+    # this because certain clang-tidy checks (such as out of bounds or clang static
+    # analyzer) work better when they see assert()'s. In this case we don't actually
+    # intend to run any of the benchmarks, we just need them to be compilable, so a simple
+    # warning is enough.
+    #
+    # We don't ignore this outright (by making it say, DEBUG or VERBOSE), because it's
+    # possible that a user may accidentally stumble into enabling the option.
+    set(message_type WARNING)
+  endif()
+  message(${message_type} "libcu++ benchmarks must be built in release mode.")
 endif()
 
 if (NOT DEFINED CMAKE_CUDA_ARCHITECTURES)

--- a/libcudacxx/include/cuda/std/__memory/allocator_traits.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator_traits.h
@@ -53,6 +53,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
   template <class _Tp>                                       \
   inline constexpr bool NAME##_v<_Tp, void_t<typename _Tp::PROPERTY>> = true;
 
+// Allocator::pointer is deprecated since C++17
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 // __pointer
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_pointer, pointer)
 template <class _Tp, class _Alloc, class _RawAlloc = remove_reference_t<_Alloc>, bool = __has_pointer_v<_RawAlloc>>
@@ -65,7 +67,10 @@ struct __pointer<_Tp, _Alloc, _RawAlloc, false>
 {
   using type _CCCL_NODEBUG_ALIAS = _Tp*;
 };
+_CCCL_SUPPRESS_DEPRECATED_POP
 
+// Allocator::const_pointer is deprecated since C++17
+_CCCL_SUPPRESS_DEPRECATED_PUSH
 // __const_pointer
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_const_pointer, const_pointer)
 template <class _Tp, class _Ptr, class _Alloc, bool = __has_const_pointer_v<_Alloc>>
@@ -78,6 +83,7 @@ struct __const_pointer<_Tp, _Ptr, _Alloc, false>
 {
   using type _CCCL_NODEBUG_ALIAS = typename pointer_traits<_Ptr>::template rebind<const _Tp>;
 };
+_CCCL_SUPPRESS_DEPRECATED_POP
 
 // __void_pointer
 _LIBCUDACXX_ALLOCATOR_TRAITS_HAS_XXX(__has_void_pointer, void_pointer)

--- a/thrust/benchmarks/bench/transform/zip_transform.cu
+++ b/thrust/benchmarks/bench/transform/zip_transform.cu
@@ -34,6 +34,10 @@ static void nstream_zip_transform(nvbench::state& state, nvbench::type_list<T>)
 
   const T scalar = startScalar;
   auto lambda    = cuda::proclaim_copyable_arguments([scalar] _CCCL_DEVICE(const T& ai, const T& bi, const T& ci) -> T {
+    // Needed to silence clangs -Wunused-lambda-capture. We cannot just remove it because other
+    // implementations (e.g. MSVC) will emit errors if we don't capture it. See discussion in
+    // https://reviews.llvm.org/D28467.
+    static_cast<void>(scalar);
     return ai + bi + scalar * ci;
   });
   cuda::zip_transform_iterator begin{lambda, a.begin(), b.begin(), c.begin()};

--- a/thrust/thrust/system/cuda/detail/cross_system.h
+++ b/thrust/thrust/system/cuda/detail/cross_system.h
@@ -76,7 +76,7 @@ direction_of_copy(thrust::system::cuda::execution_policy<Sys1> const&, thrust::c
                   decltype(direction_of_copy(std::declval<ExecutionPolicy0>(), std::declval<ExecutionPolicy1>()))>
       constexpr _CCCL_HOST_DEVICE thrust::detail::
         integral_constant<bool, cudaMemcpyDeviceToHost == Direction::value> is_device_to_host_copy(
-          ExecutionPolicy0 const& exec0, ExecutionPolicy1 const& exec1) noexcept
+          ExecutionPolicy0 const&, ExecutionPolicy1 const&) noexcept
 {
   return {};
 }
@@ -85,7 +85,7 @@ template <typename ExecutionPolicy,
           // MSVC2015 WAR: put decltype here instead of in trailing return type
           typename Direction = decltype(direction_of_copy(std::declval<ExecutionPolicy>()))>
 constexpr _CCCL_HOST_DEVICE thrust::detail::integral_constant<bool, cudaMemcpyDeviceToHost == Direction::value>
-is_device_to_host_copy(ExecutionPolicy const& exec) noexcept
+is_device_to_host_copy(ExecutionPolicy const&) noexcept
 {
   return {};
 }
@@ -96,7 +96,7 @@ template <
   // MSVC2015 WAR: put decltype here instead of in trailing return type
   typename Direction = decltype(direction_of_copy(std::declval<ExecutionPolicy0>(), std::declval<ExecutionPolicy1>()))>
 constexpr _CCCL_HOST_DEVICE thrust::detail::integral_constant<bool, cudaMemcpyHostToDevice == Direction::value>
-is_host_to_device_copy(ExecutionPolicy0 const& exec0, ExecutionPolicy1 const& exec1) noexcept
+is_host_to_device_copy(ExecutionPolicy0 const&, ExecutionPolicy1 const&) noexcept
 {
   return {};
 }
@@ -105,7 +105,7 @@ template <typename ExecutionPolicy,
           // MSVC2015 WAR: put decltype here instead of in trailing return type
           typename Direction = decltype(direction_of_copy(std::declval<ExecutionPolicy>()))>
 constexpr _CCCL_HOST_DEVICE thrust::detail::integral_constant<bool, cudaMemcpyHostToDevice == Direction::value>
-is_host_to_device_copy(ExecutionPolicy const& exec) noexcept
+is_host_to_device_copy(ExecutionPolicy const&) noexcept
 {
   return {};
 }
@@ -116,7 +116,7 @@ template <
   // MSVC2015 WAR: put decltype here instead of in trailing return type
   typename Direction = decltype(direction_of_copy(std::declval<ExecutionPolicy0>(), std::declval<ExecutionPolicy1>()))>
 constexpr _CCCL_HOST_DEVICE thrust::detail::integral_constant<bool, cudaMemcpyDeviceToDevice == Direction::value>
-is_device_to_device_copy(ExecutionPolicy0 const& exec0, ExecutionPolicy1 const& exec1) noexcept
+is_device_to_device_copy(ExecutionPolicy0 const&, ExecutionPolicy1 const&) noexcept
 {
   return {};
 }
@@ -125,7 +125,7 @@ template <typename ExecutionPolicy,
           // MSVC2015 WAR: put decltype here instead of in trailing return type
           typename Direction = decltype(direction_of_copy(std::declval<ExecutionPolicy>()))>
 constexpr _CCCL_HOST_DEVICE thrust::detail::integral_constant<bool, cudaMemcpyDeviceToDevice == Direction::value>
-is_device_to_device_copy(ExecutionPolicy const& exec) noexcept
+is_device_to_device_copy(ExecutionPolicy const&) noexcept
 {
   return {};
 }


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Add a `clang-tidy` pass that runs over every created executable in CCCL. Run it via
```sh
# run clang-tidy over the whole repository
$ cmake --build build --target cccl.tidy
[0/212] clang-tidy build/all-dev-debug/thrust/testing/thrust.cpp.cpp/address_stability.cu.cpp
# Or only over thrust
$ cmake --build build --target thrust.tidy
# Or libcudacxx...
$ cmake --build build --target libcudacxx.tidy
...
```
A sub-target is also created per project, so `cub.tidy`, `libcudacxx.tidy`, `thrust.tidy`, etc. that will run `clang-tidy` over only that subset of the codebase. These sub-targets depend on the value of `${PROJECT_NAME}`, so whenever a new `project()` call is found, it will create a new sub-target if any `clang-tidy` targets are created in that directory.

The `cccl.tidy` target is only created for top-level builds. Crucially, the `cccl.tidy` target is _lazy_; if the host system has no `clang-tidy`, then an error is only emitted when you invoke `--target cccl.tidy`, not at configure-time. This allows seamless "opt-in" behavior.

Example of current errors generated: 
[clang_tidy_errors_sample.log](https://github.com/user-attachments/files/26069358/clang_tidy_errors_sample.log)

Please note that many errors (notably `bugprone-reserved-identifier` inside libcu++) can be locally silenced by a directory-local `.clang-tidy`, so please ignore them until the local `.clang-tidy` has been added.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [x] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
