### PR TITLE
Allow passing additional build options to the cmake build command

### DIFF
--- a/ci/build_common.sh
+++ b/ci/build_common.sh
@@ -337,6 +337,8 @@ function build_preset() {
     local green="1;32"
     local red="1;31"
     local GROUP_NAME="🏗️  Build ${BUILD_NAME}"
+    shift 2
+    local BUILD_OPTIONS=("$@")
 
     symlink_latest_preset "$PRESET"
 
@@ -362,7 +364,7 @@ function build_preset() {
 
     pushd .. > /dev/null
     status=0
-    run_ci_timed_command "$GROUP_NAME" cmake --build --preset="$PRESET" -v || status=$?
+    run_ci_timed_command "$GROUP_NAME" cmake --build --preset="$PRESET" -v "${BUILD_OPTIONS[@]}" || status=$?
     popd > /dev/null
 
     if [[ -n "${GITHUB_ACTIONS:-}" || -n "${MEMMON:-}" ]]; then


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Allows passing specific options through to `cmake --build` (such as tool specific ones like `-k 0`).

Currently this is only accessible by calling `build_preset` directly, since `configure_and_build_preset` will gobble any extra args and pass them to `configure_preset`.

Needed by https://github.com/NVIDIA/cccl/pull/8073

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
