### PR TITLE
Supress vectorization false positive werrors in permutation_iterator test

### DIFF
--- a/thrust/testing/permutation_iterator.cu
+++ b/thrust/testing/permutation_iterator.cu
@@ -8,6 +8,12 @@
 
 #include <unittest/unittest.h>
 
+#if _CCCL_COMPILER(GCC, >=, 11)
+#  define THRUST_DISABLE_BROKEN_GCC_VECTORIZER __attribute__((optimize("no-tree-vectorize")))
+#else
+#  define THRUST_DISABLE_BROKEN_GCC_VECTORIZER
+#endif
+
 // ensure that we properly support thrust::permutation_iterator from cuda::std
 void TestPermutationIteratorTraits()
 {
@@ -243,7 +249,7 @@ void TestPermutationIteratorHostDeviceScatter()
 DECLARE_UNITTEST(TestPermutationIteratorHostDeviceScatter);
 
 template <typename Vector>
-void TestPermutationIteratorWithCountingIterator()
+THRUST_DISABLE_BROKEN_GCC_VECTORIZER void TestPermutationIteratorWithCountingIterator()
 {
   using T      = typename Vector::value_type;
   using diff_t = typename thrust::counting_iterator<T>::difference_type;


### PR DESCRIPTION
fixes the first bug in the **2-Thrust** section of https://nvbugspro.nvidia.com/bug/5999870

Detailed explanation of what gcc is messing up can be found in my comment under the nvbug or [here](https://gist.github.com/gonidelis/77c08a9c0baf529196c439fe591934d0)  

It's basically a false positive where vectorizer is smart enough to generate guarded wide stores (16-byte vector(16) stores into a 4-byte buffer), but the warning pass is too dumb to see the guard that makes it unreachable

We suppress vectorization for `TestPermutationIteratorWithCountingIterator()` as this is the test that uses `general_copy.h` underneath which results in the bogus vectorization werror.