### PR TITLE
Use cccl_add_executable() in more places

### DIFF
--- a/c/experimental/stf/test/CMakeLists.txt
+++ b/c/experimental/stf/test/CMakeLists.txt
@@ -10,8 +10,13 @@ function(cccl_c_experimental_stf_add_test target_name_var source)
   )
   set(target_name_var ${target_name} PARENT_SCOPE)
 
-  add_executable(${target_name} "${source}")
-  cccl_configure_target(${target_name} DIALECT 20)
+  cccl_add_executable(
+    ${target_name}
+    ADD_CTEST
+    NO_METATARGETS
+    DIALECT 20
+    SOURCES "${source}"
+  )
 
   set_target_properties(${target_name} PROPERTIES CUDA_RUNTIME_LIBRARY STATIC)
   target_link_libraries(
@@ -24,8 +29,6 @@ function(cccl_c_experimental_stf_add_test target_name_var source)
       cccl.c2h.main
       CUDA::cuda_driver
   )
-
-  add_test(NAME ${target_name} COMMAND ${target_name})
 endfunction()
 
 file(

--- a/c/parallel/test/CMakeLists.txt
+++ b/c/parallel/test/CMakeLists.txt
@@ -11,8 +11,13 @@ function(cccl_c_parallel_add_test target_name_var source)
   )
   set(target_name_var ${target_name} PARENT_SCOPE)
 
-  add_executable(${target_name} "${source}")
-  cccl_configure_target(${target_name} DIALECT 20)
+  cccl_add_executable(
+    ${target_name}
+    ADD_CTEST
+    NO_METATARGETS
+    DIALECT 20
+    SOURCES "${source}"
+  )
 
   set_target_properties(${target_name} PROPERTIES CUDA_RUNTIME_LIBRARY STATIC)
   target_link_libraries(
@@ -36,8 +41,6 @@ function(cccl_c_parallel_add_test target_name_var source)
       TEST_CTK_PATH="-I${CUDA_FIRST_INCLUDE_DIR}"
       TEST_INCLUDE_PATH="${CMAKE_CURRENT_SOURCE_DIR}"
   )
-
-  add_test(NAME ${target_name} COMMAND ${target_name})
 endfunction()
 
 file(

--- a/cmake/CCCLAddExecutable.cmake
+++ b/cmake/CCCLAddExecutable.cmake
@@ -8,7 +8,7 @@
 # which runs the executable with no arguments.
 function(cccl_add_executable target_name)
   set(options ADD_CTEST NO_METATARGETS)
-  set(oneValueArgs METATARGET_PATH)
+  set(oneValueArgs METATARGET_PATH DIALECT)
   set(multiValueArgs SOURCES)
   cmake_parse_arguments(
     _cccl
@@ -27,7 +27,13 @@ function(cccl_add_executable target_name)
   endif()
 
   add_executable(${target_name} ${_cccl_SOURCES})
-  cccl_configure_target(${target_name})
+
+  if (_cccl_DIALECT)
+    set(configure_args DIALECT "${_cccl_DIALECT}")
+  else()
+    set(configure_args)
+  endif()
+  cccl_configure_target(${target_name} ${configure_args})
 
   if (_cccl_ADD_CTEST)
     add_test(NAME ${target_name} COMMAND "$<TARGET_FILE:${target_name}>")

--- a/cub/benchmarks/CMakeLists.txt
+++ b/cub/benchmarks/CMakeLists.txt
@@ -72,8 +72,12 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  add_executable(${bench_target} "${bench_src}")
-  cccl_configure_target(${bench_target} DIALECT 17)
+  cccl_add_executable(
+    ${bench_target}
+    NO_METATARGETS
+    DIALECT 17
+    SOURCES "${bench_src}"
+  )
   target_link_libraries(
     ${bench_target}
     PRIVATE #

--- a/cub/test/CMakeLists.txt
+++ b/cub/test/CMakeLists.txt
@@ -197,11 +197,18 @@ function(
       endif()
     endif()
   else() # Not catch2:
-    cccl_add_executable(
-      ${test_target}
-      SOURCES "${test_src}"
-      NO_METATARGETS # Added manually for non-fail tests
-    )
+    _cub_is_fail_test(is_fail_test "${test_src}")
+
+    if (is_fail_test)
+      cccl_add_executable(${test_target} SOURCES "${test_src}" NO_METATARGETS)
+    else()
+      cccl_add_executable(
+        ${test_target}
+        SOURCES "${test_src}"
+        METATARGET_PATH ${metatarget_path}
+      )
+    endif()
+
     target_link_libraries(
       ${test_target}
       PRIVATE #
@@ -215,7 +222,6 @@ function(
       target_link_libraries(${test_target} PRIVATE nvtx3-cpp)
     endif()
 
-    _cub_is_fail_test(is_fail_test "${test_src}")
     if (is_fail_test)
       cccl_add_xfail_compile_target_test(
         ${test_target}
@@ -224,8 +230,6 @@ function(
         ERROR_NUMBER_TARGET_NAME_REGEX "\\.err_([0-9]+)"
       )
     else()
-      cccl_ensure_metatargets(${test_target} METATARGET_PATH ${metatarget_path})
-
       add_test(
         NAME ${test_target}
         # gersemi: off

--- a/cudax/benchmarks/CMakeLists.txt
+++ b/cudax/benchmarks/CMakeLists.txt
@@ -27,8 +27,12 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  add_executable(${bench_target} "${bench_src}")
-  cccl_configure_target(${bench_target} DIALECT 17)
+  cccl_add_executable(
+    ${bench_target}
+    NO_METATARGETS
+    DIALECT 17
+    SOURCES "${bench_src}"
+  )
   target_link_libraries(
     ${bench_target}
     PRIVATE #

--- a/libcudacxx/benchmarks/CMakeLists.txt
+++ b/libcudacxx/benchmarks/CMakeLists.txt
@@ -42,8 +42,12 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  add_executable(${bench_target} "${bench_src}")
-  cccl_configure_target(${bench_target} DIALECT 17)
+  cccl_add_executable(
+    ${bench_target}
+    NO_METATARGETS
+    DIALECT 17
+    SOURCES "${bench_src}"
+  )
   target_link_libraries(
     ${bench_target}
     PRIVATE libcudacxx::libcudacxx cccl.nvbench_helper nvbench::main

--- a/libcudacxx/test/libcudacxx/CMakeLists.txt
+++ b/libcudacxx/test/libcudacxx/CMakeLists.txt
@@ -25,8 +25,13 @@ if (NOT LIBCUDACXX_TEST_WITH_NVRTC)
     string(REGEX REPLACE "\\.[^.]+$" "" target_name "${target_name}")
     set(${target_name_var} ${target_name} PARENT_SCOPE)
 
-    add_executable(${target_name} "${source}")
-    cccl_configure_target(${target_name} DIALECT ${CMAKE_CUDA_STANDARD})
+    cccl_add_executable(
+      ${target_name}
+      ADD_CTEST
+      NO_METATARGETS
+      DIALECT ${CMAKE_CUDA_STANDARD}
+      SOURCES "${source}"
+    )
     target_include_directories(
       ${target_name}
       PRIVATE
@@ -45,8 +50,6 @@ if (NOT LIBCUDACXX_TEST_WITH_NVRTC)
     endif()
 
     add_dependencies(${c2h_all_target} ${target_name})
-
-    add_test(NAME ${target_name} COMMAND ${target_name})
   endfunction()
 
   foreach (test_src IN LISTS test_srcs)

--- a/nvbench_helper/CMakeLists.txt
+++ b/nvbench_helper/CMakeLists.txt
@@ -55,15 +55,18 @@ if (nvbench_helper_ENABLE_TESTING)
 
   function(add_nvbench_helper_test device_system)
     set(nvbench_helper_test_target nvbench_helper.test.${device_system})
-    add_executable(
+    cccl_add_executable(
       ${nvbench_helper_test_target}
-      test/gen_seed.cu
-      test/gen_range.cu
-      test/gen_entropy.cu
-      test/gen_uniform_distribution.cu
-      test/gen_power_law_distribution.cu
+      ADD_CTEST
+      NO_METATARGETS
+      DIALECT 17
+      SOURCES
+        test/gen_seed.cu
+        test/gen_range.cu
+        test/gen_entropy.cu
+        test/gen_uniform_distribution.cu
+        test/gen_power_law_distribution.cu
     )
-    cccl_configure_target(${nvbench_helper_test_target} DIALECT 17)
     target_link_libraries(
       ${nvbench_helper_test_target}
       PRIVATE
@@ -72,11 +75,6 @@ if (nvbench_helper_ENABLE_TESTING)
         cccl.nvbench_helper.test.Thrust.cpp.${device_system}
         Catch2::Catch2WithMain
         Boost::math
-    )
-
-    add_test(
-      NAME ${nvbench_helper_test_target}
-      COMMAND ${nvbench_helper_test_target}
     )
   endfunction()
 

--- a/thrust/benchmarks/CMakeLists.txt
+++ b/thrust/benchmarks/CMakeLists.txt
@@ -27,8 +27,12 @@ function(add_bench target_name bench_name bench_src)
   set(bench_target ${bench_name})
   set(${target_name} ${bench_target} PARENT_SCOPE)
 
-  add_executable(${bench_target} "${bench_src}")
-  cccl_configure_target(${bench_target} DIALECT 17)
+  cccl_add_executable(
+    ${bench_target}
+    NO_METATARGETS
+    DIALECT 17
+    SOURCES "${bench_src}"
+  )
   target_link_libraries(
     ${bench_target}
     PRIVATE #


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Use `cccl_add_executable()` in place of `add_executable()` -> `cccl_configure_target()` (and optionally `add_test()`).

Extracted out of https://github.com/NVIDIA/cccl/pull/8073 while that chugs along.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
