### PR TITLE
Add `explicit bool` operator for `cuda::device::lane_mask`

### DIFF
--- a/docs/libcudacxx/extended_api/warp/lane_mask.rst
+++ b/docs/libcudacxx/extended_api/warp/lane_mask.rst
@@ -22,6 +22,7 @@ Defined in ``<cuda/warp>`` header.
 
         // conversion operators
         __device__ explicit constexpr operator cuda::std::uint32_t() const noexcept;
+        __device__ explicit constexpr operator bool() const noexcept;
 
         // static member functions
         [[nodiscard]] __device__ static constexpr lane_mask none() noexcept;

--- a/libcudacxx/include/cuda/__warp/lane_mask.h
+++ b/libcudacxx/include/cuda/__warp/lane_mask.h
@@ -63,6 +63,14 @@ public:
     return __value_;
   }
 
+  //! @brief Converts the lane mask to a bool.
+  //!
+  //! @return \c true if the mask is not zero, \c false otherwise.
+  _CCCL_DEVICE_API explicit constexpr operator bool() const noexcept
+  {
+    return __value_ != 0;
+  }
+
   //! @brief Returns a lane mask object with no lane bits set.
   //!
   //! @return A lane mask with no lane bits set.

--- a/libcudacxx/test/libcudacxx/cuda/warp/lane_mask.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/warp/lane_mask.pass.cpp
@@ -62,6 +62,16 @@ __device__ constexpr void test_conversion_operators()
     const auto value = static_cast<cuda::std::uint32_t>(lm);
     assert(lm.value() == value);
   }
+
+  // explicit conversion to bool
+  static_assert(cuda::std::is_constructible_v<bool, lane_mask>);
+  static_assert(!cuda::std::is_convertible_v<lane_mask, bool>);
+  static_assert(noexcept(lane_mask{}.operator bool()));
+  {
+    assert(!lane_mask::none());
+    assert(lane_mask{0x1});
+    assert(lane_mask::all());
+  }
 }
 
 __device__ constexpr void test_bitwise_operators()


### PR DESCRIPTION
It can be really useful for example `assert(my_lane_mask & cuda::device::lane_mask::this_lane())`.