### PR TITLE
Verify repo in context7

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://context7.com/nvidia/cccl",
+  "public_key": "pk_gupaHhsdvsuT1j3BZpb7i"
+}


### PR DESCRIPTION
Context7 is a popular MCP server for providing docs to AI agents.

They auto index repos and CCCL has been indexed here https://context7.com/nvidia/cccl. By claiming admin on the repo we can update the docs (currently it was updated 9 months ago), split into C++ and Python for the different libs and provide a better experience in general.

So adding this public key to the repo claim we own the repo, currently this is using my nvidia login on context7 but it can easily be reclaimed by others after by just updating this file.