### PR TITLE
unify float comparison helpers with isclose

### DIFF
--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -22,6 +22,7 @@
 #include <c2h/checked_allocator.cuh>
 #include <c2h/device_policy.h>
 #include <c2h/extended_types.h>
+#include <c2h/isclose.h>
 #include <c2h/test_util_vec.h>
 #include <c2h/utility.h>
 #include <c2h/vector.h>
@@ -214,25 +215,37 @@ std::vector<T> to_vec(std::vector<T> const& vec)
 }
 } // namespace detail
 
-#define REQUIRE_APPROX_EQ(ref, out)                          \
-  {                                                          \
-    auto vec_ref = detail::to_vec(ref);                      \
-    auto vec_out = detail::to_vec(out);                      \
-    REQUIRE_THAT(vec_ref, Catch::Matchers::Approx(vec_out)); \
+#define REQUIRE_APPROX_EQ(ref, out)                                      \
+  {                                                                      \
+    auto vec_ref = detail::to_vec(ref);                                  \
+    auto vec_out = detail::to_vec(out);                                  \
+    for (size_t i = 0; i < vec_ref.size(); i++)                          \
+    {                                                                    \
+      INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]); \
+      REQUIRE(isclose(vec_ref[i], vec_out[i]));                          \
+    }                                                                    \
   }
 
-#define REQUIRE_APPROX_EQ_EPSILON(ref, out, eps)                          \
-  {                                                                       \
-    auto vec_ref = detail::to_vec(ref);                                   \
-    auto vec_out = detail::to_vec(out);                                   \
-    REQUIRE_THAT(vec_ref, Catch::Matchers::Approx(vec_out).epsilon(eps)); \
+#define REQUIRE_APPROX_EQ_EPSILON(ref, out, eps)                         \
+  {                                                                      \
+    auto vec_ref = detail::to_vec(ref);                                  \
+    auto vec_out = detail::to_vec(out);                                  \
+    for (size_t i = 0; i < vec_ref.size(); i++)                          \
+    {                                                                    \
+      INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]); \
+      REQUIRE(isclose(vec_ref[i], vec_out[i], eps));                     \
+    }                                                                    \
   }
 
 #define REQUIRE_APPROX_EQ_ABS(ref, out, abs)                             \
   {                                                                      \
     auto vec_ref = detail::to_vec(ref);                                  \
     auto vec_out = detail::to_vec(out);                                  \
-    REQUIRE_THAT(vec_ref, Catch::Matchers::Approx(vec_out).margin(abs)); \
+    for (size_t i = 0; i < vec_ref.size(); i++)                          \
+    {                                                                    \
+      INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]); \
+      REQUIRE(isclose(vec_ref[i], vec_out[i], 0 * vec_ref[i], abs));     \
+    }                                                                    \
   }
 
 namespace c2h::detail

--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -215,49 +215,49 @@ std::vector<T> to_vec(std::vector<T> const& vec)
 }
 } // namespace detail
 
-#define REQUIRE_APPROX_EQ(ref, out)                                                \
-  {                                                                                \
-    auto vec_ref = detail::to_vec(ref);                                            \
-    auto vec_out = detail::to_vec(out);                                            \
-    for (size_t i = 0; i < vec_ref.size(); i++)                                    \
-    {                                                                              \
-      bool close = isclose(vec_ref[i], vec_out[i]);                                \
-      if (!close)                                                                  \
-      {                                                                            \
-        INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]);         \
-      }                                                                            \
-      REQUIRE(close);                                                              \
-    }                                                                              \
+#define REQUIRE_APPROX_EQ(ref, out)                                        \
+  {                                                                        \
+    auto vec_ref = detail::to_vec(ref);                                    \
+    auto vec_out = detail::to_vec(out);                                    \
+    for (size_t i = 0; i < vec_ref.size(); i++)                            \
+    {                                                                      \
+      bool close = isclose(vec_ref[i], vec_out[i]);                        \
+      if (!close)                                                          \
+      {                                                                    \
+        INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]); \
+      }                                                                    \
+      REQUIRE(close);                                                      \
+    }                                                                      \
   }
 
-#define REQUIRE_APPROX_EQ_EPSILON(ref, out, eps)                                   \
-  {                                                                                \
-    auto vec_ref = detail::to_vec(ref);                                            \
-    auto vec_out = detail::to_vec(out);                                            \
-    for (size_t i = 0; i < vec_ref.size(); i++)                                    \
-    {                                                                              \
-      bool close = isclose(vec_ref[i], vec_out[i], eps);                           \
-      if (!close)                                                                  \
-      {                                                                            \
-        INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]);         \
-      }                                                                            \
-      REQUIRE(close);                                                              \
-    }                                                                              \
+#define REQUIRE_APPROX_EQ_EPSILON(ref, out, eps)                           \
+  {                                                                        \
+    auto vec_ref = detail::to_vec(ref);                                    \
+    auto vec_out = detail::to_vec(out);                                    \
+    for (size_t i = 0; i < vec_ref.size(); i++)                            \
+    {                                                                      \
+      bool close = isclose(vec_ref[i], vec_out[i], eps);                   \
+      if (!close)                                                          \
+      {                                                                    \
+        INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]); \
+      }                                                                    \
+      REQUIRE(close);                                                      \
+    }                                                                      \
   }
 
-#define REQUIRE_APPROX_EQ_ABS(ref, out, abs)                                       \
-  {                                                                                \
-    auto vec_ref = detail::to_vec(ref);                                            \
-    auto vec_out = detail::to_vec(out);                                            \
-    for (size_t i = 0; i < vec_ref.size(); i++)                                    \
-    {                                                                              \
-      bool close = isclose(vec_ref[i], vec_out[i], 0 * vec_ref[i], abs);           \
-      if (!close)                                                                  \
-      {                                                                            \
-        INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]);         \
-      }                                                                            \
-      REQUIRE(close);                                                              \
-    }                                                                              \
+#define REQUIRE_APPROX_EQ_ABS(ref, out, abs)                               \
+  {                                                                        \
+    auto vec_ref = detail::to_vec(ref);                                    \
+    auto vec_out = detail::to_vec(out);                                    \
+    for (size_t i = 0; i < vec_ref.size(); i++)                            \
+    {                                                                      \
+      bool close = isclose(vec_ref[i], vec_out[i], 0 * vec_ref[i], abs);   \
+      if (!close)                                                          \
+      {                                                                    \
+        INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]); \
+      }                                                                    \
+      REQUIRE(close);                                                      \
+    }                                                                      \
   }
 
 namespace c2h::detail

--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -215,37 +215,49 @@ std::vector<T> to_vec(std::vector<T> const& vec)
 }
 } // namespace detail
 
-#define REQUIRE_APPROX_EQ(ref, out)                                      \
-  {                                                                      \
-    auto vec_ref = detail::to_vec(ref);                                  \
-    auto vec_out = detail::to_vec(out);                                  \
-    for (size_t i = 0; i < vec_ref.size(); i++)                          \
-    {                                                                    \
-      INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]); \
-      REQUIRE(isclose(vec_ref[i], vec_out[i]));                          \
-    }                                                                    \
+#define REQUIRE_APPROX_EQ(ref, out)                                                \
+  {                                                                                \
+    auto vec_ref = detail::to_vec(ref);                                            \
+    auto vec_out = detail::to_vec(out);                                            \
+    for (size_t i = 0; i < vec_ref.size(); i++)                                    \
+    {                                                                              \
+      bool close = isclose(vec_ref[i], vec_out[i]);                                \
+      if (!close)                                                                  \
+      {                                                                            \
+        INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]);         \
+      }                                                                            \
+      REQUIRE(close);                                                              \
+    }                                                                              \
   }
 
-#define REQUIRE_APPROX_EQ_EPSILON(ref, out, eps)                         \
-  {                                                                      \
-    auto vec_ref = detail::to_vec(ref);                                  \
-    auto vec_out = detail::to_vec(out);                                  \
-    for (size_t i = 0; i < vec_ref.size(); i++)                          \
-    {                                                                    \
-      INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]); \
-      REQUIRE(isclose(vec_ref[i], vec_out[i], eps));                     \
-    }                                                                    \
+#define REQUIRE_APPROX_EQ_EPSILON(ref, out, eps)                                   \
+  {                                                                                \
+    auto vec_ref = detail::to_vec(ref);                                            \
+    auto vec_out = detail::to_vec(out);                                            \
+    for (size_t i = 0; i < vec_ref.size(); i++)                                    \
+    {                                                                              \
+      bool close = isclose(vec_ref[i], vec_out[i], eps);                           \
+      if (!close)                                                                  \
+      {                                                                            \
+        INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]);         \
+      }                                                                            \
+      REQUIRE(close);                                                              \
+    }                                                                              \
   }
 
-#define REQUIRE_APPROX_EQ_ABS(ref, out, abs)                             \
-  {                                                                      \
-    auto vec_ref = detail::to_vec(ref);                                  \
-    auto vec_out = detail::to_vec(out);                                  \
-    for (size_t i = 0; i < vec_ref.size(); i++)                          \
-    {                                                                    \
-      INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]); \
-      REQUIRE(isclose(vec_ref[i], vec_out[i], 0 * vec_ref[i], abs));     \
-    }                                                                    \
+#define REQUIRE_APPROX_EQ_ABS(ref, out, abs)                                       \
+  {                                                                                \
+    auto vec_ref = detail::to_vec(ref);                                            \
+    auto vec_out = detail::to_vec(out);                                            \
+    for (size_t i = 0; i < vec_ref.size(); i++)                                    \
+    {                                                                              \
+      bool close = isclose(vec_ref[i], vec_out[i], 0 * vec_ref[i], abs);           \
+      if (!close)                                                                  \
+      {                                                                            \
+        INFO("index " << i << ": " << vec_ref[i] << " vs " << vec_out[i]);         \
+      }                                                                            \
+      REQUIRE(close);                                                              \
+    }                                                                              \
   }
 
 namespace c2h::detail

--- a/c2h/include/c2h/check_results.cuh
+++ b/c2h/include/c2h/check_results.cuh
@@ -71,36 +71,28 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
   else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<__nv_bfloat16>>
                      || cuda::std::is_same_v<T, cuda::std::complex<__half>>)
   {
-    using real_t             = decltype(expected_data[0].real());
+    using real_t             = typename T::value_type;
     constexpr real_t rel_err = cuda::std::is_same_v<T, cuda::std::complex<__half>> ? real_t{0.08f} : real_t{0.2f};
     for (size_t i = 0; i < test_results.size(); ++i)
     {
-      bool close_real = isclose(expected_data[i].real(), test_results[i].real(), rel_err);
-      bool close_imag = isclose(expected_data[i].imag(), test_results[i].imag(), rel_err);
-      if (!close_real || !close_imag)
+      bool close = isclose(expected_data[i], test_results[i], rel_err);
+      if (!close)
       {
         INFO("index " << i);
       }
-      REQUIRE(close_real);
-      REQUIRE(close_imag);
+      REQUIRE(close);
     }
   }
   else if constexpr (cuda::std::__is_cuda_std_complex_v<T>)
   {
     for (size_t i = 0; i < test_results.size(); ++i)
     {
-      auto expected_real = expected_data[i].real();
-      auto test_real     = test_results[i].real();
-      auto expected_imag = expected_data[i].imag();
-      auto test_imag     = test_results[i].imag();
-      bool close_real    = isclose(expected_real, test_real);
-      bool close_imag    = isclose(expected_imag, test_imag);
-      if (!close_real || !close_imag)
+      bool close = isclose(expected_data[i], test_results[i]);
+      if (!close)
       {
         INFO("index " << i);
       }
-      REQUIRE(close_real);
-      REQUIRE(close_imag);
+      REQUIRE(close);
     }
   }
   else

--- a/c2h/include/c2h/check_results.cuh
+++ b/c2h/include/c2h/check_results.cuh
@@ -35,7 +35,7 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
   }
   else if constexpr (cuda::std::is_same_v<T, __nv_bfloat16> || cuda::std::is_same_v<T, __half>)
   {
-    constexpr auto rel_err = cuda::std::is_same_v<T, __half> ? 0.08f : 0.2f;
+    constexpr T rel_err = cuda::std::is_same_v<T, __half> ? T{0.08f} : T{0.2f};
     REQUIRE_APPROX_EQ_EPSILON(expected_data, test_results, rel_err);
   }
   else if constexpr (cuda::std::is_same_v<T, float2>)
@@ -54,13 +54,12 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
   }
   else if constexpr (cuda::std::is_same_v<T, __nv_bfloat162> || cuda::std::is_same_v<T, __half2>)
   {
-    constexpr auto rel_err = cuda::std::is_same_v<T, __half2> ? 0.08f : 0.2f;
+    using elem_t           = decltype(expected_data[0].x);
+    constexpr elem_t rel_err = cuda::std::is_same_v<T, __half2> ? elem_t{0.08f} : elem_t{0.2f};
     for (size_t i = 0; i < test_results.size(); ++i)
     {
-      bool close_x =
-        isclose(static_cast<float>(expected_data[i].x), static_cast<float>(test_results[i].x), rel_err);
-      bool close_y =
-        isclose(static_cast<float>(expected_data[i].y), static_cast<float>(test_results[i].y), rel_err);
+      bool close_x = isclose(expected_data[i].x, test_results[i].x, rel_err);
+      bool close_y = isclose(expected_data[i].y, test_results[i].y, rel_err);
       if (!close_x || !close_y)
       {
         INFO("index " << i);
@@ -72,15 +71,12 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
   else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<__nv_bfloat16>>
                      || cuda::std::is_same_v<T, cuda::std::complex<__half>>)
   {
-    constexpr auto rel_err = cuda::std::is_same_v<T, cuda::std::complex<__half>> ? 0.08f : 0.2f;
+    using real_t           = decltype(expected_data[0].real());
+    constexpr real_t rel_err = cuda::std::is_same_v<T, cuda::std::complex<__half>> ? real_t{0.08f} : real_t{0.2f};
     for (size_t i = 0; i < test_results.size(); ++i)
     {
-      auto expected_real = static_cast<float>(expected_data[i].real());
-      auto test_real     = static_cast<float>(test_results[i].real());
-      auto expected_imag = static_cast<float>(expected_data[i].imag());
-      auto test_imag     = static_cast<float>(test_results[i].imag());
-      bool close_real    = isclose(expected_real, test_real, rel_err);
-      bool close_imag    = isclose(expected_imag, test_imag, rel_err);
+      bool close_real = isclose(expected_data[i].real(), test_results[i].real(), rel_err);
+      bool close_imag = isclose(expected_data[i].imag(), test_results[i].imag(), rel_err);
       if (!close_real || !close_imag)
       {
         INFO("index " << i);

--- a/c2h/include/c2h/check_results.cuh
+++ b/c2h/include/c2h/check_results.cuh
@@ -11,7 +11,7 @@
 
 #include <test_util.h>
 
-#include <catch2/matchers/catch_matchers_floating_point.hpp>
+#include <c2h/isclose.h>
 
 template <typename T>
 void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_vector<T>& test_results)
@@ -42,8 +42,9 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
   {
     for (size_t i = 0; i < test_results.size(); ++i)
     {
-      REQUIRE_THAT(expected_data[i].x, Catch::Matchers::WithinRel(test_results[i].x, 0.01f));
-      REQUIRE_THAT(expected_data[i].y, Catch::Matchers::WithinRel(test_results[i].y, 0.01f));
+      INFO("index " << i);
+      REQUIRE(isclose(expected_data[i].x, test_results[i].x, 0.01f));
+      REQUIRE(isclose(expected_data[i].y, test_results[i].y, 0.01f));
     }
   }
   else if constexpr (cuda::std::is_same_v<T, __nv_bfloat162> || cuda::std::is_same_v<T, __half2>)
@@ -51,8 +52,9 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
     constexpr auto rel_err = cuda::std::is_same_v<T, __half2> ? 0.08f : 0.2f;
     for (size_t i = 0; i < test_results.size(); ++i)
     {
-      REQUIRE_THAT(expected_data[i].x, Catch::Matchers::WithinRel(test_results[i].x, rel_err));
-      REQUIRE_THAT(expected_data[i].y, Catch::Matchers::WithinRel(test_results[i].y, rel_err));
+      INFO("index " << i);
+      REQUIRE(isclose(static_cast<float>(expected_data[i].x), static_cast<float>(test_results[i].x), rel_err));
+      REQUIRE(isclose(static_cast<float>(expected_data[i].y), static_cast<float>(test_results[i].y), rel_err));
     }
   }
   else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<__nv_bfloat16>>
@@ -62,11 +64,12 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
     for (size_t i = 0; i < test_results.size(); ++i)
     {
       auto expected_real = static_cast<float>(expected_data[i].real());
-      auto test_real     = test_results[i].real();
+      auto test_real     = static_cast<float>(test_results[i].real());
       auto expected_imag = static_cast<float>(expected_data[i].imag());
-      auto test_imag     = test_results[i].imag();
-      REQUIRE_THAT(expected_real, Catch::Matchers::WithinRel(test_real, rel_err));
-      REQUIRE_THAT(expected_imag, Catch::Matchers::WithinRel(test_imag, rel_err));
+      auto test_imag     = static_cast<float>(test_results[i].imag());
+      INFO("index " << i);
+      REQUIRE(isclose(expected_real, test_real, rel_err));
+      REQUIRE(isclose(expected_imag, test_imag, rel_err));
     }
   }
   else if constexpr (cuda::std::__is_cuda_std_complex_v<T>)
@@ -77,8 +80,9 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
       auto test_real     = test_results[i].real();
       auto expected_imag = expected_data[i].imag();
       auto test_imag     = test_results[i].imag();
-      REQUIRE_THAT(expected_real, Catch::Matchers::WithinRel(test_real));
-      REQUIRE_THAT(expected_imag, Catch::Matchers::WithinRel(test_imag));
+      INFO("index " << i);
+      REQUIRE(isclose(expected_real, test_real));
+      REQUIRE(isclose(expected_imag, test_imag));
     }
   }
   else

--- a/c2h/include/c2h/check_results.cuh
+++ b/c2h/include/c2h/check_results.cuh
@@ -42,9 +42,14 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
   {
     for (size_t i = 0; i < test_results.size(); ++i)
     {
-      INFO("index " << i);
-      REQUIRE(isclose(expected_data[i].x, test_results[i].x, 0.01f));
-      REQUIRE(isclose(expected_data[i].y, test_results[i].y, 0.01f));
+      bool close_x = isclose(expected_data[i].x, test_results[i].x, 0.01f);
+      bool close_y = isclose(expected_data[i].y, test_results[i].y, 0.01f);
+      if (!close_x || !close_y)
+      {
+        INFO("index " << i);
+      }
+      REQUIRE(close_x);
+      REQUIRE(close_y);
     }
   }
   else if constexpr (cuda::std::is_same_v<T, __nv_bfloat162> || cuda::std::is_same_v<T, __half2>)
@@ -52,9 +57,16 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
     constexpr auto rel_err = cuda::std::is_same_v<T, __half2> ? 0.08f : 0.2f;
     for (size_t i = 0; i < test_results.size(); ++i)
     {
-      INFO("index " << i);
-      REQUIRE(isclose(static_cast<float>(expected_data[i].x), static_cast<float>(test_results[i].x), rel_err));
-      REQUIRE(isclose(static_cast<float>(expected_data[i].y), static_cast<float>(test_results[i].y), rel_err));
+      bool close_x =
+        isclose(static_cast<float>(expected_data[i].x), static_cast<float>(test_results[i].x), rel_err);
+      bool close_y =
+        isclose(static_cast<float>(expected_data[i].y), static_cast<float>(test_results[i].y), rel_err);
+      if (!close_x || !close_y)
+      {
+        INFO("index " << i);
+      }
+      REQUIRE(close_x);
+      REQUIRE(close_y);
     }
   }
   else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<__nv_bfloat16>>
@@ -67,9 +79,14 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
       auto test_real     = static_cast<float>(test_results[i].real());
       auto expected_imag = static_cast<float>(expected_data[i].imag());
       auto test_imag     = static_cast<float>(test_results[i].imag());
-      INFO("index " << i);
-      REQUIRE(isclose(expected_real, test_real, rel_err));
-      REQUIRE(isclose(expected_imag, test_imag, rel_err));
+      bool close_real    = isclose(expected_real, test_real, rel_err);
+      bool close_imag    = isclose(expected_imag, test_imag, rel_err);
+      if (!close_real || !close_imag)
+      {
+        INFO("index " << i);
+      }
+      REQUIRE(close_real);
+      REQUIRE(close_imag);
     }
   }
   else if constexpr (cuda::std::__is_cuda_std_complex_v<T>)
@@ -80,9 +97,14 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
       auto test_real     = test_results[i].real();
       auto expected_imag = expected_data[i].imag();
       auto test_imag     = test_results[i].imag();
-      INFO("index " << i);
-      REQUIRE(isclose(expected_real, test_real));
-      REQUIRE(isclose(expected_imag, test_imag));
+      bool close_real    = isclose(expected_real, test_real);
+      bool close_imag    = isclose(expected_imag, test_imag);
+      if (!close_real || !close_imag)
+      {
+        INFO("index " << i);
+      }
+      REQUIRE(close_real);
+      REQUIRE(close_imag);
     }
   }
   else

--- a/c2h/include/c2h/check_results.cuh
+++ b/c2h/include/c2h/check_results.cuh
@@ -54,7 +54,7 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
   }
   else if constexpr (cuda::std::is_same_v<T, __nv_bfloat162> || cuda::std::is_same_v<T, __half2>)
   {
-    using elem_t           = decltype(expected_data[0].x);
+    using elem_t             = decltype(expected_data[0].x);
     constexpr elem_t rel_err = cuda::std::is_same_v<T, __half2> ? elem_t{0.08f} : elem_t{0.2f};
     for (size_t i = 0; i < test_results.size(); ++i)
     {
@@ -71,7 +71,7 @@ void verify_results(const c2h::host_vector<T>& expected_data, const c2h::host_ve
   else if constexpr (cuda::std::is_same_v<T, cuda::std::complex<__nv_bfloat16>>
                      || cuda::std::is_same_v<T, cuda::std::complex<__half>>)
   {
-    using real_t           = decltype(expected_data[0].real());
+    using real_t             = decltype(expected_data[0].real());
     constexpr real_t rel_err = cuda::std::is_same_v<T, cuda::std::complex<__half>> ? real_t{0.08f} : real_t{0.2f};
     for (size_t i = 0; i < test_results.size(); ++i)
     {

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -29,7 +29,7 @@ bool isclose(T a, T b, T r_tol, T a_tol)
 template <typename T>
 bool isclose(T a, T b, T r_tol)
 {
-  return isclose(a, b, r_tol, T(0));
+  return isclose(a, b, r_tol, T{});
 }
 
 template <typename T>
@@ -37,7 +37,7 @@ bool isclose(T a, T b)
 {
   if constexpr (cuda::std::is_floating_point_v<T>)
   {
-    return isclose(a, b, T(1 << 8) * cuda::std::numeric_limits<T>::epsilon(), T(0));
+    return isclose(a, b, T(1 << 8) * cuda::std::numeric_limits<T>::epsilon(), T{});
   }
   else
   {

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3-Clause
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 #pragma once
 

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -21,6 +21,7 @@ bool isclose(T a, T b, T r_tol, T a_tol)
   }
   else
   {
+    static_assert(std::is_integral_v<T>, "isclose: unsupported type, expected floating point or integral");
     return a == b;
   }
 }
@@ -40,6 +41,7 @@ bool isclose(T a, T b)
   }
   else
   {
+    static_assert(std::is_integral_v<T>, "isclose: unsupported type, expected floating point or integral");
     return a == b;
   }
 }

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -7,6 +7,7 @@
 #include <cuda/std/algorithm>
 #include <cuda/std/cassert>
 #include <cuda/std/cmath>
+#include <cuda/std/complex>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
 
@@ -53,4 +54,22 @@ bool isclose(T a, T b)
     static_assert(cuda::std::is_integral_v<T>, "isclose: unsupported type, expected floating point or integral");
     return a == b;
   }
+}
+
+template <typename T>
+bool isclose(cuda::std::complex<T> a, cuda::std::complex<T> b, T r_tol, T a_tol)
+{
+  return isclose(a.real(), b.real(), r_tol, a_tol) && isclose(a.imag(), b.imag(), r_tol, a_tol);
+}
+
+template <typename T>
+bool isclose(cuda::std::complex<T> a, cuda::std::complex<T> b, T r_tol)
+{
+  return isclose(a, b, r_tol, T{});
+}
+
+template <typename T>
+bool isclose(cuda::std::complex<T> a, cuda::std::complex<T> b)
+{
+  return isclose(a.real(), b.real()) && isclose(a.imag(), b.imag());
 }

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -3,25 +3,25 @@
 
 #pragma once
 
-#include <algorithm>
-#include <cmath>
-#include <limits>
-#include <type_traits>
+#include <cuda/std/algorithm>
+#include <cuda/std/cmath>
+#include <cuda/std/limits>
+#include <cuda/std/type_traits>
 
 template <typename T>
 bool isclose(T a, T b, T r_tol, T a_tol)
 {
-  if constexpr (std::is_floating_point_v<T>)
+  if constexpr (cuda::std::is_floating_point_v<T>)
   {
     if (a == b)
     {
       return true;
     }
-    return std::abs(a - b) <= std::max(a_tol, r_tol * std::max(std::abs(a), std::abs(b)));
+    return cuda::std::abs(a - b) <= cuda::std::max(a_tol, r_tol * cuda::std::max(cuda::std::abs(a), cuda::std::abs(b)));
   }
   else
   {
-    static_assert(std::is_integral_v<T>, "isclose: unsupported type, expected floating point or integral");
+    static_assert(cuda::std::is_integral_v<T>, "isclose: unsupported type, expected floating point or integral");
     return a == b;
   }
 }
@@ -35,13 +35,13 @@ bool isclose(T a, T b, T r_tol)
 template <typename T>
 bool isclose(T a, T b)
 {
-  if constexpr (std::is_floating_point_v<T>)
+  if constexpr (cuda::std::is_floating_point_v<T>)
   {
-    return isclose(a, b, T(1 << 8) * std::numeric_limits<T>::epsilon(), T(0));
+    return isclose(a, b, T(1 << 8) * cuda::std::numeric_limits<T>::epsilon(), T(0));
   }
   else
   {
-    static_assert(std::is_integral_v<T>, "isclose: unsupported type, expected floating point or integral");
+    static_assert(cuda::std::is_integral_v<T>, "isclose: unsupported type, expected floating point or integral");
     return a == b;
   }
 }

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -11,7 +11,7 @@
 #include <cuda/std/type_traits>
 
 template <typename T>
-bool isclose(T a, T b, T r_tol, T a_tol)
+bool isclose(T a, T b, [[maybe_unused]] T r_tol, [[maybe_unused]] T a_tol)
 {
   if constexpr (cuda::is_floating_point_v<T>)
   {

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -37,7 +37,7 @@ bool isclose(T a, T b)
 {
   if constexpr (std::is_floating_point_v<T>)
   {
-    return isclose(a, b, T(1000) * std::numeric_limits<T>::epsilon(), T(0));
+    return isclose(a, b, T(1 << 8) * std::numeric_limits<T>::epsilon(), T(0));
   }
   else
   {

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -45,7 +45,8 @@ bool isclose(T a, T b)
 {
   if constexpr (cuda::is_floating_point_v<T>)
   {
-    return isclose(a, b, T(1 << 8) * cuda::std::numeric_limits<T>::epsilon(), T{});
+    return isclose(
+      a, b, T(1 << (cuda::std::numeric_limits<T>::digits / 4)) * cuda::std::numeric_limits<T>::epsilon(), T{});
   }
   else
   {

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -5,6 +5,7 @@
 
 #include <cuda/__type_traits/is_floating_point.h>
 #include <cuda/std/algorithm>
+#include <cuda/std/cassert>
 #include <cuda/std/cmath>
 #include <cuda/std/limits>
 #include <cuda/std/type_traits>
@@ -14,6 +15,8 @@ bool isclose(T a, T b, T r_tol, T a_tol)
 {
   if constexpr (cuda::is_floating_point_v<T>)
   {
+    assert(cuda::std::isfinite(r_tol) && r_tol >= T{} && "r_tol must be finite and non-negative");
+    assert(cuda::std::isfinite(a_tol) && a_tol >= T{} && "a_tol must be finite and non-negative");
     if (cuda::std::isnan(a) || cuda::std::isnan(b))
     {
       return false;

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <cuda/__type_traits/is_floating_point.h>
 #include <cuda/std/algorithm>
 #include <cuda/std/cmath>
 #include <cuda/std/limits>
@@ -11,11 +12,15 @@
 template <typename T>
 bool isclose(T a, T b, T r_tol, T a_tol)
 {
-  if constexpr (cuda::std::is_floating_point_v<T>)
+  if constexpr (cuda::is_floating_point_v<T>)
   {
-    if (a == b)
+    if (cuda::std::isnan(a) || cuda::std::isnan(b))
     {
-      return true;
+      return false;
+    }
+    if (cuda::std::isinf(a) || cuda::std::isinf(b))
+    {
+      return a == b;
     }
     return cuda::std::abs(a - b) <= cuda::std::max(a_tol, r_tol * cuda::std::max(cuda::std::abs(a), cuda::std::abs(b)));
   }
@@ -35,7 +40,7 @@ bool isclose(T a, T b, T r_tol)
 template <typename T>
 bool isclose(T a, T b)
 {
-  if constexpr (cuda::std::is_floating_point_v<T>)
+  if constexpr (cuda::is_floating_point_v<T>)
   {
     return isclose(a, b, T(1 << 8) * cuda::std::numeric_limits<T>::epsilon(), T{});
   }

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3
+
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <type_traits>
+
+template <typename T>
+bool isclose(T a, T b, T r_tol, T a_tol)
+{
+  if constexpr (std::is_floating_point_v<T>)
+  {
+    if (a == b)
+    {
+      return true;
+    }
+    return std::abs(a - b) <= std::max(a_tol, r_tol * std::max(std::abs(a), std::abs(b)));
+  }
+  else
+  {
+    return a == b;
+  }
+}
+
+template <typename T>
+bool isclose(T a, T b, T r_tol)
+{
+  return isclose(a, b, r_tol, T(0));
+}
+
+template <typename T>
+bool isclose(T a, T b)
+{
+  if constexpr (std::is_floating_point_v<T>)
+  {
+    return isclose(a, b, T(1000) * std::numeric_limits<T>::epsilon(), T(0));
+  }
+  else
+  {
+    return a == b;
+  }
+}

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -1,5 +1,5 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
-// SPDX-License-Identifier: BSD-3
+// SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once
 

--- a/c2h/include/c2h/isclose.h
+++ b/c2h/include/c2h/isclose.h
@@ -46,7 +46,7 @@ bool isclose(T a, T b)
   if constexpr (cuda::is_floating_point_v<T>)
   {
     return isclose(
-      a, b, T(1 << (cuda::std::numeric_limits<T>::digits / 4)) * cuda::std::numeric_limits<T>::epsilon(), T{});
+      a, b, T(1u << (cuda::std::numeric_limits<T>::digits / 4)) * cuda::std::numeric_limits<T>::epsilon(), T{});
   }
   else
   {

--- a/cub/test/catch2_test_device_segmented_scan.cu
+++ b/cub/test/catch2_test_device_segmented_scan.cu
@@ -16,6 +16,7 @@
 #include <c2h/catch2_test_helper.h>
 #include <c2h/custom_type.h>
 #include <c2h/extended_types.h>
+#include <c2h/isclose.h>
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedScan::InclusiveSegmentedSum, device_inclusive_segmented_sum);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceSegmentedScan::ExclusiveSegmentedSum, device_exclusive_segmented_sum);
@@ -73,34 +74,20 @@ bool check_segment(const c2h::host_vector<ValueT>& h_output,
   {
     if constexpr (cuda::std::is_floating_point_v<ValueT>)
     {
-      ValueT ref_v  = h_ref[pos];
-      ValueT act_v  = h_output[pos];
-      ValueT diff   = (ref_v - act_v);
-      ValueT adiff  = (diff > ValueT{0}) ? diff : -diff;
-      ValueT ref_av = (ref_v > ValueT{0}) ? ref_v : -ref_v;
-      ValueT act_av = (act_v > ValueT{0}) ? act_v : -act_v;
-
-      ValueT eps = ::cuda::std::numeric_limits<ValueT>::epsilon();
-      correct    = correct && (adiff < 3 * eps + 2 * eps * (::cuda::std::max(ref_av, act_av)));
+      correct = correct && isclose(h_ref[pos], h_output[pos]);
     }
     else if constexpr (cuda::std::is_same_v<ValueT, half_t> || cuda::std::is_same_v<ValueT, bfloat16_t>)
     {
-      float ref_v = h_ref[pos];
-      float act_v = h_output[pos];
+      float ref_v = static_cast<float>(h_ref[pos]);
+      float act_v = static_cast<float>(h_output[pos]);
       if (cuda::std::isfinite(ref_v) && cuda::std::isfinite(act_v))
       {
-        float diff   = (ref_v - act_v);
-        float adiff  = (diff > float{0}) ? diff : -diff;
-        float ref_av = (ref_v > float{0}) ? ref_v : -ref_v;
-        float act_av = (act_v > float{0}) ? act_v : -act_v;
-
-        float eps = float{1} / float{128};
-        correct   = correct && (adiff < 3 * eps + 5 * eps * (::cuda::std::max(ref_av, act_av)));
+        correct = correct && isclose(ref_v, act_v);
       }
     }
     else
     {
-      correct = correct && (h_ref[pos] == h_output[pos]);
+      correct = correct && isclose(h_ref[pos], h_output[pos]);
     }
     if (!correct)
     {

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -38,6 +38,7 @@
 #include "mersenne.h"
 #include <c2h/catch2_test_helper.h>
 #include <c2h/extended_types.h>
+#include <c2h/isclose.h>
 #include <c2h/test_util_vec.h>
 
 /******************************************************************************
@@ -1074,22 +1075,17 @@ int CompareResults(float* computed, float* reference, OffsetT len, bool verbose 
 {
   for (OffsetT i = 0; i < len; i++)
   {
-    if (computed[i] != reference[i])
+    if (!isclose(computed[i], reference[i]))
     {
-      float difference = std::abs(computed[i] - reference[i]);
-      float fraction   = difference / std::abs(reference[i]);
-
-      if (fraction > 0.00015)
+      if (verbose)
       {
-        if (verbose)
-        {
-          std::cout
-            << "INCORRECT: [" << i << "]: "
-            << "(computed) " << CoutCast(computed[i]) << " != " << CoutCast(reference[i])
-            << " (difference:" << difference << ", fraction: " << fraction << ")";
-        }
-        return 1;
+        float difference = std::abs(computed[i] - reference[i]);
+        std::cout
+          << "INCORRECT: [" << i << "]: "
+          << "(computed) " << CoutCast(computed[i]) << " != " << CoutCast(reference[i]) << " (difference:" << difference
+          << ")";
       }
+      return 1;
     }
   }
   return 0;
@@ -1113,20 +1109,15 @@ int CompareResults(double* computed, double* reference, OffsetT len, bool verbos
 {
   for (OffsetT i = 0; i < len; i++)
   {
-    if (computed[i] != reference[i])
+    if (!isclose(computed[i], reference[i]))
     {
-      double difference = std::abs(computed[i] - reference[i]);
-      double fraction   = difference / std::abs(reference[i]);
-
-      if (fraction > 0.00015)
+      if (verbose)
       {
-        if (verbose)
-        {
-          std::cout << "INCORRECT: [" << i << "]: " << CoutCast(computed[i]) << " != " << CoutCast(reference[i])
-                    << " (difference:" << difference << ", fraction: " << fraction << ")";
-        }
-        return 1;
+        double difference = std::abs(computed[i] - reference[i]);
+        std::cout << "INCORRECT: [" << i << "]: " << CoutCast(computed[i]) << " != " << CoutCast(reference[i])
+                  << " (difference:" << difference << ")";
       }
+      return 1;
     }
   }
   return 0;

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -1079,7 +1079,7 @@ int CompareResults(float* computed, float* reference, OffsetT len, bool verbose 
     {
       if (verbose)
       {
-        float difference = std::abs(computed[i] - reference[i]);
+        float difference = cuda::std::abs(computed[i] - reference[i]);
         std::cout
           << "INCORRECT: [" << i << "]: "
           << "(computed) " << CoutCast(computed[i]) << " != " << CoutCast(reference[i]) << " (difference:" << difference

--- a/cub/test/thread_reduce/catch2_test_thread_reduce.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce.cu
@@ -323,7 +323,7 @@ C2H_TEST("ThreadReduce Narrow PrecisionType Tests",
     auto reference_result =
       std::accumulate(h_in_float.begin(), h_in_float.begin() + num_items, operator_identity, std_reduce_op);
     run_thread_reduce_kernel(num_items, d_in, d_out, reduce_op);
-    float test_result = float{c2h::host_vector<value_t>(d_out)[0]};
+    float test_result{c2h::host_vector<value_t>(d_out)[0]};
     REQUIRE(isclose(reference_result, test_result, 0.05f));
   }
 }

--- a/cub/test/thread_reduce/catch2_test_thread_reduce.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce.cu
@@ -20,6 +20,7 @@
 #include "c2h/catch2_test_helper.h"
 #include "c2h/extended_types.h"
 #include "c2h/generators.h"
+#include <c2h/isclose.h>
 #include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 /***********************************************************************************************************************
@@ -170,18 +171,10 @@ using cub_operator_fp_list =
  * Verify results and kernel launch
  **********************************************************************************************************************/
 
-_CCCL_TEMPLATE(typename T)
-_CCCL_REQUIRES((cuda::std::is_floating_point_v<T>) )
+template <typename T>
 void verify_results(const T& expected_data, const T& test_results)
 {
-  REQUIRE_THAT(expected_data, Catch::Matchers::WithinRel(test_results, T{0.05}));
-}
-
-_CCCL_TEMPLATE(typename T)
-_CCCL_REQUIRES((!cuda::std::is_floating_point_v<T>) )
-void verify_results(const T& expected_data, const T& test_results)
-{
-  REQUIRE(expected_data == test_results);
+  REQUIRE(isclose(expected_data, test_results));
 }
 
 template <typename T, typename ReduceOperator>
@@ -330,7 +323,8 @@ C2H_TEST("ThreadReduce Narrow PrecisionType Tests",
     auto reference_result =
       std::accumulate(h_in_float.begin(), h_in_float.begin() + num_items, operator_identity, std_reduce_op);
     run_thread_reduce_kernel(num_items, d_in, d_out, reduce_op);
-    verify_results(reference_result, float{c2h::host_vector<value_t>(d_out)[0]});
+    float test_result = float{c2h::host_vector<value_t>(d_out)[0]};
+    REQUIRE(isclose(reference_result, test_result, 0.05f));
   }
 }
 

--- a/cub/test/thread_reduce/catch2_test_thread_reduce_check_sass.cu
+++ b/cub/test/thread_reduce/catch2_test_thread_reduce_check_sass.cu
@@ -23,6 +23,7 @@
 #  include "c2h/catch2_test_helper.h"
 #  include "c2h/extended_types.h"
 #  include "c2h/generators.h"
+#  include <c2h/isclose.h>
 #  include <catch2/matchers/catch_matchers_floating_point.hpp>
 
 /***********************************************************************************************************************
@@ -110,18 +111,10 @@ using cub_operator_fp_list = c2h::type_list<cuda::std::plus<>, cuda::minimum<>>;
  * Verify results and kernel launch
  **********************************************************************************************************************/
 
-_CCCL_TEMPLATE(typename T)
-_CCCL_REQUIRES((cuda::std::is_floating_point<T>::value))
+template <typename T>
 void verify_results(const T& expected_data, const T& test_results)
 {
-  REQUIRE_THAT(expected_data, Catch::Matchers::WithinRel(test_results, T{0.05}));
-}
-
-_CCCL_TEMPLATE(typename T)
-_CCCL_REQUIRES((!cuda::std::is_floating_point<T>::value))
-void verify_results(const T& expected_data, const T& test_results)
-{
-  REQUIRE(expected_data == test_results);
+  REQUIRE(isclose(expected_data, test_results));
 }
 
 template <typename T, typename ReduceOperator>

--- a/thrust/testing/catch2_test_complex.cu
+++ b/thrust/testing/catch2_test_complex.cu
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "catch2_test_helper.h"
-#include <c2h/isclose.h>
 #include <unittest/random.h>
 #include <unittest/testframework.h>
 
@@ -43,6 +42,11 @@ struct other_floating_point_type<double>
 template <typename T>
 using other_floating_point_type_t = typename other_floating_point_type<T>::type;
 
+// Helper to compare complex numbers with approximate equality
+// Supports both scalar and thrust::complex<T> types
+double const DEFAULT_RELATIVE_TOL = 1e-4;
+double const DEFAULT_ABSOLUTE_TOL = 1e-4;
+
 template <typename T>
 inline constexpr bool is_complex = false;
 template <typename T>
@@ -50,17 +54,18 @@ inline constexpr bool is_complex<thrust::complex<T>> = true;
 template <typename T>
 inline constexpr bool is_complex<std::complex<T>> = true;
 
+// Overload for complex types
 template <typename T1, typename T2>
 ::cuda::std::enable_if_t<is_complex<T1> && is_complex<T2>> require_almost_equal(const T1& a, const T2& b)
 {
-  CHECK(isclose(static_cast<double>(a.real()), static_cast<double>(b.real())));
-  CHECK(isclose(static_cast<double>(a.imag()), static_cast<double>(b.imag())));
+  CHECK(a.real() == Catch::Approx(b.real()).margin(DEFAULT_ABSOLUTE_TOL).epsilon(DEFAULT_RELATIVE_TOL));
+  CHECK(a.imag() == Catch::Approx(b.imag()).margin(DEFAULT_ABSOLUTE_TOL).epsilon(DEFAULT_RELATIVE_TOL));
 }
 
 template <typename T1, typename T2>
 ::cuda::std::enable_if_t<!is_complex<T1> && !is_complex<T2>> require_almost_equal(const T1& a, const T2& b)
 {
-  CHECK(isclose(static_cast<double>(a), static_cast<double>(b)));
+  CHECK(a == Catch::Approx(b).margin(DEFAULT_ABSOLUTE_TOL).epsilon(DEFAULT_RELATIVE_TOL));
 }
 } // anonymous namespace
 

--- a/thrust/testing/catch2_test_complex.cu
+++ b/thrust/testing/catch2_test_complex.cu
@@ -8,6 +8,7 @@
 #include <vector>
 
 #include "catch2_test_helper.h"
+#include <c2h/isclose.h>
 #include <unittest/random.h>
 #include <unittest/testframework.h>
 
@@ -42,11 +43,6 @@ struct other_floating_point_type<double>
 template <typename T>
 using other_floating_point_type_t = typename other_floating_point_type<T>::type;
 
-// Helper to compare complex numbers with approximate equality
-// Supports both scalar and thrust::complex<T> types
-double const DEFAULT_RELATIVE_TOL = 1e-4;
-double const DEFAULT_ABSOLUTE_TOL = 1e-4;
-
 template <typename T>
 inline constexpr bool is_complex = false;
 template <typename T>
@@ -54,18 +50,17 @@ inline constexpr bool is_complex<thrust::complex<T>> = true;
 template <typename T>
 inline constexpr bool is_complex<std::complex<T>> = true;
 
-// Overload for complex types
 template <typename T1, typename T2>
 ::cuda::std::enable_if_t<is_complex<T1> && is_complex<T2>> require_almost_equal(const T1& a, const T2& b)
 {
-  CHECK(a.real() == Catch::Approx(b.real()).margin(DEFAULT_ABSOLUTE_TOL).epsilon(DEFAULT_RELATIVE_TOL));
-  CHECK(a.imag() == Catch::Approx(b.imag()).margin(DEFAULT_ABSOLUTE_TOL).epsilon(DEFAULT_RELATIVE_TOL));
+  CHECK(isclose(static_cast<double>(a.real()), static_cast<double>(b.real())));
+  CHECK(isclose(static_cast<double>(a.imag()), static_cast<double>(b.imag())));
 }
 
 template <typename T1, typename T2>
 ::cuda::std::enable_if_t<!is_complex<T1> && !is_complex<T2>> require_almost_equal(const T1& a, const T2& b)
 {
-  CHECK(a == Catch::Approx(b).margin(DEFAULT_ABSOLUTE_TOL).epsilon(DEFAULT_RELATIVE_TOL));
+  CHECK(isclose(static_cast<double>(a), static_cast<double>(b)));
 }
 } // anonymous namespace
 


### PR DESCRIPTION
## Description

closes #7662

replaced 6 different float comparison implementations across cub/thrust/c2h with one `isclose` function using the PEP-0485 symmetric formula: `|a - b| <= max(a_tol, r_tol * max(|a|, |b|))`

what changed:
- added `c2h/include/c2h/isclose.h` with the canonical isclose function
- rewrote `REQUIRE_APPROX_EQ*` macros to use isclose
- replaced `CompareResults` float/double in test_util.h
- replaced `WithinRel` calls in check_results.cuh and thread_reduce tests
- replaced `require_almost_equal` in thrust complex tests
- replaced hand-rolled inline comparison in segmented scan tests

default tolerance is `1000 * numeric_limits<T>::epsilon()` which is derived from the type's precision instead of hardcoded magic numbers. callers can still pass custom tolerances when needed.

left per-algorithm wilkinson tolerance tuning and libcudacxx/cudax test unification for follow-ups.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.