### PR TITLE
Rename `with_{stream, memory_resource}` to `with(get_{stream, memory_resource}, `

### DIFF
--- a/libcudacxx/include/cuda/__execution/policy.h
+++ b/libcudacxx/include/cuda/__execution/policy.h
@@ -125,8 +125,8 @@ public:
 
   //! @brief Convert to a policy that holds a stream
   //! @note This cannot be merged with the other case where we already have a stream as this needs to be const qualified
-  //!       This is because we start with a constexpr global and modify that through with_stream
-  [[nodiscard]] _CCCL_HOST_API auto with_stream(::cuda::stream_ref __stream) const noexcept
+  //!       This is because we start with a constexpr global and modify that through with
+  [[nodiscard]] _CCCL_HOST_API auto with(const ::cuda::get_stream_t&, ::cuda::stream_ref __stream) const noexcept
   {
     constexpr uint32_t __new_policy = __set_cuda_backend_option<_Policy, __cuda_backend_options::__with_stream>;
     if constexpr (__cuda_policy_with_memory_resource<_Policy>)
@@ -150,13 +150,13 @@ public:
   //! @brief Convert to a policy that holds a memory resource
   //! @warning We hold the memory resource by reference, so passing rvalue is a bug
   template <class _Resource>
-  [[nodiscard]] _CCCL_HOST_API auto with_memory_resource(_Resource&&) const = delete;
+  [[nodiscard]] _CCCL_HOST_API auto with(const cuda::mr::get_memory_resource_t&, _Resource&&) const = delete;
 
   //! @brief Convert to a policy that holds a memory resource
   //! @note This cannot be merged with the other case as this needs to be const qualified
-  //!       This is because we start with a constexpr global and modify that through with_stream
+  //!       This is because we start with a constexpr global and modify that through with
   template <class _Resource>
-  [[nodiscard]] _CCCL_HOST_API auto with_memory_resource(_Resource& __resource) const noexcept
+  [[nodiscard]] _CCCL_HOST_API auto with(const cuda::mr::get_memory_resource_t&, _Resource& __resource) const noexcept
   {
     constexpr uint32_t __new_policy =
       __set_cuda_backend_option<_Policy, __cuda_backend_options::__with_memory_resource>;

--- a/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_memory_resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_memory_resource.pass.cpp
@@ -70,24 +70,24 @@ void test(Policy pol)
 
   { // Ensure that we can attach a memory resource to an execution policy
     test_resource resource{42};
-    auto pol_with_resource = pol.with_memory_resource(resource);
+    auto pol_with_resource = pol.with(cuda::mr::get_memory_resource, resource);
     assert(cuda::__call_or(::cuda::mr::get_memory_resource, fallback_resource, pol_with_resource) == resource);
     assert(cuda::__call_or(::cuda::get_stream, cuda::stream_ref{cudaStreamPerThread}, pol_with_resource) == old_stream);
 
     using policy_t = decltype(pol_with_resource);
-    static_assert(noexcept(pol.with_memory_resource(resource)));
+    static_assert(noexcept(pol.with(cuda::mr::get_memory_resource, resource)));
     static_assert(cuda::std::is_execution_policy_v<policy_t>);
   }
 
   { // Ensure that attaching a memory resource multiple times just overwrites the old one
     test_resource resource{42};
-    auto pol_with_resource = pol.with_memory_resource(resource);
+    auto pol_with_resource = pol.with(cuda::mr::get_memory_resource, resource);
     assert(cuda::__call_or(::cuda::mr::get_memory_resource, fallback_resource, pol_with_resource) == resource);
     assert(cuda::__call_or(::cuda::get_stream, cuda::stream_ref{cudaStreamPerThread}, pol_with_resource) == old_stream);
 
     using policy_t = decltype(pol_with_resource);
     test_resource other_resource{1337};
-    decltype(auto) pol_with_other_resource = pol_with_resource.with_memory_resource(other_resource);
+    decltype(auto) pol_with_other_resource = pol_with_resource.with(cuda::mr::get_memory_resource, other_resource);
     static_assert(cuda::std::is_same_v<decltype(pol_with_other_resource), policy_t>);
 
     // The original resource is unchanged
@@ -110,7 +110,7 @@ void test()
   test(cuda::execution::__cub_par_unseq);
 
   // Ensure that all works even if we have a stream attached
-  test(cuda::execution::__cub_par_unseq.with_stream(::cuda::stream{cuda::device_ref{0}}));
+  test(cuda::execution::__cub_par_unseq.with(cuda::get_stream, ::cuda::stream{cuda::device_ref{0}}));
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_stream.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/execution/execution_policy/get_stream.pass.cpp
@@ -34,22 +34,22 @@ void test(Policy pol)
 
   { // Ensure that we can attach a stream to an execution policy
     cuda::stream stream{cuda::device_ref{0}};
-    auto pol_with_stream = pol.with_stream(stream);
+    auto pol_with_stream = pol.with(cuda::get_stream, stream);
     assert(cuda::__call_or(::cuda::get_stream, default_stream, pol_with_stream) == stream);
 
     using stream_policy_t = decltype(pol_with_stream);
-    static_assert(noexcept(pol.with_stream(stream)));
+    static_assert(noexcept(pol.with(cuda::get_stream, stream)));
     static_assert(cuda::std::is_execution_policy_v<stream_policy_t>);
   }
 
   { // Ensure that attaching a stream multiple times just overwrites the old stream
     cuda::stream stream{cuda::device_ref{0}};
-    auto pol_with_stream = pol.with_stream(stream);
+    auto pol_with_stream = pol.with(cuda::get_stream, stream);
     assert(cuda::__call_or(::cuda::get_stream, default_stream, pol_with_stream) == stream);
 
     using stream_policy_t = decltype(pol_with_stream);
     cuda::stream other_stream{cuda::device_ref{0}};
-    decltype(auto) pol_with_other_stream = pol_with_stream.with_stream(other_stream);
+    decltype(auto) pol_with_other_stream = pol_with_stream.with(cuda::get_stream, other_stream);
     static_assert(cuda::std::is_same_v<decltype(pol_with_other_stream), stream_policy_t>);
 
     // The original stream remains unchanged
@@ -70,7 +70,7 @@ void test()
 
   // Ensure that all works even if we have a memory resource
   cuda::device_memory_pool_ref resource = ::cuda::device_default_memory_pool(::cuda::device_ref{0});
-  test(cuda::execution::__cub_par_unseq.with_memory_resource(resource));
+  test(cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, resource));
 }
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy.cu
@@ -63,7 +63,7 @@ C2H_TEST("cuda::std::copy", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
 
     test_copy(policy, input, output);
   }
@@ -71,7 +71,7 @@ C2H_TEST("cuda::std::copy", "[parallel algorithm]")
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
 
     test_copy(policy, input, output);
   }
@@ -80,7 +80,8 @@ C2H_TEST("cuda::std::copy", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
 
     test_copy(policy, input, output);
   }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy_if.cu
@@ -126,14 +126,14 @@ C2H_TEST("cuda::std::copy_if", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_copy_if(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_copy_if(policy, input, output);
   }
 
@@ -141,7 +141,8 @@ C2H_TEST("cuda::std::copy_if", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_copy_if(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy_n.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.copy/pstl_copy_n.cu
@@ -57,7 +57,7 @@ C2H_TEST("cuda::std::copy_n", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
 
     cuda::std::fill(policy, output.begin(), output.end(), -1);
     { // With non-contiguous iterator
@@ -75,7 +75,7 @@ C2H_TEST("cuda::std::copy_n", "[parallel algorithm]")
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
 
     cuda::std::fill(policy, output.begin(), output.end(), -1);
     { // With non-contiguous iterator
@@ -94,7 +94,8 @@ C2H_TEST("cuda::std::copy_n", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
 
     cuda::std::fill(policy, output.begin(), output.end(), -1);
     { // With non-contiguous iterator

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/pstl_fill.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/pstl_fill.cu
@@ -61,14 +61,14 @@ C2H_TEST("cuda::std::fill", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_fill(policy, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_fill(policy, output);
   }
 
@@ -76,7 +76,8 @@ C2H_TEST("cuda::std::fill", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_fill(policy, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/pstl_fill_n.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.fill/pstl_fill_n.cu
@@ -61,14 +61,14 @@ C2H_TEST("cuda::std::fill_n", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_fill_n(policy, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_fill_n(policy, output);
   }
 
@@ -76,7 +76,8 @@ C2H_TEST("cuda::std::fill_n", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_fill_n(policy, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate.cu
@@ -78,14 +78,14 @@ C2H_TEST("cuda::std::generate", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_generate(policy, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_generate(policy, output);
   }
 
@@ -93,7 +93,8 @@ C2H_TEST("cuda::std::generate", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_generate(policy, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate_n.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.generate/pstl_generate_n.cu
@@ -78,14 +78,14 @@ C2H_TEST("cuda::std::generate_n", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_generate_n(policy, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_generate_n(policy, output);
   }
 
@@ -93,7 +93,8 @@ C2H_TEST("cuda::std::generate_n", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_generate_n(policy, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove.cu
@@ -81,14 +81,14 @@ C2H_TEST("cuda::std::remove", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_remove(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_remove(policy, input);
   }
 
@@ -96,7 +96,8 @@ C2H_TEST("cuda::std::remove", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_remove(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy.cu
@@ -76,14 +76,14 @@ C2H_TEST("cuda::std::remove_copy", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_remove_copy(policy, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_remove_copy(policy, output);
   }
 
@@ -91,7 +91,8 @@ C2H_TEST("cuda::std::remove_copy", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_remove_copy(policy, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_copy_if.cu
@@ -83,14 +83,14 @@ C2H_TEST("cuda::std::remove_copy_if", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_remove_copy_if(policy, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_remove_copy_if(policy, output);
   }
 
@@ -98,7 +98,8 @@ C2H_TEST("cuda::std::remove_copy_if", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_remove_copy_if(policy, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.remove/pstl_remove_if.cu
@@ -76,14 +76,14 @@ C2H_TEST("cuda::std::remove_if", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_remove_if(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_remove_if(policy, input);
   }
 
@@ -91,7 +91,8 @@ C2H_TEST("cuda::std::remove_if", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_remove_if(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace.cu
@@ -71,14 +71,14 @@ C2H_TEST("cuda::std::replace", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_replace(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_replace(policy, input);
   }
 
@@ -86,7 +86,8 @@ C2H_TEST("cuda::std::replace", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_replace(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_copy.cu
@@ -91,14 +91,14 @@ C2H_TEST("cuda::std::replace_copy", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_replace_copy(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_replace_copy(policy, input);
   }
 
@@ -106,7 +106,8 @@ C2H_TEST("cuda::std::replace_copy", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_replace_copy(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_copy_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_copy_if.cu
@@ -101,14 +101,14 @@ C2H_TEST("cuda::std::replace_copy_if", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_replace_copy_if(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_replace_copy_if(policy, input);
   }
 
@@ -116,7 +116,8 @@ C2H_TEST("cuda::std::replace_copy_if", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_replace_copy_if(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.replace/pstl_replace_if.cu
@@ -79,14 +79,14 @@ C2H_TEST("cuda::std::replace_if", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_replace_if(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_replace_if(policy, input);
   }
 
@@ -94,7 +94,8 @@ C2H_TEST("cuda::std::replace_if", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_replace_if(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.reverse/pstl_reverse.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.reverse/pstl_reverse.cu
@@ -59,14 +59,14 @@ C2H_TEST("cuda::std::reverse", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_reverse(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_reverse(policy, input);
   }
 
@@ -74,7 +74,8 @@ C2H_TEST("cuda::std::reverse", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_reverse(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.reverse/pstl_reverse_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.reverse/pstl_reverse_copy.cu
@@ -87,14 +87,14 @@ C2H_TEST("cuda::std::reverse_copy", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_replace_copy(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_replace_copy(policy, input, output);
   }
 
@@ -102,7 +102,8 @@ C2H_TEST("cuda::std::reverse_copy", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_replace_copy(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.transform/pstl_binary_transform.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.transform/pstl_binary_transform.cu
@@ -107,14 +107,14 @@ C2H_TEST("cuda::std::transform", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_transform(policy, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_transform(policy, output);
   }
 
@@ -122,7 +122,8 @@ C2H_TEST("cuda::std::transform", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_transform(policy, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.transform/pstl_unary_transform.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.transform/pstl_unary_transform.cu
@@ -86,14 +86,14 @@ C2H_TEST("cuda::std::transform", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_transform(policy, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_transform(policy, output);
   }
 
@@ -101,7 +101,8 @@ C2H_TEST("cuda::std::transform", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_transform(policy, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique.cu
@@ -78,14 +78,14 @@ C2H_TEST("cuda::std::unique", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_unique(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_unique(policy, input);
   }
 
@@ -93,7 +93,8 @@ C2H_TEST("cuda::std::unique", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_unique(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_copy.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_copy.cu
@@ -87,14 +87,14 @@ C2H_TEST("cuda::std::unique_copy", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_unique_copy(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_unique_copy(policy, input, output);
   }
 
@@ -102,7 +102,8 @@ C2H_TEST("cuda::std::unique_copy", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_unique_copy(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_copy_pred.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_copy_pred.cu
@@ -103,14 +103,14 @@ C2H_TEST("cuda::std::unique_copy", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_unique_copy(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_unique_copy(policy, input, output);
   }
 
@@ -118,7 +118,8 @@ C2H_TEST("cuda::std::unique_copy", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_unique_copy(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_pred.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.modifying/alg.unique/pstl_unique_pred.cu
@@ -86,14 +86,14 @@ C2H_TEST("cuda::std::unique", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_unique(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_unique(policy, input);
   }
 
@@ -101,7 +101,8 @@ C2H_TEST("cuda::std::unique", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_unique(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl_adjacent_find.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl_adjacent_find.cu
@@ -66,14 +66,14 @@ C2H_TEST("cuda::std::adjacent_find(Iter, Iter)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_adjacent_find(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_adjacent_find(policy, input);
   }
 
@@ -81,7 +81,8 @@ C2H_TEST("cuda::std::adjacent_find(Iter, Iter)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_adjacent_find(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl_adjacent_find_pred.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.adjacent.find/pstl_adjacent_find_pred.cu
@@ -70,14 +70,14 @@ C2H_TEST("cuda::std::adjacent_find(Iter, Iter, comp)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_adjacent_find(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_adjacent_find(policy, input);
   }
 
@@ -85,7 +85,8 @@ C2H_TEST("cuda::std::adjacent_find(Iter, Iter, comp)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_adjacent_find(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.all_of/pstl_all_of.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.all_of/pstl_all_of.cu
@@ -84,14 +84,14 @@ C2H_TEST("cuda::std::all_of", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_all_of(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_all_of(policy);
   }
 
@@ -99,7 +99,8 @@ C2H_TEST("cuda::std::all_of", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_all_of(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.any_of/pstl_any_of.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.any_of/pstl_any_of.cu
@@ -84,14 +84,14 @@ C2H_TEST("cuda::std::any_of", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_any_of(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_any_of(policy);
   }
 
@@ -99,7 +99,8 @@ C2H_TEST("cuda::std::any_of", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_any_of(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.count/pstl_count.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.count/pstl_count.cu
@@ -61,14 +61,14 @@ C2H_TEST("cuda::std::count", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_count(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_count(policy);
   }
 
@@ -76,7 +76,8 @@ C2H_TEST("cuda::std::count", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_count(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.count/pstl_count_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.count/pstl_count_if.cu
@@ -70,14 +70,14 @@ C2H_TEST("cuda::std::count_if", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_count_if(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_count_if(policy);
   }
 
@@ -85,7 +85,8 @@ C2H_TEST("cuda::std::count_if", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_count_if(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/pstl_equal.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/pstl_equal.cu
@@ -66,14 +66,14 @@ C2H_TEST("cuda::std::equal(first1, last1, first2)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_equal(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_equal(policy);
   }
 
@@ -81,7 +81,8 @@ C2H_TEST("cuda::std::equal(first1, last1, first2)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_equal(policy);
   }
 }
@@ -141,14 +142,14 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, last2)", "[parallel algorithm]
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_equal2(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_equal2(policy);
   }
 
@@ -156,7 +157,8 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, last2)", "[parallel algorithm]
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_equal2(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/pstl_equal_pred.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.equal/pstl_equal_pred.cu
@@ -100,14 +100,14 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, pred)", "[parallel algorithm]"
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_equal(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_equal(policy);
   }
 
@@ -115,7 +115,8 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, pred)", "[parallel algorithm]"
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_equal(policy);
   }
 }
@@ -201,14 +202,14 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, last2, pred)", "[parallel algo
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_equal2(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_equal2(policy);
   }
 
@@ -216,7 +217,8 @@ C2H_TEST("cuda::std::equal(first1, last1, first2, last2, pred)", "[parallel algo
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_equal2(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find.cu
@@ -57,14 +57,14 @@ C2H_TEST("cuda::std::find", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_find(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_find(policy);
   }
 
@@ -72,7 +72,8 @@ C2H_TEST("cuda::std::find", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_find(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if.cu
@@ -58,14 +58,14 @@ C2H_TEST("cuda::std::find_if", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_find_if(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_find_if(policy);
   }
 
@@ -73,7 +73,8 @@ C2H_TEST("cuda::std::find_if", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_find_if(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if_not.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.find/pstl_find_if_not.cu
@@ -77,14 +77,14 @@ C2H_TEST("cuda::std::find_if_not", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_find_if_not(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_find_if_not(policy);
   }
 
@@ -92,7 +92,8 @@ C2H_TEST("cuda::std::find_if_not", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_find_if_not(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each.cu
@@ -74,14 +74,14 @@ C2H_TEST("cuda::std::for_each", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_for_each(policy, res);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_for_each(policy, res);
   }
 
@@ -89,7 +89,8 @@ C2H_TEST("cuda::std::for_each", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_for_each(policy, res);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each_n.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.for_each/pstl_for_each_n.cu
@@ -76,14 +76,14 @@ C2H_TEST("cuda::std::for_each_n", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_for_each_n(policy, res);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_for_each_n(policy, res);
   }
 
@@ -91,7 +91,8 @@ C2H_TEST("cuda::std::for_each_n", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_for_each_n(policy, res);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.mismatch/pstl_mismatch.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.mismatch/pstl_mismatch.cu
@@ -66,14 +66,14 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_mismatch(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_mismatch(policy);
   }
 
@@ -81,7 +81,8 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_mismatch(policy);
   }
 }
@@ -141,14 +142,14 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2, last2)", "[parallel algorit
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_mismatch2(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_mismatch2(policy);
   }
 
@@ -156,7 +157,8 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2, last2)", "[parallel algorit
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_mismatch2(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.mismatch/pstl_mismatch_pred.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.mismatch/pstl_mismatch_pred.cu
@@ -100,14 +100,14 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_mismatch(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_mismatch(policy);
   }
 
@@ -115,7 +115,8 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_mismatch(policy);
   }
 }
@@ -190,14 +191,14 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2, last2, pred)", "[parallel a
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_mismatch2(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_mismatch2(policy);
   }
 
@@ -205,7 +206,8 @@ C2H_TEST("cuda::std::mismatch(first1, last1, first2, last2, pred)", "[parallel a
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_mismatch2(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.none_of/pstl_none_of.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.nonmodifying/alg.none_of/pstl_none_of.cu
@@ -84,14 +84,14 @@ C2H_TEST("cuda::std::none_of", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_none_of(policy);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_none_of(policy);
   }
 
@@ -99,7 +99,8 @@ C2H_TEST("cuda::std::none_of", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_none_of(policy);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/pstl_merge.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/pstl_merge.cu
@@ -133,14 +133,14 @@ C2H_TEST("cuda::std::merge", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_merge(policy, in1, in2, out);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_merge(policy, in1, in2, out);
   }
 
@@ -148,7 +148,8 @@ C2H_TEST("cuda::std::merge", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_merge(policy, in1, in2, out);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/pstl_merge_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.merge/pstl_merge_comp.cu
@@ -149,14 +149,14 @@ C2H_TEST("cuda::std::merge", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_merge(policy, in1, in2, out);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_merge(policy, in1, in2, out);
   }
 
@@ -164,7 +164,8 @@ C2H_TEST("cuda::std::merge", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_merge(policy, in1, in2, out);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted.cu
@@ -83,14 +83,14 @@ C2H_TEST("cuda::std::is_sorted(iter, iter)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_is_sorted(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_is_sorted(policy, input);
   }
 
@@ -98,7 +98,8 @@ C2H_TEST("cuda::std::is_sorted(iter, iter)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_is_sorted(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_comp.cu
@@ -89,14 +89,14 @@ C2H_TEST("cuda::std::is_sorted(iter, iter, pred)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_is_sorted(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_is_sorted(policy, input);
   }
 
@@ -104,7 +104,8 @@ C2H_TEST("cuda::std::is_sorted(iter, iter, pred)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_is_sorted(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until.cu
@@ -84,14 +84,14 @@ C2H_TEST("cuda::std::is_sorted_until(iter, iter)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_is_sorted_until(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_is_sorted_until(policy, input);
   }
 
@@ -99,7 +99,8 @@ C2H_TEST("cuda::std::is_sorted_until(iter, iter)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_is_sorted_until(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/algorithms/alg.sorting/alg.sort/is.sorted/is_sorted_until_comp.cu
@@ -90,14 +90,14 @@ C2H_TEST("cuda::std::is_sorted_until(iter, iter, pred)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_is_sorted_until(policy, input);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_is_sorted_until(policy, input);
   }
 
@@ -105,7 +105,8 @@ C2H_TEST("cuda::std::is_sorted_until(iter, iter, pred)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_is_sorted_until(policy, input);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/pstl_adjacent_difference.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/pstl_adjacent_difference.cu
@@ -81,14 +81,14 @@ C2H_TEST("cuda::std::adjacent_difference(Iter1, Iter1, Iter2, Init)", "[parallel
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_adjacent_difference(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_adjacent_difference(policy, input, output);
   }
 
@@ -96,7 +96,8 @@ C2H_TEST("cuda::std::adjacent_difference(Iter1, Iter1, Iter2, Init)", "[parallel
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_adjacent_difference(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/pstl_adjacent_difference_comp.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/adjacent.difference/pstl_adjacent_difference_comp.cu
@@ -90,14 +90,14 @@ C2H_TEST("cuda::std::adjacent_difference(Iter1, Iter1, Iter2, Init)", "[parallel
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_adjacent_difference(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_adjacent_difference(policy, input, output);
   }
 
@@ -105,7 +105,8 @@ C2H_TEST("cuda::std::adjacent_difference(Iter1, Iter1, Iter2, Init)", "[parallel
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_adjacent_difference(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/pstl_exclusive_scan.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/pstl_exclusive_scan.cu
@@ -97,14 +97,14 @@ C2H_TEST("cuda::std::exclusive_scan(Iter1, Iter1, Iter2, Init)", "[parallel algo
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_exclusive_scan(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_exclusive_scan(policy, input, output);
   }
 
@@ -112,7 +112,8 @@ C2H_TEST("cuda::std::exclusive_scan(Iter1, Iter1, Iter2, Init)", "[parallel algo
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_exclusive_scan(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/pstl_exclusive_scan_init_op.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/exclusive.scan/pstl_exclusive_scan_init_op.cu
@@ -114,14 +114,14 @@ C2H_TEST("cuda::std::exclusive_scan(Iter1, Iter1, Iter2, Init)", "[parallel algo
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_exclusive_scan(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_exclusive_scan(policy, input, output);
   }
 
@@ -129,7 +129,8 @@ C2H_TEST("cuda::std::exclusive_scan(Iter1, Iter1, Iter2, Init)", "[parallel algo
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_exclusive_scan(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan.cu
@@ -82,14 +82,14 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2)", "[parallel algorithm]
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_inclusive_scan(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_inclusive_scan(policy, input, output);
   }
 
@@ -97,7 +97,8 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2)", "[parallel algorithm]
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_inclusive_scan(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan_op.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan_op.cu
@@ -109,14 +109,14 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2, Op)", "[parallel algori
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_inclusive_scan(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_inclusive_scan(policy, input, output);
   }
 
@@ -124,7 +124,8 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2, Op)", "[parallel algori
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_inclusive_scan(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan_op_init.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/inclusive.scan/pstl_inclusive_scan_op_init.cu
@@ -154,14 +154,14 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2, Op, Init)", "[parallel 
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_inclusive_scan(policy, input, output);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_inclusive_scan(policy, input, output);
   }
 
@@ -169,7 +169,8 @@ C2H_TEST("cuda::std::inclusive_scan(Iter1, Iter1, Iter2, Op, Init)", "[parallel 
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_inclusive_scan(policy, input, output);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/pstl_reduce.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/reduce/pstl_reduce.cu
@@ -71,14 +71,14 @@ C2H_TEST("cuda::std::reduce(Iter, Iter)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_reduce(policy, data);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_reduce(policy, data);
   }
 
@@ -86,7 +86,8 @@ C2H_TEST("cuda::std::reduce(Iter, Iter)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_reduce(policy, data);
   }
 }
@@ -137,14 +138,14 @@ C2H_TEST("cuda::std::reduce(Iter, Iter, Tp)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_reduce_init(policy, data);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_reduce_init(policy, data);
   }
 
@@ -152,7 +153,8 @@ C2H_TEST("cuda::std::reduce(Iter, Iter, Tp)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_reduce_init(policy, data);
   }
 }
@@ -213,14 +215,14 @@ C2H_TEST("cuda::std::reduce(Iter, Iter, Tp, Fn)", "[parallel algorithm]")
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_reduce_init_fn(policy, data);
   }
 
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_reduce_init_fn(policy, data);
   }
 
@@ -228,7 +230,8 @@ C2H_TEST("cuda::std::reduce(Iter, Iter, Tp, Fn)", "[parallel algorithm]")
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream).with_memory_resource(device_resource);
+    const auto policy                            = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream)
+                          .with(cuda::mr::get_memory_resource, device_resource);
     test_reduce_init_fn(policy, data);
   }
 }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/pstl_transform_reduce_binary.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/pstl_transform_reduce_binary.cu
@@ -119,7 +119,7 @@ C2H_TEST("cuda::std::transform_reduce(Iter1, Iter1, Iter2, Init)", "[parallel al
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_transform_reduce(policy, input1, input2.begin());
     test_transform_reduce(policy, input1, ::cuda::constant_iterator<int>{1});
   }
@@ -127,7 +127,7 @@ C2H_TEST("cuda::std::transform_reduce(Iter1, Iter1, Iter2, Init)", "[parallel al
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_transform_reduce(policy, input1, input2.begin());
     test_transform_reduce(policy, input1, ::cuda::constant_iterator<int>{1});
   }
@@ -136,7 +136,8 @@ C2H_TEST("cuda::std::transform_reduce(Iter1, Iter1, Iter2, Init)", "[parallel al
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_transform_reduce(policy, input1, input2.begin());
     test_transform_reduce(policy, input1, ::cuda::constant_iterator<int>{1});
   }

--- a/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/pstl_transform_reduce_unary.cu
+++ b/libcudacxx/test/libcudacxx/std/numerics/numeric.ops/transform.reduce/pstl_transform_reduce_unary.cu
@@ -96,7 +96,7 @@ C2H_TEST("cuda::std::transform_reduce(Iter1, Iter1, Iter2, Init)", "[parallel al
   SECTION("with provided stream")
   {
     cuda::stream stream{cuda::device_ref{0}};
-    const auto policy = cuda::execution::__cub_par_unseq.with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::get_stream, stream);
     test_transform_reduce(policy, input1.begin());
     test_transform_reduce(policy, ::cuda::counting_iterator<int>{1});
   }
@@ -104,7 +104,7 @@ C2H_TEST("cuda::std::transform_reduce(Iter1, Iter1, Iter2, Init)", "[parallel al
   SECTION("with provided memory_resource")
   {
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(cuda::device_ref{0});
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource);
     test_transform_reduce(policy, input1.begin());
     test_transform_reduce(policy, ::cuda::counting_iterator<int>{1});
   }
@@ -113,7 +113,8 @@ C2H_TEST("cuda::std::transform_reduce(Iter1, Iter1, Iter2, Init)", "[parallel al
   {
     cuda::stream stream{cuda::device_ref{0}};
     cuda::device_memory_pool_ref device_resource = cuda::device_default_memory_pool(stream.device());
-    const auto policy = cuda::execution::__cub_par_unseq.with_memory_resource(device_resource).with_stream(stream);
+    const auto policy = cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, device_resource)
+                          .with(cuda::get_stream, stream);
     test_transform_reduce(policy, input1.begin());
     test_transform_reduce(policy, ::cuda::counting_iterator<int>{1});
   }

--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -686,7 +686,7 @@ auto policy(caching_allocator_t& alloc)
 }
 auto cuda_policy(caching_allocator_t& alloc)
 {
-  return cuda::execution::__cub_par_unseq.with_memory_resource(alloc);
+  return cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, alloc);
 }
 #else
 auto policy(caching_allocator_t&)
@@ -702,7 +702,8 @@ auto policy(caching_allocator_t& alloc, nvbench::launch& launch)
 }
 auto cuda_policy(caching_allocator_t& alloc, nvbench::launch& launch)
 {
-  return cuda::execution::__cub_par_unseq.with_memory_resource(alloc).with_stream(launch.get_stream().get_stream());
+  return cuda::execution::__cub_par_unseq.with(cuda::mr::get_memory_resource, alloc)
+    .with(cuda::get_stream, launch.get_stream().get_stream());
 }
 #else
 auto policy(caching_allocator_t&, nvbench::launch&)


### PR DESCRIPTION
We want to use latter API because it is closer to the sender & receiver style
