### PR TITLE
[libcu++] Add missing braces supression to other mempool types

### DIFF
--- a/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
@@ -36,6 +36,10 @@
 //! that allocates device memory in stream order.
 _CCCL_BEGIN_NAMESPACE_CUDA
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
+// clang complains about missing braces in CUmemLocation constructor but GCC complains if we add them
+
 //! @rst
 //! .. _libcudacxx-memory-resource-async:
 //!
@@ -155,6 +159,8 @@ private:
 static_assert(::cuda::mr::synchronous_resource_with<device_memory_pool_ref, ::cuda::mr::device_accessible>, "");
 
 static_assert(::cuda::mr::resource_with<device_memory_pool, ::cuda::mr::device_accessible>, "");
+
+_CCCL_DIAG_POP
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__memory_pool/managed_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/managed_memory_pool.h
@@ -34,6 +34,10 @@
 //! allocates managed memory.
 _CCCL_BEGIN_NAMESPACE_CUDA
 
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
+// clang complains about missing braces in CUmemLocation constructor but GCC complains if we add them
+
 //! @rst
 //! .. _libcudacxx-memory-resource-async:
 //!
@@ -150,6 +154,8 @@ static_assert(::cuda::mr::resource_with<managed_memory_pool_ref, ::cuda::mr::hos
 
 static_assert(::cuda::mr::resource_with<managed_memory_pool, ::cuda::mr::device_accessible>, "");
 static_assert(::cuda::mr::resource_with<managed_memory_pool, ::cuda::mr::host_accessible>, "");
+
+_CCCL_DIAG_POP
 
 _CCCL_END_NAMESPACE_CUDA
 


### PR DESCRIPTION
It seems the compiler have trouble with CUmemLocation initialization, the missing braces suppression was already added in other mempool files, this PR adds them to the rest of them.

NVBUG 5999870