### PR TITLE
Replace include of `<functional>` with forward declaration of `std::reference_wrapper`

### DIFF
--- a/libcudacxx/include/cuda/std/__execution/env.h
+++ b/libcudacxx/include/cuda/std/__execution/env.h
@@ -23,7 +23,7 @@
 
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__concepts/derived_from.h>
-#include <cuda/std/__functional/reference_wrapper.h>
+#include <cuda/std/__fwd/reference_wrapper.h>
 #include <cuda/std/__tuple_dir/ignore.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_callable.h>
@@ -31,10 +31,6 @@
 #include <cuda/std/__type_traits/is_valid_expansion.h>
 #include <cuda/std/__utility/declval.h>
 #include <cuda/std/__utility/pod_tuple.h>
-
-#if !_CCCL_COMPILER(NVRTC)
-#  include <functional> // IWYU pragma: keep for ::std::reference_wrapper
-#endif // !_CCCL_COMPILER(NVRTC)
 
 //! @file env.h
 //! @brief Provides utilities for querying and managing environments, an unordered

--- a/libcudacxx/include/cuda/std/__fwd/reference_wrapper.h
+++ b/libcudacxx/include/cuda/std/__fwd/reference_wrapper.h
@@ -22,6 +22,19 @@
 
 #include <cuda/std/__cccl/prologue.h>
 
+// std:: forward declarations
+
+#if _CCCL_HAS_HOST_STD_LIB()
+_CCCL_BEGIN_NAMESPACE_STD
+
+template <class>
+class reference_wrapper;
+
+_CCCL_END_NAMESPACE_STD
+#endif // _CCCL_HAS_HOST_STD_LIB()
+
+// cuda::std:: forward declarations
+
 _CCCL_BEGIN_NAMESPACE_CUDA_STD
 
 template <class _Tp>


### PR DESCRIPTION
I was wondering why `<cuda/std/execution>` takes so long to include

Turns out we are pulling in `<functional>` for `std::reference_wrapper`

Replace that include by a forward declaration