### PR TITLE
Improve groups test

### DIFF
--- a/cudax/test/hierarchy/group.cu
+++ b/cudax/test/hierarchy/group.cu
@@ -14,10 +14,12 @@
 #include <cub/thread/thread_reduce.cuh>
 #include <cub/warp/warp_reduce.cuh>
 
+#include <cuda/atomic>
 #include <cuda/devices>
 #include <cuda/hierarchy>
 #include <cuda/launch>
 #include <cuda/std/optional>
+#include <cuda/std/type_traits>
 #include <cuda/std/utility>
 #include <cuda/stream>
 
@@ -26,6 +28,55 @@
 #include <cooperative_groups.h>
 
 #include "testing.cuh"
+
+__device__ unsigned global_var = 0;
+
+template <class Config, class Group>
+__device__ void test_common_properties(const Config&, Group& group)
+{
+  // Assert that Group satisfies the group concept.
+  static_assert(cudax::group<Group>);
+
+  // Test that the group can be queried for it's hierarchy.
+  {
+    using ExpectedHierarchy = typename Config::hierarchy_type;
+    static_assert(cuda::std::is_same_v<ExpectedHierarchy, typename Group::hierarchy_type>);
+
+    decltype(auto) hierarchy = cuda::std::as_const(group).hierarchy();
+    static_assert(cuda::std::is_same_v<decltype(hierarchy), const typename Config::hierarchy_type&>);
+  }
+
+  // Test that the group can be synchronized using .sync() method.
+  {
+    static_assert(cuda::std::is_same_v<void, decltype(group.sync())>);
+    static_assert(noexcept(group.sync()));
+
+    // .sync() method must support calls from different branches. Add some dummy work to make sure the branches are not
+    // collided.
+    cuda::atomic_ref<unsigned, cuda::thread_scope_device> atomic{global_var};
+    if (cuda::gpu_thread.rank(group) % 2 == 0)
+    {
+      atomic++;
+      group.sync();
+      atomic--;
+    }
+    else
+    {
+      atomic--;
+      group.sync();
+      atomic++;
+    }
+  }
+
+  // Test that the group can be synchronized using .sync_aligned() method.
+  {
+    static_assert(cuda::std::is_same_v<void, decltype(group.sync_aligned())>);
+    static_assert(noexcept(group.sync_aligned()));
+
+    // .sync_aligned() method must be called by all threads in the group uniformly in one place.
+    group.sync_aligned();
+  }
+}
 
 template <class Hierarchy, class T, cuda::std::size_t N>
 __device__ cuda::std::optional<T> sum(cudax::this_thread<Hierarchy> group, T (&array)[N])
@@ -114,26 +165,43 @@ __device__ cuda::std::optional<T> sum(cudax::this_cluster<Hierarchy> group, T (&
   return (cuda::gpu_thread.is_root_rank(group)) ? cuda::std::optional{result} : cuda::std::nullopt;
 }
 
+template <class Group>
+__device__ void test_cooperative_algorithm(Group& group)
+{
+  using Level = typename Group::level_type;
+
+  unsigned array[]{1, 2, 3};
+  const auto result = sum(group, array);
+
+  unsigned ref_sum = 6;
+  if constexpr (!cuda::std::is_same_v<Level, cuda::thread_level>)
+  {
+    ref_sum *= cuda::gpu_thread.count(Level{});
+  }
+
+  // Only the root rank should have the correct result.
+  if (cuda::gpu_thread.is_root_rank(group))
+  {
+    CUDAX_REQUIRE(result.has_value());
+    CUDAX_REQUIRE(result == ref_sum);
+  }
+  else
+  {
+    CUDAX_REQUIRE(!result.has_value());
+  }
+}
+
 struct TestKernel
 {
   template <class Config>
   __device__ void operator()(const Config& config)
   {
     {
-      unsigned array[]{1, 2, 3};
-
       cudax::this_thread this_thread{config};
-      static_assert(cudax::group<decltype(this_thread)>);
+      test_common_properties(config, this_thread);
+      test_cooperative_algorithm(this_thread);
 
-      this_thread.sync();
-      this_thread.sync_aligned();
-
-      decltype(auto) hierarchy = cuda::std::as_const(this_thread).hierarchy();
-      static_assert(cuda::std::is_same_v<decltype(hierarchy), const typename Config::hierarchy_type&>);
-
-      const auto result = sum(this_thread, array);
-      CUDAX_REQUIRE(result == 6);
-
+      // Test queries.
       CUDAX_REQUIRE(cuda::gpu_thread.count(this_thread) == 1);
       CUDAX_REQUIRE(this_thread.count(cuda::warp) == cuda::gpu_thread.count(cuda::warp));
       CUDAX_REQUIRE(this_thread.count(cuda::block) == cuda::gpu_thread.count(cuda::block));
@@ -151,28 +219,11 @@ struct TestKernel
       CUDAX_REQUIRE(cuda::gpu_thread.is_part_of(this_thread));
     }
     {
-      unsigned array[]{1, 2, 3};
-
       cudax::this_warp this_warp{config};
-      static_assert(cudax::group<decltype(this_warp)>);
+      test_common_properties(config, this_warp);
+      test_cooperative_algorithm(this_warp);
 
-      this_warp.sync();
-      this_warp.sync_aligned();
-
-      decltype(auto) hierarchy = cuda::std::as_const(this_warp).hierarchy();
-      static_assert(cuda::std::is_same_v<decltype(hierarchy), const typename Config::hierarchy_type&>);
-
-      const auto result = sum(this_warp, array);
-      if (cuda::gpu_thread.is_root_rank(this_warp))
-      {
-        CUDAX_REQUIRE(result.has_value());
-        CUDAX_REQUIRE(result == 6 * cuda::gpu_thread.count(cuda::warp));
-      }
-      else
-      {
-        CUDAX_REQUIRE(!result.has_value());
-      }
-
+      // Test queries.
       CUDAX_REQUIRE(cuda::gpu_thread.count(this_warp) == cuda::gpu_thread.count(cuda::warp));
       CUDAX_REQUIRE(cuda::warp.count(this_warp) == 1);
       CUDAX_REQUIRE(this_warp.count(cuda::block) == cuda::warp.count(cuda::block));
@@ -192,28 +243,11 @@ struct TestKernel
       CUDAX_REQUIRE(cuda::warp.is_part_of(this_warp));
     }
     {
-      unsigned array[]{1, 2, 3};
-
       cudax::this_block this_block{config};
-      static_assert(cudax::group<decltype(this_block)>);
+      test_common_properties(config, this_block);
+      test_cooperative_algorithm(this_block);
 
-      this_block.sync();
-      this_block.sync_aligned();
-
-      decltype(auto) hierarchy = cuda::std::as_const(this_block).hierarchy();
-      static_assert(cuda::std::is_same_v<decltype(hierarchy), const typename Config::hierarchy_type&>);
-
-      const auto result = sum(this_block, array);
-      if (cuda::gpu_thread.is_root_rank(this_block))
-      {
-        CUDAX_REQUIRE(result.has_value());
-        CUDAX_REQUIRE(result == 6 * cuda::gpu_thread.count(cuda::block));
-      }
-      else
-      {
-        CUDAX_REQUIRE(!result.has_value());
-      }
-
+      // Test queries.
       CUDAX_REQUIRE(cuda::gpu_thread.count(this_block) == cuda::gpu_thread.count(cuda::block));
       CUDAX_REQUIRE(cuda::warp.count(this_block) == cuda::warp.count(cuda::block));
       CUDAX_REQUIRE(cuda::block.count(this_block) == 1);
@@ -235,28 +269,11 @@ struct TestKernel
       CUDAX_REQUIRE(cuda::block.is_part_of(this_block));
     }
     {
-      unsigned array[]{1, 2, 3};
-
       cudax::this_cluster this_cluster{config};
-      static_assert(cudax::group<decltype(this_cluster)>);
+      test_common_properties(config, this_cluster);
+      test_cooperative_algorithm(this_cluster);
 
-      this_cluster.sync();
-      this_cluster.sync_aligned();
-
-      decltype(auto) hierarchy = cuda::std::as_const(this_cluster).hierarchy();
-      static_assert(cuda::std::is_same_v<decltype(hierarchy), const typename Config::hierarchy_type&>);
-
-      const auto result = sum(this_cluster, array);
-      if (cuda::gpu_thread.is_root_rank(this_cluster))
-      {
-        CUDAX_REQUIRE(result.has_value());
-        CUDAX_REQUIRE(result == 6 * cuda::gpu_thread.count(cuda::cluster));
-      }
-      else
-      {
-        CUDAX_REQUIRE(!result.has_value());
-      }
-
+      // Test queries.
       CUDAX_REQUIRE(cuda::gpu_thread.count(this_cluster) == cuda::gpu_thread.count(cuda::cluster));
       CUDAX_REQUIRE(cuda::warp.count(this_cluster) == cuda::warp.count(cuda::cluster));
       CUDAX_REQUIRE(cuda::block.count(this_cluster) == cuda::block.count(cuda::cluster));
@@ -281,14 +298,9 @@ struct TestKernel
     }
     {
       cudax::this_grid this_grid{config};
-      static_assert(cudax::group<decltype(this_grid)>);
+      test_common_properties(config, this_grid);
 
-      this_grid.sync();
-      this_grid.sync_aligned();
-
-      decltype(auto) hierarchy = cuda::std::as_const(this_grid).hierarchy();
-      static_assert(cuda::std::is_same_v<decltype(hierarchy), const typename Config::hierarchy_type&>);
-
+      // Test queries.
       CUDAX_REQUIRE(cuda::gpu_thread.count(this_grid) == cuda::gpu_thread.count(cuda::grid));
       CUDAX_REQUIRE(cuda::warp.count(this_grid) == cuda::warp.count(cuda::grid));
       CUDAX_REQUIRE(cuda::block.count(this_grid) == cuda::block.count(cuda::grid));
@@ -322,18 +334,16 @@ C2H_TEST("Hierarchy groups", "[hierarchy]")
 
   const cuda::stream stream{device};
 
+  const auto config = cuda::make_config(cuda::grid_dims<2>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
+  cuda::launch(stream, config, TestKernel{});
+
   // todo: investigate what causes cluster launches to hang, disable them temporarily
   bool false_value = false;
   if (false_value && cuda::device_attributes::compute_capability(device) >= cuda::compute_capability{90})
   {
-    const auto config = cuda::make_config(
+    const auto config_cluster = cuda::make_config(
       cuda::grid_dims<2>(), cuda::cluster_dims<3>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
-    cuda::launch(stream, config, TestKernel{});
-  }
-  else
-  {
-    const auto config = cuda::make_config(cuda::grid_dims<2>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
-    cuda::launch(stream, config, TestKernel{});
+    cuda::launch(stream, config_cluster, TestKernel{});
   }
 
   stream.sync();
@@ -387,18 +397,16 @@ C2H_TEST("Groups interoperability with coopertive groups", "[hierarchy][cg_inter
 
   const cuda::stream stream{device};
 
+  const auto config = cuda::make_config(cuda::grid_dims<2>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
+  cuda::launch(stream, config, TestKernel{});
+
   // todo: investigate what causes cluster launches to hang, disable them temporarily
   bool false_value = false;
   if (false_value && cuda::device_attributes::compute_capability(device) >= cuda::compute_capability{90})
   {
-    const auto config = cuda::make_config(
-      cuda::grid_dims<2>(), cuda::cluster_dims<3>(), cuda::block_dims<32>(), cuda::cooperative_launch{});
-    cuda::launch(stream, config, CgInteropKernel{});
-  }
-  else
-  {
-    const auto config = cuda::make_config(cuda::grid_dims<2>(), cuda::block_dims<32>(), cuda::cooperative_launch{});
-    cuda::launch(stream, config, CgInteropKernel{});
+    const auto config_cluster = cuda::make_config(
+      cuda::grid_dims<2>(), cuda::cluster_dims<3>(), cuda::block_dims<128>(), cuda::cooperative_launch{});
+    cuda::launch(stream, config_cluster, TestKernel{});
   }
 
   stream.sync();


### PR DESCRIPTION
This PR refactors and improves the groups test. Now, we test that `.sync()` doesn't suppose aligned threads. For architectures that support cluster launches, we also launch a kernel without cluster dimensions