### PR TITLE
Add env-based API for DoubleBuffer cub::DeviceSegmentedRadixSort

### DIFF
--- a/cub/cub/device/device_segmented_radix_sort.cuh
+++ b/cub/cub/device/device_segmented_radix_sort.cuh
@@ -18,7 +18,10 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cub/detail/env_dispatch.cuh>
 #include <cub/device/dispatch/dispatch_segmented_radix_sort.cuh>
+
+#include <cuda/std/__execution/env.h>
 
 CUB_NAMESPACE_BEGIN
 
@@ -420,6 +423,136 @@ public:
   }
 
   //! @rst
+  //! Overview
+  //!
+  //! Sorts segments of key-value pairs into ascending order. (``~N`` auxiliary storage required)
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The sorting operation is given a pair of key buffers and a corresponding
+  //!   pair of associated value buffers. Each pair is managed by a DoubleBuffer
+  //!   structure that indicates which of the two buffers is "current" (and thus
+  //!   contains the input data to be sorted).
+  //! - The contents of both buffers within each pair may be altered by the sorting operation.
+  //! - Upon completion, the sorting operation will update the "current"
+  //!   indicator within each DoubleBuffer wrapper to reference which of the two
+  //!   buffers now contains the sorted output sequence (a function of the number
+  //!   of key bits specified and the targeted device architecture).
+  //! - An optional bit subrange ``[begin_bit, end_bit)`` of differentiating key
+  //!   bits can be specified. This can reduce overall sorting overhead and
+  //!   yield a corresponding performance improvement.
+  //! - Note, the size of any segment may not exceed ``INT_MAX``. Please consider using ``DeviceSegmentedSort`` instead,
+  //!   if the size of at least one of your segments could exceed ``INT_MAX``.
+  //!
+  //! Snippet
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-radix-sort-pairs-db-env
+  //!     :end-before: example-end segmented-radix-sort-pairs-db-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyT
+  //!   **[inferred]** Key type
+  //!
+  //! @tparam ValueT
+  //!   **[inferred]** Value type
+  //!
+  //! @tparam BeginOffsetIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets @iterator
+  //!
+  //! @tparam EndOffsetIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segment ending offsets @iterator
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
+  //! @param[in,out] d_keys
+  //!   Reference to the double-buffer of keys whose "current" device-accessible
+  //!   buffer contains the unsorted input keys and, upon return, is updated to
+  //!   point to the sorted output keys
+  //!
+  //! @param[in,out] d_values
+  //!   Double-buffer of values whose "current" device-accessible buffer
+  //!   contains the unsorted input values and, upon return, is updated to point
+  //!   to the sorted output values
+  //!
+  //! @param[in] num_items
+  //!   The total number of items within the segmented array
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the sorting data
+  //!
+  //! @param[in] d_begin_offsets
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_begin_offsets[i]`` is the first
+  //!   element of the *i*\ :sup:`th` data segment in ``d_keys_*`` and ``d_values_*``
+  //!   @endrst
+  //!
+  //! @param[in] d_end_offsets
+  //!   @rst
+  //!   Random-access input iterator to the sequence of ending offsets of length
+  //!   ``num_segments``, such that ``d_end_offsets[i] - 1`` is the last element of
+  //!   the *i*\ :sup:`th` data segment in ``d_keys_*`` and ``d_values_*``.
+  //!   If ``d_end_offsets[i] - 1 <= d_begin_offsets[i]``, the *i*\ :sup:`th` is considered empty.
+  //!   @endrst
+  //!
+  //! @param[in] begin_bit
+  //!   The least-significant bit index (inclusive) needed for key comparison
+  //!
+  //! @param[in] end_bit
+  //!   The most-significant bit index (exclusive) needed for key comparison
+  //!   (e.g., ``sizeof(unsigned int) * 8``)
+  //!
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename KeyT,
+            typename ValueT,
+            typename BeginOffsetIteratorT,
+            typename EndOffsetIteratorT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortPairs(
+    DoubleBuffer<KeyT>& d_keys,
+    DoubleBuffer<ValueT>& d_values,
+    ::cuda::std::int64_t num_items,
+    ::cuda::std::int64_t num_segments,
+    BeginOffsetIteratorT d_begin_offsets,
+    EndOffsetIteratorT d_end_offsets,
+    int begin_bit = 0,
+    int end_bit   = sizeof(KeyT) * 8,
+    EnvT env      = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE(GetName());
+
+    using SegmentSizeT = ::cuda::std::int32_t;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      return detail::radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
+        storage,
+        bytes,
+        d_keys,
+        d_values,
+        num_items,
+        num_segments,
+        d_begin_offsets,
+        d_end_offsets,
+        begin_bit,
+        end_bit,
+        true,
+        stream);
+    });
+  }
+
+  //! @rst
   //! Sorts segments of key-value pairs into descending order. (``~2N`` auxiliary storage required).
   //!
   //! .. versionadded:: 2.2.0
@@ -781,6 +914,136 @@ public:
       stream);
   }
 
+  //! @rst
+  //! Overview
+  //!
+  //! Sorts segments of key-value pairs into descending order. (``~N`` auxiliary storage required)
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The sorting operation is given a pair of key buffers and a corresponding
+  //!   pair of associated value buffers. Each pair is managed by a DoubleBuffer
+  //!   structure that indicates which of the two buffers is "current" (and thus
+  //!   contains the input data to be sorted).
+  //! - The contents of both buffers within each pair may be altered by the sorting operation.
+  //! - Upon completion, the sorting operation will update the "current"
+  //!   indicator within each DoubleBuffer wrapper to reference which of the two
+  //!   buffers now contains the sorted output sequence (a function of the number
+  //!   of key bits specified and the targeted device architecture).
+  //! - An optional bit subrange ``[begin_bit, end_bit)`` of differentiating key
+  //!   bits can be specified. This can reduce overall sorting overhead and
+  //!   yield a corresponding performance improvement.
+  //! - Note, the size of any segment may not exceed ``INT_MAX``. Please consider using ``DeviceSegmentedSort`` instead,
+  //!   if the size of at least one of your segments could exceed ``INT_MAX``.
+  //!
+  //! Snippet
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-radix-sort-pairs-descending-db-env
+  //!     :end-before: example-end segmented-radix-sort-pairs-descending-db-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyT
+  //!   **[inferred]** Key type
+  //!
+  //! @tparam ValueT
+  //!   **[inferred]** Value type
+  //!
+  //! @tparam BeginOffsetIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets @iterator
+  //!
+  //! @tparam EndOffsetIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segment ending offsets @iterator
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
+  //! @param[in,out] d_keys
+  //!   Reference to the double-buffer of keys whose "current" device-accessible
+  //!   buffer contains the unsorted input keys and, upon return, is updated to
+  //!   point to the sorted output keys
+  //!
+  //! @param[in,out] d_values
+  //!   Double-buffer of values whose "current" device-accessible buffer
+  //!   contains the unsorted input values and, upon return, is updated to point
+  //!   to the sorted output values
+  //!
+  //! @param[in] num_items
+  //!   The total number of items within the segmented array
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the sorting data
+  //!
+  //! @param[in] d_begin_offsets
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_begin_offsets[i]`` is the first
+  //!   element of the *i*\ :sup:`th` data segment in ``d_keys_*`` and ``d_values_*``
+  //!   @endrst
+  //!
+  //! @param[in] d_end_offsets
+  //!   @rst
+  //!   Random-access input iterator to the sequence of ending offsets of length
+  //!   ``num_segments``, such that ``d_end_offsets[i] - 1`` is the last element of
+  //!   the *i*\ :sup:`th` data segment in ``d_keys_*`` and ``d_values_*``.
+  //!   If ``d_end_offsets[i] - 1 <= d_begin_offsets[i]``, the *i*\ :sup:`th` is considered empty.
+  //!   @endrst
+  //!
+  //! @param[in] begin_bit
+  //!   The least-significant bit index (inclusive) needed for key comparison
+  //!
+  //! @param[in] end_bit
+  //!   The most-significant bit index (exclusive) needed for key comparison
+  //!   (e.g., ``sizeof(unsigned int) * 8``)
+  //!
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename KeyT,
+            typename ValueT,
+            typename BeginOffsetIteratorT,
+            typename EndOffsetIteratorT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortPairsDescending(
+    DoubleBuffer<KeyT>& d_keys,
+    DoubleBuffer<ValueT>& d_values,
+    ::cuda::std::int64_t num_items,
+    ::cuda::std::int64_t num_segments,
+    BeginOffsetIteratorT d_begin_offsets,
+    EndOffsetIteratorT d_end_offsets,
+    int begin_bit = 0,
+    int end_bit   = sizeof(KeyT) * 8,
+    EnvT env      = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE(GetName());
+
+    using SegmentSizeT = ::cuda::std::int32_t;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      return detail::radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
+        storage,
+        bytes,
+        d_keys,
+        d_values,
+        num_items,
+        num_segments,
+        d_begin_offsets,
+        d_end_offsets,
+        begin_bit,
+        end_bit,
+        true,
+        stream);
+    });
+  }
+
   //! @}
   //! @name Keys-only
   //! @{
@@ -1119,6 +1382,127 @@ public:
   }
 
   //! @rst
+  //! Overview
+  //!
+  //! Sorts segments of keys into ascending order. (``~N`` auxiliary storage required)
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The sorting operation is given a pair of key buffers managed by a
+  //!   DoubleBuffer structure that indicates which of the two buffers is
+  //!   "current" (and thus contains the input data to be sorted).
+  //! - The contents of both buffers may be altered by the sorting operation.
+  //! - Upon completion, the sorting operation will update the "current"
+  //!   indicator within the DoubleBuffer wrapper to reference which of the two
+  //!   buffers now contains the sorted output sequence (a function of the
+  //!   number of key bits specified and the targeted device architecture).
+  //! - An optional bit subrange ``[begin_bit, end_bit)`` of differentiating key
+  //!   bits can be specified. This can reduce overall sorting overhead and
+  //!   yield a corresponding performance improvement.
+  //! - Note, the size of any segment may not exceed ``INT_MAX``. Please consider using ``DeviceSegmentedSort`` instead,
+  //!   if the size of at least one of your segments could exceed ``INT_MAX``.
+  //!
+  //! Snippet
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-radix-sort-keys-db-env
+  //!     :end-before: example-end segmented-radix-sort-keys-db-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyT
+  //!   **[inferred]** Key type
+  //!
+  //! @tparam BeginOffsetIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets @iterator
+  //!
+  //! @tparam EndOffsetIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segment ending offsets @iterator
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
+  //! @param[in,out] d_keys
+  //!   Reference to the double-buffer of keys whose "current" device-accessible
+  //!   buffer contains the unsorted input keys and, upon return, is updated to
+  //!   point to the sorted output keys
+  //!
+  //! @param[in] num_items
+  //!   The total number of items within the segmented array
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the sorting data
+  //!
+  //! @param[in] d_begin_offsets
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_begin_offsets[i]`` is the first
+  //!   element of the *i*\ :sup:`th` data segment in ``d_keys_*``
+  //!   @endrst
+  //!
+  //! @param[in] d_end_offsets
+  //!   @rst
+  //!   Random-access input iterator to the sequence of ending offsets of length
+  //!   ``num_segments``, such that ``d_end_offsets[i] - 1`` is the last element of
+  //!   the *i*\ :sup:`th` data segment in ``d_keys_*``.
+  //!   If ``d_end_offsets[i] - 1 <= d_begin_offsets[i]``, the *i*\ :sup:`th` is considered empty.
+  //!   @endrst
+  //!
+  //! @param[in] begin_bit
+  //!   The least-significant bit index (inclusive) needed for key comparison
+  //!
+  //! @param[in] end_bit
+  //!   The most-significant bit index (exclusive) needed for key comparison
+  //!   (e.g., ``sizeof(unsigned int) * 8``)
+  //!
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename KeyT,
+            typename BeginOffsetIteratorT,
+            typename EndOffsetIteratorT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortKeys(
+    DoubleBuffer<KeyT>& d_keys,
+    ::cuda::std::int64_t num_items,
+    ::cuda::std::int64_t num_segments,
+    BeginOffsetIteratorT d_begin_offsets,
+    EndOffsetIteratorT d_end_offsets,
+    int begin_bit = 0,
+    int end_bit   = sizeof(KeyT) * 8,
+    EnvT env      = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE(GetName());
+
+    using SegmentSizeT = ::cuda::std::int32_t;
+
+    DoubleBuffer<NullType> d_values;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      return detail::radix_sort::dispatch<SortOrder::Ascending, SegmentSizeT>(
+        storage,
+        bytes,
+        d_keys,
+        d_values,
+        num_items,
+        num_segments,
+        d_begin_offsets,
+        d_end_offsets,
+        begin_bit,
+        end_bit,
+        true,
+        stream);
+    });
+  }
+
+  //! @rst
   //! Sorts segments of keys into descending order. (``~2N`` auxiliary storage required).
   //!
   //! .. versionadded:: 2.2.0
@@ -1447,6 +1831,127 @@ public:
       end_bit,
       true,
       stream);
+  }
+
+  //! @rst
+  //! Overview
+  //!
+  //! Sorts segments of keys into descending order. (``~N`` auxiliary storage required)
+  //!
+  //! .. versionadded:: 3.4.0
+  //!    First appears in CUDA Toolkit 13.4.
+  //!
+  //! This is an environment-based API that allows customization of:
+  //!
+  //! - Stream: Query via ``cuda::get_stream``
+  //! - Memory resource: Query via ``cuda::mr::get_memory_resource``
+  //!
+  //! - The sorting operation is given a pair of key buffers managed by a
+  //!   DoubleBuffer structure that indicates which of the two buffers is
+  //!   "current" (and thus contains the input data to be sorted).
+  //! - The contents of both buffers may be altered by the sorting operation.
+  //! - Upon completion, the sorting operation will update the "current"
+  //!   indicator within the DoubleBuffer wrapper to reference which of the two
+  //!   buffers now contains the sorted output sequence (a function of the
+  //!   number of key bits specified and the targeted device architecture).
+  //! - An optional bit subrange ``[begin_bit, end_bit)`` of differentiating key
+  //!   bits can be specified. This can reduce overall sorting overhead and
+  //!   yield a corresponding performance improvement.
+  //! - Note, the size of any segment may not exceed ``INT_MAX``. Please consider using ``DeviceSegmentedSort`` instead,
+  //!   if the size of at least one of your segments could exceed ``INT_MAX``.
+  //!
+  //! Snippet
+  //!
+  //! .. literalinclude:: ../../../cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
+  //!     :language: c++
+  //!     :dedent:
+  //!     :start-after: example-begin segmented-radix-sort-keys-descending-db-env
+  //!     :end-before: example-end segmented-radix-sort-keys-descending-db-env
+  //!
+  //! @endrst
+  //!
+  //! @tparam KeyT
+  //!   **[inferred]** Key type
+  //!
+  //! @tparam BeginOffsetIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets @iterator
+  //!
+  //! @tparam EndOffsetIteratorT
+  //!   **[inferred]** Random-access input iterator type for reading segment ending offsets @iterator
+  //!
+  //! @tparam EnvT
+  //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
+  //!
+  //! @param[in,out] d_keys
+  //!   Reference to the double-buffer of keys whose "current" device-accessible
+  //!   buffer contains the unsorted input keys and, upon return, is updated to
+  //!   point to the sorted output keys
+  //!
+  //! @param[in] num_items
+  //!   The total number of items within the segmented array
+  //!
+  //! @param[in] num_segments
+  //!   The number of segments that comprise the sorting data
+  //!
+  //! @param[in] d_begin_offsets
+  //!   @rst
+  //!   Random-access input iterator to the sequence of beginning offsets of
+  //!   length ``num_segments``, such that ``d_begin_offsets[i]`` is the first
+  //!   element of the *i*\ :sup:`th` data segment in ``d_keys_*``
+  //!   @endrst
+  //!
+  //! @param[in] d_end_offsets
+  //!   @rst
+  //!   Random-access input iterator to the sequence of ending offsets of length
+  //!   ``num_segments``, such that ``d_end_offsets[i] - 1`` is the last element of
+  //!   the *i*\ :sup:`th` data segment in ``d_keys_*``.
+  //!   If ``d_end_offsets[i] - 1 <= d_begin_offsets[i]``, the *i*\ :sup:`th` is considered empty.
+  //!   @endrst
+  //!
+  //! @param[in] begin_bit
+  //!   The least-significant bit index (inclusive) needed for key comparison
+  //!
+  //! @param[in] end_bit
+  //!   The most-significant bit index (exclusive) needed for key comparison
+  //!   (e.g., ``sizeof(unsigned int) * 8``)
+  //!
+  //! @param[in] env
+  //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
+  template <typename KeyT,
+            typename BeginOffsetIteratorT,
+            typename EndOffsetIteratorT,
+            typename EnvT = ::cuda::std::execution::env<>>
+  [[nodiscard]] CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t SortKeysDescending(
+    DoubleBuffer<KeyT>& d_keys,
+    ::cuda::std::int64_t num_items,
+    ::cuda::std::int64_t num_segments,
+    BeginOffsetIteratorT d_begin_offsets,
+    EndOffsetIteratorT d_end_offsets,
+    int begin_bit = 0,
+    int end_bit   = sizeof(KeyT) * 8,
+    EnvT env      = {})
+  {
+    _CCCL_NVTX_RANGE_SCOPE(GetName());
+
+    using SegmentSizeT = ::cuda::std::int32_t;
+
+    DoubleBuffer<NullType> d_values;
+
+    return detail::dispatch_with_env(env, [&]([[maybe_unused]] auto tuning, void* storage, size_t& bytes, auto stream) {
+      return detail::radix_sort::dispatch<SortOrder::Descending, SegmentSizeT>(
+        storage,
+        bytes,
+        d_keys,
+        d_values,
+        num_items,
+        num_segments,
+        d_begin_offsets,
+        d_end_offsets,
+        begin_bit,
+        end_bit,
+        true,
+        stream);
+    });
   }
 
   //! @}

--- a/cub/test/catch2_test_device_segmented_radix_sort_env.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env.cu
@@ -1,0 +1,360 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+// Should precede any includes
+struct stream_registry_factory_t;
+#define CUB_DETAIL_DEFAULT_KERNEL_LAUNCHER_FACTORY stream_registry_factory_t
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_segmented_radix_sort.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/devices>
+#include <cuda/stream>
+
+#include "catch2_test_env_launch_helper.h"
+
+DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedRadixSort::SortPairs, sort_pairs);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedRadixSort::SortPairsDescending, sort_pairs_descending);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedRadixSort::SortKeys, sort_keys);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedRadixSort::SortKeysDescending, sort_keys_descending);
+
+// %PARAM% TEST_LAUNCH lid 0:1:2
+
+#include <c2h/catch2_test_helper.h>
+
+namespace stdexec = cuda::std::execution;
+
+#if TEST_LAUNCH == 0
+
+TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer works with default environment",
+          "[segmented_radix_sort][device]")
+{
+  auto keys_buf   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt   = c2h::device_vector<int>(7);
+  auto values_buf = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
+  auto values_alt = c2h::device_vector<int>(7);
+  auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+  cub::DoubleBuffer<int> d_values(
+    thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceSegmentedRadixSort::SortPairs(
+            d_keys, d_values, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
+
+  c2h::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+  c2h::device_vector<int> result_values(
+    thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
+
+  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  REQUIRE(result_keys == expected_keys);
+  REQUIRE(result_values == expected_values);
+}
+
+TEST_CASE("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer works with default environment",
+          "[segmented_radix_sort][device]")
+{
+  auto keys_buf   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt   = c2h::device_vector<int>(7);
+  auto values_buf = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
+  auto values_alt = c2h::device_vector<int>(7);
+  auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+  cub::DoubleBuffer<int> d_values(
+    thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceSegmentedRadixSort::SortPairsDescending(
+            d_keys, d_values, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
+
+  c2h::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+  c2h::device_vector<int> result_values(
+    thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
+
+  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  REQUIRE(result_keys == expected_keys);
+  REQUIRE(result_values == expected_values);
+}
+
+TEST_CASE("DeviceSegmentedRadixSort::SortKeys DoubleBuffer works with default environment",
+          "[segmented_radix_sort][device]")
+{
+  auto keys_buf = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt = c2h::device_vector<int>(7);
+  auto offsets  = c2h::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceSegmentedRadixSort::SortKeys(
+            d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
+
+  c2h::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+
+  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  REQUIRE(result_keys == expected_keys);
+}
+
+TEST_CASE("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer works with default environment",
+          "[segmented_radix_sort][device]")
+{
+  auto keys_buf = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt = c2h::device_vector<int>(7);
+  auto offsets  = c2h::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+
+  REQUIRE(cudaSuccess
+          == cub::DeviceSegmentedRadixSort::SortKeysDescending(
+            d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1));
+
+  c2h::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+
+  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  REQUIRE(result_keys == expected_keys);
+}
+
+#endif
+
+C2H_TEST("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses environment", "[segmented_radix_sort][device]")
+{
+  auto keys_buf   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt   = c2h::device_vector<int>(7);
+  auto values_buf = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
+  auto values_alt = c2h::device_vector<int>(7);
+  auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+  cub::DoubleBuffer<int> d_values(
+    thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedRadixSort::SortPairs(
+      nullptr,
+      expected_bytes_allocated,
+      d_keys,
+      d_values,
+      static_cast<::cuda::std::int64_t>(keys_buf.size()),
+      static_cast<::cuda::std::int64_t>(3),
+      offsets.begin(),
+      offsets.begin() + 1));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  sort_pairs(
+    d_keys,
+    d_values,
+    static_cast<int>(keys_buf.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1,
+    0,
+    static_cast<int>(sizeof(int) * 8),
+    env);
+
+  c2h::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+  c2h::device_vector<int> result_values(
+    thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
+
+  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  REQUIRE(result_keys == expected_keys);
+  REQUIRE(result_values == expected_values);
+}
+
+C2H_TEST("DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer uses environment",
+         "[segmented_radix_sort][device]")
+{
+  auto keys_buf   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt   = c2h::device_vector<int>(7);
+  auto values_buf = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
+  auto values_alt = c2h::device_vector<int>(7);
+  auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+  cub::DoubleBuffer<int> d_values(
+    thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedRadixSort::SortPairsDescending(
+      nullptr,
+      expected_bytes_allocated,
+      d_keys,
+      d_values,
+      static_cast<::cuda::std::int64_t>(keys_buf.size()),
+      static_cast<::cuda::std::int64_t>(3),
+      offsets.begin(),
+      offsets.begin() + 1));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  sort_pairs_descending(
+    d_keys,
+    d_values,
+    static_cast<int>(keys_buf.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1,
+    0,
+    static_cast<int>(sizeof(int) * 8),
+    env);
+
+  c2h::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+  c2h::device_vector<int> result_values(
+    thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
+
+  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  c2h::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  REQUIRE(result_keys == expected_keys);
+  REQUIRE(result_values == expected_values);
+}
+
+C2H_TEST("DeviceSegmentedRadixSort::SortKeys DoubleBuffer uses environment", "[segmented_radix_sort][device]")
+{
+  auto keys_buf = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt = c2h::device_vector<int>(7);
+  auto offsets  = c2h::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedRadixSort::SortKeys(
+      nullptr,
+      expected_bytes_allocated,
+      d_keys,
+      static_cast<::cuda::std::int64_t>(keys_buf.size()),
+      static_cast<::cuda::std::int64_t>(3),
+      offsets.begin(),
+      offsets.begin() + 1));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  sort_keys(
+    d_keys,
+    static_cast<int>(keys_buf.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1,
+    0,
+    static_cast<int>(sizeof(int) * 8),
+    env);
+
+  c2h::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+
+  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  REQUIRE(result_keys == expected_keys);
+}
+
+C2H_TEST("DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer uses environment", "[segmented_radix_sort][device]")
+{
+  auto keys_buf = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt = c2h::device_vector<int>(7);
+  auto offsets  = c2h::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedRadixSort::SortKeysDescending(
+      nullptr,
+      expected_bytes_allocated,
+      d_keys,
+      static_cast<::cuda::std::int64_t>(keys_buf.size()),
+      static_cast<::cuda::std::int64_t>(3),
+      offsets.begin(),
+      offsets.begin() + 1));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  sort_keys_descending(
+    d_keys,
+    static_cast<int>(keys_buf.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1,
+    0,
+    static_cast<int>(sizeof(int) * 8),
+    env);
+
+  c2h::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+
+  c2h::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  REQUIRE(result_keys == expected_keys);
+}
+
+TEST_CASE("DeviceSegmentedRadixSort::SortPairs DoubleBuffer uses custom stream", "[segmented_radix_sort][device]")
+{
+  auto keys_buf   = c2h::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt   = c2h::device_vector<int>(7);
+  auto values_buf = c2h::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
+  auto values_alt = c2h::device_vector<int>(7);
+  auto offsets    = c2h::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+  cub::DoubleBuffer<int> d_values(
+    thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
+
+  cuda::stream custom_stream{cuda::devices[0]};
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceSegmentedRadixSort::SortPairs(
+      nullptr,
+      expected_bytes_allocated,
+      d_keys,
+      d_values,
+      static_cast<::cuda::std::int64_t>(keys_buf.size()),
+      static_cast<::cuda::std::int64_t>(3),
+      offsets.begin(),
+      offsets.begin() + 1));
+
+  cuda::stream_ref stream_ref{custom_stream};
+  auto stream_prop = stdexec::prop{cuda::get_stream_t{}, stream_ref};
+  auto env         = stdexec::env{stream_prop, expected_allocation_size(expected_bytes_allocated)};
+
+  sort_pairs(
+    d_keys,
+    d_values,
+    static_cast<int>(keys_buf.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1,
+    0,
+    static_cast<int>(sizeof(int) * 8),
+    env);
+
+  custom_stream.sync();
+
+  c2h::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+  c2h::device_vector<int> result_values(
+    thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
+
+  c2h::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  c2h::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  REQUIRE(result_keys == expected_keys);
+  REQUIRE(result_values == expected_values);
+}

--- a/cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_radix_sort_env_api.cu
@@ -1,0 +1,175 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include "insert_nested_NVTX_range_guard.h"
+
+#include <cub/device/device_segmented_radix_sort.cuh>
+
+#include <thrust/device_vector.h>
+
+#include <cuda/devices>
+#include <cuda/stream>
+
+#include <iostream>
+
+#include <c2h/catch2_test_helper.h>
+
+C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairs DoubleBuffer env with stream", "[segmented_radix_sort][env]")
+{
+  // example-begin segmented-radix-sort-pairs-db-env
+  auto keys_buf   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt   = thrust::device_vector<int>(7);
+  auto values_buf = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
+  auto values_alt = thrust::device_vector<int>(7);
+  auto offsets    = thrust::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+  cub::DoubleBuffer<int> d_values(
+    thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSegmentedRadixSort::SortPairs(
+    d_keys,
+    d_values,
+    static_cast<int>(keys_buf.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1,
+    0,
+    sizeof(int) * 8,
+    stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSegmentedRadixSort::SortPairs (DoubleBuffer) failed with status: " << error << std::endl;
+  }
+
+  stream.sync();
+
+  thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  thrust::device_vector<int> expected_values{1, 2, 0, 5, 4, 3, 6};
+  // example-end segmented-radix-sort-pairs-db-env
+
+  REQUIRE(error == cudaSuccess);
+
+  thrust::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+  thrust::device_vector<int> result_values(
+    thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
+  REQUIRE(result_keys == expected_keys);
+  REQUIRE(result_values == expected_values);
+}
+
+C2H_TEST("cub::DeviceSegmentedRadixSort::SortPairsDescending DoubleBuffer env with stream",
+         "[segmented_radix_sort][env]")
+{
+  // example-begin segmented-radix-sort-pairs-descending-db-env
+  auto keys_buf   = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt   = thrust::device_vector<int>(7);
+  auto values_buf = thrust::device_vector<int>{0, 1, 2, 3, 4, 5, 6};
+  auto values_alt = thrust::device_vector<int>(7);
+  auto offsets    = thrust::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+  cub::DoubleBuffer<int> d_values(
+    thrust::raw_pointer_cast(values_buf.data()), thrust::raw_pointer_cast(values_alt.data()));
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSegmentedRadixSort::SortPairsDescending(
+    d_keys,
+    d_values,
+    static_cast<int>(keys_buf.size()),
+    3,
+    offsets.begin(),
+    offsets.begin() + 1,
+    0,
+    sizeof(int) * 8,
+    stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr
+      << "cub::DeviceSegmentedRadixSort::SortPairsDescending (DoubleBuffer) failed with status: " << error << std::endl;
+  }
+
+  stream.sync();
+
+  thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  thrust::device_vector<int> expected_values{0, 2, 1, 6, 3, 4, 5};
+  // example-end segmented-radix-sort-pairs-descending-db-env
+
+  REQUIRE(error == cudaSuccess);
+
+  thrust::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+  thrust::device_vector<int> result_values(
+    thrust::device_pointer_cast(d_values.Current()), thrust::device_pointer_cast(d_values.Current()) + 7);
+  REQUIRE(result_keys == expected_keys);
+  REQUIRE(result_values == expected_values);
+}
+
+C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeys DoubleBuffer env with stream", "[segmented_radix_sort][env]")
+{
+  // example-begin segmented-radix-sort-keys-db-env
+  auto keys_buf = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt = thrust::device_vector<int>(7);
+  auto offsets  = thrust::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSegmentedRadixSort::SortKeys(
+    d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1, 0, sizeof(int) * 8, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr << "cub::DeviceSegmentedRadixSort::SortKeys (DoubleBuffer) failed with status: " << error << std::endl;
+  }
+
+  stream.sync();
+
+  thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
+  // example-end segmented-radix-sort-keys-db-env
+
+  REQUIRE(error == cudaSuccess);
+
+  thrust::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+  REQUIRE(result_keys == expected_keys);
+}
+
+C2H_TEST("cub::DeviceSegmentedRadixSort::SortKeysDescending DoubleBuffer env with stream",
+         "[segmented_radix_sort][env]")
+{
+  // example-begin segmented-radix-sort-keys-descending-db-env
+  auto keys_buf = thrust::device_vector<int>{8, 6, 7, 5, 3, 0, 9};
+  auto keys_alt = thrust::device_vector<int>(7);
+  auto offsets  = thrust::device_vector<int>{0, 3, 3, 7};
+
+  cub::DoubleBuffer<int> d_keys(thrust::raw_pointer_cast(keys_buf.data()), thrust::raw_pointer_cast(keys_alt.data()));
+
+  cuda::stream stream{cuda::devices[0]};
+  cuda::stream_ref stream_ref{stream};
+
+  auto error = cub::DeviceSegmentedRadixSort::SortKeysDescending(
+    d_keys, static_cast<int>(keys_buf.size()), 3, offsets.begin(), offsets.begin() + 1, 0, sizeof(int) * 8, stream_ref);
+  if (error != cudaSuccess)
+  {
+    std::cerr
+      << "cub::DeviceSegmentedRadixSort::SortKeysDescending (DoubleBuffer) failed with status: " << error << std::endl;
+  }
+
+  stream.sync();
+
+  thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
+  // example-end segmented-radix-sort-keys-descending-db-env
+
+  REQUIRE(error == cudaSuccess);
+
+  thrust::device_vector<int> result_keys(
+    thrust::device_pointer_cast(d_keys.Current()), thrust::device_pointer_cast(d_keys.Current()) + 7);
+  REQUIRE(result_keys == expected_keys);
+}


### PR DESCRIPTION
closes https://github.com/NVIDIA/cccl/issues/8017