### PR TITLE
 Unified equal_to_value functions 

### DIFF
--- a/libcudacxx/benchmarks/bench/all_of/basic.cu
+++ b/libcudacxx/benchmarks/bench/all_of/basic.cu
@@ -10,7 +10,7 @@
 
 #include <thrust/device_vector.h>
 
-#include <cuda/__functional/equal_to_value.h>
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/std/__pstl_algorithm>
 #include <cuda/stream>

--- a/libcudacxx/benchmarks/bench/any_of/basic.cu
+++ b/libcudacxx/benchmarks/bench/any_of/basic.cu
@@ -10,7 +10,7 @@
 
 #include <thrust/device_vector.h>
 
-#include <cuda/__functional/equal_to_value.h>
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/std/__pstl_algorithm>
 #include <cuda/stream>

--- a/libcudacxx/benchmarks/bench/none_of/basic.cu
+++ b/libcudacxx/benchmarks/bench/none_of/basic.cu
@@ -10,7 +10,7 @@
 
 #include <thrust/device_vector.h>
 
-#include <cuda/__functional/equal_to_value.h>
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/std/__pstl_algorithm>
 #include <cuda/stream>

--- a/thrust/benchmarks/bench/all_of/basic.cu
+++ b/thrust/benchmarks/bench/all_of/basic.cu
@@ -5,7 +5,7 @@
 #include <thrust/fill.h>
 #include <thrust/logical.h>
 
-#include <cuda/__functional/equal_to_value.h>
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/stream>
 

--- a/thrust/benchmarks/bench/any_of/basic.cu
+++ b/thrust/benchmarks/bench/any_of/basic.cu
@@ -5,7 +5,7 @@
 #include <thrust/fill.h>
 #include <thrust/logical.h>
 
-#include <cuda/__functional/equal_to_value.h>
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/stream>
 

--- a/thrust/benchmarks/bench/find/basic.cu
+++ b/thrust/benchmarks/bench/find/basic.cu
@@ -11,6 +11,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/find.h>
 
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/stream>
 

--- a/thrust/benchmarks/bench/none_of/basic.cu
+++ b/thrust/benchmarks/bench/none_of/basic.cu
@@ -5,7 +5,7 @@
 #include <thrust/fill.h>
 #include <thrust/logical.h>
 
-#include <cuda/__functional/equal_to_value.h>
+#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/stream>
 


### PR DESCRIPTION

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes #7457 

<!-- Provide a standalone description of changes in this PR. -->
Removed all the equal_to_val implementations and used equal_to_value from cuda::_functional::equal_to_value.h

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [X] I am familiar with the [Contributing Guidelines](). -->
- [X] New or existing tests cover these changes.
- [X] The documentation is up to date with these changes.
