### PR TITLE
Use `cuda::is_power_of_2` instead of `cuda::std::has_single_bit`

### DIFF
--- a/cub/cub/block/block_load_to_shared.cuh
+++ b/cub/cub/block/block_load_to_shared.cuh
@@ -23,6 +23,7 @@
 
 #include <thrust/type_traits/is_trivially_relocatable.h>
 
+#include <cuda/__cmath/pow2.h>
 #include <cuda/__cmath/round_down.h>
 #include <cuda/__cmath/round_up.h>
 #include <cuda/__memory/address_space.h>
@@ -37,7 +38,6 @@
 #include <cuda/__ptx/instructions/mbarrier_wait.h>
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
-#include <cuda/std/__bit/has_single_bit.h>
 #include <cuda/std/__iterator/data.h>
 #include <cuda/std/__iterator/size.h>
 #include <cuda/std/cstdint>
@@ -305,7 +305,7 @@ public:
   CopyAsync(::cuda::std::span<char> smem_dst, ::cuda::std::span<const T> gmem_src)
   {
     static_assert(THRUST_NS_QUALIFIER::is_trivially_relocatable_v<T>);
-    static_assert(::cuda::std::has_single_bit(unsigned{GmemAlign}));
+    static_assert(::cuda::is_power_of_two(GmemAlign));
     static_assert(GmemAlign >= int{alignof(T)});
     constexpr bool bulk_aligned = GmemAlign >= detail::bulk_copy_min_align;
     // Avoid 64b multiplication in span::size_bytes()

--- a/cub/cub/detail/fast_modulo_division.cuh
+++ b/cub/cub/detail/fast_modulo_division.cuh
@@ -17,7 +17,7 @@
 #include <cub/util_type.cuh> // _CCCL_HAS_INT128()
 
 #include <cuda/__cmath/ceil_div.h>
-#include <cuda/std/__bit/has_single_bit.h>
+#include <cuda/__cmath/pow2.h>
 #include <cuda/std/__bit/integral.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
@@ -146,7 +146,7 @@ public:
     _CCCL_ASSERT(divisor > 0, "divisor must be positive");
     auto udivisor = static_cast<unsigned_t>(divisor);
     // the following branches are needed to avoid negative shift
-    if (::cuda::std::has_single_bit(udivisor)) // power of two
+    if (::cuda::is_power_of_two(udivisor))
     {
       _shift_right = ::cuda::std::bit_width(udivisor) - 1;
       return;
@@ -159,7 +159,7 @@ public:
     constexpr int BitOffset = BitSize / 16; // 2
     int num_bits            = ::cuda::std::bit_width(udivisor) + 1;
     _CCCL_ASSERT(static_cast<size_t>(num_bits + BitSize - BitOffset) < sizeof(larger_t) * CHAR_BIT, "overflow error");
-    // without explicit power-of-two check, num_bits needs to replace +1 with !::cuda::std::has_single_bit(udivisor)
+    // without explicit power-of-two check, num_bits needs to replace +1 with !::cuda::is_power_of_two(udivisor)
     _multiplier  = static_cast<unsigned_t>(::cuda::ceil_div(larger_t{1} << (num_bits + BitSize - BitOffset), //
                                                            static_cast<larger_t>(divisor)));
     _shift_right = num_bits - BitOffset;

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -37,7 +37,6 @@
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__algorithm/transform.h>
 #include <cuda/std/__bit/bit_cast.h>
-#include <cuda/std/__bit/has_single_bit.h>
 #include <cuda/std/__cstring/memcpy.h>
 #include <cuda/std/__functional/invoke.h>
 #include <cuda/std/__memory/construct_at.h>
@@ -64,7 +63,7 @@ namespace detail::transform
 template <typename T>
 _CCCL_HOST_DEVICE _CCCL_FORCEINLINE const char* round_down_ptr(const T* ptr, unsigned alignment)
 {
-  _CCCL_ASSERT(::cuda::std::has_single_bit(alignment), "");
+  _CCCL_ASSERT(::cuda::is_power_of_two(alignment), "");
   return reinterpret_cast<const char*>(
     reinterpret_cast<::cuda::std::uintptr_t>(ptr) & ~::cuda::std::uintptr_t{alignment - 1});
 }

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -23,6 +23,7 @@
 // for backward compatibility
 #include <cub/util_temporary_storage.cuh>
 
+#include <cuda/__cmath/pow2.h>
 #include <cuda/__device/arch_id.h>
 #include <cuda/__device/compute_capability.h>
 #include <cuda/std/__concepts/regular.h>
@@ -609,7 +610,7 @@ _CCCL_HOST_DEVICE constexpr int LoadToSharedBufferAlignBytes()
 template <typename T, int GmemAlign = alignof(T)>
 _CCCL_HOST_DEVICE constexpr int LoadToSharedBufferSizeBytes(::cuda::std::size_t num_items)
 {
-  static_assert(::cuda::std::has_single_bit(unsigned{GmemAlign}));
+  static_assert(::cuda::is_power_of_two(GmemAlign));
   static_assert(GmemAlign >= int{alignof(T)});
   _CCCL_ASSERT(num_items <= ::cuda::std::size_t{::cuda::std::numeric_limits<int>::max()},
                "num_items must fit into an int");

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -24,10 +24,10 @@
 #include <cub/util_ptx.cuh>
 #include <cub/util_type.cuh>
 
+#include <cuda/__cmath/pow2.h>
 #include <cuda/__ptx/instructions/get_sreg.h>
 #include <cuda/__warp/warp_shuffle.h>
 #include <cuda/std/__algorithm/clamp.h>
-#include <cuda/std/__bit/has_single_bit.h>
 #include <cuda/std/__bit/integral.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__type_traits/integral_constant.h>
@@ -419,7 +419,7 @@ struct WarpScanShfl
                  "first_lane must be in range [0, lane_id]");
     _CCCL_ASSERT((offset > 0) && (offset < LOGICAL_WARP_THREADS),
                  "offset must be in the range [1, LOGICAL_WARP_THREADS)");
-    _CCCL_ASSERT(::cuda::std::has_single_bit(static_cast<unsigned>(offset)), "offset must be a power of two");
+    _CCCL_ASSERT(::cuda::is_power_of_two(offset), "offset must be a power of two");
     _Tp temp = ::cuda::device::warp_shuffle_up<LOGICAL_WARP_THREADS>(input, offset, member_mask);
 
     // Perform scan op if from a valid peer

--- a/cub/cub/warp/warp_reduce.cuh
+++ b/cub/cub/warp/warp_reduce.cuh
@@ -28,9 +28,9 @@
 #include <cub/warp/specializations/warp_reduce_shfl.cuh>
 #include <cub/warp/specializations/warp_reduce_smem.cuh>
 
+#include <cuda/__cmath/pow2.h>
 #include <cuda/__functional/maximum.h>
 #include <cuda/__functional/minimum.h>
-#include <cuda/std/__bit/has_single_bit.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__type_traits/conditional.h>
@@ -134,7 +134,7 @@ class WarpReduce
                 "LogicalWarpThreads must be in the range [1, 32]");
 
   static constexpr bool is_full_warp    = (LogicalWarpThreads == detail::warp_threads);
-  static constexpr bool is_power_of_two = ::cuda::std::has_single_bit(uint32_t{LogicalWarpThreads});
+  static constexpr bool is_power_of_two = ::cuda::is_power_of_two(LogicalWarpThreads);
 
 public:
 #ifndef _CCCL_DOXYGEN_INVOKED // Do not document

--- a/cub/test/catch2_test_warp_scan_partial_helper.cuh
+++ b/cub/test/catch2_test_warp_scan_partial_helper.cuh
@@ -168,7 +168,7 @@ struct total_warps_t
 private:
   static constexpr int max_warps      = 2;
   static constexpr bool is_arch_warp  = (LogicalWarpThreads == cub::detail::warp_threads);
-  static constexpr bool is_pow_of_two = cuda::std::has_single_bit(LogicalWarpThreads);
+  static constexpr bool is_pow_of_two = cuda::is_power_of_two(LogicalWarpThreads);
   static constexpr int total_warps    = (is_arch_warp || is_pow_of_two) ? max_warps : 1;
 
 public:

--- a/cub/test/warp/catch2_test_warp_reduce.cu
+++ b/cub/test/warp/catch2_test_warp_reduce.cu
@@ -6,10 +6,10 @@
 
 #include <thrust/iterator/constant_iterator.h>
 
+#include <cuda/cmath>
 #include <cuda/functional>
 #include <cuda/ptx>
 #include <cuda/std/__functional/invoke.h>
-#include <cuda/std/bit>
 #include <cuda/std/functional>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
@@ -42,7 +42,7 @@ __device__ void warp_reduce_function(T& thread_data, Output* output, ReductionOp
   using warp_reduce_t = cub::WarpReduce<Output, LogicalWarpThreads>;
   using storage_t     = typename warp_reduce_t::TempStorage;
   __shared__ storage_t storage[total_warps];
-  constexpr bool is_power_of_two = cuda::std::has_single_bit(LogicalWarpThreads);
+  constexpr bool is_power_of_two = cuda::is_power_of_two(LogicalWarpThreads);
   auto lane                      = cuda::ptx::get_sreg_laneid();
   auto logical_warp              = is_power_of_two ? threadIdx.x / LogicalWarpThreads : threadIdx.x / warp_size;
   auto logical_lane              = is_power_of_two ? threadIdx.x % LogicalWarpThreads : lane;
@@ -212,7 +212,7 @@ _CCCL_DIAG_POP
 
 std::array<unsigned, 3> get_test_config(unsigned logical_warp_threads, unsigned items_per_thread = 1)
 {
-  bool is_power_of_two = cuda::std::has_single_bit(logical_warp_threads);
+  bool is_power_of_two = cuda::is_power_of_two(logical_warp_threads);
   auto logical_warps   = is_power_of_two ? warp_size / logical_warp_threads : 1;
   auto input_size      = total_warps * warp_size * items_per_thread;
   auto output_size     = total_warps * logical_warps;

--- a/libcudacxx/include/cuda/__warp/warp_shuffle.h
+++ b/libcudacxx/include/cuda/__warp/warp_shuffle.h
@@ -25,9 +25,9 @@
 #  if __cccl_ptx_isa >= 600
 
 #    include <cuda/__cmath/ceil_div.h>
+#    include <cuda/__cmath/pow2.h>
 #    include <cuda/__ptx/instructions/get_sreg.h>
 #    include <cuda/__ptx/instructions/shfl_sync.h>
-#    include <cuda/std/__bit/has_single_bit.h>
 #    include <cuda/std/__concepts/concept_macros.h>
 #    include <cuda/std/__memory/addressof.h>
 #    include <cuda/std/__type_traits/enable_if.h>
@@ -62,7 +62,7 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
   static_assert(!::cuda::std::is_pointer_v<_Up> || __is_void_ptr,
                 "non-void pointers are not allowed to prevent bug-prone code");
-  static_assert(::cuda::std::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
+  static_assert(::cuda::is_power_of_two(_Width) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
   if constexpr (_Width == 1)
   {
@@ -105,7 +105,7 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
   static_assert(!::cuda::std::is_pointer_v<_Up> || __is_void_ptr,
                 "non-void pointers are not allowed to prevent bug-prone code");
-  static_assert(::cuda::std::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
+  static_assert(::cuda::is_power_of_two(_Width) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                ([[maybe_unused]] int __pred1; _CCCL_ASSERT(::__match_all_sync(::__activemask(), __delta, &__pred1),
@@ -153,7 +153,7 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
   static_assert(!::cuda::std::is_pointer_v<_Up> || __is_void_ptr,
                 "non-void pointers are not allowed to prevent bug-prone code");
-  static_assert(::cuda::std::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
+  static_assert(::cuda::is_power_of_two(_Width) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                ([[maybe_unused]] int __pred1; _CCCL_ASSERT(::__match_all_sync(::__activemask(), __delta, &__pred1),
@@ -201,7 +201,7 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
   static_assert(!::cuda::std::is_pointer_v<_Up> || __is_void_ptr,
                 "non-void pointers are not allowed to prevent bug-prone code");
-  static_assert(::cuda::std::has_single_bit(uint32_t{_Width}) && _Width >= 1 && _Width <= __warp_size,
+  static_assert(::cuda::is_power_of_two(_Width) && _Width >= 1 && _Width <= __warp_size,
                 "_Width must be a power of 2 and less or equal to the warp size");
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                ([[maybe_unused]] int __pred1; _CCCL_ASSERT(::__match_all_sync(::__activemask(), __xor_mask, &__pred1),

--- a/libcudacxx/include/cuda/std/__mdspan/aligned_accessor.h
+++ b/libcudacxx/include/cuda/std/__mdspan/aligned_accessor.h
@@ -29,7 +29,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/std/__bit/has_single_bit.h>
+#include <cuda/__cmath/pow2.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__mdspan/default_accessor.h>
 #include <cuda/std/__memory/assume_aligned.h>
@@ -48,7 +48,7 @@ class aligned_accessor
 public:
   static constexpr auto byte_alignment = _ByteAlignment;
 
-  static_assert(::cuda::std::has_single_bit(byte_alignment), "byte_alignment must be a power of two.");
+  static_assert(::cuda::is_power_of_two(byte_alignment), "byte_alignment must be a power of two.");
 
   static_assert(byte_alignment >= alignof(_ElementType), "Insufficient byte alignment for _ElementType");
 

--- a/libcudacxx/include/cuda/std/__memory/assume_aligned.h
+++ b/libcudacxx/include/cuda/std/__memory/assume_aligned.h
@@ -22,8 +22,8 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__cmath/pow2.h>
 #include <cuda/std/__bit/bit_cast.h>
-#include <cuda/std/__bit/has_single_bit.h>
 #include <cuda/std/cstddef> // size_t
 #include <cuda/std/cstdint> // uintptr_t
 
@@ -34,7 +34,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD
 template <size_t _Align, class _Tp>
 [[nodiscard]] _CCCL_API constexpr _Tp* assume_aligned(_Tp* __ptr) noexcept
 {
-  static_assert(::cuda::std::has_single_bit(_Align), "std::assume_aligned requires the alignment to be a power of 2");
+  static_assert(::cuda::is_power_of_two(_Align), "std::assume_aligned requires the alignment to be a power of 2");
   static_assert(_Align >= alignof(_Tp), "Alignment must be greater than or equal to the alignment of the input type");
 #if !defined(_CCCL_BUILTIN_IS_CONSTANT_EVALUATED)
   return __ptr;


### PR DESCRIPTION
We often use `cuda::std::has_single_bit` to check whether a value is a power of 2, however the name is not straight forward and requires the type to be `unsigned`. I think we should rather use `cuda::is_power_of_2` instead in many of the cases, which much better describes what we are actually trying to do