### PR TITLE
Use `cuda::std::distance()` for zip iterator distance instead of operator-

### DIFF
--- a/thrust/thrust/iterator/zip_iterator.h
+++ b/thrust/thrust/iterator/zip_iterator.h
@@ -33,6 +33,7 @@
 #include <thrust/type_traits/integer_sequence.h>
 
 #include <cuda/std/__iterator/advance.h>
+#include <cuda/std/__iterator/distance.h>
 #include <cuda/std/__type_traits/conditional.h>
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/is_constructible.h>
@@ -293,7 +294,8 @@ private:
   inline _CCCL_HOST_DEVICE typename super_t::difference_type
   distance_to(const zip_iterator<OtherIteratorTuple>& other) const
   {
-    return ::cuda::std::get<0>(other.get_iterator_tuple()) - ::cuda::std::get<0>(get_iterator_tuple());
+    return ::cuda::std::distance(
+      ::cuda::std::get<0>(get_iterator_tuple()), ::cuda::std::get<0>(other.get_iterator_tuple()));
   }
 
   // The iterator tuple.


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
Not really sure how CI isn't catching this right now. My best guess is that GCC has special list iterators which secretly support random-access iteration.

The test which triggers this (very indirectly, via `thrust::uninitialized_fill()`) is `thrust/testing/vector.cu:TestVectorAssignFromBiDirectionalIterator()`. It triggers with `clang`.

Fix
```
  /home/coder/cccl/lib/cmake/thrust/../../../thrust/thrust/iterator/zip_iterator.h:296:60: error: invalid operands to binary expression ('const tuple_element_t<0UL, tuple<_List_iterator<custom_numeric>, custom_numeric *>>' (aka 'const std::_List_iterator<custom_numeric>') and 'const tuple_element_t<0UL, tuple<_List_iterator<custom_numeric>, custom_numeric *>>') [clang-diagnostic-error]
    296 |     return ::cuda::std::get<0>(other.get_iterator_tuple()) - ::cuda::std::get<0>(get_iterator_tuple());
        |            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  /home/coder/cccl/lib/cmake/thrust/../../../thrust/thrust/iterator/iterator_facade.h:239:16: note: in instantiation of function template specialization 'thrust::zip_iterator<cuda::std::tuple<std::_List_iterator<custom_numeric>, custom_numeric *>>::distance_to<cuda::std::tuple<std::_List_iterator<custom_numeric>, custom_numeric *>>' requested here
    239 |     return -f1.distance_to(f2);
        |                ^
  /home/coder/cccl/lib/cmake/thrust/../../../thrust/thrust/iterator/iterator_facade.h:257:12: note: in instantiation of function template specialization 'thrust::iterator_core_access::distance_from<thrust::zip_iterator<cuda::std::tuple<std::_List_iterator<custom_numeric>, custom_numeric *>>, thrust::zip_iterator<cuda::std::tuple<std::_List_iterator<custom_numeric>, custom_numeric *>>>' requested here
    257 |     return distance_from(f1, f2, typename ::cuda::std::is_convertible<Facade2, Facade1>::type());
        |            ^
  /home/coder/cccl/lib/cmake/thrust/../../../thrust/thrust/iterator/iterator_facade.h:615:33: note: in instantiation of function template specialization 'thrust::iterator_core_access::distance_from<thrust::zip_iterator<cuda::std::tuple<std::_List_iterator<custom_numeric>, custom_numeric *>>, thrust::zip_iterator<cuda::std::tuple<std::_List_iterator<custom_numeric>, custom_numeric *>>>' requested here
    615 |   return iterator_core_access ::distance_from(static_cast<Derived1 const&>(lhs), static_cast<Derived2 const&>(rhs));
        |                                 ^
  /home/coder/cccl/lib/cmake/libcudacxx/../../../libcudacxx/include/cuda/std/__iterator/distance.h:48:19: note: in instantiation of function template specialization 'thrust::operator-<thrust::zip_iterator<cuda::std::tuple<std::_List_iterator<custom_numeric>, custom_numeric *>>, cuda::std::tuple<custom_numeric, custom_numeric>, thrust::system::omp::detail::tag, thrust::bidirectional_traversal_tag, thrust::detail::tuple_of_iterator_references<custom_numeric &, custom_numeric &>, long, thrust::zip_iterator<cuda::std::tuple<std::_List_iterator<custom_numeric>, custom_numeric *>>, cuda::std::tuple<custom_numeric, custom_numeric>, thrust::system::omp::detail::tag, thrust::bidirectional_traversal_tag, thrust::detail::tuple_of_iterator_references<custom_numeric &, custom_numeric &>, long>' requested here
     48 |     return __last - __first;
        |                   ^
  /home/coder/cccl/lib/cmake/thrust/../../../thrust/thrust/detail/for_each.inl:47:10: note: in instantiation of function template specialization 'thrust::system::omp::detail::for_each<thrust::system::omp::detail::tag, thrust::zip_iterator<cuda::std::tuple<std::_List_iterator<custom_numeric>, custom_numeric *>>, thrust::detail::copy_construct_with_allocator<std::allocator<custom_numeric>, custom_numeric, custom_numeric>>' requested here
     47 |   return for_each(thrust::detail::derived_cast(thrust::detail::strip_const(exec)), first, last, f);
        |          ^
```

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
