### PR TITLE
[libcu++] Fixes to memory resource inline docs

### DIFF
--- a/libcudacxx/include/cuda/__memory_resource/resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/resource.h
@@ -43,8 +43,8 @@ _CCCL_BEGIN_NAMESPACE_CUDA_MR
 //! @rst
 //! We require that a resource supports the following interface
 //!
-//!   - ``allocate(size_t bytes, size_t alignment)``
-//!   - ``deallocate(void* ptr, size_t bytes, size_t alignment)``
+//!   - ``allocate_sync(size_t bytes, size_t alignment)``
+//!   - ``deallocate_sync(void* ptr, size_t bytes, size_t alignment)``
 //!   - ``T() == T()``
 //!   - ``T() != T()``
 //!
@@ -62,8 +62,8 @@ _CCCL_CONCEPT synchronous_resource =
 //! @rst
 //! We require that an resource supports the following interface
 //!
-//!   - ``allocate(size_t bytes, size_t alignment)``
-//!   - ``deallocate(void* ptr, size_t bytes, size_t alignment)``
+//!   - ``allocate_sync(size_t bytes, size_t alignment)``
+//!   - ``deallocate_sync(void* ptr, size_t bytes, size_t alignment)``
 //!   - ``T() == T()``
 //!   - ``T() != T()``
 //!

--- a/libcudacxx/include/cuda/__memory_resource/shared_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/shared_resource.h
@@ -45,8 +45,10 @@ _CCCL_BEGIN_NAMESPACE_CUDA_MR
 //!
 //! ``shared_resource`` holds a reference counted instance of a memory resource. This allows
 //! the user to pass a resource around with reference semantics while avoiding lifetime issues.
+//! Shared resource works with both synchronous and stream-ordered resources. Depending if the contained resource
+//! satisfies the `cuda::mr::synchronous_resource` concept or the `cuda::mr::resource` concept, the shared resource
+//! will also satisfy the respective concept.
 //!
-//! @note ``shared_resource`` satisfies the ``cuda::mr::resource`` concept iff \tparam _Resource satisfies it.
 //! @tparam _Resource The resource type to hold.
 //! @endrst
 template <class _Resource>


### PR DESCRIPTION
1. It was not obvious `shared_resource` works for both `synchronous_resource` and `resource`
2. Resource concepts had a mistake in the inline doc