### PR TITLE
Implement parallel `cuda::std::shift_left`

### DIFF
--- a/cub/cub/device/device_select.cuh
+++ b/cub/cub/device/device_select.cuh
@@ -29,6 +29,7 @@
 #include <cuda/std/__iterator/concepts.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_convertible.h>
+#include <cuda/std/__type_traits/is_integral.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cstdint>
 
@@ -260,7 +261,11 @@ public:
   //!   @rst
   //!   **[optional]** CUDA stream to launch kernels within. Default is stream\ :sub:`0`.
   //!   @endrst
-  template <typename InputIteratorT, typename FlagIterator, typename OutputIteratorT, typename NumSelectedIteratorT>
+  template <typename InputIteratorT,
+            typename FlagIterator,
+            typename OutputIteratorT,
+            typename NumSelectedIteratorT,
+            ::cuda::std::enable_if_t<!::cuda::std::is_integral_v<NumSelectedIteratorT>, int> = 0>
   CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE static cudaError_t Flagged(
     void* d_temp_storage,
     size_t& temp_storage_bytes,

--- a/libcudacxx/benchmarks/bench/shift_left/basic.cu
+++ b/libcudacxx/benchmarks/bench/shift_left/basic.cu
@@ -1,0 +1,43 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto midpoint_float = state.get_float64("ShiftedTo");
+  const auto midpoint       = static_cast<std::size_t>(elements * midpoint_float);
+
+  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<T>(elements - midpoint);
+
+  caching_allocator_t alloc{};
+
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(cuda::std::shift_left(cuda_policy(alloc, launch), in.begin(), in.end(), midpoint));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("ShiftedTo", std::vector{0.9, 0.5, 0.01});

--- a/libcudacxx/benchmarks/bench/shift_left/basic.cu
+++ b/libcudacxx/benchmarks/bench/shift_left/basic.cu
@@ -23,10 +23,10 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   const auto midpoint_float = state.get_float64("ShiftedTo");
   const auto midpoint       = static_cast<std::size_t>(elements * midpoint_float);
 
-  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+  thrust::device_vector<T> in = generate(elements);
 
   state.add_element_count(elements);
-  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_reads<T>(elements - midpoint);
   state.add_global_memory_writes<T>(elements - midpoint);
 
   caching_allocator_t alloc{};

--- a/libcudacxx/benchmarks/bench/shift_right/basic.cu
+++ b/libcudacxx/benchmarks/bench/shift_right/basic.cu
@@ -23,19 +23,11 @@ static void basic(nvbench::state& state, nvbench::type_list<T>)
   const auto midpoint_float = state.get_float64("ShiftedTo");
   const auto midpoint       = static_cast<std::size_t>(elements * midpoint_float);
 
-  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+  thrust::device_vector<T> in = generate(elements);
 
   state.add_element_count(elements);
-  if (3 * midpoint > elements)
-  {
-    state.add_global_memory_reads<T>(elements - midpoint);
-    state.add_global_memory_writes<T>(elements - midpoint);
-  }
-  else
-  {
-    state.add_global_memory_reads<T>(2 * (elements - midpoint));
-    state.add_global_memory_writes<T>(2 * (elements - midpoint));
-  }
+  state.add_global_memory_reads<T>(elements - midpoint);
+  state.add_global_memory_writes<T>(elements - midpoint);
 
   caching_allocator_t alloc{};
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,

--- a/libcudacxx/benchmarks/bench/shift_right/basic.cu
+++ b/libcudacxx/benchmarks/bench/shift_right/basic.cu
@@ -1,0 +1,50 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of CUDA Experimental in CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#include <thrust/device_vector.h>
+
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include "nvbench_helper.cuh"
+
+template <typename T>
+static void basic(nvbench::state& state, nvbench::type_list<T>)
+{
+  const auto elements       = static_cast<std::size_t>(state.get_int64("Elements"));
+  const auto midpoint_float = state.get_float64("ShiftedTo");
+  const auto midpoint       = static_cast<std::size_t>(elements * midpoint_float);
+
+  thrust::device_vector<T> in = generate(elements, bit_entropy::_1_000, T{0}, T{42});
+
+  state.add_element_count(elements);
+  if (3 * midpoint > elements)
+  {
+    state.add_global_memory_reads<T>(elements - midpoint);
+    state.add_global_memory_writes<T>(elements - midpoint);
+  }
+  else
+  {
+    state.add_global_memory_reads<T>(2 * (elements - midpoint));
+    state.add_global_memory_writes<T>(2 * (elements - midpoint));
+  }
+
+  caching_allocator_t alloc{};
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(cuda::std::shift_right(cuda_policy(alloc, launch), in.begin(), in.end(), midpoint));
+             });
+}
+
+NVBENCH_BENCH_TYPES(basic, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("base")
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4))
+  .add_float64_axis("ShiftedTo", std::vector{0.9, 0.6, 0.45, 0.01});

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_left.h
@@ -1,0 +1,164 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_CUDA_SHIFT_LEFT_H
+#define _CUDA_STD___PSTL_CUDA_SHIFT_LEFT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_BACKEND_CUDA()
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+_CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
+
+#  include <cub/device/device_select.cuh>
+
+_CCCL_DIAG_POP
+
+#  include <cuda/__execution/policy.h>
+#  include <cuda/__functional/call_or.h>
+#  include <cuda/__iterator/counting_iterator.h>
+#  include <cuda/__iterator/transform_iterator.h>
+#  include <cuda/__stream/get_stream.h>
+#  include <cuda/__stream/stream_ref.h>
+#  include <cuda/std/__algorithm/shift_left.h>
+#  include <cuda/std/__exception/cuda_error.h>
+#  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__execution/env.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/incrementable_traits.h>
+#  include <cuda/std/__pstl/cuda/temporary_storage.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__utility/move.h>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
+
+struct __shift_left_predicate
+{
+  size_t __start_;
+
+  [[nodiscard]] _CCCL_API constexpr bool operator()(size_t __index) const noexcept
+  {
+    return __index >= __start_;
+  }
+};
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+template <>
+struct __pstl_dispatch<__pstl_algorithm::__shift_left, __execution_backend::__cuda>
+{
+  template <class _Policy, class _InputIterator>
+  [[nodiscard]] _CCCL_HOST_API static _InputIterator __par_impl(
+    const _Policy& __policy,
+    _InputIterator __first,
+    _InputIterator __last,
+    iter_difference_t<_InputIterator> __num_shifted)
+  {
+    using _OffsetType   = iter_difference_t<_InputIterator>;
+    const auto __count  = ::cuda::std::distance(__first, __last);
+    const auto __result = __first + static_cast<_OffsetType>(__count - __num_shifted);
+    auto __flag_iter    = ::cuda::transform_iterator{
+      ::cuda::counting_iterator<size_t>{0}, __shift_left_predicate{static_cast<size_t>(__num_shifted)}};
+
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+
+    // Determine temporary device storage requirements for DeviceSelect::Flagged
+    size_t __num_bytes = 0;
+    _CCCL_TRY_CUDA_API(
+      CUB_NS_QUALIFIER::DeviceSelect::Flagged,
+      "__pstl_cuda_shift_left: determination of device storage for cub::DeviceSelect::Flagged failed",
+      static_cast<void*>(nullptr),
+      __num_bytes,
+      __first,
+      __flag_iter,
+      static_cast<_OffsetType*>(nullptr),
+      __count,
+      __stream.get());
+
+    {
+      __temporary_storage<_OffsetType> __storage{__policy, __num_bytes, 1};
+
+      // Run the kernel
+      _CCCL_TRY_CUDA_API(
+        CUB_NS_QUALIFIER::DeviceSelect::Flagged,
+        "__pstl_cuda_shift_left: kernel launch of cub::DeviceSelect::Flagged failed",
+        __storage.__get_temp_storage(),
+        __num_bytes,
+        ::cuda::std::move(__first),
+        ::cuda::std::move(__flag_iter),
+        __storage.template __get_ptr<0>(),
+        __count,
+        __stream.get());
+    }
+
+    __stream.sync();
+    return __result;
+  }
+
+  _CCCL_TEMPLATE(class _Policy, class _InputIterator)
+  _CCCL_REQUIRES(__has_forward_traversal<_InputIterator>)
+  [[nodiscard]] _CCCL_HOST_API _InputIterator operator()(
+    [[maybe_unused]] const _Policy& __policy,
+    _InputIterator __first,
+    _InputIterator __last,
+    iter_difference_t<_InputIterator> __num_shifted) const
+  {
+    if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
+    {
+      try
+      {
+        return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), __num_shifted);
+      }
+      catch (const ::cuda::cuda_error& __err)
+      {
+        if (__err.status() == cudaErrorMemoryAllocation)
+        {
+          _CCCL_THROW(::std::bad_alloc);
+        }
+        else
+        {
+          throw __err;
+        }
+      }
+    }
+    else
+    {
+      static_assert(__always_false_v<_Policy>,
+                    "CUDA backend of cuda::std::shift_left requires random access iterators");
+      return ::cuda::std::shift_left(::cuda::std::move(__first), ::cuda::std::move(__last), __num_shifted);
+    }
+  }
+};
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HAS_BACKEND_CUDA()
+
+#endif // _CUDA_STD___PSTL_CUDA_SHIFT_LEFT_H

--- a/libcudacxx/include/cuda/std/__pstl/cuda/shift_right.h
+++ b/libcudacxx/include/cuda/std/__pstl/cuda/shift_right.h
@@ -1,0 +1,193 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_CUDA_SHIFT_RIGHT_H
+#define _CUDA_STD___PSTL_CUDA_SHIFT_RIGHT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_BACKEND_CUDA()
+
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wshadow")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedef")
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+_CCCL_DIAG_SUPPRESS_NVHPC(attribute_requires_external_linkage)
+
+#  include <cub/device/device_transform.cuh>
+
+_CCCL_DIAG_POP
+
+#  include <cuda/__execution/policy.h>
+#  include <cuda/__functional/call_or.h>
+#  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/__stream/get_stream.h>
+#  include <cuda/__stream/stream_ref.h>
+#  include <cuda/std/__algorithm/shift_right.h>
+#  include <cuda/std/__exception/cuda_error.h>
+#  include <cuda/std/__exception/exception_macros.h>
+#  include <cuda/std/__execution/env.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__functional/identity.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/incrementable_traits.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__memory/pointer_traits.h>
+#  include <cuda/std/__pstl/cuda/temporary_storage.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__utility/move.h>
+#  include <cuda/std/cstdint>
+#  include <cuda/std/tuple>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_EXECUTION
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+template <>
+struct __pstl_dispatch<__pstl_algorithm::__shift_right, __execution_backend::__cuda>
+{
+  template <class _Policy, class _InputIterator>
+  [[nodiscard]] _CCCL_HOST_API static _InputIterator __par_impl(
+    const _Policy& __policy,
+    _InputIterator __first,
+    _InputIterator __last,
+    iter_difference_t<_InputIterator> __num_shifted)
+  {
+    using _OffsetType            = iter_difference_t<_InputIterator>;
+    using value_type             = iter_value_t<_InputIterator>;
+    const auto __count           = ::cuda::std::distance(__first, __last);
+    const auto __count_remaining = static_cast<_OffsetType>(__count - __num_shifted);
+    const auto __result          = __first + __num_shifted;
+
+    auto __stream = ::cuda::__call_or(::cuda::get_stream, ::cuda::stream_ref{cudaStreamPerThread}, __policy);
+
+    if (2 * __num_shifted > __count)
+    { // There is no overlap between the source and destination, so we can just copy
+      _CCCL_TRY_CUDA_API(
+        CUB_NS_QUALIFIER::DeviceTransform::Transform,
+        "__pstl_cuda_shift_right: first kernel launch of cub::DeviceTransform::Transform failed",
+        tuple<_InputIterator>{__first},
+        __result,
+        __count_remaining,
+        identity{},
+        __stream.get());
+    }
+    else if (3 * __num_shifted > __count)
+    { // We do need two copies, but we can avoid temporary storage
+      const auto __count_second_batch = static_cast<_OffsetType>(__count_remaining - __num_shifted);
+      // The first batch is __num_shifted elements, starting at the end of the second batch
+      _CCCL_TRY_CUDA_API(
+        CUB_NS_QUALIFIER::DeviceTransform::Transform,
+        "__pstl_cuda_shift_right: first kernel launch of cub::DeviceTransform::Transform failed",
+        tuple<_InputIterator>{__first + __count_second_batch},
+        __result + __count_second_batch,
+        __num_shifted,
+        identity{},
+        __stream.get());
+
+      _CCCL_TRY_CUDA_API(
+        CUB_NS_QUALIFIER::DeviceTransform::Transform,
+        "__pstl_cuda_shift_right: second kernel launch of cub::DeviceTransform::Transform failed",
+        tuple<_InputIterator>{__first},
+        __result,
+        __count_second_batch,
+        identity{},
+        __stream.get());
+    }
+    else
+    { // Need temporary storage
+      size_t __num_bytes = 1;
+      __temporary_storage<value_type> __storage{__policy, __num_bytes, static_cast<size_t>(__count - __num_shifted)};
+
+      // Run the kernel to copy to temporary storage
+      _CCCL_TRY_CUDA_API(
+        CUB_NS_QUALIFIER::DeviceTransform::Transform,
+        "__pstl_cuda_shift_right: first kernel launch of cub::DeviceTransform::Transform failed",
+        __storage.__get_temp_storage(),
+        __num_bytes,
+        tuple<_InputIterator>{::cuda::std::move(__first)},
+        __storage.template __get_ptr<0>(),
+        __count_remaining,
+        identity{},
+        __stream.get());
+
+      // Run the kernel to copy back from temporary storage
+      _CCCL_TRY_CUDA_API(
+        CUB_NS_QUALIFIER::DeviceTransform::Transform,
+        "__pstl_cuda_shift_right: second kernel launch of cub::DeviceTransform::Transform failed",
+        __storage.__get_temp_storage(),
+        __num_bytes,
+        tuple<value_type*>{__storage.template __get_ptr<0>()},
+        __result,
+        __count_remaining,
+        identity{},
+        __stream.get());
+    }
+
+    __stream.sync();
+    return __result;
+  }
+
+  _CCCL_TEMPLATE(class _Policy, class _InputIterator)
+  _CCCL_REQUIRES(__has_forward_traversal<_InputIterator>)
+  [[nodiscard]] _CCCL_HOST_API _InputIterator operator()(
+    [[maybe_unused]] const _Policy& __policy,
+    _InputIterator __first,
+    _InputIterator __last,
+    iter_difference_t<_InputIterator> __num_shifted) const
+  {
+    if constexpr (::cuda::std::__has_random_access_traversal<_InputIterator>)
+    {
+      try
+      {
+        return __par_impl(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), __num_shifted);
+      }
+      catch (const ::cuda::cuda_error& __err)
+      {
+        if (__err.status() == cudaErrorMemoryAllocation)
+        {
+          _CCCL_THROW(::std::bad_alloc);
+        }
+        else
+        {
+          throw __err;
+        }
+      }
+    }
+    else
+    {
+      static_assert(__always_false_v<_Policy>,
+                    "__pstl_dispatch: CUDA backend of cuda::std::shift_right requires at least random access "
+                    "iterators");
+      return ::cuda::std::shift_right(::cuda::std::move(__first), ::cuda::std::move(__last), __num_shifted);
+    }
+  }
+};
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD_EXECUTION
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif /// _CCCL_HAS_BACKEND_CUDA()
+
+#endif // _CUDA_STD___PSTL_CUDA_SHIFT_RIGHT_H

--- a/libcudacxx/include/cuda/std/__pstl/dispatch.h
+++ b/libcudacxx/include/cuda/std/__pstl/dispatch.h
@@ -47,6 +47,8 @@ enum class __pstl_algorithm
   __remove_if,
   __rotate,
   __rotate_copy,
+  __shift_left,
+  __shift_right,
   __transform,
   __transform_reduce,
   __unique,

--- a/libcudacxx/include/cuda/std/__pstl/shift_left.h
+++ b/libcudacxx/include/cuda/std/__pstl/shift_left.h
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_SHIFT_LEFT_H
+#define _CUDA_STD___PSTL_SHIFT_LEFT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__nvtx/nvtx.h>
+#  include <cuda/std/__algorithm/shift_left.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/incrementable_traits.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/shift_left.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+_CCCL_HOST_API _InputIterator shift_left(
+  [[maybe_unused]] const _Policy& __policy,
+  _InputIterator __first,
+  _InputIterator __last,
+  iter_difference_t<_InputIterator> __num_shifted)
+{
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__shift_left, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::std::shift_left");
+
+    const auto __count = ::cuda::std::distance(__first, __last);
+    if (__num_shifted == 0 || __num_shifted >= __count)
+    {
+      return __first;
+    }
+
+    return __dispatch(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), __num_shifted);
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::shift_left requires at least one selected backend");
+    return ::cuda::std::shift_left(::cuda::std::move(__first), ::cuda::std::move(__last), __num_shifted);
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_SHIFT_LEFT_H

--- a/libcudacxx/include/cuda/std/__pstl/shift_right.h
+++ b/libcudacxx/include/cuda/std/__pstl/shift_right.h
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___PSTL_SHIFT_RIGHT_H
+#define _CUDA_STD___PSTL_SHIFT_RIGHT_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if !_CCCL_COMPILER(NVRTC)
+
+#  include <cuda/__nvtx/nvtx.h>
+#  include <cuda/std/__algorithm/shift_right.h>
+#  include <cuda/std/__concepts/concept_macros.h>
+#  include <cuda/std/__execution/policy.h>
+#  include <cuda/std/__iterator/distance.h>
+#  include <cuda/std/__iterator/incrementable_traits.h>
+#  include <cuda/std/__iterator/iterator_traits.h>
+#  include <cuda/std/__pstl/dispatch.h>
+#  include <cuda/std/__type_traits/always_false.h>
+#  include <cuda/std/__type_traits/is_execution_policy.h>
+#  include <cuda/std/__utility/move.h>
+
+#  if _CCCL_HAS_BACKEND_CUDA()
+#    include <cuda/std/__pstl/cuda/shift_right.h>
+#  endif // _CCCL_HAS_BACKEND_CUDA()
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD
+
+_CCCL_BEGIN_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_TEMPLATE(class _Policy, class _InputIterator)
+_CCCL_REQUIRES(__has_forward_traversal<_InputIterator> _CCCL_AND is_execution_policy_v<_Policy>)
+_CCCL_HOST_API _InputIterator shift_right(
+  [[maybe_unused]] const _Policy& __policy,
+  _InputIterator __first,
+  _InputIterator __last,
+  iter_difference_t<_InputIterator> __num_shifted)
+{
+  [[maybe_unused]] auto __dispatch =
+    ::cuda::std::execution::__pstl_select_dispatch<::cuda::std::execution::__pstl_algorithm::__shift_right, _Policy>();
+  if constexpr (::cuda::std::execution::__pstl_can_dispatch<decltype(__dispatch)>)
+  {
+    _CCCL_NVTX_RANGE_SCOPE("cuda::std::shift_right");
+
+    const auto __count = ::cuda::std::distance(__first, __last);
+    if (__num_shifted == 0 || __num_shifted >= __count)
+    {
+      return __last;
+    }
+
+    return __dispatch(__policy, ::cuda::std::move(__first), ::cuda::std::move(__last), __num_shifted);
+  }
+  else
+  {
+    static_assert(__always_false_v<_Policy>, "Parallel cuda::std::shift_right requires at least one selected backend");
+    return ::cuda::std::shift_right(::cuda::std::move(__first), ::cuda::std::move(__last), __num_shifted);
+  }
+}
+
+_CCCL_END_NAMESPACE_ARCH_DEPENDENT
+
+_CCCL_END_NAMESPACE_CUDA_STD
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // !_CCCL_COMPILER(NVRTC)
+
+#endif // _CUDA_STD___PSTL_SHIFT_RIGHT_H

--- a/libcudacxx/include/cuda/std/execution
+++ b/libcudacxx/include/cuda/std/execution
@@ -70,6 +70,8 @@
 #  include <cuda/std/__pstl/reverse_copy.h>
 #  include <cuda/std/__pstl/rotate.h>
 #  include <cuda/std/__pstl/rotate_copy.h>
+#  include <cuda/std/__pstl/shift_left.h>
+#  include <cuda/std/__pstl/shift_right.h>
 #  include <cuda/std/__pstl/swap_ranges.h>
 #  include <cuda/std/__pstl/transform.h>
 #  include <cuda/std/__pstl/transform_exclusive_scan.h>

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/pstl_shift_left.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/pstl_shift_left.cu
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template <class Policy, class InputIterator>
+// void shift_left(const Policy& policy, InputIterator first, InputIterator last, iter_difference_t<InputIterator> n);
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/sequence.h>
+
+#include <cuda/cmath>
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+#include "test_macros.h"
+
+inline constexpr int size = 1000;
+
+template <class Policy>
+void test_shift_left(const Policy& policy, thrust::device_vector<int>& input)
+{
+  { // Empty does not access anything
+    auto res = cuda::std::shift_left(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), 42);
+    CHECK(res == nullptr);
+  }
+
+  thrust::sequence(input.begin(), input.end(), 0);
+  { // No shift does nothing
+    auto res = cuda::std::shift_left(policy, input.begin(), input.end(), 0);
+    CHECK(cuda::std::equal(policy, input.begin(), input.end(), cuda::counting_iterator{0}));
+    CHECK(res == input.begin());
+  }
+
+  { // Shift larger than size does nothing
+    auto res = cuda::std::shift_left(policy, input.begin(), input.end(), size + 1);
+    CHECK(cuda::std::equal(policy, input.begin(), input.end(), cuda::counting_iterator{0}));
+    CHECK(res == input.begin());
+  }
+
+  thrust::sequence(input.begin(), input.end(), 0);
+  { // Small shift
+    const int num_shifted = 42;
+    const auto expected   = cuda::std::next(input.begin(), size - num_shifted);
+    auto res              = cuda::std::shift_left(policy, input.begin(), input.end(), num_shifted);
+    CHECK(cuda::std::equal(policy, input.begin(), expected, cuda::counting_iterator{num_shifted}));
+    CHECK(res == expected);
+  }
+
+  thrust::sequence(input.begin(), input.end(), 0);
+  { // Large shift
+    const int num_shifted = size / 2 + 10;
+    const auto expected   = cuda::std::next(input.begin(), size - num_shifted);
+    auto res              = cuda::std::shift_left(policy, input.begin(), input.end(), num_shifted);
+    CHECK(cuda::std::equal(policy, input.begin(), expected, cuda::counting_iterator{num_shifted}));
+    CHECK(res == expected);
+  }
+}
+
+C2H_TEST("cuda::std::shift_left", "[parallel algorithm]")
+{
+  thrust::device_vector<int> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::gpu;
+
+    test_shift_left(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+
+    test_shift_left(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource);
+
+    test_shift_left(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy =
+      cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);
+
+    test_shift_left(policy, input);
+  }
+}

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/pstl_shift_right.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.shift/pstl_shift_right.cu
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// template <class Policy, class InputIterator>
+// void shift_right(const Policy& policy, InputIterator first, InputIterator last, iter_difference_t<InputIterator> n);
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/sequence.h>
+
+#include <cuda/cmath>
+#include <cuda/iterator>
+#include <cuda/memory_pool>
+#include <cuda/std/execution>
+#include <cuda/stream>
+
+#include <testing.cuh>
+#include <utility.cuh>
+
+#include "test_macros.h"
+
+inline constexpr int size = 1000;
+
+template <class Policy>
+void test_shift_right(const Policy& policy, thrust::device_vector<int>& input)
+{
+  { // Empty does not access anything
+    auto res = cuda::std::shift_right(policy, static_cast<int*>(nullptr), static_cast<int*>(nullptr), 42);
+    CHECK(res == nullptr);
+  }
+
+  thrust::sequence(input.begin(), input.end(), 0);
+  { // No shift does nothing
+    auto res = cuda::std::shift_right(policy, input.begin(), input.end(), 0);
+    CHECK(cuda::std::equal(policy, input.begin(), input.end(), cuda::counting_iterator{0}));
+    CHECK(res == input.end());
+  }
+
+  { // Shift larger than size does nothing
+    auto res = cuda::std::shift_right(policy, input.begin(), input.end(), size + 1);
+    CHECK(cuda::std::equal(policy, input.begin(), input.end(), cuda::counting_iterator{0}));
+    CHECK(res == input.end());
+  }
+
+  thrust::sequence(input.begin(), input.end(), 0);
+  { // shift small
+    const int num_shifted = 42;
+    const auto expected   = cuda::std::next(input.begin(), num_shifted);
+    auto res              = cuda::std::shift_right(policy, input.begin(), input.end(), num_shifted);
+    CHECK(cuda::std::equal(policy, expected, input.end(), cuda::counting_iterator{0}));
+    CHECK(res == expected);
+  }
+
+  thrust::sequence(input.begin(), input.end(), 0);
+  { // shift smaller than half size but large enough for two step
+    const int num_shifted = size / 2 - 10;
+    const auto expected   = cuda::std::next(input.begin(), num_shifted);
+    auto res              = cuda::std::shift_right(policy, input.begin(), input.end(), num_shifted);
+    CHECK(cuda::std::equal(policy, expected, input.end(), cuda::counting_iterator{0}));
+    CHECK(res == expected);
+  }
+
+  thrust::sequence(input.begin(), input.end(), 0);
+  { // shift larger than half size
+    const int num_shifted = size / 2 + 10;
+    const auto expected   = cuda::std::next(input.begin(), num_shifted);
+    auto res              = cuda::std::shift_right(policy, input.begin(), input.end(), num_shifted);
+    CHECK(cuda::std::equal(policy, expected, input.end(), cuda::counting_iterator{0}));
+    CHECK(res == expected);
+  }
+}
+
+C2H_TEST("cuda::std::shift_right", "[parallel algorithm]")
+{
+  thrust::device_vector<int> input(size, thrust::no_init);
+
+  SECTION("with default stream")
+  {
+    const auto policy = cuda::execution::gpu;
+
+    test_shift_right(policy, input);
+  }
+
+  SECTION("with provided stream")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    const auto policy = cuda::execution::gpu.with(cuda::get_stream, stream);
+
+    test_shift_right(policy, input);
+  }
+
+  SECTION("with provided memory_resource")
+  {
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
+    const auto policy = cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource);
+
+    test_shift_right(policy, input);
+  }
+
+  SECTION("with provided stream and memory_resource")
+  {
+    cuda::stream stream{cuda::device_ref{0}};
+    cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
+    const auto policy =
+      cuda::execution::gpu.with(cuda::mr::get_memory_resource, device_resource).with(cuda::get_stream, stream);
+
+    test_shift_right(policy, input);
+  }
+}


### PR DESCRIPTION
This implements the shift algorithms for the cuda backend.

* `std::shift_left` see https://en.cppreference.com/w/cpp/algorithm/shift.html
* `std::shift_right` see https://en.cppreference.com/w/cpp/algorithm/shift.html

It provides tests and benchmarks similar to Thrust and some boilerplate for libcu++

The functionality is publicly available yet and implemented in a private internal header

Fixes #7769
