### PR TITLE
[cudax] Refactor graph APIs to use CUDA Driver API

### DIFF
--- a/cudax/include/cuda/experimental/__driver/driver_api.cuh
+++ b/cudax/include/cuda/experimental/__driver/driver_api.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__graph/graph.cuh
+++ b/cudax/include/cuda/experimental/__graph/graph.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__graph/graph_builder.cuh
+++ b/cudax/include/cuda/experimental/__graph/graph_builder.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -161,7 +161,6 @@ struct _CCCL_TYPE_VISIBILITY_DEFAULT graph_builder : graph_builder_ref
   }
 
   //! \brief Resets the `graph_builder` object, destroying the underlying CUDA graph object.
-  //! \throws cuda::std::cuda_error if `cudaGraphDestroy` fails.
   //! \post `get() == nullptr`
   _CCCL_HOST_API constexpr void reset() noexcept
   {

--- a/cudax/include/cuda/experimental/__graph/graph_builder_ref.cuh
+++ b/cudax/include/cuda/experimental/__graph/graph_builder_ref.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__graph/graph_node_ref.cuh
+++ b/cudax/include/cuda/experimental/__graph/graph_node_ref.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/cudax/include/cuda/experimental/__graph/path_builder.cuh
+++ b/cudax/include/cuda/experimental/__graph/path_builder.cuh
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 


### PR DESCRIPTION
Currently graph APIs use CUDA Runtime, but we should bring it in line with the rest of the project and use the driver API

This PR also introduces experimental version of the driver API layer that uses type defines from a driver header, which was necessary for one of the graph functions. Once tested we can think about migrating the main driver layer in libcu++ to this new implementation