### PR TITLE
Enable strict C++ compiler warnings and fix all violations

### DIFF
--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -238,10 +238,6 @@ std::vector<T> to_vec(std::vector<T> const& vec)
 namespace c2h::detail
 {
 // Copy of Catch2::MatchExpr, but streamReconstructedExpression does not print arg
-// Catch2's ITransientExpression has virtual functions but a non-virtual destructor.
-// We can't fix the third-party base class, so suppress the warning here.
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_GCC("-Wnon-virtual-dtor")
 template <typename ArgT, typename MatcherT>
 class QuietMatchExpr : public Catch::ITransientExpression
 {
@@ -255,12 +251,13 @@ public:
       , m_matcher(matcher)
   {}
 
+  ~QuietMatchExpr() override = default;
+
   void streamReconstructedExpression(std::ostream& os) const override
   {
     os << m_matcher.toString();
   }
 };
-_CCCL_DIAG_POP
 
 template <typename ArgT, typename MatcherT>
 QuietMatchExpr(ArgT&&, MatcherT) -> QuietMatchExpr<ArgT, MatcherT>;

--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -238,6 +238,10 @@ std::vector<T> to_vec(std::vector<T> const& vec)
 namespace c2h::detail
 {
 // Copy of Catch2::MatchExpr, but streamReconstructedExpression does not print arg
+// Catch2's ITransientExpression has virtual functions but a non-virtual destructor.
+// We can't fix the third-party base class, so suppress the warning here.
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wnon-virtual-dtor")
 template <typename ArgT, typename MatcherT>
 class QuietMatchExpr : public Catch::ITransientExpression
 {
@@ -256,6 +260,7 @@ public:
     os << m_matcher.toString();
   }
 };
+_CCCL_DIAG_POP
 
 template <typename ArgT, typename MatcherT>
 QuietMatchExpr(ArgT&&, MatcherT) -> QuietMatchExpr<ArgT, MatcherT>;

--- a/c2h/include/c2h/catch2_test_helper.h
+++ b/c2h/include/c2h/catch2_test_helper.h
@@ -251,7 +251,7 @@ public:
       , m_matcher(matcher)
   {}
 
-  ~QuietMatchExpr() override = default;
+  virtual ~QuietMatchExpr() = default;
 
   void streamReconstructedExpression(std::ostream& os) const override
   {

--- a/c2h/include/c2h/cpu_timer.h
+++ b/c2h/include/c2h/cpu_timer.h
@@ -55,7 +55,7 @@ public:
 
   void print_elapsed_seconds(const std::string& label)
   {
-    printf("%0.6f s: %s\n", this->elapsed_us() / 1000000.f, label.c_str());
+    printf("%0.6f s: %s\n", static_cast<double>(this->elapsed_us()) / 1000000.0, label.c_str());
   }
 
   void print_elapsed_seconds_and_reset(const std::string& label)

--- a/cmake/CCCLBuildCompilerTargets.cmake
+++ b/cmake/CCCLBuildCompilerTargets.cmake
@@ -179,25 +179,29 @@ function(cccl_build_compiler_targets)
     append_option_if_available("-Wvla" cxx_compile_options)
 
     # Strict warnings: catch shadowed variables, missing virtual destructors,
-    # null dereference, implicit float-to-double, and format string issues.
+    # implicit float-to-double, and format string issues.
     # Note: -Wpedantic is intentionally omitted — nvcc's preprocessor emits
     # GCC-style line directives that trigger unavoidable pedantic warnings.
+    # Note: -Wnull-dereference is intentionally omitted — GCC produces many
+    # false positives in system headers (e.g. streambuf) when inlining user code.
     append_option_if_available("-Wshadow=local" cxx_compile_options)
     append_option_if_available("-Wnon-virtual-dtor" cxx_compile_options)
-    append_option_if_available("-Wnull-dereference" cxx_compile_options)
     append_option_if_available("-Wdouble-promotion" cxx_compile_options)
     append_option_if_available("-Wformat=2" cxx_compile_options)
 
-    # Disable GNU extensions (flag is clang only)
-    append_option_if_available("-Wgnu" cxx_compile_options)
-    append_option_if_available("-Wno-gnu-line-marker" cxx_compile_options) # WAR 3916341
-    # Calling a variadic macro with zero args is a GNU extension until C++20,
-    # but the THRUST_PP_ARITY macro is used with zero args. Need to see if this
-    # is a real problem worth fixing.
-    append_option_if_available(
-      "-Wno-gnu-zero-variadic-macro-arguments"
-      cxx_compile_options
-    )
+    # Disable GNU extensions (flags are clang only — GCC rejects unknown
+    # -Wno-* flags under -Werror)
+    if ("Clang" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
+      append_option_if_available("-Wgnu" cxx_compile_options)
+      append_option_if_available("-Wno-gnu-line-marker" cxx_compile_options) # WAR 3916341
+      # Calling a variadic macro with zero args is a GNU extension until C++20,
+      # but the THRUST_PP_ARITY macro is used with zero args. Need to see if this
+      # is a real problem worth fixing.
+      append_option_if_available(
+        "-Wno-gnu-zero-variadic-macro-arguments"
+        cxx_compile_options
+      )
+    endif()
 
     # This complains about functions in CUDA system headers when used with nvcc.
     append_option_if_available("-Wno-unused-function" cxx_compile_options)

--- a/cmake/CCCLBuildCompilerTargets.cmake
+++ b/cmake/CCCLBuildCompilerTargets.cmake
@@ -178,6 +178,16 @@ function(cccl_build_compiler_targets)
     append_option_if_available("-Wunused-local-typedefs" cxx_compile_options)
     append_option_if_available("-Wvla" cxx_compile_options)
 
+    # Strict warnings: catch shadowed variables, missing virtual destructors,
+    # null dereference, implicit float-to-double, and format string issues.
+    # Note: -Wpedantic is intentionally omitted — nvcc's preprocessor emits
+    # GCC-style line directives that trigger unavoidable pedantic warnings.
+    append_option_if_available("-Wshadow=local" cxx_compile_options)
+    append_option_if_available("-Wnon-virtual-dtor" cxx_compile_options)
+    append_option_if_available("-Wnull-dereference" cxx_compile_options)
+    append_option_if_available("-Wdouble-promotion" cxx_compile_options)
+    append_option_if_available("-Wformat=2" cxx_compile_options)
+
     # Disable GNU extensions (flag is clang only)
     append_option_if_available("-Wgnu" cxx_compile_options)
     append_option_if_available("-Wno-gnu-line-marker" cxx_compile_options) # WAR 3916341

--- a/cub/test/catch2_test_device_decoupled_look_back.cu
+++ b/cub/test/catch2_test_device_decoupled_look_back.cu
@@ -85,6 +85,7 @@ c2h::host_vector<MessageT> compute_reference(const c2h::device_vector<MessageT>&
 
   c2h::host_vector<MessageT> reference = tile_aggregates;
   MessageT* h_reference                = thrust::raw_pointer_cast(reference.data());
+  REQUIRE(h_reference != nullptr);
 
   MessageT aggregate = h_reference[0];
   for (std::size_t i = 1; i < reference.size(); i++)

--- a/cub/test/catch2_test_device_transform_if.cu
+++ b/cub/test/catch2_test_device_transform_if.cu
@@ -43,10 +43,10 @@ C2H_TEST("DeviceTransform::TransformIf conditional BabelStream add",
   c2h::host_vector<type> a_h = a;
   c2h::host_vector<type> b_h = b;
   c2h::host_vector<type> reference_h(num_items);
-  std::transform(a_h.begin(), a_h.end(), b_h.begin(), reference_h.begin(), [](type a, type b) {
-    if (a < 10)
+  std::transform(a_h.begin(), a_h.end(), b_h.begin(), reference_h.begin(), [](type lhs, type rhs) {
+    if (lhs < 10)
     {
-      return static_cast<type>(a + b);
+      return static_cast<type>(lhs + rhs);
     }
     return type{42 + 1};
   });

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -427,10 +427,10 @@ void launch(ActionT action, Args... args)
   REQUIRE(cudaSuccess == cudaStreamBeginCapture(stream, cudaStreamCaptureModeGlobal));
 
   cuda::std::apply(
-    [stream, action](auto... args) {
+    [stream, action](auto... inner_args) {
       // Make sure specified stream is used
       stream_scope scope(stream);
-      cudaError_t error = action(args...);
+      cudaError_t error = action(inner_args...);
       REQUIRE(cudaSuccess == error);
     },
     fixed_args);
@@ -502,8 +502,8 @@ void launch(ActionT action, Args... args)
   auto fixed_args = replace_back(cuda::std::make_index_sequence<env_idx>{}, tuple, fixed_env);
 
   cuda::std::apply(
-    [&](auto... args) {
-      device_side_api_launch_kernel<<<1, 1>>>(thrust::raw_pointer_cast(d_error.data()), action, args...);
+    [&](auto... inner_args) {
+      device_side_api_launch_kernel<<<1, 1>>>(thrust::raw_pointer_cast(d_error.data()), action, inner_args...);
       REQUIRE(cudaSuccess == d_error[0]);
     },
     fixed_args);
@@ -555,8 +555,8 @@ void launch(ActionT action, Args... args)
     auto fixed_args = replace_back(cuda::std::make_index_sequence<env_idx>{}, tuple, fixed_env);
 
     cuda::std::apply(
-      [action](auto... args) {
-        REQUIRE(cudaErrorMemoryAllocation == action(args...));
+      [action](auto... inner_args) {
+        REQUIRE(cudaErrorMemoryAllocation == action(inner_args...));
       },
       fixed_args);
   }
@@ -570,11 +570,11 @@ void launch(ActionT action, Args... args)
   auto kernels    = cuda::std::execution::__query_or(env, get_allowed_kernels_t{}, cuda::std::span<void*>{});
 
   cuda::std::apply(
-    [stream, kernels, action](auto... args) {
+    [stream, kernels, action](auto... inner_args) {
       // Make sure specified stream and kernels are used
       stream_scope allowed_stream(stream);
       kernel_scope allowed_kernels(kernels);
-      cudaError_t error = action(args...);
+      cudaError_t error = action(inner_args...);
       REQUIRE(cudaSuccess == error);
     },
     fixed_args);

--- a/cub/test/test_allocator.cu
+++ b/cub/test/test_allocator.cu
@@ -444,9 +444,9 @@ int main(int argc, char** argv)
 
   printf("\t CUB CachingDeviceAllocator allocation CPU speedup: %.2f (avg cudaMalloc %.4f ms vs. avg DeviceAllocate "
          "%.4f ms)\n",
-         cuda_malloc_elapsed_millis / cub_calloc_elapsed_millis,
-         cuda_malloc_elapsed_millis / timing_iterations,
-         cub_calloc_elapsed_millis / timing_iterations);
+         static_cast<double>(cuda_malloc_elapsed_millis / cub_calloc_elapsed_millis),
+         static_cast<double>(cuda_malloc_elapsed_millis / timing_iterations),
+         static_cast<double>(cub_calloc_elapsed_millis / timing_iterations));
 
   // GPU performance comparisons.  Allocate and free a 1MB block 2000 times
   GpuTimer gpu_timer;
@@ -488,9 +488,9 @@ int main(int argc, char** argv)
 
   printf("\t CUB CachingDeviceAllocator allocation GPU speedup: %.2f (avg cudaMalloc %.4f ms vs. avg DeviceAllocate "
          "%.4f ms)\n",
-         cuda_malloc_elapsed_millis / cub_calloc_elapsed_millis,
-         cuda_malloc_elapsed_millis / timing_iterations,
-         cub_calloc_elapsed_millis / timing_iterations);
+         static_cast<double>(cuda_malloc_elapsed_millis / cub_calloc_elapsed_millis),
+         static_cast<double>(cuda_malloc_elapsed_millis / timing_iterations),
+         static_cast<double>(cub_calloc_elapsed_millis / timing_iterations));
 
   printf("Success\n");
 

--- a/cub/test/test_util.h
+++ b/cub/test/test_util.h
@@ -318,7 +318,7 @@ struct CommandLineArgs
           deviceProp.multiProcessorCount,
           (unsigned long long) device_free_physmem / 1024 / 1024,
           (unsigned long long) device_total_physmem / 1024 / 1024,
-          device_giga_bandwidth,
+          static_cast<double>(device_giga_bandwidth),
           memoryClockRate,
           (deviceProp.ECCEnabled) ? "on" : "off");
         fflush(stdout);
@@ -1079,7 +1079,7 @@ int CompareResults(float* computed, float* reference, OffsetT len, bool verbose 
       float difference = std::abs(computed[i] - reference[i]);
       float fraction   = difference / std::abs(reference[i]);
 
-      if (fraction > 0.00015)
+      if (fraction > 0.00015f)
       {
         if (verbose)
         {

--- a/cudax/include/cuda/experimental/__stf/internal/executable_graph_cache.cuh
+++ b/cudax/include/cuda/experimental/__stf/internal/executable_graph_cache.cuh
@@ -206,6 +206,8 @@ private:
     auto cmp = [&device_cache](const key_type& key_a, const key_type& key_b) {
       auto iter_a = device_cache.find(key_a);
       auto iter_b = device_cache.find(key_b);
+      _CCCL_ASSERT(iter_a != device_cache.end(), "LRU queue key not found in cache");
+      _CCCL_ASSERT(iter_b != device_cache.end(), "LRU queue key not found in cache");
 
       // Directly compare last_use timestamps
       return iter_a->second.last_use > iter_b->second.last_use;

--- a/cudax/test/execution/test_bulk.cu
+++ b/cudax/test/execution/test_bulk.cu
@@ -470,10 +470,10 @@ void bulk_forwards_values()
   int counter[n]{0};
 
   auto sndr = ex::just(magic_number, &counter) //
-            | ex::bulk(ex::par, n, [](int i, int val, int (*counter)[n]) {
+            | ex::bulk(ex::par, n, [](int i, int val, int (*ctr)[n]) {
                 if (val == magic_number)
                 {
-                  (*counter)[i]++;
+                  (*ctr)[i]++;
                 }
               });
   auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{magic_number, &counter});
@@ -541,8 +541,8 @@ void bulk_forwards_values_that_can_be_taken_by_reference()
   ::cuda::std::iota(vals_expected.begin(), vals_expected.end(), 0);
 
   auto sndr = ex::just(cuda::std::move(vals)) //
-            | ex::bulk(ex::par, n, [&](std::size_t i, ::cuda::std::array<int, n>& vals) {
-                vals[i] = static_cast<int>(i);
+            | ex::bulk(ex::par, n, [&](std::size_t i, ::cuda::std::array<int, n>& arr) {
+                arr[i] = static_cast<int>(i);
               });
   auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{vals_expected});
   ex::start(op);
@@ -555,10 +555,10 @@ void bulk_chunked_forwards_values_that_can_be_taken_by_reference()
   ::cuda::std::iota(vals_expected.begin(), vals_expected.end(), 0);
 
   auto sndr = ex::just(cuda::std::move(vals)) //
-            | ex::bulk_chunked(ex::par, n, [&](std::size_t b, std::size_t e, ::cuda::std::array<int, n>& vals) {
+            | ex::bulk_chunked(ex::par, n, [&](std::size_t b, std::size_t e, ::cuda::std::array<int, n>& arr) {
                 for (; b != e; ++b)
                 {
-                  vals[b] = static_cast<int>(b);
+                  arr[b] = static_cast<int>(b);
                 }
               });
   auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{vals_expected});
@@ -572,8 +572,8 @@ void bulk_unchunked_forwards_values_that_can_be_taken_by_reference()
   ::cuda::std::iota(vals_expected.begin(), vals_expected.end(), 0);
 
   auto sndr = ex::just(cuda::std::move(vals)) //
-            | ex::bulk_unchunked(ex::par, n, [&](std::size_t i, ::cuda::std::array<int, n>& vals) {
-                vals[i] = static_cast<int>(i);
+            | ex::bulk_unchunked(ex::par, n, [&](std::size_t i, ::cuda::std::array<int, n>& arr) {
+                arr[i] = static_cast<int>(i);
               });
   auto op = ex::connect(cuda::std::move(sndr), checked_value_receiver{vals_expected});
   ex::start(op);

--- a/cudax/test/execution/test_conditional.cu
+++ b/cudax/test/execution/test_conditional.cu
@@ -30,8 +30,8 @@ C2H_TEST("simple use of conditional runs exactly one of the two closures", "[ada
     auto sndr1 =
       ex::just(i)
       | ex::conditional(
-        [](int i) {
-          return i % 2 == 0;
+        [](int val) {
+          return val % 2 == 0;
         },
         ex::then([&](int) {
           even = true;

--- a/cudax/test/execution/test_stream_context.cu
+++ b/cudax/test/execution/test_stream_context.cu
@@ -147,11 +147,11 @@ void bulk_on_stream_scheduler()
         return data;
       })
     // enqueue a bulk kernel on the GPU
-    | ex::bulk(ex::par_unseq, 10, [] __host__ __device__(int i, cuda::std::span<int> data) -> void {
+    | ex::bulk(ex::par_unseq, 10, [] __host__ __device__(int i, cuda::std::span<int> span) -> void {
         printf("Hello from bulk kernel on device! i = %d\n", i);
         CUDAX_CHECK(_is_on_device());
-        CUDAX_CHECK(i < data.size());
-        data[i] += 2;
+        CUDAX_CHECK(i < span.size());
+        span[i] += 2;
       });
 
   auto expected = cuda::make_buffer<int>(sctx, mr2, 10, 42, env); // a device buffer of 10 integers, initialized

--- a/cudax/test/execution/test_visit.cu
+++ b/cudax/test/execution/test_visit.cu
@@ -60,18 +60,18 @@ C2H_TEST("sender visitation API works", "[visit]")
                 return x + y + z;
               });
 
-  auto count_leaves = recursive_lambda{[](auto& self, int& leaves, auto, auto&, auto&... child) {
-    leaves += (sizeof...(child) == 0);
-    ((cudax_async::visit(self, child, leaves)), ...);
+  auto count_leaves = recursive_lambda{[](auto& self, int& leaf_count, auto, auto&, auto&... child) {
+    leaf_count += (sizeof...(child) == 0);
+    ((cudax_async::visit(self, child, leaf_count)), ...);
   }};
 
   cudax_async::visit(count_leaves, snd1, leaves);
   CHECK(leaves == 3);
 
-  auto max_depth = recursive_lambda{[i = 0](auto& self, int& depth, auto, auto&, auto&... child) mutable {
+  auto max_depth = recursive_lambda{[i = 0](auto& self, int& max_d, auto, auto&, auto&... child) mutable {
     ++i;
-    depth = cuda::std::max(depth, i);
-    ((cudax_async::visit(self, child, depth)), ...);
+    max_d = cuda::std::max(max_d, i);
+    ((cudax_async::visit(self, child, max_d)), ...);
     --i;
   }};
 

--- a/cudax/test/launch/launch_smoke.cu
+++ b/cudax/test/launch/launch_smoke.cu
@@ -264,25 +264,25 @@ void launch_smoke_test(StreamOrPathBuilder& dst)
     auto test = [&](const auto& input_config) {
       // Single element
       {
-        auto config = input_config.add(cuda::dynamic_shared_memory<my_dynamic_smem_t>());
+        auto smem_config = input_config.add(cuda::dynamic_shared_memory<my_dynamic_smem_t>());
 
-        cudax::launch(dst, config, dynamic_smem_single<my_dynamic_smem_t>());
+        cudax::launch(dst, smem_config, dynamic_smem_single<my_dynamic_smem_t>());
         check_kernel_run(dst);
       }
 
       // Dynamic span
       {
-        const int size = 2;
-        auto config    = input_config.add(cuda::dynamic_shared_memory<my_dynamic_smem_t[]>(size));
-        cudax::launch(dst, config, dynamic_smem_span<my_dynamic_smem_t, ::cuda::std::dynamic_extent>(), size);
+        const int size   = 2;
+        auto smem_config = input_config.add(cuda::dynamic_shared_memory<my_dynamic_smem_t[]>(size));
+        cudax::launch(dst, smem_config, dynamic_smem_span<my_dynamic_smem_t, ::cuda::std::dynamic_extent>(), size);
         check_kernel_run(dst);
       }
 
       // Static span
       {
         constexpr int size = 3;
-        auto config        = input_config.add(cuda::dynamic_shared_memory<my_dynamic_smem_t[size]>());
-        cudax::launch(dst, config, dynamic_smem_span<my_dynamic_smem_t, size>(), size);
+        auto smem_config   = input_config.add(cuda::dynamic_shared_memory<my_dynamic_smem_t[size]>());
+        cudax::launch(dst, smem_config, dynamic_smem_span<my_dynamic_smem_t, size>(), size);
         check_kernel_run(dst);
       }
     };

--- a/cudax/test/stf/dot/sections_2.cu
+++ b/cudax/test/stf/dot/sections_2.cu
@@ -36,7 +36,7 @@ int main()
     for (size_t j = 0; j < 2; j++)
     {
       // Section named "baz" using RAII
-      auto s_bar = ctx.dot_section("baz");
+      auto s_baz = ctx.dot_section("baz");
       ctx.task(lA.read(), lC.rw()).set_symbol("t2")->*[](cudaStream_t) {};
       ctx.task(lB.read(), lC.read(), lA.rw()).set_symbol("t3")->*[](cudaStream_t) {};
       // Implicit end of section "baz"

--- a/cudax/test/stf/examples/09-nbody-blocked.cu
+++ b/cudax/test/stf/examples/09-nbody-blocked.cu
@@ -279,5 +279,7 @@ int main(int argc, char** argv)
   // rough approximation !
   double FLOP_COUNT = 21.0 * (1.0 * BODY_CNT) * (1.0 * BODY_CNT) * NITER;
 
-  printf("NBODY: elapsed %f ms, %f GFLOPS\n", static_cast<double>(elapsed), FLOP_COUNT / static_cast<double>(elapsed) / 1000000.0);
+  printf("NBODY: elapsed %f ms, %f GFLOPS\n",
+         static_cast<double>(elapsed),
+         FLOP_COUNT / static_cast<double>(elapsed) / 1000000.0);
 }

--- a/cudax/test/stf/examples/09-nbody-blocked.cu
+++ b/cudax/test/stf/examples/09-nbody-blocked.cu
@@ -279,5 +279,5 @@ int main(int argc, char** argv)
   // rough approximation !
   double FLOP_COUNT = 21.0 * (1.0 * BODY_CNT) * (1.0 * BODY_CNT) * NITER;
 
-  printf("NBODY: elapsed %f ms, %f GFLOPS\n", elapsed, FLOP_COUNT / elapsed / 1000000.0);
+  printf("NBODY: elapsed %f ms, %f GFLOPS\n", static_cast<double>(elapsed), FLOP_COUNT / static_cast<double>(elapsed) / 1000000.0);
 }

--- a/libcudacxx/include/cuda/__event/timed_event.h
+++ b/libcudacxx/include/cuda/__event/timed_event.h
@@ -97,7 +97,8 @@ public:
   operator-(const timed_event& __end, const timed_event& __start)
   {
     const auto __ms = ::cuda::__driver::__eventElapsedTime(__start.get(), __end.get());
-    return ::cuda::std::chrono::nanoseconds(static_cast<::cuda::std::chrono::nanoseconds::rep>(__ms * 1'000'000.0));
+    return ::cuda::std::chrono::nanoseconds(
+      static_cast<::cuda::std::chrono::nanoseconds::rep>(static_cast<double>(__ms) * 1'000'000.0));
   }
 
 private:

--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
@@ -21,12 +21,6 @@
 #  pragma system_header
 #endif // no system header
 
-// GCC's -Wnull-dereference fires false positives on __query_interface() return
-// values, which are guaranteed non-null by the library's invariants when called
-// on a valid vptr.
-_CCCL_DIAG_PUSH
-_CCCL_DIAG_SUPPRESS_GCC("-Wnull-dereference")
-
 #include <cuda/__utility/__basic_any/basic_any_base.h>
 #include <cuda/__utility/__basic_any/basic_any_fwd.h>
 #include <cuda/__utility/__basic_any/basic_any_ref.h>
@@ -354,9 +348,12 @@ public:
   {
     if (auto __vptr = __get_vptr())
     {
-      _CCCL_ASSERT(__vptr->__query_interface(__iunknown())->__cookie_ == 0xDEADBEEF,
+      auto* __unk = __vptr->__query_interface(__iunknown());
+      _CCCL_ASSERT(__unk != nullptr, "query_interface returned a null pointer");
+      _CCCL_ASSUME(__unk != nullptr);
+      _CCCL_ASSERT(__unk->__cookie_ == 0xDEADBEEF,
                    "query_interface returned a bad pointer to the __iunknown vtable");
-      __vptr->__query_interface(__iunknown())->__dtor_(__buffer_, __in_situ());
+      __unk->__dtor_(__buffer_, __in_situ());
       __release_();
     }
   }
@@ -367,9 +364,12 @@ public:
   {
     if (auto __vptr = __get_vptr())
     {
-      _CCCL_ASSERT(__vptr->__query_interface(__iunknown())->__cookie_ == 0xDEADBEEF,
+      auto* __unk = __vptr->__query_interface(__iunknown());
+      _CCCL_ASSERT(__unk != nullptr, "query_interface returned a null pointer");
+      _CCCL_ASSUME(__unk != nullptr);
+      _CCCL_ASSERT(__unk->__cookie_ == 0xDEADBEEF,
                    "query_interface returned a bad pointer to the __iunknown vtable");
-      return *__vptr->__query_interface(__iunknown())->__object_info_->__object_typeid_;
+      return *__unk->__object_info_->__object_typeid_;
     }
     return _CCCL_TYPEID(void);
   }
@@ -567,8 +567,6 @@ private:
 };
 
 _CCCL_END_NAMESPACE_CUDA
-
-_CCCL_DIAG_POP
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
@@ -351,8 +351,7 @@ public:
       auto* __unk = __vptr->__query_interface(__iunknown());
       _CCCL_ASSERT(__unk != nullptr, "query_interface returned a null pointer");
       _CCCL_ASSUME(__unk != nullptr);
-      _CCCL_ASSERT(__unk->__cookie_ == 0xDEADBEEF,
-                   "query_interface returned a bad pointer to the __iunknown vtable");
+      _CCCL_ASSERT(__unk->__cookie_ == 0xDEADBEEF, "query_interface returned a bad pointer to the __iunknown vtable");
       __unk->__dtor_(__buffer_, __in_situ());
       __release_();
     }
@@ -367,8 +366,7 @@ public:
       auto* __unk = __vptr->__query_interface(__iunknown());
       _CCCL_ASSERT(__unk != nullptr, "query_interface returned a null pointer");
       _CCCL_ASSUME(__unk != nullptr);
-      _CCCL_ASSERT(__unk->__cookie_ == 0xDEADBEEF,
-                   "query_interface returned a bad pointer to the __iunknown vtable");
+      _CCCL_ASSERT(__unk->__cookie_ == 0xDEADBEEF, "query_interface returned a bad pointer to the __iunknown vtable");
       return *__unk->__object_info_->__object_typeid_;
     }
     return _CCCL_TYPEID(void);

--- a/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/basic_any_value.h
@@ -21,6 +21,12 @@
 #  pragma system_header
 #endif // no system header
 
+// GCC's -Wnull-dereference fires false positives on __query_interface() return
+// values, which are guaranteed non-null by the library's invariants when called
+// on a valid vptr.
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_GCC("-Wnull-dereference")
+
 #include <cuda/__utility/__basic_any/basic_any_base.h>
 #include <cuda/__utility/__basic_any/basic_any_fwd.h>
 #include <cuda/__utility/__basic_any/basic_any_ref.h>
@@ -561,6 +567,8 @@ private:
 };
 
 _CCCL_END_NAMESPACE_CUDA
+
+_CCCL_DIAG_POP
 
 #include <cuda/std/__cccl/epilogue.h>
 

--- a/libcudacxx/include/cuda/__utility/__basic_any/virtcall.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/virtcall.h
@@ -33,6 +33,7 @@
 
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedefs")
+_CCCL_DIAG_SUPPRESS_GCC("-Wnull-dereference")
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__utility/__basic_any/virtcall.h
+++ b/libcudacxx/include/cuda/__utility/__basic_any/virtcall.h
@@ -33,7 +33,6 @@
 
 _CCCL_DIAG_PUSH
 _CCCL_DIAG_SUPPRESS_CLANG("-Wunused-local-typedefs")
-_CCCL_DIAG_SUPPRESS_GCC("-Wnull-dereference")
 
 _CCCL_BEGIN_NAMESPACE_CUDA
 
@@ -112,7 +111,9 @@ _CCCL_API auto __virtcall(_Self* __self, _Args&&... __args) //
   -> typename __virtual_fn<_Mbr>::__result_t
 {
   auto* __vptr = __basic_any_access::__get_vptr(*__self)->__query_interface(_Interface());
-  auto* __obj  = __basic_any_access::__get_optr(*__self);
+  _CCCL_ASSERT(__vptr != nullptr, "__query_interface returned a null pointer");
+  _CCCL_ASSUME(__vptr != nullptr);
+  auto* __obj = __basic_any_access::__get_optr(*__self);
   // map the member function pointer to the correct one if necessary
   using __virtual_fn_t = __virtual_fn_for<_Mbr, _Interface, _Super>;
   return __vptr->__virtual_fn_t::__fn_(__obj, static_cast<_Args&&>(__args)...);

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -245,8 +245,8 @@ _CCCL_API inline complex<float>::complex(const complex<__nv_bfloat16>& __c)
 template <> // complex<double>
 template <> // complex<__half>
 _CCCL_API inline complex<double>::complex(const complex<__nv_bfloat16>& __c)
-    : __re_(::__bfloat162float(__c.real()))
-    , __im_(::__bfloat162float(__c.imag()))
+    : __re_(static_cast<double>(::__bfloat162float(__c.real())))
+    , __im_(static_cast<double>(::__bfloat162float(__c.imag())))
 {}
 
 template <> // complex<float>
@@ -262,8 +262,8 @@ template <> // complex<double>
 template <> // complex<__nv_bfloat16>
 _CCCL_API inline complex<double>& complex<double>::operator=(const complex<__nv_bfloat16>& __c)
 {
-  __re_ = ::__bfloat162float(__c.real());
-  __im_ = ::__bfloat162float(__c.imag());
+  __re_ = static_cast<double>(::__bfloat162float(__c.real()));
+  __im_ = static_cast<double>(::__bfloat162float(__c.imag()));
   return *this;
 }
 

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -245,8 +245,8 @@ _CCCL_API inline complex<float>::complex(const complex<__half>& __c)
 template <> // complex<double>
 template <> // complex<__half>
 _CCCL_API inline complex<double>::complex(const complex<__half>& __c)
-    : __re_(::__half2float(__c.real()))
-    , __im_(::__half2float(__c.imag()))
+    : __re_(static_cast<double>(::__half2float(__c.real())))
+    , __im_(static_cast<double>(::__half2float(__c.imag())))
 {}
 
 template <> // complex<float>
@@ -262,8 +262,8 @@ template <> // complex<double>
 template <> // complex<__half>
 _CCCL_API inline complex<double>& complex<double>::operator=(const complex<__half>& __c)
 {
-  __re_ = ::__half2float(__c.real());
-  __im_ = ::__half2float(__c.imag());
+  __re_ = static_cast<double>(::__half2float(__c.real()));
+  __im_ = static_cast<double>(::__half2float(__c.imag()));
   return *this;
 }
 

--- a/libcudacxx/include/cuda/std/__floating_point/native_type.h
+++ b/libcudacxx/include/cuda/std/__floating_point/native_type.h
@@ -44,7 +44,7 @@ _CCCL_API constexpr auto __fp_native_type_impl()
   else if constexpr (_Fmt == __fp_format::__binary128)
   {
 #if _CCCL_HAS_FLOAT128()
-    return __float128{0.0};
+    return __float128{};
 #elif _CCCL_HAS_LONG_DOUBLE() && LDBL_MIN_EXP == -16381 && LDBL_MAX_EXP == 16384 && LDBL_MANT_DIG == 113
     return (long double) {};
 #else // ^^^ has native binary128 ^^^ / vvv no native binary128 vvv

--- a/nvbench_helper/nvbench_helper/nvbench_helper.cu
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cu
@@ -344,8 +344,8 @@ void generator_t::generate(
     case bit_entropy::_0_000: {
       std::mt19937 rng;
       rng.seed(static_cast<std::mt19937::result_type>(seed.get()));
-      std::uniform_real_distribution<float> dist(0.0f, 1.0f);
-      T random_value = random_to_item_t<T>(min, max)(dist(rng));
+      std::uniform_real_distribution<float> float_dist(0.0f, 1.0f);
+      T random_value = random_to_item_t<T>(min, max)(static_cast<double>(float_dist(rng)));
       thrust::fill(exec, span.data(), span.data() + span.size(), random_value);
       return;
     }
@@ -415,9 +415,9 @@ void generator_t::generate(
     case bit_entropy::_0_000: {
       std::mt19937 rng;
       rng.seed(static_cast<std::mt19937::result_type>(seed.get()));
-      std::uniform_real_distribution<double> dist(0.0f, 1.0f);
-      const float random_imag = random_to_item_t<double>(min.imag(), max.imag())(dist(rng));
-      const float random_real = random_to_item_t<double>(min.imag(), max.imag())(dist(rng));
+      std::uniform_real_distribution<double> double_dist(0.0, 1.0);
+      const float random_imag = random_to_item_t<double>(min.imag(), max.imag())(double_dist(rng));
+      const float random_real = random_to_item_t<double>(min.imag(), max.imag())(double_dist(rng));
       thrust::fill(exec, span.data(), span.data() + span.size(), cuda::std::complex<T>{random_real, random_imag});
       return;
     }

--- a/nvbench_helper/test/gen_entropy.cu
+++ b/nvbench_helper/test/gen_entropy.cu
@@ -126,8 +126,8 @@ TEMPLATE_LIST_TEST_CASE("Generators produce data with given entropy", "[gen]", f
     bit_entropy::_1_000};
 
   std::vector<double> entropy(num_entropy_levels);
-  std::transform(entropy_levels.cbegin(), entropy_levels.cend(), entropy.begin(), [](bit_entropy entropy) {
-    const thrust::device_vector<TestType> data = generate(1 << 24, entropy);
+  std::transform(entropy_levels.cbegin(), entropy_levels.cend(), entropy.begin(), [](bit_entropy level) {
+    const thrust::device_vector<TestType> data = generate(1 << 24, level);
     return compute_actual_entropy(data);
   });
 

--- a/nvbench_helper/test/gen_uniform_distribution.cu
+++ b/nvbench_helper/test/gen_uniform_distribution.cu
@@ -29,7 +29,8 @@ bool is_uniform(thrust::host_vector<T> data, T min, T max)
 
   for (T val : data)
   {
-    int bin_index = exact_binning ? static_cast<int>(val - min) : static_cast<int>((static_cast<double>(val) - static_cast<double>(min)) / interval);
+    int bin_index = exact_binning ? static_cast<int>(val - min)
+                                  : static_cast<int>((static_cast<double>(val) - static_cast<double>(min)) / interval);
 
     if (bin_index >= 0 && bin_index < number_of_bins)
     {

--- a/nvbench_helper/test/gen_uniform_distribution.cu
+++ b/nvbench_helper/test/gen_uniform_distribution.cu
@@ -19,7 +19,7 @@
 template <typename T>
 bool is_uniform(thrust::host_vector<T> data, T min, T max)
 {
-  const double value_range = static_cast<double>(max) - min;
+  const double value_range = static_cast<double>(max) - static_cast<double>(min);
   const bool exact_binning = value_range < (1 << 20);
   const int number_of_bins = exact_binning ? static_cast<int>(max - min + 1) : static_cast<int>(std::sqrt(data.size()));
   thrust::host_vector<int> bins(number_of_bins, 0);
@@ -29,7 +29,7 @@ bool is_uniform(thrust::host_vector<T> data, T min, T max)
 
   for (T val : data)
   {
-    int bin_index = exact_binning ? val - min : (val - static_cast<double>(min)) / interval;
+    int bin_index = exact_binning ? static_cast<int>(val - min) : static_cast<int>((static_cast<double>(val) - static_cast<double>(min)) / interval);
 
     if (bin_index >= 0 && bin_index < number_of_bins)
     {

--- a/thrust/testing/catch2_test_complex.cu
+++ b/thrust/testing/catch2_test_complex.cu
@@ -213,8 +213,8 @@ TEMPLATE_LIST_TEST_CASE("ComplexConstructionAndAssignmentWithPromoting", "[compl
     thrust::complex<T0> copy_assign{};
     const thrust::complex<T1> expected{real_T1, imag_T1};
     copy_assign = expected;
-    CHECK(expected.real() == copy_assign.real());
-    CHECK(expected.imag() == copy_assign.imag());
+    CHECK(static_cast<double>(expected.real()) == static_cast<double>(copy_assign.real()));
+    CHECK(static_cast<double>(expected.imag()) == static_cast<double>(copy_assign.imag()));
   }
 
   {
@@ -223,7 +223,7 @@ TEMPLATE_LIST_TEST_CASE("ComplexConstructionAndAssignmentWithPromoting", "[compl
     const T1 to_be_copied = real_T1;
     assign_from_lvalue_T  = to_be_copied;
     require_almost_equal(expected.real(), assign_from_lvalue_T.real());
-    CHECK(expected.imag() == assign_from_lvalue_T.imag());
+    CHECK(static_cast<double>(expected.imag()) == static_cast<double>(assign_from_lvalue_T.imag()));
   }
 
   {

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -7,9 +7,8 @@
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/universal_vector.h>
 
+#include <cuda/std/type_traits>
 #include <cuda/std/utility>
-
-#include <type_traits>
 
 #include <unittest/exceptions.h>
 #include <unittest/util.h>
@@ -22,9 +21,9 @@ namespace unittest::detail
 template <typename T1, typename T2>
 auto promote(const T1& a, const T2& b)
 {
-  if constexpr (std::is_arithmetic_v<std::decay_t<T1>> && std::is_arithmetic_v<std::decay_t<T2>>)
+  if constexpr (cuda::std::is_arithmetic_v<cuda::std::decay_t<T1>> && cuda::std::is_arithmetic_v<cuda::std::decay_t<T2>>)
   {
-    using common_t = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+    using common_t = cuda::std::common_type_t<cuda::std::decay_t<T1>, cuda::std::decay_t<T2>>;
     return std::pair<common_t, common_t>{static_cast<common_t>(a), static_cast<common_t>(b)};
   }
   else

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -21,7 +21,8 @@ namespace unittest::detail
 template <typename T1, typename T2>
 auto promote(const T1& a, const T2& b)
 {
-  if constexpr (cuda::std::is_arithmetic_v<cuda::std::decay_t<T1>> && cuda::std::is_arithmetic_v<cuda::std::decay_t<T2>>)
+  if constexpr (cuda::std::is_arithmetic_v<cuda::std::decay_t<T1>>
+                && cuda::std::is_arithmetic_v<cuda::std::decay_t<T2>>)
   {
     using common_t = cuda::std::common_type_t<cuda::std::decay_t<T1>, cuda::std::decay_t<T2>>;
     return std::pair<common_t, common_t>{static_cast<common_t>(a), static_cast<common_t>(b)};

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -25,11 +25,11 @@ auto promote(const T1& a, const T2& b)
                 && cuda::std::is_arithmetic_v<cuda::std::decay_t<T2>>)
   {
     using common_t = cuda::std::common_type_t<cuda::std::decay_t<T1>, cuda::std::decay_t<T2>>;
-    return std::pair<common_t, common_t>{static_cast<common_t>(a), static_cast<common_t>(b)};
+    return cuda::std::pair{static_cast<common_t>(a), static_cast<common_t>(b)};
   }
   else
   {
-    return std::pair<const T1&, const T2&>{a, b};
+    return cuda::std::pair{a, b};
   }
 }
 } // namespace unittest::detail

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -1,12 +1,5 @@
 #pragma once
 
-// This test utility compares mixed numeric types (e.g. float vs double) via
-// templated assertions, so implicit float-to-double promotion is intentional.
-#if defined(__GNUC__) && !defined(__clang__)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wdouble-promotion"
-#endif
-
 #include <thrust/complex.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/device_vector.h>
@@ -16,8 +9,30 @@
 
 #include <cuda/std/utility>
 
+#include <type_traits>
+
 #include <unittest/exceptions.h>
 #include <unittest/util.h>
+
+namespace unittest::detail
+{
+// Promote both operands to their common type before comparing, avoiding
+// implicit float-to-double promotion warnings (-Wdouble-promotion).
+// For non-arithmetic types, compare directly with no cast.
+template <typename T1, typename T2>
+auto promote(const T1& a, const T2& b)
+{
+  if constexpr (std::is_arithmetic_v<std::decay_t<T1>> && std::is_arithmetic_v<std::decay_t<T2>>)
+  {
+    using common_t = std::common_type_t<std::decay_t<T1>, std::decay_t<T2>>;
+    return std::pair<common_t, common_t>{static_cast<common_t>(a), static_cast<common_t>(b)};
+  }
+  else
+  {
+    return std::pair<const T1&, const T2&>{a, b};
+  }
+}
+} // namespace unittest::detail
 
 #define ASSERT_EQUAL_WITH_FILE_AND_LINE(X, Y, FILE_, LINE_)       unittest::assert_equal((X), (Y), FILE_, LINE_)
 #define ASSERT_EQUAL_QUIET_WITH_FILE_AND_LINE(X, Y, FILE_, LINE_) unittest::assert_equal_quiet((X), (Y), FILE_, LINE_)
@@ -126,7 +141,8 @@ struct value_type<THRUST_NS_QUALIFIER::device_reference<T>>
 template <typename T1, typename T2>
 void assert_equal(T1 a, T2 b, const std::string& filename = "unknown", int lineno = -1)
 {
-  if (!(a == b))
+  auto [x, y] = detail::promote(a, b);
+  if (!(x == y))
   {
     unittest::UnitTestFailure f;
     f << "[" << filename << ":" << lineno << "] ";
@@ -152,7 +168,8 @@ void assert_equal(char a, char b, const std::string& filename = "unknown", int l
 template <typename T1, typename T2>
 void assert_equal_quiet(const T1& a, const T2& b, const std::string& filename = "unknown", int lineno = -1)
 {
-  if (!(a == b))
+  auto [x, y] = detail::promote(a, b);
+  if (!(x == y))
   {
     unittest::UnitTestFailure f;
     f << "[" << filename << ":" << lineno << "] ";
@@ -167,7 +184,8 @@ void assert_equal_quiet(const T1& a, const T2& b, const std::string& filename = 
 template <typename T1, typename T2>
 void assert_not_equal(T1 a, T2 b, const std::string& filename = "unknown", int lineno = -1)
 {
-  if (a == b)
+  auto [x, y] = detail::promote(a, b);
+  if (x == y)
   {
     unittest::UnitTestFailure f;
     f << "[" << filename << ":" << lineno << "] ";
@@ -193,7 +211,8 @@ void assert_not_equal(char a, char b, const std::string& filename = "unknown", i
 template <typename T1, typename T2>
 void assert_not_equal_quiet(const T1& a, const T2& b, const std::string& filename = "unknown", int lineno = -1)
 {
-  if (a == b)
+  auto [x, y] = detail::promote(a, b);
+  if (x == y)
   {
     unittest::UnitTestFailure f;
     f << "[" << filename << ":" << lineno << "] ";
@@ -206,7 +225,8 @@ void assert_not_equal_quiet(const T1& a, const T2& b, const std::string& filenam
 template <typename T1, typename T2>
 void assert_less(T1 a, T2 b, const std::string& filename = "unknown", int lineno = -1)
 {
-  if (!(a < b))
+  auto [x, y] = detail::promote(a, b);
+  if (!(x < y))
   {
     unittest::UnitTestFailure f;
     f << "[" << filename << ":" << lineno << "] ";
@@ -231,7 +251,8 @@ void assert_less(char a, char b, const std::string& filename = "unknown", int li
 template <typename T1, typename T2>
 void assert_greater(T1 a, T2 b, const std::string& filename = "unknown", int lineno = -1)
 {
-  if (!(a > b))
+  auto [x, y] = detail::promote(a, b);
+  if (!(x > y))
   {
     unittest::UnitTestFailure f;
     f << "[" << filename << ":" << lineno << "] ";
@@ -256,7 +277,8 @@ void assert_greater(char a, char b, const std::string& filename = "unknown", int
 template <typename T1, typename T2>
 void assert_lequal(T1 a, T2 b, const std::string& filename = "unknown", int lineno = -1)
 {
-  if (!(a <= b))
+  auto [x, y] = detail::promote(a, b);
+  if (!(x <= y))
   {
     unittest::UnitTestFailure f;
     f << "[" << filename << ":" << lineno << "] ";
@@ -281,7 +303,8 @@ void assert_lequal(char a, char b, const std::string& filename = "unknown", int 
 template <typename T1, typename T2>
 void assert_gequal(T1 a, T2 b, const std::string& filename = "unknown", int lineno = -1)
 {
-  if (!(a >= b))
+  auto [x, y] = detail::promote(a, b);
+  if (!(x >= y))
   {
     unittest::UnitTestFailure f;
     f << "[" << filename << ":" << lineno << "] ";
@@ -772,7 +795,3 @@ void check_assert_throws(
   }
 }
 }; // end namespace unittest
-
-#if defined(__GNUC__) && !defined(__clang__)
-#  pragma GCC diagnostic pop
-#endif

--- a/thrust/testing/unittest/assertions.h
+++ b/thrust/testing/unittest/assertions.h
@@ -1,5 +1,12 @@
 #pragma once
 
+// This test utility compares mixed numeric types (e.g. float vs double) via
+// templated assertions, so implicit float-to-double promotion is intentional.
+#if defined(__GNUC__) && !defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdouble-promotion"
+#endif
+
 #include <thrust/complex.h>
 #include <thrust/detail/type_traits.h>
 #include <thrust/device_vector.h>
@@ -765,3 +772,7 @@ void check_assert_throws(
   }
 }
 }; // end namespace unittest
+
+#if defined(__GNUC__) && !defined(__clang__)
+#  pragma GCC diagnostic pop
+#endif

--- a/thrust/thrust/detail/complex/arithmetic.h
+++ b/thrust/thrust/detail/complex/arithmetic.h
@@ -66,11 +66,11 @@ _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const T0
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const complex<T1>& y)
 {
-  using T  = ::cuda::std::common_type_t<T0, T1>;
-  T xr     = static_cast<T>(x.real());
-  T xi     = static_cast<T>(x.imag());
-  T yr     = static_cast<T>(y.real());
-  T yi     = static_cast<T>(y.imag());
+  using T = ::cuda::std::common_type_t<T0, T1>;
+  T xr    = static_cast<T>(x.real());
+  T xi    = static_cast<T>(x.imag());
+  T yr    = static_cast<T>(y.real());
+  T yi    = static_cast<T>(y.imag());
   return complex<T>(xr * yr - xi * yi, xr * yi + xi * yr);
 }
 
@@ -78,16 +78,14 @@ template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const T1& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(static_cast<T>(x.real()) * static_cast<T>(y),
-                    static_cast<T>(x.imag()) * static_cast<T>(y));
+  return complex<T>(static_cast<T>(x.real()) * static_cast<T>(y), static_cast<T>(x.imag()) * static_cast<T>(y));
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const T0& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(static_cast<T>(x) * static_cast<T>(y.real()),
-                    static_cast<T>(x) * static_cast<T>(y.imag()));
+  return complex<T>(static_cast<T>(x) * static_cast<T>(y.real()), static_cast<T>(x) * static_cast<T>(y.imag()));
 }
 
 template <typename T0, typename T1>
@@ -115,8 +113,7 @@ template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const T1& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(static_cast<T>(x.real()) / static_cast<T>(y),
-                    static_cast<T>(x.imag()) / static_cast<T>(y));
+  return complex<T>(static_cast<T>(x.real()) / static_cast<T>(y), static_cast<T>(x.imag()) / static_cast<T>(y));
 }
 
 template <typename T0, typename T1>

--- a/thrust/thrust/detail/complex/arithmetic.h
+++ b/thrust/thrust/detail/complex/arithmetic.h
@@ -23,77 +23,85 @@ template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(x.real() + y.real(), x.imag() + y.imag());
+  return complex<T>(static_cast<T>(x.real()) + static_cast<T>(y.real()),
+                    static_cast<T>(x.imag()) + static_cast<T>(y.imag()));
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const complex<T0>& x, const T1& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(x.real() + y, x.imag());
+  return complex<T>(static_cast<T>(x.real()) + static_cast<T>(y), static_cast<T>(x.imag()));
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator+(const T0& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(x + y.real(), y.imag());
+  return complex<T>(static_cast<T>(x) + static_cast<T>(y.real()), static_cast<T>(y.imag()));
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(x.real() - y.real(), x.imag() - y.imag());
+  return complex<T>(static_cast<T>(x.real()) - static_cast<T>(y.real()),
+                    static_cast<T>(x.imag()) - static_cast<T>(y.imag()));
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const complex<T0>& x, const T1& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(x.real() - y, x.imag());
+  return complex<T>(static_cast<T>(x.real()) - static_cast<T>(y), static_cast<T>(x.imag()));
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator-(const T0& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(x - y.real(), -y.imag());
+  return complex<T>(static_cast<T>(x) - static_cast<T>(y.real()), -static_cast<T>(y.imag()));
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const complex<T1>& y)
 {
-  using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(x.real() * y.real() - x.imag() * y.imag(), x.real() * y.imag() + x.imag() * y.real());
+  using T  = ::cuda::std::common_type_t<T0, T1>;
+  T xr     = static_cast<T>(x.real());
+  T xi     = static_cast<T>(x.imag());
+  T yr     = static_cast<T>(y.real());
+  T yi     = static_cast<T>(y.imag());
+  return complex<T>(xr * yr - xi * yi, xr * yi + xi * yr);
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const complex<T0>& x, const T1& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(x.real() * y, x.imag() * y);
+  return complex<T>(static_cast<T>(x.real()) * static_cast<T>(y),
+                    static_cast<T>(x.imag()) * static_cast<T>(y));
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator*(const T0& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(x * y.real(), x * y.imag());
+  return complex<T>(static_cast<T>(x) * static_cast<T>(y.real()),
+                    static_cast<T>(x) * static_cast<T>(y.imag()));
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  T s     = ::cuda::std::abs(y.real()) + ::cuda::std::abs(y.imag());
+  T s     = ::cuda::std::abs(static_cast<T>(y.real())) + ::cuda::std::abs(static_cast<T>(y.imag()));
 
   T oos = T(1.0) / s;
 
-  T ars = x.real() * oos;
-  T ais = x.imag() * oos;
-  T brs = y.real() * oos;
-  T bis = y.imag() * oos;
+  T ars = static_cast<T>(x.real()) * oos;
+  T ais = static_cast<T>(x.imag()) * oos;
+  T brs = static_cast<T>(y.real()) * oos;
+  T bis = static_cast<T>(y.imag()) * oos;
 
   s = (brs * brs) + (bis * bis);
 
@@ -107,7 +115,8 @@ template <typename T0, typename T1>
 _CCCL_HOST_DEVICE complex<::cuda::std::common_type_t<T0, T1>> operator/(const complex<T0>& x, const T1& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return complex<T>(x.real() / y, x.imag() / y);
+  return complex<T>(static_cast<T>(x.real()) / static_cast<T>(y),
+                    static_cast<T>(x.imag()) / static_cast<T>(y));
 }
 
 template <typename T0, typename T1>

--- a/thrust/thrust/detail/complex/complex.inl
+++ b/thrust/thrust/detail/complex/complex.inl
@@ -164,8 +164,7 @@ template <typename T0, typename T1>
 _CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const complex<T1>& y)
 {
   using T = ::cuda::std::common_type_t<T0, T1>;
-  return static_cast<T>(x.real()) == static_cast<T>(y.real())
-      && static_cast<T>(x.imag()) == static_cast<T>(y.imag());
+  return static_cast<T>(x.real()) == static_cast<T>(y.real()) && static_cast<T>(x.imag()) == static_cast<T>(y.imag());
 }
 
 #if !_CCCL_COMPILER(NVRTC)

--- a/thrust/thrust/detail/complex/complex.inl
+++ b/thrust/thrust/detail/complex/complex.inl
@@ -163,33 +163,41 @@ _CCCL_HOST_DEVICE complex<T>& complex<T>::operator/=(const U& z)
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const complex<T1>& y)
 {
-  return x.real() == y.real() && x.imag() == y.imag();
+  using T = ::cuda::std::common_type_t<T0, T1>;
+  return static_cast<T>(x.real()) == static_cast<T>(y.real())
+      && static_cast<T>(x.imag()) == static_cast<T>(y.imag());
 }
 
 #if !_CCCL_COMPILER(NVRTC)
 template <typename T0, typename T1>
 _CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const complex<T0>& x, const ::std::complex<T1>& y)
 {
-  return x.real() == THRUST_STD_COMPLEX_REAL(y) && x.imag() == THRUST_STD_COMPLEX_IMAG(y);
+  using T = ::cuda::std::common_type_t<T0, T1>;
+  return static_cast<T>(x.real()) == static_cast<T>(THRUST_STD_COMPLEX_REAL(y))
+      && static_cast<T>(x.imag()) == static_cast<T>(THRUST_STD_COMPLEX_IMAG(y));
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST THRUST_STD_COMPLEX_DEVICE bool operator==(const ::std::complex<T0>& x, const complex<T1>& y)
 {
-  return THRUST_STD_COMPLEX_REAL(x) == y.real() && THRUST_STD_COMPLEX_IMAG(x) == y.imag();
+  using T = ::cuda::std::common_type_t<T0, T1>;
+  return static_cast<T>(THRUST_STD_COMPLEX_REAL(x)) == static_cast<T>(y.real())
+      && static_cast<T>(THRUST_STD_COMPLEX_IMAG(x)) == static_cast<T>(y.imag());
 }
 #endif // !_CCCL_COMPILER(NVRTC)
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE bool operator==(const T0& x, const complex<T1>& y)
 {
-  return x == y.real() && y.imag() == T1();
+  using T = ::cuda::std::common_type_t<T0, T1>;
+  return static_cast<T>(x) == static_cast<T>(y.real()) && static_cast<T>(y.imag()) == T();
 }
 
 template <typename T0, typename T1>
 _CCCL_HOST_DEVICE bool operator==(const complex<T0>& x, const T1& y)
 {
-  return x.real() == y && x.imag() == T1();
+  using T = ::cuda::std::common_type_t<T0, T1>;
+  return static_cast<T>(x.real()) == static_cast<T>(y) && static_cast<T>(x.imag()) == T();
 }
 
 template <typename T0, typename T1>


### PR DESCRIPTION
## Summary

- Add 4 new strict warning flags beyond the existing `-Wall -Wextra -Werror`: `-Wshadow=local`, `-Wnon-virtual-dtor`, `-Wdouble-promotion`, `-Wformat=2`
- Fix all resulting warnings across CUB, Thrust, libcudacxx, cudax, nvbench_helper, and C Parallel (25+ files)
- Guard Clang-only `-Wgnu` / `-Wno-gnu-*` flags behind a compiler check to fix GCC9 builds
- `-Wpedantic` was evaluated but excluded — nvcc's preprocessor emits GCC-style line directives that trigger unavoidable pedantic warnings
- `-Wnull-dereference` was evaluated but excluded — GCC produces many false positives in system headers (e.g. `streambuf`) when inlining user code

### New warnings

| Warning | What it catches |
|---|---|
| `-Wshadow=local` | Local variable shadowing another local (dangerous scoping bugs) |
| `-Wnon-virtual-dtor` | Classes with virtual functions but non-virtual destructors |
| `-Wdouble-promotion` | Implicit `float` → `double` promotion (performance/precision bugs) |
| `-Wformat=2` | Format string security issues |

### Flags evaluated but excluded

| Warning | Why excluded |
|---|---|
| `-Wpedantic` | nvcc's preprocessor emits GCC-style line directives that trigger unavoidable warnings |
| `-Wnull-dereference` | GCC produces false positives in system headers (e.g. `<streambuf>`) when inlining user code |

### Fixes applied

**`-Wdouble-promotion` (implicit float→double):**
- `libcudacxx` nvbf16.h / nvfp16.h: wrap `__bfloat162float()` / `__half2float()` in `static_cast<double>()` in `complex<double>` constructors and assignments
- `libcudacxx` native_type.h: use `__float128{}` instead of `__float128{0.0}` to avoid double→\_\_float128 promotion
- `thrust` complex arithmetic.h: cast all mixed-type operands to `common_type` before arithmetic
- `thrust` complex.inl: same `common_type` cast pattern in equality operators
- `thrust` catch2_test_complex.cu: cast to `double` before CHECK comparisons of mixed float/double components
- `nvbench_helper` nvbench_helper.cu: fix float→double in `random_to_item_t` calls and distribution constructors
- `nvbench_helper` gen_uniform_distribution.cu: explicit casts in mixed-type arithmetic
- `cudax` 09-nbody-blocked.cu: cast float `elapsed` to double for printf
- `cub` test_allocator.cu, test_util.h, cpu_timer.h: explicit casts for printf and float comparisons

**`-Wshadow=local` (variable shadowing):**
- `cub` catch2_test_env_launch_helper.h: `args` → `inner_args` in nested lambdas
- `cub` catch2_test_device_transform_if.cu: `a`/`b` → `lhs`/`rhs`
- `cudax` test_bulk.cu, test_conditional.cu, test_stream_context.cu, test_visit.cu, launch_smoke.cu: renamed shadowed variables (`counter`→`ctr`, `vals`→`arr`, `config`→`smem_config`, etc.)
- `cudax` sections_2.cu: inner `s_bar` → `s_baz`
- `nvbench_helper` nvbench_helper.cu: `dist` → `float_dist` / `double_dist`
- `nvbench_helper` gen_entropy.cu: lambda parameter `entropy` → `level`

**`-Wnon-virtual-dtor`:**
- `c2h` catch2_test_helper.h: changed `~QuietMatchExpr() override` to `virtual ~QuietMatchExpr()` — base class `ITransientExpression` (Catch2) has no virtual destructor, so `override` is invalid

**Null-dereference hardening (defensive, not required by a flag):**
- `libcudacxx` basic_any_value.h, virtcall.h: added `_CCCL_ASSERT` + `_CCCL_ASSUME` for `__query_interface` return values
- `cudax` executable_graph_cache.cuh: added `_CCCL_ASSERT` for LRU cache iterator validity
- `cub` catch2_test_device_decoupled_look_back.cu: added `REQUIRE` for pointer validity

**CMake infrastructure:**
- Guarded `-Wgnu`, `-Wno-gnu-line-marker`, `-Wno-gnu-zero-variadic-macro-arguments` behind `if (Clang)` — GCC (especially GCC9) rejects unrecognized `-Wno-*` flags under `-Werror`

## Test plan

- [ ] CI matrix validation across all compiler/toolkit combinations
- [ ] CUB builds (GCC, Clang, ClangCUDA, nvcc) — zero new warnings
- [ ] Thrust builds (GCC, Clang, ClangCUDA, nvcc) — zero new warnings
- [ ] cudax builds (GCC, Clang) — zero new warnings
- [ ] libcudacxx builds — zero new warnings
- [ ] C Parallel builds — zero new warnings
- [ ] NVBench helper builds — zero new warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)