### PR TITLE
Disable cluster launch for groups test

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/this_group.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/this_group.cuh
@@ -63,13 +63,13 @@ _CCCL_DEVICE_API void __cluster_sync() noexcept
                     ({
                       if constexpr (_Aligned)
                       {
-                        ::__cluster_barrier_arrive();
-                        ::__cluster_barrier_wait();
+                        asm volatile("barrier.cluster.arrive.aligned;");
+                        asm volatile("barrier.cluster.wait.aligned;");
                       }
                       else
                       {
-                        asm volatile("barrier.cluster.arrive.aligned;");
-                        asm volatile("barrier.cluster.wait.aligned;");
+                        ::__cluster_barrier_arrive();
+                        ::__cluster_barrier_wait();
                       }
                     }),
                     ({ ::cuda::experimental::__block_sync<_Aligned>(); }))
@@ -292,12 +292,26 @@ public:
 
   _CCCL_DEVICE_API void sync() noexcept
   {
-    ::cuda::experimental::__cluster_sync<false>();
+    if constexpr (_Hierarchy::has_level(cluster))
+    {
+      ::cuda::experimental::__cluster_sync<false>();
+    }
+    else
+    {
+      ::cuda::experimental::__block_sync<false>();
+    }
   }
 
   _CCCL_DEVICE_API void sync_aligned() noexcept
   {
-    ::cuda::experimental::__cluster_sync<true>();
+    if constexpr (_Hierarchy::has_level(cluster))
+    {
+      ::cuda::experimental::__cluster_sync<true>();
+    }
+    else
+    {
+      ::cuda::experimental::__block_sync<true>();
+    }
   }
 
   [[nodiscard]] _CCCL_DEVICE_API const _Hierarchy& hierarchy() const noexcept

--- a/cudax/test/hierarchy/group.cu
+++ b/cudax/test/hierarchy/group.cu
@@ -322,7 +322,9 @@ C2H_TEST("Hierarchy groups", "[hierarchy]")
 
   const cuda::stream stream{device};
 
-  if (cuda::device_attributes::compute_capability(device) >= cuda::compute_capability{90})
+  // todo: investigate what causes cluster launches to hang, disable them temporarily
+  bool false_value = false;
+  if (false_value && cuda::device_attributes::compute_capability(device) >= cuda::compute_capability{90})
   {
     const auto config = cuda::make_config(
       cuda::grid_dims<2>(), cuda::cluster_dims<3>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
@@ -385,7 +387,9 @@ C2H_TEST("Groups interoperability with coopertive groups", "[hierarchy][cg_inter
 
   const cuda::stream stream{device};
 
-  if (cuda::device_attributes::compute_capability(device) >= cuda::compute_capability{90})
+  // todo: investigate what causes cluster launches to hang, disable them temporarily
+  bool false_value = false;
+  if (false_value && cuda::device_attributes::compute_capability(device) >= cuda::compute_capability{90})
   {
     const auto config = cuda::make_config(
       cuda::grid_dims<2>(), cuda::cluster_dims<3>(), cuda::block_dims<32>(), cuda::cooperative_launch{});


### PR DESCRIPTION
When clusters are launched, the test hangs. This PR disables cluster launches temporarily. However, we are still compiling everything.