### PR TITLE
Implement parallel `cuda::std::is_partitioned`

### DIFF
--- a/libcudacxx/benchmarks/bench/is_partitioned/basic.cu
+++ b/libcudacxx/benchmarks/bench/is_partitioned/basic.cu
@@ -1,0 +1,49 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+#include <thrust/partition.h>
+#include <thrust/sequence.h>
+
+#include <cuda/functional>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  using select_op_t = less_then_t<T>;
+
+  // set up input
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto common_prefix  = state.get_float64("MismatchAt");
+  const auto mismatch_point = ::cuda::std::clamp<std::size_t>(elements * common_prefix, 0ull, elements - 1);
+
+  thrust::device_vector<T> dinput(elements, thrust::no_init);
+  thrust::sequence(dinput.begin(), dinput.end(), T{0});
+
+  state.add_global_memory_reads<T>(2 * elements);
+  state.add_global_memory_writes<size_t>(1);
+
+  caching_allocator_t alloc{};
+
+  state.exec(
+    nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync, [&](nvbench::launch& launch) {
+      do_not_optimize(cuda::std::is_partitioned(
+        cuda_policy(alloc, launch), dinput.begin(), dinput.end(), select_op_t{static_cast<T>(mismatch_point)}));
+    });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("MismatchAt", std::vector{1.0, 0.5, 0.01});

--- a/libcudacxx/include/cuda/std/__pstl/is_partitioned.h
+++ b/libcudacxx/include/cuda/std/__pstl/is_partitioned.h
@@ -1,0 +1,106 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_IS_PARTITIONED_H
+#define _CUDA_STD___PSTL_IS_PARTITIONED_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__iterator/zip_iterator.h>
+#  include <cuda/__nvtx/nvtx.h>
+#  include <cuda/std/__algorithm/is_partitioned.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/concepts.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+#  include <cuda/std/tuple>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/find_if.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+template <class _UnaryPred>
+struct __is_partitioned_fn
+{
+  _UnaryPred __pred_;
+
+  template <class _Tuple>
+  [[nodiscard]] _CCCL_DEVICE_API constexpr bool operator()(const _Tuple& __tuple) const
+  {
+    const bool __pred_lhs = __pred_(::cuda::std::get<0>(__tuple));
+    const bool __pred_rhs = __pred_(::cuda::std::get<1>(__tuple));
+
+    return (!__pred_lhs && __pred_rhs);
+  }
+};
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator, class _UnaryPred)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+[[nodiscard]] _CCCL_HOST_API bool is_partitioned(
+  [[maybe_unused]] const _Policy& __policy, _InputIterator __first, _InputIterator __last, _UnaryPred __pred)
+{
+  static_assert(indirect_unary_predicate<_UnaryPred, _InputIterator>,
+                "cuda::std::is_partitioned: UnaryPred must satisfy indirect_unary_predicate<UnaryPred, InputIterator>");
+
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__find_if, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::std::is_partitioned");
+
+    if (__first == __last)
+    {
+      return true;
+    }
+
+    const auto __result = __dispatch(
+      __policy,
+      ::cuda::zip_iterator{__first, __first + 1},
+      ::cuda::zip_iterator{__last, __last},
+      __is_partitioned_fn<_UnaryPred>{::cuda::std::move(__pred)});
+    return ::cuda::std::get<1>(__result.__iterators()) == __last;
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>,
+                  "Parallel cuda::std::is_partitioned requires at least one selected backend");
+    return ::cuda::std::is_partitioned(::cuda::std::move(__first), ::cuda::std::move(__last), ::cuda::std::move(__pred));
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_IS_PARTITIONED_H

--- a/libcudacxx/include/cuda/std/execution
+++ b/libcudacxx/include/cuda/std/execution
@@ -49,6 +49,7 @@
 #  include <cuda/std/__pstl/generate.h>
 #  include <cuda/std/__pstl/generate_n.h>
 #  include <cuda/std/__pstl/inclusive_scan.h>
+#  include <cuda/std/__pstl/is_partitioned.h>
 #  include <cuda/std/__pstl/is_sorted.h>
 #  include <cuda/std/__pstl/is_sorted_until.h>
 #  include <cuda/std/__pstl/merge.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/is_partitioned.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.partitions/is_partitioned.cu
@@ -1,0 +1,123 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template<class ExecutionPolicy, ForwardIterator Iter, UnaryPredicate>
+// bool is_partitioned(ExecutionPolicy&& policy, Iter first, Iter last, UnaryPredicate pred);
+
+#include <thrust/device_vector.h>
+#include <thrust/sequence.h>
+#include <thrust/sort.h>
+
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/std/functional>
+#include <cuda/std/iterator>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+inline constexpr int size = 1000;
+
+template <class T>
+struct less_than
+{
+  T value_;
+  __device__ constexpr bool operator()(const T& value) const noexcept
+  {
+    return value < value_;
+  }
+};
+
+template <class Policy>
+void test_is_partitioned(const Policy& policy, thrust::device_vector<int>& input)
+{
+  { // empty should not access anything
+    const auto res =
+      cuda::std::is_partitioned(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), less_than<int>{42});
+    CHECK(res);
+  }
+
+  thrust::sequence(input.begin(), input.end(), 0);
+  { // contiguous range
+    const auto res = cuda::std::is_partitioned(policy, input.begin(), input.end(), less_than<int>{42});
+    CHECK(res);
+  }
+
+  { // random access range
+    const auto res =
+      cuda::std::is_partitioned(policy, cuda::counting_iterator{0}, cuda::counting_iterator{size}, less_than<int>{42});
+    CHECK(res);
+  }
+
+  { // contiguous range, converting predicate
+    const auto res = cuda::std::is_partitioned(policy, input.begin(), input.end(), less_than<long>{42ul});
+    CHECK(res);
+  }
+
+  { // random access range, converting predicate
+    const auto res = cuda::std::is_partitioned(
+      policy, cuda::counting_iterator{0}, cuda::counting_iterator{size}, less_than<long>{42ul});
+    CHECK(res);
+  }
+
+  { // unpartitioned contiguous range
+    input[10]      = 1337;
+    const auto res = cuda::std::is_partitioned(policy, input.begin(), input.end(), less_than<int>{42});
+    CHECK(!res);
+  }
+
+  { // unpartitioned contiguous range, first element
+    input[0]       = 1337;
+    const auto res = cuda::std::is_partitioned(policy, input.begin(), input.end(), less_than<int>{42});
+    CHECK(!res);
+  }
+
+  { // unpartitioned contiguous range, last element
+    input[size - 1] = 0;
+    const auto res  = cuda::std::is_partitioned(policy, input.begin(), input.end(), less_than<int>{42});
+    CHECK(!res);
+  }
+}
+
+C2H_TEST("cuda::std::is_partitioned(iter, iter, pred)", "[parallel algorithm]")
+{
+  thrust::device_vector<int> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::gpu;
+    test_is_partitioned(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+    test_is_partitioned(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource);
+    test_is_partitioned(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy =
+      cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);
+    test_is_partitioned(policy, input);
+  }
+}


### PR DESCRIPTION
This implements the is_sorted algorithms for the cuda backend.

* std::is_partitioned see https://en.cppreference.com/w/cpp/algorithm/is_partitioned.html

It provides tests and benchmarks similar to Thrust and some boilerplate for libcu++

The functionality is publicly available yet and implemented in a private internal header

Fixes #7746
