### PR TITLE
Only pass --extended-lambda and friends when NVCC is the device compiler

### DIFF
--- a/cub/benchmarks/CMakeLists.txt
+++ b/cub/benchmarks/CMakeLists.txt
@@ -97,7 +97,10 @@ function(add_bench_dir bench_dir)
     add_bench(base_bench_target ${base_bench_name} "${bench_src}")
     add_dependencies(${benches_meta_target} ${base_bench_target})
     target_compile_definitions(${base_bench_target} PRIVATE TUNE_BASE=1)
-    target_compile_options(${base_bench_target} PRIVATE "--extended-lambda")
+    target_compile_options(
+      ${base_bench_target}
+      PRIVATE "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>"
+    )
 
     if (CUB_ENABLE_TUNING)
       # tuning
@@ -115,7 +118,7 @@ function(add_bench_dir bench_dir)
       target_compile_options(
         ${bench_target}
         PRIVATE #
-          "--extended-lambda"
+          "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>"
           "-include${tuning_path}"
       )
     else()

--- a/cudax/benchmarks/CMakeLists.txt
+++ b/cudax/benchmarks/CMakeLists.txt
@@ -52,7 +52,10 @@ function(add_bench_dir bench_dir)
 
     add_bench(base_bench_target ${bench_name} "${bench_src}")
     target_link_libraries(${bench_name} PRIVATE cudax.compiler_interface)
-    target_compile_options(${bench_name} PRIVATE "--extended-lambda")
+    target_compile_options(
+      ${bench_name}
+      PRIVATE "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>"
+    )
   endforeach()
 endfunction()
 

--- a/examples/cudax_stf/CMakeLists.txt
+++ b/examples/cudax_stf/CMakeLists.txt
@@ -54,8 +54,8 @@ if (CMAKE_CUDA_COMPILER)
   target_compile_options(
     simple_stf
     PUBLIC
-      $<$<COMPILE_LANGUAGE:CUDA>:--expt-relaxed-constexpr>
-      $<$<COMPILE_LANGUAGE:CUDA>:--extended-lambda>
+      $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--expt-relaxed-constexpr>
+      $<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>
   )
 endif()
 

--- a/libcudacxx/benchmarks/CMakeLists.txt
+++ b/libcudacxx/benchmarks/CMakeLists.txt
@@ -65,7 +65,10 @@ function(add_bench_dir bench_dir)
     add_bench(base_bench_target ${base_bench_name} "${bench_src}")
     add_dependencies(${benches_meta_target} ${base_bench_target})
     target_compile_definitions(${base_bench_target} PRIVATE TUNE_BASE=1)
-    target_compile_options(${base_bench_target} PRIVATE "--extended-lambda")
+    target_compile_options(
+      ${base_bench_target}
+      PRIVATE "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>"
+    )
     # benchmarking
     register_cccl_benchmark("${bench_name}" "")
   endforeach()

--- a/thrust/benchmarks/CMakeLists.txt
+++ b/thrust/benchmarks/CMakeLists.txt
@@ -76,7 +76,10 @@ function(add_bench_dir bench_dir)
       target_link_libraries(${bench_name} PRIVATE ${thrust_target})
 
       if ("CUDA" STREQUAL "${config_device}")
-        target_compile_options(${bench_name} PRIVATE "--extended-lambda")
+        target_compile_options(
+          ${bench_name}
+          PRIVATE "$<$<COMPILE_LANG_AND_ID:CUDA,NVIDIA>:--extended-lambda>"
+        )
       endif()
     endforeach()
   endforeach()


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

`clang` does not understand `--extended-lambda` or `--relaxed-constexpr`, so only pass these flags when exactly `nvcc` is the compiler.

Needed by https://github.com/NVIDIA/cccl/pull/8073

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
