### PR TITLE
[CUB] Replace `Shuffle(Up|Down|Index)` with `cuda::device::warp_shuffle`

### DIFF
--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -29,16 +29,30 @@ benchmarks:
     # Examples:
     # - '^cub\.bench\.for_each\.base'
     # - '^cub\.bench\.reduce\.(sum|min)\.'
+    - '^cub\.bench\.reduce\.'
+    - '^cub\.bench\.scan\.'
+    - '^cub\.bench\.radix_sort\.'
+    - '^cub\.bench\.merge_sort\.'
+    - '^cub\.bench\.select\.'
+    - '^cub\.bench\.partition\.'
+    - '^cub\.bench\.run_length_encode\.'
+    - '^cub\.bench\.segmented_reduce\.'
+    - '^cub\.bench\.segmented_sort\.'
+    - '^cub\.bench\.segmented_radix_sort\.'
+    - '^cub\.bench\.topk\.'
+    - '^cub\.bench\.segmented_topk\.'
+    - '^cub\.bench\.transform_reduce\.'
+    - '^cub\.bench\.copy\.'
 
   # Select GPUs. These are limited and shared, be intentional and conservative.
   gpus:
     # - "t4"         # sm_75, 16 GB
     # - "rtx2080"    # sm_75,  8 GB
-    # - "rtxa6000"   # sm_86, 48 GB
+      - "rtxa6000"   # sm_86, 48 GB
     # - "l4"         # sm_89, 24 GB
     # - "rtx4090"    # sm_89, 24 GB
-    # - "h100"       # sm_90, 80 GB
-    # - "rtxpro6000" # sm_120
+      - "h100"       # sm_90, 80 GB
+      - "rtxpro6000" # sm_120
 
   # Extra .devcontainer/launch.sh -d args
   # launch_args: "--cuda 13.1 --host gcc14"

--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -29,17 +29,17 @@ benchmarks:
     # Examples:
     # - '^cub\.bench\.for_each\.base'
     # - '^cub\.bench\.reduce\.(sum|min)\.'
-    - '^cub\.bench\.reduce\.'
-    - '^cub\.bench\.scan\.'
-    - '^cub\.bench\.radix_sort\.'
-    - '^cub\.bench\.merge_sort\.'
-    - '^cub\.bench\.select\.'
-    - '^cub\.bench\.partition\.'
+    - '^cub\.bench\.reduce\.(sum|min|nondeterministic|deterministic|by_key)\.'
+    - '^cub\.bench\.scan\.exclusive\.(sum|by_key)\.'
+    - '^cub\.bench\.radix_sort\.keys\.'
+    - '^cub\.bench\.merge_sort\.keys\.'
+    - '^cub\.bench\.select\.if\.'
+    - '^cub\.bench\.partition\.if\.'
     - '^cub\.bench\.run_length_encode\.'
-    - '^cub\.bench\.segmented_reduce\.'
+    - '^cub\.bench\.segmented_reduce\.sum\.'
     - '^cub\.bench\.segmented_sort\.'
     - '^cub\.bench\.segmented_radix_sort\.'
-    - '^cub\.bench\.topk\.'
+    - '^cub\.bench\.topk\.keys\.'
     - '^cub\.bench\.segmented_topk\.'
     - '^cub\.bench\.transform_reduce\.'
     - '^cub\.bench\.copy\.'
@@ -63,7 +63,7 @@ benchmarks:
   test_ref: "HEAD"
   arch: "native"
   nvbench_args: >-
-    --timeout 30
+    --timeout 100
     --skip-time 15e-6
     --stopping-criterion entropy
     --throttle-threshold 90

--- a/cub/cub/agent/agent_radix_sort_downsweep.cuh
+++ b/cub/cub/agent/agent_radix_sort_downsweep.cuh
@@ -35,6 +35,7 @@
 #  include <cub/agent/agent_unique_by_key.cuh>
 #endif
 
+#include <cuda/__warp/warp_shuffle.h>
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
@@ -353,7 +354,7 @@ struct AgentRadixSortDownsweep
   {
     // Register pressure work-around: moving valid_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
-    valid_items = ShuffleIndex<warp_threads>(valid_items, 0, 0xffffffff);
+    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
 
     BlockLoadKeysT(temp_storage.load_keys).Load(d_keys_in + block_offset, keys, valid_items, oob_item);
 
@@ -387,7 +388,7 @@ struct AgentRadixSortDownsweep
   {
     // Register pressure work-around: moving valid_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
-    valid_items = ShuffleIndex<warp_threads>(valid_items, 0, 0xffffffff);
+    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
 
     LoadDirectWarpStriped(threadIdx.x, d_keys_in + block_offset, keys, valid_items, oob_item);
   }
@@ -419,7 +420,7 @@ struct AgentRadixSortDownsweep
   {
     // Register pressure work-around: moving valid_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
-    valid_items = ShuffleIndex<warp_threads>(valid_items, 0, 0xffffffff);
+    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
 
     BlockLoadValuesT(temp_storage.load_values).Load(d_values_in + block_offset, values, valid_items);
 
@@ -451,7 +452,7 @@ struct AgentRadixSortDownsweep
   {
     // Register pressure work-around: moving valid_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
-    valid_items = ShuffleIndex<warp_threads>(valid_items, 0, 0xffffffff);
+    valid_items = ::cuda::device::warp_shuffle_idx(valid_items, 0);
 
     LoadDirectWarpStriped(threadIdx.x, d_values_in + block_offset, values, valid_items);
   }

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -23,6 +23,7 @@
 #include <cub/device/dispatch/tuning/tuning_radix_sort.cuh>
 #include <cub/grid/grid_even_share.cuh>
 
+#include <cuda/__warp/warp_shuffle.h>
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__type_traits/conditional.h>
@@ -399,7 +400,7 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).single_ti
   {
     // Register pressure work-around: moving num_items through shfl prevents compiler
     // from reusing guards/addressing from prior guarded loads
-    num_items = ShuffleIndex<warp_threads>(num_items, 0, 0xffffffff);
+    num_items = ::cuda::device::warp_shuffle_idx(num_items, 0);
 
     BlockLoadValues(temp_storage.load_values).Load(d_values_in, values, num_items);
 

--- a/cub/cub/util_ptx.cuh
+++ b/cub/cub/util_ptx.cuh
@@ -90,6 +90,8 @@ BFE(UnsignedBits source, unsigned int bit_start, unsigned int num_bits)
 /**
  * Warp synchronous shfl_up
  */
+//! deprecated [Since 3.0]
+CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_up()")
 _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int
 SHFL_UP_SYNC(unsigned int word, int src_offset, int flags, unsigned int member_mask)
 {
@@ -102,6 +104,8 @@ SHFL_UP_SYNC(unsigned int word, int src_offset, int flags, unsigned int member_m
 /**
  * Warp synchronous shfl_down
  */
+//! deprecated [Since 3.0]
+CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_down()")
 _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int
 SHFL_DOWN_SYNC(unsigned int word, int src_offset, int flags, unsigned int member_mask)
 {
@@ -207,7 +211,9 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE unsigned int WarpMask([[maybe_unused]] unsig
  * @param[in] member_mask
  *   32-bit mask of participating warp lanes
  */
+//! deprecated [Since 3.0]
 template <int LOGICAL_WARP_THREADS, typename T>
+CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_up()")
 _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleUp(T input, int src_offset, int first_thread, unsigned int member_mask)
 {
   /// The 5-bit SHFL mask for logically splitting warps into sub-segments starts 8-bits up
@@ -285,7 +291,9 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleUp(T input, int src_offset, int first_th
  * @param[in] member_mask
  *   32-bit mask of participating warp lanes
  */
+//! deprecated [Since 3.0]
 template <int LOGICAL_WARP_THREADS, typename T>
+CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_down()")
 _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleDown(T input, int src_offset, int last_thread, unsigned int member_mask)
 {
   /// The 5-bit SHFL mask for logically splitting warps into sub-segments starts 8-bits up
@@ -362,7 +370,9 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleDown(T input, int src_offset, int last_t
  * @param[in] member_mask
  *   32-bit mask of participating warp lanes
  */
+//! deprecated [Since 3.0]
 template <int LOGICAL_WARP_THREADS, typename T>
+CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_idx()")
 _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleIndex(T input, int src_lane, unsigned int member_mask)
 {
   using ShuffleWord = typename UnitWord<T>::ShuffleWord;

--- a/cub/cub/util_ptx.cuh
+++ b/cub/cub/util_ptx.cuh
@@ -91,8 +91,7 @@ BFE(UnsignedBits source, unsigned int bit_start, unsigned int num_bits)
  * Warp synchronous shfl_up
  */
 //! deprecated [Since 3.0]
-CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_up()")
-_CCCL_DEVICE _CCCL_FORCEINLINE unsigned int
+CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_up()") _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int
 SHFL_UP_SYNC(unsigned int word, int src_offset, int flags, unsigned int member_mask)
 {
   asm volatile("shfl.sync.up.b32 %0, %1, %2, %3, %4;"
@@ -105,8 +104,7 @@ SHFL_UP_SYNC(unsigned int word, int src_offset, int flags, unsigned int member_m
  * Warp synchronous shfl_down
  */
 //! deprecated [Since 3.0]
-CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_down()")
-_CCCL_DEVICE _CCCL_FORCEINLINE unsigned int
+CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_down()") _CCCL_DEVICE _CCCL_FORCEINLINE unsigned int
 SHFL_DOWN_SYNC(unsigned int word, int src_offset, int flags, unsigned int member_mask)
 {
   asm volatile("shfl.sync.down.b32 %0, %1, %2, %3, %4;"
@@ -213,8 +211,8 @@ _CCCL_HOST_DEVICE _CCCL_FORCEINLINE unsigned int WarpMask([[maybe_unused]] unsig
  */
 //! deprecated [Since 3.0]
 template <int LOGICAL_WARP_THREADS, typename T>
-CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_up()")
-_CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleUp(T input, int src_offset, int first_thread, unsigned int member_mask)
+CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_up()") _CCCL_DEVICE _CCCL_FORCEINLINE T
+ShuffleUp(T input, int src_offset, int first_thread, unsigned int member_mask)
 {
   /// The 5-bit SHFL mask for logically splitting warps into sub-segments starts 8-bits up
   constexpr int SHFL_C = (32 - LOGICAL_WARP_THREADS) << 8;
@@ -293,8 +291,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleUp(T input, int src_offset, int first_th
  */
 //! deprecated [Since 3.0]
 template <int LOGICAL_WARP_THREADS, typename T>
-CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_down()")
-_CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleDown(T input, int src_offset, int last_thread, unsigned int member_mask)
+CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_down()") _CCCL_DEVICE _CCCL_FORCEINLINE T
+ShuffleDown(T input, int src_offset, int last_thread, unsigned int member_mask)
 {
   /// The 5-bit SHFL mask for logically splitting warps into sub-segments starts 8-bits up
   static constexpr int SHFL_C = (32 - LOGICAL_WARP_THREADS) << 8;
@@ -372,8 +370,8 @@ _CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleDown(T input, int src_offset, int last_t
  */
 //! deprecated [Since 3.0]
 template <int LOGICAL_WARP_THREADS, typename T>
-CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_idx()")
-_CCCL_DEVICE _CCCL_FORCEINLINE T ShuffleIndex(T input, int src_lane, unsigned int member_mask)
+CCCL_DEPRECATED_BECAUSE("Use cuda::device::warp_shuffle_idx()") _CCCL_DEVICE _CCCL_FORCEINLINE T
+ShuffleIndex(T input, int src_lane, unsigned int member_mask)
 {
   using ShuffleWord = typename UnitWord<T>::ShuffleWord;
 

--- a/cub/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -28,6 +28,7 @@
 #include <cuda/__functional/maximum.h>
 #include <cuda/__functional/minimum.h>
 #include <cuda/__ptx/instructions/get_sreg.h>
+#include <cuda/__warp/warp_shuffle.h>
 #include <cuda/std/__bit/countr.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__type_traits/conditional.h>
@@ -360,7 +361,7 @@ struct WarpReduceShfl
   {
     KeyValuePair<KeyT, ValueT> output;
 
-    KeyT other_key = ShuffleDown<LOGICAL_WARP_THREADS>(input.key, offset, last_lane, member_mask);
+    KeyT other_key = ::cuda::device::warp_shuffle_down<LOGICAL_WARP_THREADS>(input.key, offset, member_mask);
 
     output.key   = input.key;
     output.value = ReduceStep(input.value, ::cuda::std::plus<>{}, last_lane, offset);
@@ -429,7 +430,7 @@ struct WarpReduceShfl
   {
     _Tp output = input;
 
-    _Tp temp = ShuffleDown<LOGICAL_WARP_THREADS>(output, offset, last_lane, member_mask);
+    _Tp temp = ::cuda::device::warp_shuffle_down<LOGICAL_WARP_THREADS>(output, offset, member_mask);
 
     // Perform reduction op if valid
     if (offset + lane_id <= last_lane)

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -636,7 +636,8 @@ struct WarpScanShfl
     InclusiveScan(input, inclusive_output, scan_op);
 
     // Grab aggregate from last warp lane
-    warp_aggregate = ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive_output, LOGICAL_WARP_THREADS - 1, member_mask);
+    warp_aggregate =
+      ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive_output, LOGICAL_WARP_THREADS - 1, member_mask);
   }
 
   /**
@@ -745,7 +746,8 @@ struct WarpScanShfl
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   Update(T input, T& inclusive, T& exclusive, T& warp_aggregate, ScanOpT scan_op, IsIntegerT is_integer)
   {
-    warp_aggregate = ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
+    warp_aggregate =
+      ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
     Update(input, inclusive, exclusive, scan_op, is_integer);
   }
 
@@ -757,7 +759,8 @@ struct WarpScanShfl
   _CCCL_DEVICE _CCCL_FORCEINLINE void Update(
     T input, T& inclusive, T& exclusive, T& warp_aggregate, ScanOpT scan_op, T initial_value, IsIntegerT is_integer)
   {
-    warp_aggregate = ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
+    warp_aggregate =
+      ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
     Update(input, inclusive, exclusive, scan_op, initial_value, is_integer);
   }
 

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -381,7 +381,7 @@ struct WarpScanShfl
   template <typename _Tp, typename ScanOpT>
   _CCCL_DEVICE _CCCL_FORCEINLINE _Tp InclusiveScanStep(_Tp input, ScanOpT scan_op, int first_lane, int offset)
   {
-    _Tp temp = ShuffleUp<LOGICAL_WARP_THREADS>(input, offset, first_lane, member_mask);
+    _Tp temp = ::cuda::device::warp_shuffle_up<LOGICAL_WARP_THREADS>(input, offset, member_mask);
 
     // Perform scan op if from a valid peer
     _Tp output = scan_op(temp, input);
@@ -501,7 +501,7 @@ struct WarpScanShfl
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE T Broadcast(T input, int src_lane)
   {
-    return ShuffleIndex<LOGICAL_WARP_THREADS>(input, src_lane, member_mask);
+    return ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(input, src_lane, member_mask);
   }
 
   //---------------------------------------------------------------------
@@ -592,7 +592,7 @@ struct WarpScanShfl
   {
     inclusive_output = input;
 
-    KeyT pred_key = ShuffleUp<LOGICAL_WARP_THREADS>(inclusive_output.key, 1, 0, member_mask);
+    KeyT pred_key = ::cuda::device::warp_shuffle_up<LOGICAL_WARP_THREADS>(inclusive_output.key, 1, member_mask);
 
     unsigned int ballot = __ballot_sync(member_mask, (pred_key != inclusive_output.key));
 
@@ -636,7 +636,7 @@ struct WarpScanShfl
     InclusiveScan(input, inclusive_output, scan_op);
 
     // Grab aggregate from last warp lane
-    warp_aggregate = ShuffleIndex<LOGICAL_WARP_THREADS>(inclusive_output, LOGICAL_WARP_THREADS - 1, member_mask);
+    warp_aggregate = ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive_output, LOGICAL_WARP_THREADS - 1, member_mask);
   }
 
   /**
@@ -691,7 +691,7 @@ struct WarpScanShfl
   Update(T /*input*/, T& inclusive, T& exclusive, ScanOpT /*scan_op*/, IsIntegerT /*is_integer*/)
   {
     // initial value unknown
-    exclusive = ShuffleUp<LOGICAL_WARP_THREADS>(inclusive, 1, 0, member_mask);
+    exclusive = ::cuda::device::warp_shuffle_up<LOGICAL_WARP_THREADS>(inclusive, 1, member_mask);
   }
 
   /**
@@ -714,7 +714,7 @@ struct WarpScanShfl
   Update(T /*input*/, T& inclusive, T& exclusive, ScanOpT scan_op, T initial_value, IsIntegerT /*is_integer*/)
   {
     inclusive = scan_op(initial_value, inclusive);
-    exclusive = ShuffleUp<LOGICAL_WARP_THREADS>(inclusive, 1, 0, member_mask);
+    exclusive = ::cuda::device::warp_shuffle_up<LOGICAL_WARP_THREADS>(inclusive, 1, member_mask);
 
     if (lane_id == 0)
     {
@@ -745,7 +745,7 @@ struct WarpScanShfl
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   Update(T input, T& inclusive, T& exclusive, T& warp_aggregate, ScanOpT scan_op, IsIntegerT is_integer)
   {
-    warp_aggregate = ShuffleIndex<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
+    warp_aggregate = ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
     Update(input, inclusive, exclusive, scan_op, is_integer);
   }
 
@@ -757,7 +757,7 @@ struct WarpScanShfl
   _CCCL_DEVICE _CCCL_FORCEINLINE void Update(
     T input, T& inclusive, T& exclusive, T& warp_aggregate, ScanOpT scan_op, T initial_value, IsIntegerT is_integer)
   {
-    warp_aggregate = ShuffleIndex<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
+    warp_aggregate = ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
     Update(input, inclusive, exclusive, scan_op, initial_value, is_integer);
   }
 

--- a/libcudacxx/include/cuda/__warp/warp_shuffle.h
+++ b/libcudacxx/include/cuda/__warp/warp_shuffle.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPO__RATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,22 +22,20 @@
 #endif // no system header
 
 #if _CCCL_CUDA_COMPILATION()
-#  if __cccl_ptx_isa >= 600
+#  include <cuda/__cmath/ceil_div.h>
+#  include <cuda/__cmath/pow2.h>
+#  include <cuda/__ptx/instructions/shfl_sync.h>
+#  include <cuda/std/__cstring/memcpy.h>
+#  include <cuda/std/__memory/addressof.h>
+#  include <cuda/std/__type_traits/enable_if.h>
+#  include <cuda/std/__type_traits/integral_constant.h>
+#  include <cuda/std/__type_traits/is_array.h>
+#  include <cuda/std/__type_traits/is_pointer.h>
+#  include <cuda/std/__type_traits/is_same.h>
+#  include <cuda/std/__type_traits/remove_cv.h>
+#  include <cuda/std/cstdint>
 
-#    include <cuda/__cmath/ceil_div.h>
-#    include <cuda/__cmath/pow2.h>
-#    include <cuda/__ptx/instructions/get_sreg.h>
-#    include <cuda/__ptx/instructions/shfl_sync.h>
-#    include <cuda/std/__concepts/concept_macros.h>
-#    include <cuda/std/__memory/addressof.h>
-#    include <cuda/std/__type_traits/enable_if.h>
-#    include <cuda/std/__type_traits/integral_constant.h>
-#    include <cuda/std/__type_traits/is_pointer.h>
-#    include <cuda/std/__type_traits/is_void.h>
-#    include <cuda/std/__type_traits/remove_cvref.h>
-#    include <cuda/std/cstdint>
-
-#    include <cuda/std/__cccl/prologue.h>
+#  include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA_DEVICE
 
@@ -57,7 +55,10 @@ struct warp_shuffle_result
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up> warp_shuffle_idx(
-  const _Tp& __data, int __src_lane, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
+  const _Tp& __data,
+  const int __src_lane,
+  ::cuda::std::uint32_t __lane_mask           = 0xFFFFFFFF,
+  ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
@@ -71,10 +72,10 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
   }
   else
   {
-    constexpr int __ratio = ::cuda::ceil_div(sizeof(_Up), sizeof(uint32_t));
-    auto __clamp_segmask  = (_Width - 1u) | ((__warp_size - _Width) << 8);
+    constexpr int __ratio          = ::cuda::ceil_div(sizeof(_Up), sizeof(::cuda::std::uint32_t));
+    constexpr auto __clamp_segmask = (_Width - 1u) | ((__warp_size - _Width) << 8);
     bool __pred;
-    uint32_t __array[__ratio];
+    ::cuda::std::uint32_t __array[__ratio];
     ::cuda::std::memcpy(
       static_cast<void*>(__array), static_cast<const void*>(::cuda::std::addressof(__data)), sizeof(_Up));
 
@@ -93,14 +94,17 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up>
-warp_shuffle_idx(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
+warp_shuffle_idx(const _Tp& __data, const int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
 {
   return ::cuda::device::warp_shuffle_idx(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Tp> warp_shuffle_up(
-  const _Tp& __data, int __delta, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up> warp_shuffle_up(
+  const _Tp& __data,
+  const int __delta,
+  const ::cuda::std::uint32_t __lane_mask     = 0xFFFFFFFF,
+  ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
@@ -119,10 +123,10 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
   else
   {
     _CCCL_ASSERT(__delta >= 1 && __delta < _Width, "delta must be in the range [1, _Width)");
-    constexpr int __ratio = ::cuda::ceil_div(sizeof(_Up), sizeof(uint32_t));
-    auto __clamp_segmask  = (__warp_size - _Width) << 8;
+    constexpr int __ratio          = ::cuda::ceil_div(sizeof(_Up), sizeof(::cuda::std::uint32_t));
+    constexpr auto __clamp_segmask = (__warp_size - _Width) << 8;
     bool __pred;
-    uint32_t __array[__ratio];
+    ::cuda::std::uint32_t __array[__ratio];
     ::cuda::std::memcpy(
       static_cast<void*>(__array), static_cast<const void*>(::cuda::std::addressof(__data)), sizeof(_Up));
 
@@ -141,14 +145,17 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up>
-warp_shuffle_up(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
+warp_shuffle_up(const _Tp& __data, int __delta, ::cuda::std::integral_constant<int, _Width> __width)
 {
-  return ::cuda::device::warp_shuffle_up(__data, __src_lane, 0xFFFFFFFF, __width);
+  return ::cuda::device::warp_shuffle_up(__data, __delta, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up> warp_shuffle_down(
-  const _Tp& __data, int __delta, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
+  const _Tp& __data,
+  const int __delta,
+  const ::cuda::std::uint32_t __lane_mask     = 0xFFFFFFFF,
+  ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
@@ -167,10 +174,10 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
   else
   {
     _CCCL_ASSERT(__delta >= 1 && __delta < _Width, "delta must be in the range [1, _Width)");
-    constexpr int __ratio = ::cuda::ceil_div(sizeof(_Up), sizeof(uint32_t));
-    auto __clamp_segmask  = (_Width - 1u) | ((__warp_size - _Width) << 8);
+    constexpr int __ratio          = ::cuda::ceil_div(sizeof(_Up), sizeof(::cuda::std::uint32_t));
+    constexpr auto __clamp_segmask = (_Width - 1u) | ((__warp_size - _Width) << 8);
     bool __pred;
-    uint32_t __array[__ratio];
+    ::cuda::std::uint32_t __array[__ratio];
     ::cuda::std::memcpy(
       static_cast<void*>(__array), static_cast<const void*>(::cuda::std::addressof(__data)), sizeof(_Up));
 
@@ -188,15 +195,18 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 }
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Tp>
-warp_shuffle_down(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up>
+warp_shuffle_down(const _Tp& __data, const int __delta, ::cuda::std::integral_constant<int, _Width> __width)
 {
-  return ::cuda::device::warp_shuffle_down(__data, __src_lane, 0xFFFFFFFF, __width);
+  return ::cuda::device::warp_shuffle_down(__data, __delta, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up> warp_shuffle_xor(
-  const _Tp& __data, int __xor_mask, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
+  const _Tp& __data,
+  const int __xor_mask,
+  const ::cuda::std::uint32_t __lane_mask     = 0xFFFFFFFF,
+  ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
@@ -206,19 +216,19 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
                 "_Width must be a power of 2 and less or equal to the warp size");
   NV_IF_TARGET(NV_PROVIDES_SM_70,
                ([[maybe_unused]] int __pred1; _CCCL_ASSERT(::__match_all_sync(::__activemask(), __xor_mask, &__pred1),
-                                                           "all active lanes must have the same delta");))
+                                                           "all active lanes must have the same xor_mask");))
   if constexpr (_Width == 1)
   {
-    _CCCL_ASSERT(__xor_mask == 0, "delta must be 0 when Width == 1");
+    _CCCL_ASSERT(__xor_mask == 0, "xor_mask must be 0 when Width == 1");
     return warp_shuffle_result<_Up>{__data, true};
   }
   else
   {
-    _CCCL_ASSERT(__xor_mask >= 1 && __xor_mask < _Width, "delta must be in the range [1, _Width)");
-    constexpr int __ratio = ::cuda::ceil_div(sizeof(_Up), sizeof(uint32_t));
-    auto __clamp_segmask  = (_Width - 1u) | ((__warp_size - _Width) << 8);
+    _CCCL_ASSERT(__xor_mask >= 1 && __xor_mask < _Width, "xor_mask must be in the range [1, _Width)");
+    constexpr int __ratio          = ::cuda::ceil_div(sizeof(_Up), sizeof(::cuda::std::uint32_t));
+    constexpr auto __clamp_segmask = (_Width - 1u) | ((__warp_size - _Width) << 8);
     bool __pred;
-    uint32_t __array[__ratio];
+    ::cuda::std::uint32_t __array[__ratio];
     ::cuda::std::memcpy(
       static_cast<void*>(__array), static_cast<const void*>(::cuda::std::addressof(__data)), sizeof(_Up));
 
@@ -237,15 +247,14 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
 [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up>
-warp_shuffle_xor(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
+warp_shuffle_xor(const _Tp& __data, const int __xor_mask, ::cuda::std::integral_constant<int, _Width> __width)
 {
-  return ::cuda::device::warp_shuffle_xor(__data, __src_lane, 0xFFFFFFFF, __width);
+  return ::cuda::device::warp_shuffle_xor(__data, __xor_mask, 0xFFFFFFFF, __width);
 }
 
 _CCCL_END_NAMESPACE_CUDA_DEVICE
 
-#    include <cuda/std/__cccl/epilogue.h>
+#  include <cuda/std/__cccl/epilogue.h>
 
-#  endif // __cccl_ptx_isa >= 600
 #endif // _CCCL_CUDA_COMPILATION()
 #endif // _CUDA___WARP_WARP_SHUFFLE_H

--- a/libcudacxx/include/cuda/__warp/warp_shuffle.h
+++ b/libcudacxx/include/cuda/__warp/warp_shuffle.h
@@ -48,14 +48,15 @@ struct warp_shuffle_result
   bool pred;
 
   template <typename _Up = _Tp>
-  [[nodiscard]] _CCCL_DEVICE_API operator ::cuda::std::enable_if_t<!::cuda::std::is_array_v<_Up>, _Up>() const
+  [[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE
+  operator ::cuda::std::enable_if_t<!::cuda::std::is_array_v<_Up>, _Up>() const
   {
     return data;
   }
 };
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up> warp_shuffle_idx(
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up> warp_shuffle_idx(
   const _Tp& __data, int __src_lane, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
@@ -91,14 +92,14 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 }
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up>
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up>
 warp_shuffle_idx(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
 {
   return ::cuda::device::warp_shuffle_idx(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Tp> warp_shuffle_up(
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Tp> warp_shuffle_up(
   const _Tp& __data, int __delta, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
@@ -139,14 +140,14 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 }
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up>
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up>
 warp_shuffle_up(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
 {
   return ::cuda::device::warp_shuffle_up(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up> warp_shuffle_down(
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up> warp_shuffle_down(
   const _Tp& __data, int __delta, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
@@ -187,14 +188,14 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 }
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Tp>
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Tp>
 warp_shuffle_down(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
 {
   return ::cuda::device::warp_shuffle_down(__data, __src_lane, 0xFFFFFFFF, __width);
 }
 
 template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up> warp_shuffle_xor(
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up> warp_shuffle_xor(
   const _Tp& __data, int __xor_mask, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
   constexpr auto __warp_size   = 32u;
@@ -235,7 +236,7 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 }
 
 template <int _Width, typename _Tp, typename _Up = ::cuda::std::remove_cv_t<_Tp>>
-[[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up>
+[[nodiscard]] _CCCL_DEVICE_API _CCCL_FORCEINLINE warp_shuffle_result<_Up>
 warp_shuffle_xor(const _Tp& __data, int __src_lane, ::cuda::std::integral_constant<int, _Width> __width)
 {
   return ::cuda::device::warp_shuffle_xor(__data, __src_lane, 0xFFFFFFFF, __width);


### PR DESCRIPTION

## Description

Address the aliasing issue in:

-  #8117

Additionally, deprecate legacy shuffle functions in favor of new CUDA device APIs.
Notes: `SHFL` instruction counts are preserved, reduce benchmark kernels show significantly fewer instructions (up to 20%)