### PR TITLE
Drop `thrust::detail::is_numeric`

### DIFF
--- a/thrust/testing/counting_iterator.cu
+++ b/thrust/testing/counting_iterator.cu
@@ -37,8 +37,6 @@ struct custom_int
   _CCCL_HOST_DEVICE custom_int(int) {}
   _CCCL_HOST_DEVICE operator int() const;
 };
-static_assert(thrust::detail::is_numeric<custom_int>::value);
-
 static_assert(diff_type_is<custom_int, ptrdiff_t>);
 
 _CCCL_DIAG_PUSH

--- a/thrust/thrust/detail/type_traits.h
+++ b/thrust/thrust/detail/type_traits.h
@@ -101,10 +101,6 @@ template <typename T1, typename T2, typename T = void>
 struct disable_if_convertible : disable_if<::cuda::std::is_convertible<T1, T2>::value, T>
 {};
 
-template <typename T>
-struct is_numeric : ::cuda::std::_And<::cuda::std::is_convertible<int, T>, ::cuda::std::is_convertible<T, int>>
-{}; // end is_numeric
-
 struct largest_available_float
 {
   using type = double;


### PR DESCRIPTION
Just stumbled over this and it seems unused.