### PR TITLE
Fix compilation error in thrust::find() benchmark

### DIFF
--- a/thrust/benchmarks/bench/find/basic.cu
+++ b/thrust/benchmarks/bench/find/basic.cu
@@ -4,7 +4,6 @@
 #include <thrust/device_vector.h>
 #include <thrust/find.h>
 
-#include <cuda/functional>
 #include <cuda/memory_pool>
 #include <cuda/stream>
 


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in 
the PR -->

Fix
```
/opt/compiler-explorer/libs/cccl/trunk/cub/cub/agent/agent_find.cuh(115): error: no instance of function template "thrust::_V_300400_SM_750::detail::functional::actor<Eval>::operator() [with Eval=thrust::_V_300400_SM_750::detail::functional::composite<thrust::_V_300400_SM_750::detail::functional::operator_adaptor<cuda::std::__4::equal_to<void>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::argument<0U>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::value<cuda::__4::equal_to_value<int>>>>]" matches the argument list
            argument types are: (InputT)
            object type is: thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::composite<thrust::_V_300400_SM_750::detail::functional::operator_adaptor<cuda::std::__4::equal_to<void>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::argument<0U>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::value<cuda::__4::equal_to_value<int>>>>>
        if (index < num_items && predicate(input_items[i]))
                                 ^
/opt/compiler-explorer/libs/cccl/trunk/thrust/thrust/detail/functional/actor.h(46): note #3327-D: candidate function template "thrust::_V_300400_SM_750::detail::functional::actor<Eval>::operator() [with Eval=thrust::_V_300400_SM_750::detail::functional::composite<thrust::_V_300400_SM_750::detail::functional::operator_adaptor<cuda::std::__4::equal_to<void>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::argument<0U>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::value<cuda::__4::equal_to_value<int>>>>]" failed deduction
                     auto operator()(Ts&&... ts) const -> decltype(Eval::eval(::cuda::std::forward<decltype(ts)>(ts)...))
                          ^
          detected during:
            instantiation of "__nv_bool cub::_V_300400_SM_750::detail::find::agent_t<BlockThreads, ItemsPerThread, VectorLoadLength, LoadModifier, InputIteratorT, OffsetT, PredicateT>::ConsumeTile(OffsetT, cuda::std::__4::integral_constant<__nv_bool, true>) [with BlockThreads=128, ItemsPerThread=16, VectorLoadLength=4, LoadModifier=cub::_V_300400_SM_750::LOAD_LDG, InputIteratorT=int *, OffsetT=uint32_t, PredicateT=thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::composite<thrust::_V_300400_SM_750::detail::functional::operator_adaptor<cuda::std::__4::equal_to<void>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::argument<0U>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::value<cuda::__4::equal_to_value<int>>>>>]" at line 184
            instantiation of "void cub::_V_300400_SM_750::detail::find::agent_t<BlockThreads, ItemsPerThread, VectorLoadLength, LoadModifier, InputIteratorT, OffsetT, PredicateT>::Process() [with BlockThreads=128, ItemsPerThread=16, VectorLoadLength=4, LoadModifier=cub::_V_300400_SM_750::LOAD_LDG, InputIteratorT=int *, OffsetT=uint32_t, PredicateT=thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::composite<thrust::_V_300400_SM_750::detail::functional::operator_adaptor<cuda::std::__4::equal_to<void>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::argument<0U>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::value<cuda::__4::equal_to_value<int>>>>>]" at line 74 of /opt/compiler-explorer/libs/cccl/trunk/cub/cub/device/dispatch/dispatch_find.cuh
            instantiation of "void cub::_V_300400_SM_750::detail::find::find_kernel<PolicySelector,IteratorT,OffsetT,PredicateT>(IteratorT, OffsetT, OffsetT *, PredicateT) [with PolicySelector=cub::_V_300400_SM_750::detail::find::policy_selector_from_types<int>, IteratorT=int *, OffsetT=uint32_t, PredicateT=thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::composite<thrust::_V_300400_SM_750::detail::functional::operator_adaptor<cuda::std::__4::equal_to<void>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::argument<0U>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::value<cuda::__4::equal_to_value<int>>>>>]" at line 142 of /opt/compiler-explorer/libs/cccl/trunk/cub/cub/device/dispatch/dispatch_find.cuh
            instantiation of "cudaError_t cub::_V_300400_SM_750::detail::find::dispatch(void *, size_t &, InputIteratorT, OutputIteratorT, OffsetT, PredicateT, cudaStream_t, PolicySelector) [with InputIteratorT=thrust::_V_300400_SM_750::detail::normal_iterator<thrust::_V_300400_SM_750::device_ptr<int>>, OutputIteratorT=uint32_t *, OffsetT=uint32_t, PredicateT=thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::composite<thrust::_V_300400_SM_750::detail::functional::operator_adaptor<cuda::std::__4::equal_to<void>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::argument<0U>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::value<cuda::__4::equal_to_value<int>>>>>, PolicySelector=cub::_V_300400_SM_750::detail::find::policy_selector_from_types<int>]" at line 108 of /opt/compiler-explorer/libs/cccl/trunk/cub/cub/device/device_find.cuh
            instantiation of "cudaError_t cub::_V_300400_SM_750::DeviceFind::FindIf(void *, size_t &, InputIteratorT, OutputIteratorT, ScanOpT, NumItemsT, cudaStream_t) [with InputIteratorT=thrust::_V_300400_SM_750::detail::normal_iterator<thrust::_V_300400_SM_750::device_ptr<int>>, OutputIteratorT=uint32_t *, ScanOpT=thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::composite<thrust::_V_300400_SM_750::detail::functional::operator_adaptor<cuda::std::__4::equal_to<void>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::argument<0U>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::value<cuda::__4::equal_to_value<int>>>>>, NumItemsT=int32_t]" at line 65 of /opt/compiler-explorer/libs/cccl/trunk/thrust/thrust/system/cuda/detail/find.h
            [ 2 instantiation contexts not shown ]
            instantiation of "InputIt thrust::_V_300400_SM_750::cuda_cub::find_if_n(thrust::_V_300400_SM_750::cuda_cub::execution_policy<Derived> &, InputIt, Size, Predicate) [with Derived=thrust::_V_300400_SM_750::cuda_cub::tag, InputIt=thrust::_V_300400_SM_750::detail::normal_iterator<thrust::_V_300400_SM_750::device_ptr<int>>, Size=std::ptrdiff_t, Predicate=thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::composite<thrust::_V_300400_SM_750::detail::functional::operator_adaptor<cuda::std::__4::equal_to<void>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::argument<0U>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::value<cuda::__4::equal_to_value<int>>>>>]" at line 108 of /opt/compiler-explorer/libs/cccl/trunk/thrust/thrust/system/cuda/detail/find.h
            instantiation of "InputIt thrust::_V_300400_SM_750::cuda_cub::find_if(thrust::_V_300400_SM_750::cuda_cub::execution_policy<Derived> &, InputIt, InputIt, Predicate) [with Derived=thrust::_V_300400_SM_750::cuda_cub::tag, InputIt=thrust::_V_300400_SM_750::detail::normal_iterator<thrust::_V_300400_SM_750::device_ptr<int>>, Predicate=thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::composite<thrust::_V_300400_SM_750::detail::functional::operator_adaptor<cuda::std::__4::equal_to<void>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::argument<0U>>, thrust::_V_300400_SM_750::detail::functional::actor<thrust::_V_300400_SM_750::detail::functional::value<cuda::__4::equal_to_value<int>>>>>]" at line 123 of /opt/compiler-explorer/libs/cccl/trunk/thrust/thrust/system/cuda/detail/find.h
            instantiation of "InputIt thrust::_V_300400_SM_750::cuda_cub::find(thrust::_V_300400_SM_750::cuda_cub::execution_policy<Derived> &, InputIt, InputIt, const T &) [with Derived=thrust::_V_300400_SM_750::cuda_cub::tag, InputIt=thrust::_V_300400_SM_750::detail::normal_iterator<thrust::_V_300400_SM_750::device_ptr<int>>, T=cuda::__4::equal_to_value<int>]" at line 44 of /opt/compiler-explorer/libs/cccl/trunk/thrust/thrust/detail/find.inl
            instantiation of "InputIterator thrust::_V_300400_SM_750::find(const thrust::_V_300400_SM_750::detail::execution_policy_base<DerivedPolicy> &, InputIterator, InputIterator, const T &) [with DerivedPolicy=thrust::_V_300400_SM_750::cuda_cub::tag, InputIterator=thrust::_V_300400_SM_750::detail::normal_iterator<thrust::_V_300400_SM_750::device_ptr<int>>, T=cuda::__4::equal_to_value<int>]" at line 83 of /opt/compiler-explorer/libs/cccl/trunk/thrust/thrust/detail/find.inl
            instantiation of "InputIterator thrust::_V_300400_SM_750::find(InputIterator, InputIterator, const T &) [with InputIterator=thrust::_V_300400_SM_750::detail::normal_iterator<thrust::_V_300400_SM_750::device_ptr<int>>, T=cuda::__4::equal_to_value<int>]" at line 9 of <source>
```

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
