### PR TITLE
Avoid unused variable warnings with MSVC

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/conversion.layout_stride.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/conversion.layout_stride.pass.cpp
@@ -48,7 +48,7 @@ __host__ __device__ constexpr void test_conversion(E ext, cuda::std::array<intpt
 
 __host__ __device__ constexpr bool test()
 {
-  constexpr size_t D = cuda::std::dynamic_extent;
+  [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
   // Rank-0 case
   test_conversion(cuda::std::extents<int>(), cuda::std::array<intptr_t, 0>{});
   // Rank-1 cases

--- a/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.strided_mapping.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/containers/views/mdspan/layout_stride_relaxed/ctor.strided_mapping.pass.cpp
@@ -95,12 +95,14 @@ template <class FromL, class T1, class T2>
 __host__ __device__ constexpr void test_conversion()
 {
   using cuda::std::is_same_v;
-  constexpr size_t D             = cuda::std::dynamic_extent;
-  constexpr bool idx_convertible = static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
-                                >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
-  constexpr bool l_convertible = is_same_v<FromL, cuda::std::layout_right> || is_same_v<FromL, cuda::std::layout_left>
-                              || is_same_v<FromL, cuda::std::layout_stride>;
-  constexpr bool idx_l_convertible = idx_convertible && l_convertible;
+  [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
+  [[maybe_unused]] constexpr bool idx_convertible =
+    static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
+    >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
+  [[maybe_unused]] constexpr bool l_convertible =
+    is_same_v<FromL, cuda::std::layout_right> || is_same_v<FromL, cuda::std::layout_left>
+    || is_same_v<FromL, cuda::std::layout_stride>;
+  [[maybe_unused]] constexpr bool idx_l_convertible = idx_convertible && l_convertible;
 
   // clang-format off
   test_conversion<idx_l_convertible, FromL, cuda::std::extents<T1>>(

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assign.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assign.pass.cpp
@@ -242,8 +242,8 @@ __host__ __device__ constexpr bool test()
 template <template <class, size_t> class Range>
 void test_exceptions()
 { // assign_range throws std::bad_alloc
-  constexpr size_t capacity = 4;
-  using inplace_vector      = cuda::std::inplace_vector<int, 4>; // NVCC complains about invalid second argument...
+  [[maybe_unused]] constexpr size_t capacity = 4;
+  using inplace_vector = cuda::std::inplace_vector<int, 4>; // NVCC complains about invalid second argument...
   try
   {
     [[maybe_unused]] inplace_vector too_small{};
@@ -260,8 +260,8 @@ void test_exceptions()
 
 void test_exceptions()
 { // assign throws std::bad_alloc
-  constexpr size_t capacity = 4;
-  using inplace_vector      = cuda::std::inplace_vector<int, capacity>;
+  [[maybe_unused]] constexpr size_t capacity = 4;
+  using inplace_vector                       = cuda::std::inplace_vector<int, capacity>;
   [[maybe_unused]] inplace_vector too_small{};
   [[maybe_unused]] const cuda::std::array<int, 7> input{0, 1, 2, 3, 4, 5, 6};
 

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/assignment.pass.cpp
@@ -240,8 +240,8 @@ __host__ __device__ constexpr bool test()
 #if TEST_HAS_EXCEPTIONS()
 void test_exceptions()
 { // assignment throws std::bad_alloc
-  constexpr size_t capacity = 4;
-  using inplace_vector      = cuda::std::inplace_vector<int, capacity>;
+  [[maybe_unused]] constexpr size_t capacity = 4;
+  using inplace_vector                       = cuda::std::inplace_vector<int, capacity>;
   inplace_vector too_small{};
 
   try

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/capacity.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/capacity.pass.cpp
@@ -21,8 +21,8 @@
 template <class T>
 __host__ __device__ constexpr void test()
 {
-  constexpr size_t max_capacity = 42ull;
-  using inplace_vector          = cuda::std::inplace_vector<T, max_capacity>;
+  [[maybe_unused]] constexpr size_t max_capacity = 42ull;
+  using inplace_vector                           = cuda::std::inplace_vector<T, max_capacity>;
   inplace_vector range{T(1), T(1337), T(42), T(12), T(0), T(-1)};
   const inplace_vector const_range{T(0), T(42), T(1337), T(42), T(5), T(-42)};
 

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/constructor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/constructor.pass.cpp
@@ -317,8 +317,8 @@ __host__ __device__ constexpr bool test()
 #if TEST_HAS_EXCEPTIONS()
 void test_exceptions()
 { // constructors throw std::bad_alloc
-  constexpr size_t capacity = 4;
-  using inplace_vector      = cuda::std::inplace_vector<int, capacity>;
+  [[maybe_unused]] constexpr size_t capacity = 4;
+  using inplace_vector                       = cuda::std::inplace_vector<int, capacity>;
 
   try
   {

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/emplace.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/emplace.pass.cpp
@@ -25,9 +25,9 @@
 template <class T>
 __host__ __device__ constexpr void test()
 {
-  constexpr size_t max_capacity         = 6ull;
-  using inplace_vector                  = cuda::std::inplace_vector<T, max_capacity>;
-  const cuda::std::array<T, 6> expected = {T(0), T(1), T(2), T(3), T(4), T(5)};
+  [[maybe_unused]] constexpr size_t max_capacity = 6ull;
+  using inplace_vector                           = cuda::std::inplace_vector<T, max_capacity>;
+  const cuda::std::array<T, 6> expected          = {T(0), T(1), T(2), T(3), T(4), T(5)};
 
   { // inplace_vector<T, N>::emplace(iter, args...)
     inplace_vector vec = {T(0), T(1), T(2), T(4), T(5)};

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/insert.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/insert.pass.cpp
@@ -29,8 +29,8 @@ _CCCL_DIAG_SUPPRESS_MSVC(5246)
 template <class T, template <class, size_t> class Range>
 __host__ __device__ constexpr void test_range()
 {
-  constexpr size_t max_capacity = 5ull;
-  using inplace_vector          = cuda::std::inplace_vector<T, max_capacity>;
+  [[maybe_unused]] constexpr size_t max_capacity = 5ull;
+  using inplace_vector                           = cuda::std::inplace_vector<T, max_capacity>;
 
   { // inplace_vector<T, 0>::insert_range(iter, range)
     cuda::std::inplace_vector<T, 0> vec{};
@@ -107,8 +107,8 @@ __host__ __device__ constexpr void test_range()
 template <class T>
 __host__ __device__ constexpr void test()
 {
-  constexpr size_t max_capacity = 42ull;
-  using inplace_vector          = cuda::std::inplace_vector<T, max_capacity>;
+  [[maybe_unused]] constexpr size_t max_capacity = 42ull;
+  using inplace_vector                           = cuda::std::inplace_vector<T, max_capacity>;
 
   { // inplace_vector<T, N>::insert(iter, const T&)
     const T to_be_inserted = 3;

--- a/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/resize.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/sequences/inplace_vector/resize.pass.cpp
@@ -25,8 +25,8 @@
 template <class T>
 __host__ __device__ constexpr void test_resize()
 {
-  constexpr size_t max_capacity = 42ull;
-  using inplace_vector          = cuda::std::inplace_vector<T, max_capacity>;
+  [[maybe_unused]] constexpr size_t max_capacity = 42ull;
+  using inplace_vector                           = cuda::std::inplace_vector<T, max_capacity>;
 
   { // inplace_vector<T, 0>::resize with a size
     cuda::std::inplace_vector<T, 0> vec{};
@@ -68,8 +68,8 @@ __host__ __device__ constexpr void test_resize()
 template <class T>
 __host__ __device__ constexpr void test_clear()
 {
-  constexpr size_t max_capacity = 42ull;
-  using inplace_vector          = cuda::std::inplace_vector<T, max_capacity>;
+  [[maybe_unused]] constexpr size_t max_capacity = 42ull;
+  using inplace_vector                           = cuda::std::inplace_vector<T, max_capacity>;
 
   { // inplace_vector<T, 0>::clear
     cuda::std::inplace_vector<T, 0> vec{};
@@ -102,8 +102,8 @@ struct is_one
 template <class T>
 __host__ __device__ constexpr void test_pop_back()
 {
-  constexpr size_t max_capacity = 42ull;
-  using inplace_vector          = cuda::std::inplace_vector<T, max_capacity>;
+  [[maybe_unused]] constexpr size_t max_capacity = 42ull;
+  using inplace_vector                           = cuda::std::inplace_vector<T, max_capacity>;
 
   { // inplace_vector<T, N>::pop_back
     inplace_vector vec{T(1), T(1337), T(42), T(12), T(0), T(-1)};
@@ -115,8 +115,8 @@ __host__ __device__ constexpr void test_pop_back()
 template <class T>
 __host__ __device__ constexpr void test_erase()
 {
-  constexpr size_t max_capacity = 42ull;
-  using inplace_vector          = cuda::std::inplace_vector<T, max_capacity>;
+  [[maybe_unused]] constexpr size_t max_capacity = 42ull;
+  using inplace_vector                           = cuda::std::inplace_vector<T, max_capacity>;
 
   { // inplace_vector<T, N>::erase(iter)
     inplace_vector vec{T(1), T(1337), T(42), T(12), T(0), T(-1)};
@@ -178,8 +178,8 @@ __host__ __device__ constexpr void test_erase()
 template <class T>
 __host__ __device__ constexpr void test_shrink_to_fit()
 {
-  constexpr size_t max_capacity = 42ull;
-  using inplace_vector          = cuda::std::inplace_vector<T, max_capacity>;
+  [[maybe_unused]] constexpr size_t max_capacity = 42ull;
+  using inplace_vector                           = cuda::std::inplace_vector<T, max_capacity>;
 
   { // inplace_vector<T, 0>::shrink_to_fit
     cuda::std::inplace_vector<T, 0> vec{};
@@ -205,8 +205,8 @@ __host__ __device__ constexpr void test_shrink_to_fit()
 template <class T>
 __host__ __device__ constexpr void test_reserve()
 {
-  constexpr size_t max_capacity = 42ull;
-  using inplace_vector          = cuda::std::inplace_vector<T, max_capacity>;
+  [[maybe_unused]] constexpr size_t max_capacity = 42ull;
+  using inplace_vector                           = cuda::std::inplace_vector<T, max_capacity>;
 
   { // inplace_vector<T, 0>::reserve
     cuda::std::inplace_vector<T, 0> vec{};

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/ctor.layout_right.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/ctor.layout_right.pass.cpp
@@ -64,9 +64,10 @@ __host__ __device__ constexpr void test_conversion(FromExt src_exts)
 template <class T1, class T2>
 __host__ __device__ constexpr void test_conversion()
 {
-  constexpr size_t D             = cuda::std::dynamic_extent;
-  constexpr bool idx_convertible = static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
-                                >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
+  [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
+  [[maybe_unused]] constexpr bool idx_convertible =
+    static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
+    >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
 
   // clang-format off
   test_conversion<idx_convertible && true,  cuda::std::extents<T1>>(cuda::std::extents<T2>());

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/ctor.mapping.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_left/ctor.mapping.pass.cpp
@@ -62,9 +62,10 @@ __host__ __device__ constexpr void test_conversion(FromExt src_exts)
 template <class T1, class T2>
 __host__ __device__ constexpr void test_conversion()
 {
-  constexpr size_t D             = cuda::std::dynamic_extent;
-  constexpr bool idx_convertible = static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
-                                >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
+  [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
+  [[maybe_unused]] constexpr bool idx_convertible =
+    static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
+    >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
 
   // clang-format off
   test_conversion<idx_convertible && true,  cuda::std::extents<T1>>(cuda::std::extents<T2>());

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/ctor.layout_left.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/ctor.layout_left.pass.cpp
@@ -64,9 +64,10 @@ __host__ __device__ constexpr void test_conversion(FromExt src_exts)
 template <class T1, class T2>
 __host__ __device__ constexpr void test_conversion()
 {
-  constexpr size_t D             = cuda::std::dynamic_extent;
-  constexpr bool idx_convertible = static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
-                                >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
+  [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
+  [[maybe_unused]] constexpr bool idx_convertible =
+    static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
+    >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
 
   // clang-format off
   test_conversion<idx_convertible && true,  cuda::std::extents<T1>>(cuda::std::extents<T2>());

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/ctor.mapping.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_right/ctor.mapping.pass.cpp
@@ -62,9 +62,10 @@ __host__ __device__ constexpr void test_conversion(FromExt src_exts)
 template <class T1, class T2>
 __host__ __device__ constexpr void test_conversion()
 {
-  constexpr size_t D             = cuda::std::dynamic_extent;
-  constexpr bool idx_convertible = static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
-                                >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
+  [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
+  [[maybe_unused]] constexpr bool idx_convertible =
+    static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
+    >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
 
   // clang-format off
   test_conversion<idx_convertible && true,  cuda::std::extents<T1>>(cuda::std::extents<T2>());

--- a/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/ctor.strided_mapping.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/containers/views/mdspan/layout_stride/ctor.strided_mapping.pass.cpp
@@ -99,13 +99,14 @@ __host__ __device__ constexpr void test_conversion(FromExt src_exts)
 template <class FromL, class T1, class T2>
 __host__ __device__ constexpr void test_conversion()
 {
-  constexpr size_t D             = cuda::std::dynamic_extent;
-  constexpr bool idx_convertible = static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
-                                >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
-  constexpr bool l_convertible =
+  [[maybe_unused]] constexpr size_t D = cuda::std::dynamic_extent;
+  [[maybe_unused]] constexpr bool idx_convertible =
+    static_cast<size_t>(cuda::std::numeric_limits<T1>::max())
+    >= static_cast<size_t>(cuda::std::numeric_limits<T2>::max());
+  [[maybe_unused]] constexpr bool l_convertible =
     cuda::std::is_same_v<FromL, cuda::std::layout_right> || cuda::std::is_same_v<FromL, cuda::std::layout_left>
     || cuda::std::is_same_v<FromL, cuda::std::layout_stride>;
-  constexpr bool idx_l_convertible = idx_convertible && l_convertible;
+  [[maybe_unused]] constexpr bool idx_l_convertible = idx_convertible && l_convertible;
 
   // clang-format off
   // adding extents convertibility expectation


### PR DESCRIPTION
it seems that MSVC has stated to have issues with function local constexpr variables that are only used in a compile time context. :(

Fixes nvbug5997662
