### PR TITLE
`cuda::std::simd` load and store functionalities

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -523,6 +523,7 @@
         "libcudacxx.test.lit.precompile",
         "libcudacxx.test.nvtarget",
         "libcudacxx.test.atomics.ptx",
+        "libcudacxx.test.simd.ptx",
         "libcudacxx.test.c2h_all"
       ]
     },

--- a/libcudacxx/include/cuda/std/__simd/basic_vec.h
+++ b/libcudacxx/include/cuda/std/__simd/basic_vec.h
@@ -73,6 +73,14 @@ private:
   template <size_t, typename, typename>
   friend class basic_mask;
 
+  template <typename _Result, typename _Up, typename... _Flags>
+  _CCCL_HOST_DEVICE_API friend constexpr _Result
+  __partial_load_from_ptr(const _Up*, __simd_size_type, const typename _Result::mask_type&, flags<_Flags...>) noexcept;
+
+  template <typename _Result, typename _Up, typename... _Flags>
+  _CCCL_HOST_DEVICE_API friend constexpr _Result
+  __full_load_from_ptr(const _Up*, const typename _Result::mask_type&, flags<_Flags...>) noexcept;
+
   using _Impl    = __simd_operations<_Tp, _Abi>;
   using _Storage = typename _Impl::_SimdStorage;
 
@@ -82,7 +90,7 @@ private:
   {};
   static constexpr __storage_tag_t __storage_tag{};
 
-  _CCCL_HOST_DEVICE_API constexpr basic_vec(const _Storage __s, __storage_tag_t) noexcept
+  _CCCL_HOST_DEVICE_API constexpr basic_vec(const _Storage& __s, __storage_tag_t) noexcept
       : __s_{__s}
   {}
 
@@ -196,10 +204,12 @@ public:
   _CCCL_REQUIRES(__is_compatible_range<_Range>)
   _CCCL_HOST_DEVICE_API constexpr basic_vec(_Range&& __range, flags<_Flags...> = {})
   {
-    static_assert(__has_convert_flag_v<_Flags...> || __is_value_preserving_v<ranges::range_value_t<_Range>, value_type>,
+    static_assert(__has_convert_flag_v<_Flags...>
+                    || __is_value_preserving_v<::cuda::std::ranges::range_value_t<_Range>, value_type>,
                   "Conversion from range_value_t<R> to value_type is not value-preserving; use flag_convert");
     const auto __data = ::cuda::std::ranges::__data_cpo{}(__range);
-    __assert_load_store_alignment<basic_vec, ranges::range_value_t<_Range>, _Flags...>(__data);
+    ::cuda::std::simd::__assert_load_store_alignment<basic_vec, ::cuda::std::ranges::range_value_t<_Range>, _Flags...>(
+      __data);
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < __size; ++__i)
     {
@@ -212,10 +222,12 @@ public:
   _CCCL_REQUIRES(__is_compatible_range<_Range>)
   _CCCL_HOST_DEVICE_API constexpr basic_vec(_Range&& __range, const mask_type& __mask, flags<_Flags...> = {})
   {
-    static_assert(__has_convert_flag_v<_Flags...> || __is_value_preserving_v<ranges::range_value_t<_Range>, value_type>,
+    static_assert(__has_convert_flag_v<_Flags...>
+                    || __is_value_preserving_v<::cuda::std::ranges::range_value_t<_Range>, value_type>,
                   "Conversion from range_value_t<R> to value_type is not value-preserving; use flag_convert");
     const auto __data = ::cuda::std::ranges::__data_cpo{}(__range);
-    __assert_load_store_alignment<basic_vec, ranges::range_value_t<_Range>, _Flags...>(__data);
+    ::cuda::std::simd::__assert_load_store_alignment<basic_vec, ::cuda::std::ranges::range_value_t<_Range>, _Flags...>(
+      __data);
     _CCCL_PRAGMA_UNROLL_FULL()
     for (__simd_size_type __i = 0; __i < __size; ++__i)
     {
@@ -548,16 +560,16 @@ public:
 };
 
 // [simd.ctor] deduction guide from contiguous sized range
-// Deduces vec<range_value_t<R>, static_cast<simd-size-type>(ranges::size(r))>
+// Deduces vec<range_value_t<R>, static_cast<simd-size-type>(::cuda::std::ranges::size(r))>
 //    * it is not possible to use the alias "vec" for the deduction guide
 //    * "vec" is defined as basic_vec<_Tp, __deduce_abi_t<_Tp, _Np>>
 //    * where _Np is __simd_size_v<_Tp, __static_range_size_v<_Range>>
 _CCCL_TEMPLATE(typename _Range, typename... _Ts)
-_CCCL_REQUIRES(
-  ranges::contiguous_range<_Range> _CCCL_AND ranges::sized_range<_Range> _CCCL_AND __has_static_size<_Range>)
+_CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range> _CCCL_AND ::cuda::std::ranges::sized_range<_Range>
+                 _CCCL_AND __has_static_size<_Range>)
 _CCCL_DEDUCTION_GUIDE_ATTRIBUTES basic_vec(_Range&&, _Ts...)
-  -> basic_vec<ranges::range_value_t<_Range>,
-               __deduce_abi_t<ranges::range_value_t<_Range>, __static_range_size_v<_Range>>>;
+  -> basic_vec<::cuda::std::ranges::range_value_t<_Range>,
+               __deduce_abi_t<::cuda::std::ranges::range_value_t<_Range>, __static_range_size_v<_Range>>>;
 
 // [simd.ctor] deduction guide from basic_mask
 // basic_vec<__integer_from<Bytes>, Abi> is equivalent to decltype(+k):

--- a/libcudacxx/include/cuda/std/__simd/load.h
+++ b/libcudacxx/include/cuda/std/__simd/load.h
@@ -1,0 +1,355 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___SIMD_LOAD_H
+#define _CUDA_STD___SIMD_LOAD_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__memory/is_valid_alignment.h>
+#include <cuda/__memory/ptr_rebind.h>
+#include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__concepts/same_as.h>
+#include <cuda/std/__cstring/memcpy.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/distance.h>
+#include <cuda/std/__iterator/incrementable_traits.h>
+#include <cuda/std/__iterator/readable_traits.h>
+#include <cuda/std/__memory/assume_aligned.h>
+#include <cuda/std/__memory/pointer_traits.h>
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__ranges/data.h>
+#include <cuda/std/__ranges/size.h>
+#include <cuda/std/__simd/basic_vec.h>
+#include <cuda/std/__simd/concepts.h>
+#include <cuda/std/__simd/flag.h>
+#include <cuda/std/__simd/utility.h>
+#include <cuda/std/__type_traits/remove_cvref.h>
+#include <cuda/std/__utility/cmp.h>
+#include <cuda/std/__utility/forward.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_SIMD
+
+// [simd.loadstore] helper: resolves default V template parameter for load functions
+// When _Vp = void (default), resolves to basic_vec<_Up>; otherwise uses the explicit _Vp
+template <typename _Vp, typename _Up>
+struct __load_vec_type
+{
+  using type = _Vp;
+};
+
+template <typename _Up>
+struct __load_vec_type<void, _Up>
+{
+  using type = basic_vec<_Up>;
+};
+
+template <typename _Vp, typename _Up>
+using __load_vec_t = typename __load_vec_type<_Vp, _Up>::type;
+
+template <typename _Result, typename _Up, typename... _Flags>
+_CCCL_HOST_DEVICE_API constexpr void
+__check_load_preconditions(const _Up* __ptr, flags<_Flags...>, const __simd_size_type __count = 1) noexcept
+{
+  using __value_t = typename _Result::value_type;
+  static_assert(same_as<remove_cvref_t<_Result>, _Result>, "V must not be a reference or cv-qualified type");
+
+  static_assert(__is_vectorizable_v<__value_t> && __is_enabled_abi_v<typename _Result::abi_type>,
+                "cuda::std::simd::load: V must be an enabled specialization of basic_vec");
+  static_assert(__is_vectorizable_v<_Up>, "range_value_t<R> must be a vectorizable type");
+
+  static_assert(__explicitly_convertible_to<_Up, __value_t>,
+                "cuda::std::simd::load: range_value_t<R> must satisfy explicitly-convertible-to<value_type>");
+
+  static_assert(__has_convert_flag_v<_Flags...> || __is_value_preserving_v<_Up, __value_t>,
+                "cuda::std::simd::load: Conversion from range_value_t<R> to value_type is not value-preserving; use "
+                "flag_convert");
+
+  _CCCL_ASSERT(__count == 0 || __ptr != nullptr, "cuda::std::simd::load: range data is nullptr");
+  ::cuda::std::simd::__assert_load_store_alignment<_Result, _Up, _Flags...>(__ptr);
+}
+
+// [simd.loadstore] helper: core partial load from pointer + count + mask
+template <typename _Result, typename _Up, typename... _Flags>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Result __partial_load_from_ptr(
+  const _Up* __ptr,
+  const __simd_size_type __count,
+  const typename _Result::mask_type& __mask,
+  flags<_Flags...> __flags = {}) noexcept
+{
+  using __value_t = typename _Result::value_type;
+  ::cuda::std::simd::__check_load_preconditions<_Result>(__ptr, __flags, __count);
+  constexpr auto __simd_size = _Result::__size;
+
+  _Result __result;
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (__simd_size_type __i = 0; __i < __simd_size; ++__i)
+  {
+    const auto __value = (__mask[__i] && __i < __count) ? static_cast<__value_t>(__ptr[__i]) : __value_t{};
+    __result.__set(__i, __value);
+  }
+  return __result;
+}
+
+template <typename _Result, typename _Up, typename... _Flags>
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr _Result
+__full_load_from_ptr(const _Up* __ptr, const typename _Result::mask_type& __mask, flags<_Flags...> __flags) noexcept
+{
+  ::cuda::std::simd::__check_load_preconditions<_Result>(__ptr, __flags);
+  constexpr bool __has_aligned_flag = __has_aligned_flag_v<_Flags...>;
+
+  if constexpr (__has_aligned_flag || __has_overaligned_flag_v<_Flags...>)
+  {
+    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+    {
+      // minimum condition for pointer alignment
+      constexpr auto __base_alignment = __has_aligned_flag ? alignment_v<_Result, _Up> : alignof(_Up);
+      constexpr auto __ptr_alignment  = ::cuda::std::max(__base_alignment, __overaligned_value_v<_Flags...>);
+      constexpr auto __simd_size      = _Result::__size;
+      constexpr auto __data_size      = __simd_size * sizeof(_Up);
+
+      _Up __tmp[__simd_size]{};
+      // vectorized load from pointer
+      if constexpr (__is_cuda_vectorizable_v<_Up> && __simd_size > 1 && __ptr_alignment >= __data_size
+                    && ::cuda::__is_valid_alignment(__data_size))
+      {
+        struct alignas(__data_size) __aligned_t
+        {
+          _Up __data[__simd_size];
+        };
+        // nvcc performance bug: memcpy from pointer could not be vectorized
+        const auto __aligned_ptr = ::cuda::ptr_rebind<__aligned_t>(__ptr);
+        const auto __data        = *::cuda::std::assume_aligned<__ptr_alignment>(__aligned_ptr);
+        ::cuda::std::memcpy(&__tmp, &__data, sizeof(__tmp));
+      }
+      // rely on compiler vectorization
+      else
+      {
+        const auto __aligned_ptr = ::cuda::std::assume_aligned<__ptr_alignment>(__ptr);
+        _CCCL_PRAGMA_UNROLL_FULL()
+        for (__simd_size_type __i = 0; __i < __simd_size; ++__i)
+        {
+          __tmp[__i] = __aligned_ptr[__i];
+        }
+      }
+      using __value_t = typename _Result::value_type;
+      _Result __result;
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (__simd_size_type __i = 0; __i < __simd_size; ++__i)
+      {
+        const auto __value = (!__mask[__i]) ? __value_t{} : static_cast<__value_t>(__tmp[__i]);
+        __result.__set(__i, __value);
+      }
+      return __result;
+    }
+  }
+  return ::cuda::std::simd::__partial_load_from_ptr<_Result>(__ptr, _Result::__size, __mask, __flags);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// [simd.loadstore] partial_load
+
+// partial_load: range, masked
+_CCCL_TEMPLATE(typename _Vp = void, typename _Range, typename... _Flags)
+_CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range> _CCCL_AND ::cuda::std::ranges::sized_range<_Range>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, ::cuda::std::ranges::range_value_t<_Range>>
+partial_load(_Range&& __r,
+             const typename __load_vec_t<_Vp, ::cuda::std::ranges::range_value_t<_Range>>::mask_type& __mask,
+             flags<_Flags...> __f = {})
+{
+  using __result_t        = __load_vec_t<_Vp, ::cuda::std::ranges::range_value_t<_Range>>;
+  const auto __range_size = ::cuda::std::ranges::size(__r);
+  _CCCL_ASSERT(::cuda::std::in_range<__simd_size_type>(__range_size),
+               "cuda::std::simd::partial_load: range size out of range");
+  const auto __size = static_cast<__simd_size_type>(__range_size);
+
+  return ::cuda::std::simd::__partial_load_from_ptr<__result_t>(::cuda::std::ranges::data(__r), __size, __mask, __f);
+}
+
+// partial_load: range, no mask
+_CCCL_TEMPLATE(typename _Vp = void, typename _Range, typename... _Flags)
+_CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range> _CCCL_AND ::cuda::std::ranges::sized_range<_Range>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, ::cuda::std::ranges::range_value_t<_Range>>
+partial_load(_Range&& __r, flags<_Flags...> __f = {})
+{
+  using __result_t           = __load_vec_t<_Vp, ::cuda::std::ranges::range_value_t<_Range>>;
+  constexpr auto __true_mask = typename __result_t::mask_type(true);
+
+  return ::cuda::std::simd::partial_load<_Vp>(::cuda::std::forward<_Range>(__r), __true_mask, __f);
+}
+
+// partial_load: iterator + count, masked
+_CCCL_TEMPLATE(typename _Vp = void, typename _Ip, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, iter_value_t<_Ip>> partial_load(
+  const _Ip __first,
+  const iter_difference_t<_Ip> __n,
+  const typename __load_vec_t<_Vp, iter_value_t<_Ip>>::mask_type& __mask,
+  flags<_Flags...> __f = {})
+{
+  using __result_t = __load_vec_t<_Vp, iter_value_t<_Ip>>;
+  _CCCL_ASSERT(::cuda::std::in_range<__simd_size_type>(__n), "cuda::std::simd::partial_load: n out of range");
+  const auto __ptr  = ::cuda::std::to_address(__first);
+  const auto __size = static_cast<__simd_size_type>(__n);
+
+  return ::cuda::std::simd::__partial_load_from_ptr<__result_t>(__ptr, __size, __mask, __f);
+}
+
+// partial_load: iterator + count, no mask
+_CCCL_TEMPLATE(typename _Vp = void, typename _Ip, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, iter_value_t<_Ip>>
+partial_load(const _Ip __first, const iter_difference_t<_Ip> __n, flags<_Flags...> __f = {})
+{
+  using __result_t           = __load_vec_t<_Vp, iter_value_t<_Ip>>;
+  constexpr auto __true_mask = typename __result_t::mask_type(true);
+
+  return ::cuda::std::simd::partial_load<_Vp>(__first, __n, __true_mask, __f);
+}
+
+// partial_load: iterator + sentinel, masked
+_CCCL_TEMPLATE(typename _Vp = void, typename _Ip, typename _Sp, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip> _CCCL_AND sized_sentinel_for<_Sp, _Ip>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, iter_value_t<_Ip>> partial_load(
+  const _Ip __first,
+  const _Sp __last,
+  const typename __load_vec_t<_Vp, iter_value_t<_Ip>>::mask_type& __mask,
+  flags<_Flags...> __f = {})
+{
+  using __result_t      = __load_vec_t<_Vp, iter_value_t<_Ip>>;
+  const auto __ptr      = ::cuda::std::to_address(__first);
+  const auto __distance = ::cuda::std::distance(__first, __last);
+  _CCCL_ASSERT(::cuda::std::in_range<__simd_size_type>(__distance),
+               "cuda::std::simd::partial_load: distance(first, last) out of range");
+  const auto __size = static_cast<__simd_size_type>(__distance);
+
+  return ::cuda::std::simd::__partial_load_from_ptr<__result_t>(__ptr, __size, __mask, __f);
+}
+
+// partial_load: iterator + sentinel, no mask
+_CCCL_TEMPLATE(typename _Vp = void, typename _Ip, typename _Sp, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip> _CCCL_AND sized_sentinel_for<_Sp, _Ip>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, iter_value_t<_Ip>>
+partial_load(const _Ip __first, const _Sp __last, flags<_Flags...> __f = {})
+{
+  using __result_t           = __load_vec_t<_Vp, iter_value_t<_Ip>>;
+  constexpr auto __true_mask = typename __result_t::mask_type(true);
+
+  return ::cuda::std::simd::partial_load<_Vp>(__first, __last, __true_mask, __f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// [simd.loadstore] unchecked_load
+
+// unchecked_load: range, masked
+_CCCL_TEMPLATE(typename _Vp = void, typename _Range, typename... _Flags)
+_CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range> _CCCL_AND ::cuda::std::ranges::sized_range<_Range>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, ::cuda::std::ranges::range_value_t<_Range>>
+unchecked_load(_Range&& __r,
+               const typename __load_vec_t<_Vp, ::cuda::std::ranges::range_value_t<_Range>>::mask_type& __mask,
+               flags<_Flags...> __f = {})
+{
+  using __result_t = __load_vec_t<_Vp, ::cuda::std::ranges::range_value_t<_Range>>;
+  if constexpr (__has_static_size<_Range>)
+  {
+    static_assert(__static_range_size_v<_Range> >= __result_t::__size,
+                  "cuda::std::simd::unchecked_load: requires ::cuda::std::ranges::size(r) >= V::size()");
+  }
+  _CCCL_ASSERT(::cuda::std::cmp_greater_equal(::cuda::std::ranges::size(__r), __result_t::__size),
+               "cuda::std::simd::unchecked_load: requires ::cuda::std::ranges::size(r) >= V::size()");
+
+  return ::cuda::std::simd::__full_load_from_ptr<__result_t>(::cuda::std::ranges::data(__r), __mask, __f);
+}
+
+// unchecked_load: range, no mask
+_CCCL_TEMPLATE(typename _Vp = void, typename _Range, typename... _Flags)
+_CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range> _CCCL_AND ::cuda::std::ranges::sized_range<_Range>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, ::cuda::std::ranges::range_value_t<_Range>>
+unchecked_load(_Range&& __r, flags<_Flags...> __f = {})
+{
+  using __result_t           = __load_vec_t<_Vp, ::cuda::std::ranges::range_value_t<_Range>>;
+  constexpr auto __true_mask = typename __result_t::mask_type(true);
+
+  return ::cuda::std::simd::unchecked_load<_Vp>(::cuda::std::forward<_Range>(__r), __true_mask, __f);
+}
+
+// unchecked_load: iterator + count, masked
+_CCCL_TEMPLATE(typename _Vp = void, typename _Ip, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, iter_value_t<_Ip>> unchecked_load(
+  const _Ip __first,
+  const iter_difference_t<_Ip> __n,
+  const typename __load_vec_t<_Vp, iter_value_t<_Ip>>::mask_type& __mask,
+  flags<_Flags...> __f = {})
+{
+  using __result_t = __load_vec_t<_Vp, iter_value_t<_Ip>>;
+  _CCCL_ASSERT(::cuda::std::cmp_greater_equal(__n, __result_t::__size),
+               "cuda::std::simd::unchecked_load: requires n >= V::size()");
+  const auto __ptr = ::cuda::std::to_address(__first);
+
+  return ::cuda::std::simd::__full_load_from_ptr<__result_t>(__ptr, __mask, __f);
+}
+
+// unchecked_load: iterator + count, no mask
+_CCCL_TEMPLATE(typename _Vp = void, typename _Ip, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, iter_value_t<_Ip>>
+unchecked_load(const _Ip __first, const iter_difference_t<_Ip> __n, flags<_Flags...> __f = {})
+{
+  using __result_t           = __load_vec_t<_Vp, iter_value_t<_Ip>>;
+  constexpr auto __true_mask = typename __result_t::mask_type(true);
+
+  return ::cuda::std::simd::unchecked_load<_Vp>(__first, __n, __true_mask, __f);
+}
+
+// unchecked_load: iterator + sentinel, masked
+_CCCL_TEMPLATE(typename _Vp = void, typename _Ip, typename _Sp, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip> _CCCL_AND sized_sentinel_for<_Sp, _Ip>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, iter_value_t<_Ip>> unchecked_load(
+  const _Ip __first,
+  const _Sp __last,
+  const typename __load_vec_t<_Vp, iter_value_t<_Ip>>::mask_type& __mask,
+  flags<_Flags...> __f = {})
+{
+  using __result_t = __load_vec_t<_Vp, iter_value_t<_Ip>>;
+  _CCCL_ASSERT(::cuda::std::cmp_greater_equal(::cuda::std::distance(__first, __last), __result_t::__size),
+               "unchecked_load requires distance(first, last) >= V::size()");
+
+  return ::cuda::std::simd::__full_load_from_ptr<__result_t>(::cuda::std::to_address(__first), __mask, __f);
+}
+
+// unchecked_load: iterator + sentinel, no mask
+_CCCL_TEMPLATE(typename _Vp = void, typename _Ip, typename _Sp, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip> _CCCL_AND sized_sentinel_for<_Sp, _Ip>)
+[[nodiscard]] _CCCL_HOST_DEVICE_API constexpr __load_vec_t<_Vp, iter_value_t<_Ip>>
+unchecked_load(const _Ip __first, const _Sp __last, flags<_Flags...> __f = {})
+{
+  using __result_t           = __load_vec_t<_Vp, iter_value_t<_Ip>>;
+  constexpr auto __true_mask = typename __result_t::mask_type(true);
+
+  return ::cuda::std::simd::unchecked_load<_Vp>(__first, __last, __true_mask, __f);
+}
+
+_CCCL_END_NAMESPACE_CUDA_STD_SIMD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___SIMD_LOAD_H

--- a/libcudacxx/include/cuda/std/__simd/load.h
+++ b/libcudacxx/include/cuda/std/__simd/load.h
@@ -51,19 +51,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_STD_SIMD
 // [simd.loadstore] helper: resolves default V template parameter for load functions
 // When _Vp = void (default), resolves to basic_vec<_Up>; otherwise uses the explicit _Vp
 template <typename _Vp, typename _Up>
-struct __load_vec_type
-{
-  using type = _Vp;
-};
-
-template <typename _Up>
-struct __load_vec_type<void, _Up>
-{
-  using type = basic_vec<_Up>;
-};
-
-template <typename _Vp, typename _Up>
-using __load_vec_t = typename __load_vec_type<_Vp, _Up>::type;
+using __load_vec_t = conditional_t<is_void_v<_Vp>, basic_vec<_Up>, _Vp>;
 
 template <typename _Result, typename _Up, typename... _Flags>
 _CCCL_HOST_DEVICE_API constexpr void

--- a/libcudacxx/include/cuda/std/__simd/specializations/fixed_size_mask.h
+++ b/libcudacxx/include/cuda/std/__simd/specializations/fixed_size_mask.h
@@ -40,11 +40,7 @@ struct __mask_storage<_Bytes, __fixed_size<_Np>>
 
   bool __data[_Np]{};
 
-  _CCCL_HIDE_FROM_ABI constexpr __mask_storage() noexcept                                 = default;
-  _CCCL_HIDE_FROM_ABI constexpr __mask_storage(const __mask_storage&) noexcept            = default;
-  _CCCL_HIDE_FROM_ABI constexpr __mask_storage& operator=(const __mask_storage&) noexcept = default;
-
-  [[nodiscard]] _CCCL_HOST_DEVICE_API constexpr bool __get(const __simd_size_type __idx) const noexcept
+  [[nodiscard]] _CCCL_API constexpr bool __get(const __simd_size_type __idx) const noexcept
   {
     _CCCL_ASSERT(::cuda::in_range(__idx, __simd_size_type{0}, _Np), "Index is out of bounds");
     return __data[__idx];

--- a/libcudacxx/include/cuda/std/__simd/store.h
+++ b/libcudacxx/include/cuda/std/__simd/store.h
@@ -1,0 +1,361 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA_STD___SIMD_STORE_H
+#define _CUDA_STD___SIMD_STORE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#include <cuda/__memory/is_valid_alignment.h>
+#include <cuda/__memory/ptr_rebind.h>
+#include <cuda/std/__algorithm/max.h>
+#include <cuda/std/__concepts/concept_macros.h>
+#include <cuda/std/__cstring/memcpy.h>
+#include <cuda/std/__iterator/concepts.h>
+#include <cuda/std/__iterator/distance.h>
+#include <cuda/std/__iterator/incrementable_traits.h>
+#include <cuda/std/__iterator/readable_traits.h>
+#include <cuda/std/__memory/assume_aligned.h>
+#include <cuda/std/__memory/pointer_traits.h>
+#include <cuda/std/__ranges/access.h>
+#include <cuda/std/__ranges/concepts.h>
+#include <cuda/std/__ranges/data.h>
+#include <cuda/std/__ranges/size.h>
+#include <cuda/std/__simd/basic_vec.h>
+#include <cuda/std/__simd/concepts.h>
+#include <cuda/std/__simd/flag.h>
+#include <cuda/std/__simd/utility.h>
+#include <cuda/std/__utility/cmp.h>
+#include <cuda/std/__utility/forward.h>
+
+#include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_STD_SIMD
+
+template <typename _Tp, typename _Abi, typename _Up, typename... _Flags>
+_CCCL_HOST_DEVICE_API constexpr void
+__check_store_preconditions(_Up* const __ptr, flags<_Flags...>, const __simd_size_type __count = 1) noexcept
+{
+  static_assert(__is_vectorizable_v<_Up>, "cuda::std::simd::store: range_value_t<R> must be a vectorizable type");
+
+  static_assert(__explicitly_convertible_to<_Tp, _Up>,
+                "cuda::std::simd::store: value_type must satisfy explicitly-convertible-to<range_value_t<R>>");
+
+  static_assert(__has_convert_flag_v<_Flags...> || __is_value_preserving_v<_Tp, _Up>,
+                "cuda::std::simd::store: Conversion from value_type to range_value_t<R> is not value-preserving; use "
+                "flag_convert");
+
+  _CCCL_ASSERT(__count == 0 || __ptr != nullptr, "cuda::std::simd::store: pointer is nullptr");
+  ::cuda::std::simd::__assert_load_store_alignment<basic_vec<_Tp, _Abi>, _Up, _Flags...>(__ptr);
+}
+
+// [simd.loadstore] helper: core partial store to pointer + count + mask
+template <typename _Tp, typename _Abi, typename _Up, typename... _Flags>
+_CCCL_HOST_DEVICE_API constexpr void __partial_store_to_ptr(
+  const basic_vec<_Tp, _Abi>& __v,
+  _Up* const __ptr,
+  const __simd_size_type __count,
+  const typename basic_vec<_Tp, _Abi>::mask_type& __mask,
+  flags<_Flags...> __flags = {}) noexcept
+{
+  ::cuda::std::simd::__check_store_preconditions<_Tp, _Abi>(__ptr, __flags, __count);
+  constexpr auto __simd_size = basic_vec<_Tp, _Abi>::__size;
+
+  _CCCL_PRAGMA_UNROLL_FULL()
+  for (__simd_size_type __i = 0; __i < __simd_size; ++__i)
+  {
+    if (__mask[__i] && __i < __count)
+    {
+      __ptr[__i] = static_cast<_Up>(__v[__i]);
+    }
+  }
+}
+
+template <typename _Tp, typename _Abi, typename _Up, typename... _Flags>
+_CCCL_HOST_DEVICE_API constexpr void
+__full_store_to_ptr(const basic_vec<_Tp, _Abi>& __v, _Up* const __ptr, flags<_Flags...> __flags) noexcept
+{
+  ::cuda::std::simd::__check_store_preconditions<_Tp, _Abi>(__ptr, __flags);
+  using __vec_t                     = basic_vec<_Tp, _Abi>;
+  constexpr auto __simd_size        = __vec_t::__size;
+  constexpr bool __has_aligned_flag = __has_aligned_flag_v<_Flags...>;
+
+  if constexpr (__has_aligned_flag || __has_overaligned_flag_v<_Flags...>)
+  {
+    _CCCL_IF_NOT_CONSTEVAL_DEFAULT
+    {
+      constexpr auto __base_alignment = __has_aligned_flag ? alignment_v<__vec_t, _Up> : alignof(_Up);
+      constexpr auto __ptr_alignment  = ::cuda::std::max(__base_alignment, __overaligned_value_v<_Flags...>);
+      constexpr auto __data_size      = __simd_size * sizeof(_Up);
+
+      _Up __tmp[__simd_size]{};
+      _CCCL_PRAGMA_UNROLL_FULL()
+      for (__simd_size_type __i = 0; __i < __simd_size; ++__i)
+      {
+        __tmp[__i] = static_cast<_Up>(__v[__i]);
+      }
+      // vectorized store to pointer
+      if constexpr (__is_cuda_vectorizable_v<_Up> && __simd_size > 1 && __ptr_alignment >= __data_size
+                    && ::cuda::__is_valid_alignment(__data_size))
+      {
+        struct alignas(__data_size) __aligned_t
+        {
+          char __data[__data_size];
+        };
+        // nvcc performance bug: memcpy to pointer could not be vectorized
+        const auto __aligned_ptr = ::cuda::ptr_rebind<__aligned_t>(__ptr);
+        __aligned_t __data{};
+        ::cuda::std::memcpy(&__data, &__tmp, sizeof(__tmp));
+        *::cuda::std::assume_aligned<__ptr_alignment>(__aligned_ptr) = __data;
+      }
+      // rely on compiler vectorization
+      else
+      {
+        const auto __aligned_ptr = ::cuda::std::assume_aligned<__ptr_alignment>(__ptr);
+        _CCCL_PRAGMA_UNROLL_FULL()
+        for (__simd_size_type __i = 0; __i < __simd_size; ++__i)
+        {
+          __aligned_ptr[__i] = __tmp[__i];
+        }
+      }
+      return;
+    }
+  }
+  constexpr auto __true_mask = typename basic_vec<_Tp, _Abi>::mask_type(true);
+
+  ::cuda::std::simd::__partial_store_to_ptr(__v, __ptr, __simd_size, __true_mask, __flags);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// [simd.loadstore] partial_store
+
+// partial_store: range, masked
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Range, typename... _Flags)
+_CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range> //
+                 _CCCL_AND ::cuda::std::ranges::sized_range<_Range> //
+                   _CCCL_AND indirectly_writable<::cuda::std::ranges::iterator_t<_Range>,
+                                                 ::cuda::std::ranges::range_value_t<_Range>> //
+                     _CCCL_AND __explicitly_convertible_to<_Tp, ::cuda::std::ranges::range_value_t<_Range>>)
+_CCCL_HOST_DEVICE_API constexpr void partial_store(
+  const basic_vec<_Tp, _Abi>& __v,
+  _Range&& __r,
+  const typename basic_vec<_Tp, _Abi>::mask_type& __mask,
+  flags<_Flags...> __f = {})
+{
+  const auto __range_size = ::cuda::std::ranges::size(__r);
+  _CCCL_ASSERT(::cuda::std::in_range<__simd_size_type>(__range_size),
+               "cuda::std::simd::partial_store: range size out of range");
+  const auto __size = static_cast<__simd_size_type>(__range_size);
+  const auto __ptr  = ::cuda::std::ranges::data(__r);
+
+  ::cuda::std::simd::__partial_store_to_ptr(__v, __ptr, __size, __mask, __f);
+}
+
+// partial_store: range, no mask
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Range, typename... _Flags)
+_CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range> //
+                 _CCCL_AND ::cuda::std::ranges::sized_range<_Range> //
+                   _CCCL_AND indirectly_writable<::cuda::std::ranges::iterator_t<_Range>,
+                                                 ::cuda::std::ranges::range_value_t<_Range>> //
+                     _CCCL_AND __explicitly_convertible_to<_Tp, ::cuda::std::ranges::range_value_t<_Range>>)
+_CCCL_HOST_DEVICE_API constexpr void
+partial_store(const basic_vec<_Tp, _Abi>& __v, _Range&& __r, flags<_Flags...> __f = {})
+{
+  constexpr auto __true_mask = typename basic_vec<_Tp, _Abi>::mask_type(true);
+
+  ::cuda::std::simd::partial_store(__v, ::cuda::std::forward<_Range>(__r), __true_mask, __f);
+}
+
+// partial_store: iterator + count, masked
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Ip, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip> //
+                 _CCCL_AND indirectly_writable<_Ip, iter_value_t<_Ip>> //
+                   _CCCL_AND __explicitly_convertible_to<_Tp, iter_value_t<_Ip>>)
+_CCCL_HOST_DEVICE_API constexpr void partial_store(
+  const basic_vec<_Tp, _Abi>& __v,
+  const _Ip __first,
+  const iter_difference_t<_Ip> __n,
+  const typename basic_vec<_Tp, _Abi>::mask_type& __mask,
+  flags<_Flags...> __f = {})
+{
+  _CCCL_ASSERT(::cuda::std::in_range<__simd_size_type>(__n), "cuda::std::simd::partial_store: n out of range");
+  const auto __size = static_cast<__simd_size_type>(__n);
+
+  ::cuda::std::simd::__partial_store_to_ptr(__v, ::cuda::std::to_address(__first), __size, __mask, __f);
+}
+
+// partial_store: iterator + count, no mask
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Ip, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip> //
+                 _CCCL_AND indirectly_writable<_Ip, iter_value_t<_Ip>> //
+                   _CCCL_AND __explicitly_convertible_to<_Tp, iter_value_t<_Ip>>)
+_CCCL_HOST_DEVICE_API constexpr void partial_store(
+  const basic_vec<_Tp, _Abi>& __v, const _Ip __first, const iter_difference_t<_Ip> __n, flags<_Flags...> __f = {})
+{
+  constexpr auto __true_mask = typename basic_vec<_Tp, _Abi>::mask_type(true);
+
+  ::cuda::std::simd::partial_store(__v, __first, __n, __true_mask, __f);
+}
+
+// partial_store: iterator + sentinel, masked
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Ip, typename _Sp, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip> //
+                 _CCCL_AND indirectly_writable<_Ip, iter_value_t<_Ip>> //
+                   _CCCL_AND __explicitly_convertible_to<_Tp, iter_value_t<_Ip>> //
+                     _CCCL_AND sized_sentinel_for<_Sp, _Ip>)
+_CCCL_HOST_DEVICE_API constexpr void partial_store(
+  const basic_vec<_Tp, _Abi>& __v,
+  const _Ip __first,
+  const _Sp __last,
+  const typename basic_vec<_Tp, _Abi>::mask_type& __mask,
+  flags<_Flags...> __f = {})
+{
+  const auto __distance = ::cuda::std::distance(__first, __last);
+  _CCCL_ASSERT(::cuda::std::in_range<__simd_size_type>(__distance),
+               "cuda::std::simd::partial_store: distance(first, last) out of range");
+  const auto __size = static_cast<__simd_size_type>(__distance);
+
+  ::cuda::std::simd::__partial_store_to_ptr(__v, ::cuda::std::to_address(__first), __size, __mask, __f);
+}
+
+// partial_store: iterator + sentinel, no mask
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Ip, typename _Sp, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip> //
+                 _CCCL_AND indirectly_writable<_Ip, iter_value_t<_Ip>> //
+                   _CCCL_AND __explicitly_convertible_to<_Tp, iter_value_t<_Ip>> //
+                     _CCCL_AND sized_sentinel_for<_Sp, _Ip>)
+_CCCL_HOST_DEVICE_API constexpr void
+partial_store(const basic_vec<_Tp, _Abi>& __v, const _Ip __first, const _Sp __last, flags<_Flags...> __f = {})
+{
+  constexpr auto __true_mask = typename basic_vec<_Tp, _Abi>::mask_type(true);
+
+  ::cuda::std::simd::partial_store(__v, __first, __last, __true_mask, __f);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// [simd.loadstore] unchecked_store
+
+// unchecked_store: range, masked
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Range, typename... _Flags)
+_CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range> _CCCL_AND ::cuda::std::ranges::sized_range<_Range>)
+_CCCL_HOST_DEVICE_API constexpr void unchecked_store(
+  const basic_vec<_Tp, _Abi>& __v,
+  _Range&& __r,
+  const typename basic_vec<_Tp, _Abi>::mask_type& __mask,
+  flags<_Flags...> __f = {})
+{
+  constexpr auto __simd_size = basic_vec<_Tp, _Abi>::__size;
+  if constexpr (__has_static_size<_Range>)
+  {
+    static_assert(__static_range_size_v<_Range> >= __simd_size,
+                  "cuda::std::simd::unchecked_store: requires ::cuda::std::ranges::size(r) >= V::size()");
+  }
+  _CCCL_ASSERT(::cuda::std::cmp_greater_equal(::cuda::std::ranges::size(__r), __simd_size),
+               "cuda::std::simd::unchecked_store: requires ::cuda::std::ranges::size(r) >= V::size()");
+  const auto __ptr = ::cuda::std::ranges::data(__r);
+
+  ::cuda::std::simd::__partial_store_to_ptr(__v, __ptr, __simd_size, __mask, __f);
+}
+
+// unchecked_store: range, no mask
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Range, typename... _Flags)
+_CCCL_REQUIRES(::cuda::std::ranges::contiguous_range<_Range> _CCCL_AND ::cuda::std::ranges::sized_range<_Range>)
+_CCCL_HOST_DEVICE_API constexpr void
+unchecked_store(const basic_vec<_Tp, _Abi>& __v, _Range&& __r, flags<_Flags...> __f = {})
+{
+  if constexpr (__has_static_size<_Range>)
+  {
+    static_assert(__static_range_size_v<_Range> >= basic_vec<_Tp, _Abi>::__size,
+                  "cuda::std::simd::unchecked_store: requires ::cuda::std::ranges::size(r) >= V::size()");
+  }
+  [[maybe_unused]] constexpr auto __simd_size = basic_vec<_Tp, _Abi>::__size;
+  _CCCL_ASSERT(::cuda::std::cmp_greater_equal(::cuda::std::ranges::size(__r), __simd_size),
+               "cuda::std::simd::unchecked_store: requires ::cuda::std::ranges::size(r) >= V::size()");
+
+  ::cuda::std::simd::__full_store_to_ptr(__v, ::cuda::std::ranges::data(__r), __f);
+}
+
+// unchecked_store: iterator + count, masked
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Ip, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip>)
+_CCCL_HOST_DEVICE_API constexpr void unchecked_store(
+  const basic_vec<_Tp, _Abi>& __v,
+  const _Ip __first,
+  const iter_difference_t<_Ip> __n,
+  const typename basic_vec<_Tp, _Abi>::mask_type& __mask,
+  flags<_Flags...> __f = {})
+{
+  constexpr auto __simd_size = basic_vec<_Tp, _Abi>::size();
+  _CCCL_ASSERT(::cuda::std::cmp_greater_equal(__n, __simd_size),
+               "cuda::std::simd::unchecked_store: requires n >= V::size()");
+  const auto __ptr = ::cuda::std::to_address(__first);
+
+  ::cuda::std::simd::__partial_store_to_ptr(__v, __ptr, __simd_size, __mask, __f);
+}
+
+// unchecked_store: iterator + count, no mask
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Ip, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip>)
+_CCCL_HOST_DEVICE_API constexpr void unchecked_store(
+  const basic_vec<_Tp, _Abi>& __v, const _Ip __first, const iter_difference_t<_Ip> __n, flags<_Flags...> __f = {})
+{
+  [[maybe_unused]] constexpr auto __simd_size = basic_vec<_Tp, _Abi>::__size;
+  _CCCL_ASSERT(::cuda::std::cmp_greater_equal(__n, __simd_size),
+               "cuda::std::simd::unchecked_store: requires n >= V::size()");
+  const auto __ptr = ::cuda::std::to_address(__first);
+
+  ::cuda::std::simd::__full_store_to_ptr(__v, __ptr, __f);
+}
+
+// unchecked_store: iterator + sentinel, masked
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Ip, typename _Sp, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip> _CCCL_AND sized_sentinel_for<_Sp, _Ip>)
+_CCCL_HOST_DEVICE_API constexpr void unchecked_store(
+  const basic_vec<_Tp, _Abi>& __v,
+  const _Ip __first,
+  const _Sp __last,
+  const typename basic_vec<_Tp, _Abi>::mask_type& __mask,
+  flags<_Flags...> __f = {})
+{
+  constexpr auto __simd_size = basic_vec<_Tp, _Abi>::__size;
+  _CCCL_ASSERT(::cuda::std::cmp_greater_equal(::cuda::std::distance(__first, __last), __simd_size),
+               "cuda::std::simd::unchecked_store: requires distance(first, last) >= V::size()");
+  const auto __ptr = ::cuda::std::to_address(__first);
+
+  ::cuda::std::simd::__partial_store_to_ptr(__v, __ptr, __simd_size, __mask, __f);
+}
+
+// unchecked_store: iterator + sentinel, no mask
+_CCCL_TEMPLATE(typename _Tp, typename _Abi, typename _Ip, typename _Sp, typename... _Flags)
+_CCCL_REQUIRES(contiguous_iterator<_Ip> _CCCL_AND sized_sentinel_for<_Sp, _Ip>)
+_CCCL_HOST_DEVICE_API constexpr void
+unchecked_store(const basic_vec<_Tp, _Abi>& __v, const _Ip __first, const _Sp __last, flags<_Flags...> __f = {})
+{
+  [[maybe_unused]] constexpr auto __simd_size = basic_vec<_Tp, _Abi>::__size;
+  _CCCL_ASSERT(::cuda::std::cmp_greater_equal(::cuda::std::distance(__first, __last), __simd_size),
+               "cuda::std::simd::unchecked_store: requires distance(first, last) >= V::size()");
+  const auto __ptr = ::cuda::std::to_address(__first);
+
+  ::cuda::std::simd::__full_store_to_ptr(__v, __ptr, __f);
+}
+
+_CCCL_END_NAMESPACE_CUDA_STD_SIMD
+
+#include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CUDA_STD___SIMD_STORE_H

--- a/libcudacxx/include/cuda/std/__simd/type_traits.h
+++ b/libcudacxx/include/cuda/std/__simd/type_traits.h
@@ -21,7 +21,7 @@
 #  pragma system_header
 #endif // no system header
 
-#include <cuda/__memory/is_valid_alignment.h>
+#include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__cstddef/types.h>
 #include <cuda/std/__fwd/simd.h>
 #include <cuda/std/__simd/abi.h>
@@ -32,16 +32,19 @@
 
 _CCCL_BEGIN_NAMESPACE_CUDA_STD_SIMD
 
+inline constexpr size_t __optimal_cuda_alignment = _CCCL_CTK_AT_LEAST(12, 9) ? 32 : 16;
+
+// The best alignment for a pointer to a SIMD type is the maximum of the type's alignment and the optimal CUDA
+// alignment.
+template <typename _Tp>
+inline constexpr size_t __simd_pointer_alignment_v = ::cuda::std::max(alignof(_Tp), __optimal_cuda_alignment);
+
 // [simd.traits], alignment
 template <typename _Tp, typename _Up = typename _Tp::value_type>
 struct alignment;
 
 template <typename _Tp, typename _Abi, typename _Up>
-struct alignment<basic_vec<_Tp, _Abi>, _Up>
-    : integral_constant<size_t,
-                        ::cuda::__is_valid_alignment(__simd_size_v<_Tp, _Abi> * alignof(_Up))
-                          ? __simd_size_v<_Tp, _Abi> * alignof(_Up)
-                          : alignof(_Up)>
+struct alignment<basic_vec<_Tp, _Abi>, _Up> : integral_constant<size_t, __simd_pointer_alignment_v<_Up>>
 {
   static_assert(__is_vectorizable_v<_Up>, "U must be a vectorizable type");
 };

--- a/libcudacxx/include/cuda/std/__simd/utility.h
+++ b/libcudacxx/include/cuda/std/__simd/utility.h
@@ -21,7 +21,9 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cuda/__cmath/pow2.h>
 #include <cuda/__memory/is_aligned.h>
+#include <cuda/__type_traits/is_trivially_copyable.h>
 #include <cuda/std/__concepts/concept_macros.h>
 #include <cuda/std/__fwd/span.h>
 #include <cuda/std/__ranges/concepts.h>
@@ -121,7 +123,8 @@ inline constexpr __simd_size_type __static_range_size_v = __get_static_range_siz
 // clang-19/clang-14/nvc++ when T is an incomplete specialization of tuple_size.
 template <typename _Range>
 inline constexpr bool __is_compatible_range_guard_v =
-  __has_static_size<_Range> && ranges::contiguous_range<_Range> && ranges::sized_range<_Range>;
+  __has_static_size<_Range> && ::cuda::std::ranges::contiguous_range<_Range>
+  && ::cuda::std::ranges::sized_range<_Range>;
 
 template <typename _Tp, __simd_size_type _Size, typename _Range, bool = __is_compatible_range_guard_v<_Range>>
 inline constexpr bool __is_compatible_range_v = false;
@@ -129,8 +132,8 @@ inline constexpr bool __is_compatible_range_v = false;
 template <typename _Tp, __simd_size_type _Size, typename _Range>
 inline constexpr bool __is_compatible_range_v<_Tp, _Size, _Range, true> =
   (__static_range_size_v<_Range> == _Size) //
-  && __is_vectorizable_v<ranges::range_value_t<_Range>> //
-  && __explicitly_convertible_to<ranges::range_value_t<_Range>, _Tp>;
+  && __is_vectorizable_v<::cuda::std::ranges::range_value_t<_Range>> //
+  && __explicitly_convertible_to<::cuda::std::ranges::range_value_t<_Range>, _Tp>;
 
 //----------------------------------------------------------------------------------------------------------------------
 // [simd.flags] alignment assertion for load/store pointers
@@ -140,18 +143,27 @@ _CCCL_HOST_DEVICE_API constexpr void __assert_load_store_alignment([[maybe_unuse
 {
   _CCCL_IF_NOT_CONSTEVAL_DEFAULT
   {
+    if constexpr (__has_overaligned_flag_v<_Flags...>)
+    {
+      static_assert(__overaligned_alignment_v<_Flags...> >= alignof(_Up),
+                    "overaligned flag requires alignment >= alignof(_Up)");
+      _CCCL_ASSERT(::cuda::is_aligned(__data, __overaligned_alignment_v<_Flags...>),
+                   "flag_overaligned<N> requires data to be aligned to N");
+    }
     if constexpr (__has_aligned_flag_v<_Flags...>)
     {
       _CCCL_ASSERT(::cuda::is_aligned(__data, alignment_v<_Vec, _Up>),
                    "flag_aligned requires data to be aligned to alignment_v<V, range_value_t<R>>");
     }
-    else if constexpr (__has_overaligned_flag_v<_Flags...>)
-    {
-      _CCCL_ASSERT(::cuda::is_aligned(__data, __overaligned_alignment_v<_Flags...>),
-                   "flag_overaligned<N> requires data to be aligned to N");
-    }
+    _CCCL_ASSERT(::cuda::is_aligned(__data, alignof(_Up)), "data is not aligned to alignof(_Up)");
   }
 }
+
+// used in load/store preconditions
+// e.g. char3 doesn't work: alignof(char3) == 1, sizeof(char3) == 3
+template <typename _TpIn>
+inline constexpr bool __is_cuda_vectorizable_v =
+  ::cuda::is_trivially_copyable_v<_TpIn> && ::cuda::is_power_of_two(sizeof(_TpIn));
 
 _CCCL_END_NAMESPACE_CUDA_STD_SIMD
 

--- a/libcudacxx/include/cuda/std/__simd_
+++ b/libcudacxx/include/cuda/std/__simd_
@@ -26,7 +26,9 @@
 #include <cuda/std/__simd/basic_mask.h>
 #include <cuda/std/__simd/basic_vec.h>
 #include <cuda/std/__simd/flag.h>
+#include <cuda/std/__simd/load.h>
 #include <cuda/std/__simd/reductions.h>
+#include <cuda/std/__simd/store.h>
 #include <cuda/std/__simd/type_traits.h>
 
 #endif // _CUDA_STD_SIMD

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.loadstore/partial_load.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.loadstore/partial_load.pass.cpp
@@ -1,0 +1,208 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/__simd_>
+
+// [simd.loadstore], partial_load
+//
+// partial_load<V>(Range&&, flags<> = {});
+// partial_load<V>(Range&&, const mask_type&, flags<> = {});
+// partial_load<V>(I first, iter_difference_t<I> n, flags<> = {});
+// partial_load<V>(I first, iter_difference_t<I> n, const mask_type&, flags<> = {});
+// partial_load<V>(I first, S last, flags<> = {});
+// partial_load<V>(I first, S last, const mask_type&, flags<> = {});
+
+#include <cuda/std/__simd_>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+
+#include "../simd_test_utils.h"
+#include "test_macros.h"
+
+//----------------------------------------------------------------------------------------------------------------------
+// partial_load: range
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_load_range()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  auto arr  = make_iota_array<T, N>();
+
+  Vec vec = simd::partial_load<Vec>(arr);
+  assert(vec == arr);
+
+  Vec vec2 = simd::partial_load<Vec>(arr, simd::flag_default);
+  assert(vec2 == arr);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// partial_load: range, masked
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_load_range_masked()
+{
+  using Vec  = simd::basic_vec<T, simd::fixed_size<N>>;
+  using Mask = typename Vec::mask_type;
+  auto arr   = make_iota_array<T, N>();
+
+  Mask even_mask(is_even{});
+  Vec vec = simd::partial_load<Vec>(arr, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : T{};
+    assert(vec[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// partial_load: smaller range (count < Vec.size)
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_load_smaller_range()
+{
+  if constexpr (N > 1)
+  {
+    using Vec          = simd::basic_vec<T, simd::fixed_size<N>>;
+    constexpr int Half = N / 2;
+    auto small_arr     = make_iota_array<T, Half>();
+
+    Vec vec = simd::partial_load<Vec>(small_arr);
+    for (int i = 0; i < N; ++i)
+    {
+      if (i < Half)
+      {
+        assert(vec[i] == static_cast<T>(i + 1));
+      }
+      else
+      {
+        assert(vec[i] == T{});
+      }
+    }
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// partial_load: iterator + count
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_load_iter_count()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  auto arr  = make_iota_array<T, N>();
+
+  Vec vec = simd::partial_load<Vec>(arr.data(), N);
+  assert(vec == arr);
+
+  using Mask = typename Vec::mask_type;
+  Mask even_mask(is_even{});
+  Vec masked_vec = simd::partial_load<Vec>(arr.data(), N, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : T{};
+    assert(masked_vec[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// partial_load: iterator + sentinel
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_load_iter_sentinel()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  auto arr  = make_iota_array<T, N>();
+
+  Vec vec = simd::partial_load<Vec>(arr.data(), arr.data() + N);
+  assert(vec == arr);
+
+  using Mask = typename Vec::mask_type;
+  Mask even_mask(is_even{});
+  Vec masked_vec = simd::partial_load<Vec>(arr.data(), arr.data() + N, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : T{};
+    assert(masked_vec[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// flag_convert: lossy load from wider type
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_load_convert()
+{
+  if constexpr (sizeof(T) <= sizeof(int) && cuda::std::is_integral_v<T>)
+  {
+    using Vec      = simd::basic_vec<T, simd::fixed_size<N>>;
+    using WiderT   = cuda::std::conditional_t<cuda::std::is_signed_v<T>, int64_t, uint64_t>;
+    auto wider_arr = make_iota_array<WiderT, N>();
+
+    Vec vec = simd::partial_load<Vec>(wider_arr, simd::flag_convert);
+    assert((vec == make_iota_array<T, N>()));
+  }
+  if constexpr (cuda::std::is_same_v<T, float>)
+  {
+    using Vec      = simd::basic_vec<T, simd::fixed_size<N>>;
+    auto wider_arr = make_iota_array<double, N>();
+
+    Vec vec = simd::partial_load<Vec>(wider_arr, simd::flag_convert);
+    assert((vec == make_iota_array<T, N>()));
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// noexcept: public functions must NOT be noexcept
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_load_not_noexcept()
+{
+  using Vec  = simd::basic_vec<T, simd::fixed_size<N>>;
+  using Mask = typename Vec::mask_type;
+  cuda::std::array<T, N> arr{};
+  Mask mask(true);
+  unused(arr, mask);
+
+  // range overloads
+  static_assert(!noexcept(simd::partial_load<Vec>(arr, mask)));
+  static_assert(!noexcept(simd::partial_load<Vec>(arr)));
+  // iterator + count overloads
+  static_assert(!noexcept(simd::partial_load<Vec>(arr.data(), N, mask)));
+  static_assert(!noexcept(simd::partial_load<Vec>(arr.data(), N)));
+  // iterator + sentinel overloads
+  static_assert(!noexcept(simd::partial_load<Vec>(arr.data(), arr.data() + N, mask)));
+  static_assert(!noexcept(simd::partial_load<Vec>(arr.data(), arr.data() + N)));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_type()
+{
+  test_partial_load_range<T, N>();
+  test_partial_load_range_masked<T, N>();
+  test_partial_load_smaller_range<T, N>();
+  test_partial_load_iter_count<T, N>();
+  test_partial_load_iter_sentinel<T, N>();
+  test_partial_load_convert<T, N>();
+  test_partial_load_not_noexcept<T, N>();
+}
+
+DEFINE_BASIC_VEC_TEST()
+DEFINE_BASIC_VEC_TEST_RUNTIME()
+
+int main(int, char**)
+{
+  assert(test());
+  static_assert(test());
+  assert(test_runtime());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.loadstore/partial_store.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.loadstore/partial_store.pass.cpp
@@ -1,0 +1,243 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/__simd_>
+
+// [simd.loadstore], partial_store
+//
+// partial_store(const basic_vec&, Range&&, flags<> = {});
+// partial_store(const basic_vec&, Range&&, const mask_type&, flags<> = {});
+// partial_store(const basic_vec&, I first, iter_difference_t<I> n, flags<> = {});
+// partial_store(const basic_vec&, I first, iter_difference_t<I> n, const mask_type&, flags<> = {});
+// partial_store(const basic_vec&, I first, S last, flags<> = {});
+// partial_store(const basic_vec&, I first, S last, const mask_type&, flags<> = {});
+
+#include <cuda/std/__simd_>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+
+#include "../simd_test_utils.h"
+#include "test_macros.h"
+
+//----------------------------------------------------------------------------------------------------------------------
+// partial_store: range
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_store_range()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  Vec vec(iota_generator<T>{});
+
+  cuda::std::array<T, N> dest{};
+  simd::partial_store(vec, dest);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(dest[i] == static_cast<T>(i + 1));
+  }
+
+  cuda::std::array<T, N> dest2{};
+  simd::partial_store(vec, dest2, simd::flag_default);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(dest2[i] == static_cast<T>(i + 1));
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// partial_store: range, masked — verify unmasked lanes are preserved
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_store_range_masked()
+{
+  using Vec  = simd::basic_vec<T, simd::fixed_size<N>>;
+  using Mask = typename Vec::mask_type;
+  Vec vec(iota_generator<T>{});
+
+  cuda::std::array<T, N> dest{};
+  for (int i = 0; i < N; ++i)
+  {
+    dest[i] = static_cast<T>(99);
+  }
+
+  Mask even_mask(is_even{});
+  simd::partial_store(vec, dest, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : static_cast<T>(99);
+    assert(dest[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// partial_store: smaller range (count < Vec.size)
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_store_smaller_range()
+{
+  if constexpr (N > 1)
+  {
+    using Vec          = simd::basic_vec<T, simd::fixed_size<N>>;
+    constexpr int Half = N / 2;
+    Vec vec(iota_generator<T>{});
+
+    cuda::std::array<T, Half> small_dest{};
+    simd::partial_store(vec, small_dest);
+    for (int i = 0; i < Half; ++i)
+    {
+      assert(small_dest[i] == static_cast<T>(i + 1));
+    }
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// partial_store: iterator + count
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_store_iter_count()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  Vec vec(iota_generator<T>{});
+
+  cuda::std::array<T, N> dest{};
+  simd::partial_store(vec, dest.data(), N);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(dest[i] == static_cast<T>(i + 1));
+  }
+
+  using Mask = typename Vec::mask_type;
+  cuda::std::array<T, N> masked_dest{};
+  for (int i = 0; i < N; ++i)
+  {
+    masked_dest[i] = static_cast<T>(99);
+  }
+  Mask even_mask(is_even{});
+  simd::partial_store(vec, masked_dest.data(), N, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : static_cast<T>(99);
+    assert(masked_dest[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// partial_store: iterator + sentinel
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_store_iter_sentinel()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  Vec vec(iota_generator<T>{});
+
+  cuda::std::array<T, N> dest{};
+  simd::partial_store(vec, dest.data(), dest.data() + N);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(dest[i] == static_cast<T>(i + 1));
+  }
+
+  using Mask = typename Vec::mask_type;
+  cuda::std::array<T, N> masked_dest{};
+  for (int i = 0; i < N; ++i)
+  {
+    masked_dest[i] = static_cast<T>(99);
+  }
+  Mask even_mask(is_even{});
+  simd::partial_store(vec, masked_dest.data(), masked_dest.data() + N, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : static_cast<T>(99);
+    assert(masked_dest[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// flag_convert: lossy store to narrower type
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_store_convert()
+{
+  if constexpr (sizeof(T) < 8 && cuda::std::is_integral_v<T>)
+  {
+    using WiderT = cuda::std::conditional_t<cuda::std::is_signed_v<T>, int64_t, uint64_t>;
+    using Vec    = simd::basic_vec<WiderT, simd::fixed_size<N>>;
+    Vec vec(iota_generator<WiderT>{});
+
+    cuda::std::array<T, N> dest{};
+    simd::partial_store(vec, dest, simd::flag_convert);
+    for (int i = 0; i < N; ++i)
+    {
+      assert(dest[i] == static_cast<T>(static_cast<WiderT>(i + 1)));
+    }
+  }
+  if constexpr (cuda::std::is_same_v<T, float>)
+  {
+    using Vec = simd::basic_vec<double, simd::fixed_size<N>>;
+    Vec vec(iota_generator<double>{});
+
+    cuda::std::array<T, N> dest{};
+    simd::partial_store(vec, dest, simd::flag_convert);
+    for (int i = 0; i < N; ++i)
+    {
+      assert(dest[i] == static_cast<T>(static_cast<double>(i + 1)));
+    }
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// noexcept: public functions must NOT be noexcept
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_partial_store_not_noexcept()
+{
+  using Vec  = simd::basic_vec<T, simd::fixed_size<N>>;
+  using Mask = typename Vec::mask_type;
+  Vec vec(iota_generator<T>{});
+  cuda::std::array<T, N> arr{};
+  Mask mask(true);
+  unused(vec, arr, mask);
+
+  // range overloads
+  static_assert(!noexcept(simd::partial_store(vec, arr, mask)));
+  static_assert(!noexcept(simd::partial_store(vec, arr)));
+  // iterator + count overloads
+  static_assert(!noexcept(simd::partial_store(vec, arr.data(), N, mask)));
+  static_assert(!noexcept(simd::partial_store(vec, arr.data(), N)));
+  // iterator + sentinel overloads
+  static_assert(!noexcept(simd::partial_store(vec, arr.data(), arr.data() + N, mask)));
+  static_assert(!noexcept(simd::partial_store(vec, arr.data(), arr.data() + N)));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_type()
+{
+  test_partial_store_range<T, N>();
+  test_partial_store_range_masked<T, N>();
+  test_partial_store_smaller_range<T, N>();
+  test_partial_store_iter_count<T, N>();
+  test_partial_store_iter_sentinel<T, N>();
+  test_partial_store_convert<T, N>();
+  test_partial_store_not_noexcept<T, N>();
+}
+
+DEFINE_BASIC_VEC_TEST()
+DEFINE_BASIC_VEC_TEST_RUNTIME()
+
+int main(int, char**)
+{
+  assert(test());
+  static_assert(test());
+  assert(test_runtime());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.loadstore/unchecked_load.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.loadstore/unchecked_load.pass.cpp
@@ -1,0 +1,209 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/__simd_>
+
+// [simd.loadstore], unchecked_load
+//
+// unchecked_load<V>(Range&&, flags<> = {});
+// unchecked_load<V>(Range&&, const mask_type&, flags<> = {});
+// unchecked_load<V>(I first, iter_difference_t<I> n, flags<> = {});
+// unchecked_load<V>(I first, iter_difference_t<I> n, const mask_type&, flags<> = {});
+// unchecked_load<V>(I first, S last, flags<> = {});
+// unchecked_load<V>(I first, S last, const mask_type&, flags<> = {});
+
+#include <cuda/std/__simd_>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+
+#include "../simd_test_utils.h"
+#include "test_macros.h"
+
+//----------------------------------------------------------------------------------------------------------------------
+// unchecked_load: range
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_load_range()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  auto arr  = make_iota_array<T, N>();
+
+  Vec vec = simd::unchecked_load<Vec>(arr);
+  assert(vec == arr);
+
+  Vec vec2 = simd::unchecked_load<Vec>(arr, simd::flag_default);
+  assert(vec2 == arr);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// unchecked_load: range, masked
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_load_range_masked()
+{
+  using Vec  = simd::basic_vec<T, simd::fixed_size<N>>;
+  using Mask = typename Vec::mask_type;
+  auto arr   = make_iota_array<T, N>();
+
+  Mask even_mask(is_even{});
+  Vec vec = simd::unchecked_load<Vec>(arr, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : T{};
+    assert(vec[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// unchecked_load: iterator + count
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_load_iter_count()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  auto arr  = make_iota_array<T, N>();
+
+  Vec vec = simd::unchecked_load<Vec>(arr.data(), N);
+  assert(vec == arr);
+
+  using Mask = typename Vec::mask_type;
+  Mask even_mask(is_even{});
+  Vec masked_vec = simd::unchecked_load<Vec>(arr.data(), N, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : T{};
+    assert(masked_vec[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// unchecked_load: iterator + sentinel
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_load_iter_sentinel()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  auto arr  = make_iota_array<T, N>();
+
+  Vec vec = simd::unchecked_load<Vec>(arr.data(), arr.data() + N);
+  assert(vec == arr);
+
+  using Mask = typename Vec::mask_type;
+  Mask even_mask(is_even{});
+  Vec masked_vec = simd::unchecked_load<Vec>(arr.data(), arr.data() + N, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : T{};
+    assert(masked_vec[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// alignment flags
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_load_aligned()
+{
+  using Vec            = simd::basic_vec<T, simd::fixed_size<N>>;
+  alignas(64) auto arr = make_iota_array<T, N>();
+
+  Vec vec1 = simd::unchecked_load<Vec>(arr, simd::flag_aligned);
+  Vec vec2 = simd::unchecked_load<Vec>(arr, simd::flag_overaligned<32>);
+  assert(vec1 == arr);
+  assert(vec2 == arr);
+}
+
+TEST_FUNC constexpr void test_unchecked_load_overaligned_non_power_of_two_size()
+{
+  using Vec            = simd::basic_vec<float, simd::fixed_size<3>>;
+  alignas(16) auto arr = make_iota_array<float, 3>();
+
+  Vec vec = simd::unchecked_load<Vec>(arr, simd::flag_overaligned<16>);
+  assert(vec == arr);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// flag_convert: lossy load from wider type
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_load_convert()
+{
+  if constexpr (sizeof(T) <= sizeof(int) && cuda::std::is_integral_v<T>)
+  {
+    using Vec      = simd::basic_vec<T, simd::fixed_size<N>>;
+    using WiderT   = cuda::std::conditional_t<cuda::std::is_signed_v<T>, int64_t, uint64_t>;
+    auto wider_arr = make_iota_array<WiderT, N>();
+
+    Vec vec = simd::unchecked_load<Vec>(wider_arr, simd::flag_convert);
+    assert((vec == make_iota_array<T, N>()));
+  }
+  if constexpr (cuda::std::is_same_v<T, float>)
+  {
+    using Vec      = simd::basic_vec<T, simd::fixed_size<N>>;
+    auto wider_arr = make_iota_array<double, N>();
+
+    Vec vec = simd::unchecked_load<Vec>(wider_arr, simd::flag_convert);
+    assert((vec == make_iota_array<T, N>()));
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// noexcept: public functions must NOT be noexcept
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_load_not_noexcept()
+{
+  using Vec  = simd::basic_vec<T, simd::fixed_size<N>>;
+  using Mask = typename Vec::mask_type;
+  cuda::std::array<T, N> arr{};
+  Mask mask(true);
+  unused(arr, mask);
+
+  // range overloads
+  static_assert(!noexcept(simd::unchecked_load<Vec>(arr, mask)));
+  static_assert(!noexcept(simd::unchecked_load<Vec>(arr)));
+  // iterator + count overloads
+  static_assert(!noexcept(simd::unchecked_load<Vec>(arr.data(), N, mask)));
+  static_assert(!noexcept(simd::unchecked_load<Vec>(arr.data(), N)));
+  // iterator + sentinel overloads
+  static_assert(!noexcept(simd::unchecked_load<Vec>(arr.data(), arr.data() + N, mask)));
+  static_assert(!noexcept(simd::unchecked_load<Vec>(arr.data(), arr.data() + N)));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_type()
+{
+  test_unchecked_load_range<T, N>();
+  test_unchecked_load_range_masked<T, N>();
+  test_unchecked_load_iter_count<T, N>();
+  test_unchecked_load_iter_sentinel<T, N>();
+  if constexpr (cuda::std::is_same_v<T, float> && N == 4)
+  {
+    test_unchecked_load_overaligned_non_power_of_two_size();
+  }
+  test_unchecked_load_aligned<T, N>();
+  test_unchecked_load_convert<T, N>();
+  test_unchecked_load_not_noexcept<T, N>();
+}
+
+DEFINE_BASIC_VEC_TEST()
+DEFINE_BASIC_VEC_TEST_RUNTIME()
+
+int main(int, char**)
+{
+  assert(test());
+  static_assert(test());
+  assert(test_runtime());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.loadstore/unchecked_store.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.loadstore/unchecked_store.pass.cpp
@@ -1,0 +1,282 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++ in the CUDA C++ Core Libraries,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/__simd_>
+
+// [simd.loadstore], unchecked_store
+//
+// unchecked_store(const basic_vec&, Range&&, flags<> = {});
+// unchecked_store(const basic_vec&, Range&&, const mask_type&, flags<> = {});
+// unchecked_store(const basic_vec&, I first, iter_difference_t<I> n, flags<> = {});
+// unchecked_store(const basic_vec&, I first, iter_difference_t<I> n, const mask_type&, flags<> = {});
+// unchecked_store(const basic_vec&, I first, S last, flags<> = {});
+// unchecked_store(const basic_vec&, I first, S last, const mask_type&, flags<> = {});
+
+#include <cuda/std/__simd_>
+#include <cuda/std/array>
+#include <cuda/std/cassert>
+#include <cuda/std/cstdint>
+#include <cuda/std/type_traits>
+
+#include "../simd_test_utils.h"
+#include "test_macros.h"
+
+//----------------------------------------------------------------------------------------------------------------------
+// unchecked_store: range
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_store_range()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  Vec vec(iota_generator<T>{});
+
+  cuda::std::array<T, N> dest{};
+  simd::unchecked_store(vec, dest);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(dest[i] == static_cast<T>(i + 1));
+  }
+
+  cuda::std::array<T, N> dest2{};
+  simd::unchecked_store(vec, dest2, simd::flag_default);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(dest2[i] == static_cast<T>(i + 1));
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// unchecked_store: range, masked — verify unmasked lanes are preserved
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_store_range_masked()
+{
+  using Vec  = simd::basic_vec<T, simd::fixed_size<N>>;
+  using Mask = typename Vec::mask_type;
+  Vec vec(iota_generator<T>{});
+
+  cuda::std::array<T, N> dest{};
+  for (int i = 0; i < N; ++i)
+  {
+    dest[i] = static_cast<T>(99);
+  }
+
+  Mask even_mask(is_even{});
+  simd::unchecked_store(vec, dest, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : static_cast<T>(99);
+    assert(dest[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// unchecked_store: iterator + count
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_store_iter_count()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  Vec vec(iota_generator<T>{});
+
+  cuda::std::array<T, N> dest{};
+  simd::unchecked_store(vec, dest.data(), N);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(dest[i] == static_cast<T>(i + 1));
+  }
+
+  using Mask = typename Vec::mask_type;
+  cuda::std::array<T, N> masked_dest{};
+  for (int i = 0; i < N; ++i)
+  {
+    masked_dest[i] = static_cast<T>(99);
+  }
+  Mask even_mask(is_even{});
+  simd::unchecked_store(vec, masked_dest.data(), N, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : static_cast<T>(99);
+    assert(masked_dest[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// unchecked_store: iterator + sentinel
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_store_iter_sentinel()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  Vec vec(iota_generator<T>{});
+
+  cuda::std::array<T, N> dest{};
+  simd::unchecked_store(vec, dest.data(), dest.data() + N);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(dest[i] == static_cast<T>(i + 1));
+  }
+
+  using Mask = typename Vec::mask_type;
+  cuda::std::array<T, N> masked_dest{};
+  for (int i = 0; i < N; ++i)
+  {
+    masked_dest[i] = static_cast<T>(99);
+  }
+  Mask even_mask(is_even{});
+  simd::unchecked_store(vec, masked_dest.data(), masked_dest.data() + N, even_mask);
+  for (int i = 0; i < N; ++i)
+  {
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : static_cast<T>(99);
+    assert(masked_dest[i] == expected);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// alignment flags
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_store_aligned()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  Vec vec(iota_generator<T>{});
+
+  alignas(64) cuda::std::array<T, N> dest1{};
+  simd::unchecked_store(vec, dest1, simd::flag_aligned);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(dest1[i] == static_cast<T>(i + 1));
+  }
+
+  alignas(64) cuda::std::array<T, N> dest2{};
+  simd::unchecked_store(vec, dest2, simd::flag_overaligned<32>);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(dest2[i] == static_cast<T>(i + 1));
+  }
+}
+
+TEST_FUNC constexpr void test_unchecked_store_overaligned_non_power_of_two_size()
+{
+  using Vec = simd::basic_vec<float, simd::fixed_size<3>>;
+  Vec vec(iota_generator<float>{});
+
+  alignas(16) cuda::std::array<float, 3> dest{};
+  simd::unchecked_store(vec, dest, simd::flag_overaligned<16>);
+  for (int i = 0; i < 3; ++i)
+  {
+    assert(dest[i] == static_cast<float>(i + 1));
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// flag_convert: lossy store to narrower type
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_store_convert()
+{
+  if constexpr (sizeof(T) < 8 && cuda::std::is_integral_v<T>)
+  {
+    using WiderT = cuda::std::conditional_t<cuda::std::is_signed_v<T>, int64_t, uint64_t>;
+    using Vec    = simd::basic_vec<WiderT, simd::fixed_size<N>>;
+    Vec vec(iota_generator<WiderT>{});
+
+    cuda::std::array<T, N> dest{};
+    simd::unchecked_store(vec, dest, simd::flag_convert);
+    for (int i = 0; i < N; ++i)
+    {
+      assert(dest[i] == static_cast<T>(static_cast<WiderT>(i + 1)));
+    }
+  }
+  if constexpr (cuda::std::is_same_v<T, float>)
+  {
+    using Vec = simd::basic_vec<double, simd::fixed_size<N>>;
+    Vec vec(iota_generator<double>{});
+
+    cuda::std::array<T, N> dest{};
+    simd::unchecked_store(vec, dest, simd::flag_convert);
+    for (int i = 0; i < N; ++i)
+    {
+      assert(dest[i] == static_cast<T>(static_cast<double>(i + 1)));
+    }
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// round-trip: unchecked_store then unchecked_load
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_round_trip()
+{
+  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
+  Vec original(iota_generator<T>{});
+
+  cuda::std::array<T, N> buf{};
+  simd::unchecked_store(original, buf);
+  Vec loaded = simd::unchecked_load<Vec>(buf);
+  for (int i = 0; i < N; ++i)
+  {
+    assert(loaded[i] == original[i]);
+  }
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// noexcept: public functions must NOT be noexcept
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_unchecked_store_not_noexcept()
+{
+  using Vec  = simd::basic_vec<T, simd::fixed_size<N>>;
+  using Mask = typename Vec::mask_type;
+  Vec vec(iota_generator<T>{});
+  cuda::std::array<T, N> arr{};
+  Mask mask(true);
+  unused(vec, arr, mask);
+
+  // range overloads
+  static_assert(!noexcept(simd::unchecked_store(vec, arr, mask)));
+  static_assert(!noexcept(simd::unchecked_store(vec, arr)));
+  // iterator + count overloads
+  static_assert(!noexcept(simd::unchecked_store(vec, arr.data(), N, mask)));
+  static_assert(!noexcept(simd::unchecked_store(vec, arr.data(), N)));
+  // iterator + sentinel overloads
+  static_assert(!noexcept(simd::unchecked_store(vec, arr.data(), arr.data() + N, mask)));
+  static_assert(!noexcept(simd::unchecked_store(vec, arr.data(), arr.data() + N)));
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+
+template <typename T, int N>
+TEST_FUNC constexpr void test_type()
+{
+  test_unchecked_store_range<T, N>();
+  test_unchecked_store_range_masked<T, N>();
+  test_unchecked_store_iter_count<T, N>();
+  test_unchecked_store_iter_sentinel<T, N>();
+  test_unchecked_store_aligned<T, N>();
+  if constexpr (cuda::std::is_same_v<T, float> && N == 4)
+  {
+    test_unchecked_store_overaligned_non_power_of_two_size();
+  }
+  test_unchecked_store_convert<T, N>();
+  test_round_trip<T, N>();
+  test_unchecked_store_not_noexcept<T, N>();
+}
+
+DEFINE_BASIC_VEC_TEST()
+DEFINE_BASIC_VEC_TEST_RUNTIME()
+
+int main(int, char**)
+{
+  assert(test());
+  static_assert(test());
+  assert(test_runtime());
+  return 0;
+}

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/alignment.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.traits/alignment.pass.cpp
@@ -26,27 +26,29 @@
 
 namespace simd = cuda::std::simd;
 
-template <typename T, int N, size_t ExpectedAlign = alignof(T) * N>
+inline constexpr size_t optimal_cuda_alignment = _CCCL_CTK_AT_LEAST(12, 9) ? 32 : 16;
+
+template <typename T, int N>
 TEST_FUNC void test_default_u()
 {
   using V = simd::basic_vec<T, simd::fixed_size<N>>;
-  static_assert(simd::alignment<V>::value == ExpectedAlign);
-  static_assert(simd::alignment_v<V> == ExpectedAlign);
+  static_assert(simd::alignment<V>::value == optimal_cuda_alignment);
+  static_assert(simd::alignment_v<V> == optimal_cuda_alignment);
 }
 
-template <typename T, int N, typename U, size_t ExpectedAlign = alignof(U) * N>
+template <typename T, int N, typename U>
 TEST_FUNC void test_explicit_u()
 {
   using V = simd::basic_vec<T, simd::fixed_size<N>>;
-  static_assert(simd::alignment<V, U>::value == ExpectedAlign);
-  static_assert(simd::alignment_v<V, U> == ExpectedAlign);
+  static_assert(simd::alignment<V, U>::value == optimal_cuda_alignment);
+  static_assert(simd::alignment_v<V, U> == optimal_cuda_alignment);
 }
 
 template <typename T>
 TEST_FUNC void test_type()
 {
   test_default_u<T, 1>();
-  test_default_u<T, 3, alignof(T)>();
+  test_default_u<T, 3>();
   test_default_u<T, 2>();
   test_default_u<T, 4>();
   test_default_u<T, 8>();
@@ -73,7 +75,7 @@ TEST_FUNC void test()
 
   // explicit U different from value_type
   test_explicit_u<int, 1, float>();
-  test_explicit_u<int, 3, float, alignof(float)>();
+  test_explicit_u<int, 3, float>();
   test_explicit_u<int, 4, char>();
   test_explicit_u<float, 2, double>();
   test_explicit_u<double, 4, int>();

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/ctor.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/ctor.pass.cpp
@@ -141,26 +141,16 @@ template <typename T, int N>
 TEST_FUNC constexpr void test_range()
 {
   using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
-  cuda::std::array<T, N> arr{};
-  for (int i = 0; i < N; ++i)
-  {
-    arr[i] = static_cast<T>(i + 1);
-  }
+  auto arr  = make_iota_array<T, N>();
 
   static_assert(!noexcept(Vec(arr)));
   static_assert(!noexcept(Vec(arr, simd::flag_default)));
 
   Vec vec(arr);
-  for (int i = 0; i < N; ++i)
-  {
-    assert(vec[i] == static_cast<T>(i + 1));
-  }
+  assert(vec == arr);
 
   Vec vec2(arr, simd::flag_default);
-  for (int i = 0; i < N; ++i)
-  {
-    assert(vec2[i] == static_cast<T>(i + 1));
-  }
+  assert(vec2 == arr);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -170,20 +160,13 @@ template <typename T, int N>
 TEST_FUNC constexpr void test_range_span()
 {
   using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
-  cuda::std::array<T, N> arr{};
-  for (int i = 0; i < N; ++i)
-  {
-    arr[i] = static_cast<T>(i + 1);
-  }
+  auto arr  = make_iota_array<T, N>();
 
   const cuda::std::span<T, N> values(arr);
   const Vec vec(values);
   const Vec vec2(values, simd::flag_default);
-  for (int i = 0; i < N; ++i)
-  {
-    assert(vec[i] == static_cast<T>(i + 1));
-    assert(vec2[i] == static_cast<T>(i + 1));
-  }
+  assert(vec == arr);
+  assert(vec2 == arr);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -192,20 +175,13 @@ TEST_FUNC constexpr void test_range_span()
 template <typename T, int N>
 TEST_FUNC constexpr void test_range_alignment_flags()
 {
-  using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
-  alignas(64) cuda::std::array<T, N> arr{};
-  for (int i = 0; i < N; ++i)
-  {
-    arr[i] = static_cast<T>(i + 1);
-  }
+  using Vec            = simd::basic_vec<T, simd::fixed_size<N>>;
+  alignas(64) auto arr = make_iota_array<T, N>();
 
   const Vec aligned_vec(arr, simd::flag_aligned);
   const Vec overaligned_vec(arr, simd::flag_overaligned<32>);
-  for (int i = 0; i < N; ++i)
-  {
-    assert(aligned_vec[i] == static_cast<T>(i + 1));
-    assert(overaligned_vec[i] == static_cast<T>(i + 1));
-  }
+  assert(aligned_vec == arr);
+  assert(overaligned_vec == arr);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -216,11 +192,7 @@ TEST_FUNC constexpr void test_masked_range()
 {
   using Vec  = simd::basic_vec<T, simd::fixed_size<N>>;
   using Mask = typename Vec::mask_type;
-  cuda::std::array<T, N> arr{};
-  for (int i = 0; i < N; ++i)
-  {
-    arr[i] = static_cast<T>(i + 1);
-  }
+  auto arr   = make_iota_array<T, N>();
 
   Mask even_mask(is_even{});
   static_assert(!noexcept(Vec(arr, even_mask)));
@@ -229,27 +201,15 @@ TEST_FUNC constexpr void test_masked_range()
   Vec vec(arr, even_mask);
   for (int i = 0; i < N; ++i)
   {
-    if (i % 2 == 0)
-    {
-      assert(vec[i] == static_cast<T>(i + 1));
-    }
-    else
-    {
-      assert(vec[i] == T{0});
-    }
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : T{0};
+    assert(vec[i] == expected);
   }
 
   Vec vec2(arr, even_mask, simd::flag_default);
   for (int i = 0; i < N; ++i)
   {
-    if (i % 2 == 0)
-    {
-      assert(vec2[i] == static_cast<T>(i + 1));
-    }
-    else
-    {
-      assert(vec2[i] == T{0});
-    }
+    T expected = (i % 2 == 0) ? static_cast<T>(i + 1) : T{0};
+    assert(vec2[i] == expected);
   }
 }
 
@@ -261,19 +221,12 @@ template <typename T, typename U, int N>
 TEST_FUNC constexpr void test_range_convert_lossy()
 {
   using Vec = simd::basic_vec<T, simd::fixed_size<N>>;
-  cuda::std::array<U, N> arr{};
-  for (int i = 0; i < N; ++i)
-  {
-    arr[i] = static_cast<U>(i + 1);
-  }
+  auto arr  = make_iota_array<U, N>();
 
   static_assert(!noexcept(Vec(arr, simd::flag_convert)));
 
   Vec vec(arr, simd::flag_convert);
-  for (int i = 0; i < N; ++i)
-  {
-    assert(vec[i] == static_cast<T>(static_cast<U>(i + 1)));
-  }
+  assert((vec == make_iota_array<T, N>()));
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -285,11 +238,7 @@ TEST_FUNC constexpr void test_masked_range_convert_lossy()
 {
   using Vec  = simd::basic_vec<T, simd::fixed_size<N>>;
   using Mask = typename Vec::mask_type;
-  cuda::std::array<U, N> arr{};
-  for (int i = 0; i < N; ++i)
-  {
-    arr[i] = static_cast<U>(i + 1);
-  }
+  auto arr   = make_iota_array<U, N>();
 
   Mask even_mask(is_even{});
   static_assert(!noexcept(Vec(arr, even_mask, simd::flag_convert)));
@@ -297,14 +246,8 @@ TEST_FUNC constexpr void test_masked_range_convert_lossy()
   Vec vec(arr, even_mask, simd::flag_convert);
   for (int i = 0; i < N; ++i)
   {
-    if (i % 2 == 0)
-    {
-      assert(vec[i] == static_cast<T>(static_cast<U>(i + 1)));
-    }
-    else
-    {
-      assert(vec[i] == T{0});
-    }
+    T expected = (i % 2 == 0) ? static_cast<T>(static_cast<U>(i + 1)) : T{0};
+    assert(vec[i] == expected);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/deduction.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd.vec.class/deduction.pass.cpp
@@ -37,18 +37,11 @@
 template <typename T, int N>
 TEST_FUNC constexpr void test_range_deduction()
 {
-  cuda::std::array<T, N> arr{};
-  for (int i = 0; i < N; ++i)
-  {
-    arr[i] = static_cast<T>(i);
-  }
+  auto arr = make_iota_array<T, N>(0);
   simd::basic_vec vec(arr);
   static_assert(cuda::std::is_same_v<typename decltype(vec)::value_type, T>);
   static_assert(decltype(vec)::size() == N);
-  for (int i = 0; i < N; ++i)
-  {
-    assert(vec[i] == static_cast<T>(i));
-  }
+  assert(vec == arr);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -57,20 +50,13 @@ TEST_FUNC constexpr void test_range_deduction()
 template <typename T, int N>
 TEST_FUNC constexpr void test_span_deduction()
 {
-  cuda::std::array<T, N> arr{};
-  for (int i = 0; i < N; ++i)
-  {
-    arr[i] = static_cast<T>(i);
-  }
+  auto arr = make_iota_array<T, N>(0);
 
   const cuda::std::span<T, N> values(arr);
   simd::basic_vec vec(values);
   static_assert(cuda::std::is_same_v<typename decltype(vec)::value_type, T>);
   static_assert(decltype(vec)::size() == N);
-  for (int i = 0; i < N; ++i)
-  {
-    assert(vec[i] == static_cast<T>(i));
-  }
+  assert(vec == arr);
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
+++ b/libcudacxx/test/libcudacxx/std/numerics/simd/simd_test_utils.h
@@ -109,6 +109,31 @@ struct iota_generator
 };
 
 template <typename T, int N>
+TEST_FUNC constexpr cuda::std::array<T, N> make_iota_array(int __offset = 1)
+{
+  cuda::std::array<T, N> arr{};
+  for (int i = 0; i < N; ++i)
+  {
+    arr[i] = static_cast<T>(i + __offset);
+  }
+  return arr;
+}
+
+template <typename T, typename Abi, typename U, size_t N>
+TEST_FUNC constexpr bool operator==(const simd::basic_vec<T, Abi>& vec, const cuda::std::array<U, N>& arr)
+{
+  static_assert(simd::basic_vec<T, Abi>::size() == static_cast<int>(N));
+  for (int i = 0; i < static_cast<int>(N); ++i)
+  {
+    if (vec[i] != arr[i])
+    {
+      return false;
+    }
+  }
+  return true;
+}
+
+template <typename T, int N>
 TEST_FUNC constexpr simd::basic_vec<T, simd::fixed_size<N>> make_iota_vec()
 {
   cuda::std::array<T, N> arr{};

--- a/libcudacxx/test/simd_codegen/CMakeLists.txt
+++ b/libcudacxx/test/simd_codegen/CMakeLists.txt
@@ -8,7 +8,36 @@
 ##
 ##===----------------------------------------------------------------------===##
 
+add_custom_target(libcudacxx.test.simd.ptx)
 add_custom_target(libcudacxx.test.simd.sass)
+
+#-----------------------------------------------------------------------------------------------------------------------
+# SETUP: skip unsupported compilers, find tools, set up CUDA architectures
+
+# GCC7 and NVCC 12.0 do not vectorize load/store.
+if (
+  CMAKE_CXX_COMPILER_ID STREQUAL GNU
+  AND CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 7
+  AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8
+)
+  message("-- Skipping simd codegen tests with GCC 7 host compiler")
+  return()
+endif()
+
+if (
+  CMAKE_CUDA_COMPILER_ID STREQUAL NVIDIA
+  AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.0
+  AND CMAKE_CUDA_COMPILER_VERSION VERSION_LESS 12.1
+)
+  message("-- Skipping simd codegen tests with NVCC 12.0")
+  return()
+endif()
+
+# skip nvc++
+if (CMAKE_CXX_COMPILER_ID STREQUAL NVHPC)
+  message("-- Skipping simd codegen tests with NVHPC host compiler")
+  return()
+endif()
 
 find_program(
   filecheck
@@ -24,80 +53,162 @@ endif()
 find_program(cuobjdump "cuobjdump" REQUIRED)
 find_program(bash "bash" REQUIRED)
 
-set(libcudacxx_simd_codegen_tests)
-if (NOT "NVHPC" STREQUAL "${CMAKE_CXX_COMPILER_ID}")
-  file(GLOB libcudacxx_simd_codegen_tests "*.cu")
+set(
+  dump_and_check_script
+  "${CMAKE_CURRENT_SOURCE_DIR}/../atomic_codegen/dump_and_check.bash"
+)
+
+set(simd_codegen_sass_cuda_archs 80 90)
+if (
+  CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8
+  AND NOT CMAKE_CUDA_COMPILER_ID STREQUAL Clang
+)
+  list(APPEND simd_codegen_sass_cuda_archs 100 120)
 endif()
 
-set(simd_codegen_cuda_archs 80 90)
-if (CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.8)
-  list(APPEND simd_codegen_cuda_archs 100 120)
-endif()
+#-----------------------------------------------------------------------------------------------------------------------
+# HELPER FUNCTIONS
 
-function(simd_codegen_add_tests test_path)
+function(simd_codegen_set_cuda_arch target_name arch)
+  set_target_properties(${target_name} PROPERTIES CUDA_ARCHITECTURES "${arch}")
+endfunction()
+
+# Given the test file content, extract the SM archs that are checked for.
+# SMXX:       any arch
+# SM100-PLUS: SM100 and newer
+function(simd_codegen_get_sass_check_prefixes out_var test_contents arch)
+  set(check_prefixes SMXX)
+  set(arch_prefix "SM${arch}")
+
+  string(
+    REGEX MATCH
+    "; ${arch_prefix}(:|-LABEL:|-NOT:|-NEXT:|-SAME:|-DAG:|-COUNT:|-EMPTY:)"
+    has_arch_prefix
+    "${test_contents}"
+  )
+  if (has_arch_prefix)
+    list(APPEND check_prefixes "${arch_prefix}")
+  endif()
+
+  string(
+    REGEX MATCHALL
+    "; SM[0-9]+-PLUS(:|-[A-Z]+:)"
+    plus_prefixes
+    "${test_contents}"
+  )
+  foreach (plus_prefix IN LISTS plus_prefixes)
+    string(REGEX REPLACE ".*SM([0-9]+)-PLUS.*" "\\1" plus_arch "${plus_prefix}")
+    if (arch GREATER_EQUAL plus_arch)
+      list(APPEND check_prefixes "SM${plus_arch}-PLUS")
+    endif()
+  endforeach()
+  list(REMOVE_DUPLICATES check_prefixes)
+  list(JOIN check_prefixes "," check_prefixes)
+
+  set(${out_var} "${check_prefixes}" PARENT_SCOPE)
+endfunction()
+
+# configure the library target for the test
+function(simd_codegen_add_library_target out_var kind arch test_path)
   cmake_path(GET test_path FILENAME test_file)
   cmake_path(REMOVE_EXTENSION test_file LAST_ONLY OUTPUT_VARIABLE test_name)
 
-  file(READ "${test_path}" test_contents)
-  string(
-    REGEX MATCH
-    "SM[0-9][0-9]*"
-    has_arch_specific_prefix
-    "${test_contents}"
+  set(target_name "simd_codegen_${kind}_sm${arch}_${test_name}")
+
+  add_library(${target_name} STATIC "${test_path}")
+
+  simd_codegen_set_cuda_arch(${target_name} "${arch}")
+  target_compile_options(${target_name} PRIVATE "-Wno-comment")
+
+  target_include_directories(
+    ${target_name}
+    PRIVATE "${libcudacxx_SOURCE_DIR}/include"
   )
+  set(${out_var} "${target_name}" PARENT_SCOPE)
+endfunction()
 
-  # search for SMXX prefixes in the test contents
-  set(test_archs)
-  if (has_arch_specific_prefix)
-    foreach (arch IN LISTS simd_codegen_cuda_archs)
-      string(FIND "${test_contents}" "SM${arch}" arch_specific_prefix)
-      if (NOT arch_specific_prefix EQUAL -1)
-        list(APPEND test_archs "${arch}")
-      endif()
-    endforeach()
-  else()
-    set(test_archs ${simd_codegen_cuda_archs})
-  endif()
+# generate the check target for the test (FILECHECK)
+function(
+  simd_codegen_add_check_target
+  aggregate_target
+  target_name
+  test_path
+  check_prefixes
+)
+  string(REGEX REPLACE "[^A-Za-z0-9_]" "_" check_suffix "${check_prefixes}")
+  set(check_target_name "${target_name}_${check_suffix}_check")
 
-  # Run tests for each architecture specified in the test file
-  foreach (arch IN LISTS test_archs)
-    set(target_name "simd_codegen_sm${arch}_${test_name}")
-    set(check_prefixes "SMXX")
-    if (has_arch_specific_prefix)
-      string(APPEND check_prefixes ",SM${arch}")
+  add_custom_target(
+    ${check_target_name}
+    DEPENDS ${target_name}
+    # gersemi: off
+    COMMAND
+      ${CMAKE_COMMAND} -E env "FILECHECK=${filecheck}"
+        "${dump_and_check_script}"
+        $<TARGET_FILE:${target_name}>
+        "${test_path}"
+        "${check_prefixes}"
+        ${ARGN}
+    # gersemi: on
+  )
+  add_dependencies(${aggregate_target} ${check_target_name})
+endfunction()
+
+# generate the command to run the PTX tests
+function(simd_codegen_add_ptx_tests arch prefix_list test_list)
+  foreach (test_path IN LISTS ${test_list})
+    simd_codegen_add_library_target(target_name ptx "${arch}" "${test_path}")
+
+    # Clang stopped emitting PTX in clang20. Add flags to re-enable it.
+    if (
+      CMAKE_CUDA_COMPILER_ID STREQUAL Clang
+      AND CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 20
+    )
+      target_compile_options(
+        ${target_name}
+        PRIVATE "--cuda-include-ptx=sm_${arch}"
+      )
     endif()
 
-    add_library(${target_name} STATIC "${test_path}")
-
-    set_target_properties(
-      ${target_name}
-      PROPERTIES CUDA_ARCHITECTURES "${arch}"
-    )
-
-    target_compile_options(${target_name} PRIVATE "-Wno-comment")
-
-    target_include_directories(
-      ${target_name}
-      PRIVATE "${libcudacxx_SOURCE_DIR}/include"
-    )
-    add_dependencies(libcudacxx.test.simd.sass ${target_name})
-
-    add_custom_command(
-      TARGET libcudacxx.test.simd.sass
-      POST_BUILD
-      # gersemi: off
-      COMMAND
-        ${CMAKE_COMMAND} -E env "FILECHECK=${filecheck}"
-          "${CMAKE_CURRENT_SOURCE_DIR}/../atomic_codegen/dump_and_check.bash"
-          $<TARGET_FILE:${target_name}>
-          "${test_path}"
-          "${check_prefixes}"
-          --dump-sass
-      # gersemi: on
-    )
+    foreach (prefix IN LISTS ${prefix_list})
+      simd_codegen_add_check_target(libcudacxx.test.simd.ptx ${target_name} "${test_path}" "${prefix}")
+    endforeach()
   endforeach()
 endfunction()
 
-foreach (test_path IN LISTS libcudacxx_simd_codegen_tests)
-  simd_codegen_add_tests("${test_path}")
+# generate the command to run the SASS tests
+function(simd_codegen_add_sass_test test_path)
+  file(READ "${test_path}" test_contents)
+
+  set(test_archs)
+  foreach (arch IN LISTS simd_codegen_sass_cuda_archs)
+    simd_codegen_get_sass_check_prefixes(check_prefixes "${test_contents}" "${arch}")
+    if (NOT "${check_prefixes}" STREQUAL "SMXX")
+      list(APPEND test_archs "${arch}")
+    endif()
+  endforeach()
+  if (NOT test_archs)
+    set(test_archs ${simd_codegen_sass_cuda_archs})
+  endif()
+
+  foreach (arch IN LISTS test_archs)
+    simd_codegen_add_library_target(target_name sass "${arch}" "${test_path}")
+    simd_codegen_get_sass_check_prefixes(check_prefixes "${test_contents}" "${arch}")
+
+    string(FIND "${test_contents}" "__device__" has_device_function)
+    if (NOT has_device_function EQUAL -1)
+      target_compile_options(${target_name} PRIVATE "-dc")
+    endif()
+
+    simd_codegen_add_check_target(libcudacxx.test.simd.sass ${target_name} "${test_path}" "${check_prefixes}" --dump-sass)
+  endforeach()
+endfunction()
+
+set(simd_codegen_sass_tests)
+file(GLOB simd_codegen_sass_tests "*.cu")
+
+add_subdirectory(load_store)
+
+foreach (test_path IN LISTS simd_codegen_sass_tests)
+  simd_codegen_add_sass_test("${test_path}")
 endforeach()

--- a/libcudacxx/test/simd_codegen/load_store/CMakeLists.txt
+++ b/libcudacxx/test/simd_codegen/load_store/CMakeLists.txt
@@ -1,0 +1,35 @@
+##===----------------------------------------------------------------------===##
+##
+## Part of libcu++ in the CUDA C++ Core Libraries,
+## under the Apache License v2.0 with LLVM Exceptions.
+## See https://llvm.org/LICENSE.txt for license information.
+## SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+## SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+##
+##===----------------------------------------------------------------------===##
+
+set(
+  simd_codegen_load_store_tests
+  "${CMAKE_CURRENT_SOURCE_DIR}/load_store_i8.cu"
+  "${CMAKE_CURRENT_SOURCE_DIR}/load_store_i16.cu"
+  "${CMAKE_CURRENT_SOURCE_DIR}/load_store_i32.cu"
+  "${CMAKE_CURRENT_SOURCE_DIR}/load_store_f16.cu"
+  "${CMAKE_CURRENT_SOURCE_DIR}/load_store_bf16.cu"
+  "${CMAKE_CURRENT_SOURCE_DIR}/load_store_f32.cu"
+  "${CMAKE_CURRENT_SOURCE_DIR}/load_store_i64.cu"
+  "${CMAKE_CURRENT_SOURCE_DIR}/load_store_f64.cu"
+)
+
+set(simd_codegen_default_prefixes SMXXX)
+simd_codegen_add_ptx_tests(80 simd_codegen_default_prefixes simd_codegen_load_store_tests)
+simd_codegen_add_ptx_tests(90 simd_codegen_default_prefixes simd_codegen_load_store_tests)
+
+# SM100/SM120 add 32-byte vectorized checks.
+if (
+  CMAKE_CUDA_COMPILER_VERSION VERSION_GREATER_EQUAL 12.9
+  AND NOT CMAKE_CUDA_COMPILER_ID STREQUAL Clang
+)
+  set(simd_codegen_sm100_prefixes SMXXX SM100-PLUS)
+  simd_codegen_add_ptx_tests(100 simd_codegen_sm100_prefixes simd_codegen_load_store_tests)
+  simd_codegen_add_ptx_tests(120 simd_codegen_sm100_prefixes simd_codegen_load_store_tests)
+endif()

--- a/libcudacxx/test/simd_codegen/load_store/load_store_bf16.cu
+++ b/libcudacxx/test/simd_codegen/load_store/load_store_bf16.cu
@@ -1,0 +1,54 @@
+#include <cuda/std/__simd/load.h>
+#include <cuda/std/__simd/store.h>
+
+#if _CCCL_HAS_NVBF16()
+
+namespace simd = cuda::std::simd;
+
+// --- 8-byte tier: __nv_bfloat16, N=4 ---
+
+using Vec_bf16_4 = simd::basic_vec<__nv_bfloat16, simd::fixed_size<4>>;
+
+__global__ void test_load_bf16_4(const __nv_bfloat16* in, __nv_bfloat16* out)
+{
+  Vec_bf16_4 v = simd::unchecked_load<Vec_bf16_4>(in, Vec_bf16_4::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_bf16_4::size(), simd::flag_aligned);
+}
+
+// --- 16-byte tier: __nv_bfloat16, N=8 ---
+
+using Vec_bf16_8 = simd::basic_vec<__nv_bfloat16, simd::fixed_size<8>>;
+
+__global__ void test_load_bf16_8(const __nv_bfloat16* in, __nv_bfloat16* out)
+{
+  Vec_bf16_8 v = simd::unchecked_load<Vec_bf16_8>(in, Vec_bf16_8::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_bf16_8::size(), simd::flag_aligned);
+}
+
+// --- 32-byte tier: __nv_bfloat16, N=16 ---
+
+using Vec_bf16_16 = simd::basic_vec<__nv_bfloat16, simd::fixed_size<16>>;
+
+__global__ void test_load_bf16_16(const __nv_bfloat16* in, __nv_bfloat16* out)
+{
+  Vec_bf16_16 v = simd::unchecked_load<Vec_bf16_16>(in, Vec_bf16_16::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_bf16_16::size(), simd::flag_aligned);
+}
+
+/*
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_bf16_4{{.*}}(
+; SMXXX: {{.*}}ld.global.{{([bus]64|v4\.[bus]16|v2\.[bus]32)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{([bus]64|v4\.[bus]16|v2\.[bus]32)}}{{.*}}
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_bf16_8{{.*}}(
+; SMXXX: {{.*}}ld.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+
+; SM100-PLUS-LABEL: .visible .entry {{.*}}test_load_bf16_16{{.*}}(
+; SM100-PLUS: {{.*}}ld.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+; SM100-PLUS: {{.*}}st.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+
+*/
+
+#endif // _CCCL_HAS_NVBF16()

--- a/libcudacxx/test/simd_codegen/load_store/load_store_f16.cu
+++ b/libcudacxx/test/simd_codegen/load_store/load_store_f16.cu
@@ -1,0 +1,54 @@
+#include <cuda/std/__simd/load.h>
+#include <cuda/std/__simd/store.h>
+
+#if _CCCL_HAS_NVFP16()
+
+namespace simd = cuda::std::simd;
+
+// --- 8-byte tier: __half, N=4 ---
+
+using Vec_f16_4 = simd::basic_vec<__half, simd::fixed_size<4>>;
+
+__global__ void test_load_f16_4(const __half* in, __half* out)
+{
+  Vec_f16_4 v = simd::unchecked_load<Vec_f16_4>(in, Vec_f16_4::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_f16_4::size(), simd::flag_aligned);
+}
+
+// --- 16-byte tier: __half, N=8 ---
+
+using Vec_f16_8 = simd::basic_vec<__half, simd::fixed_size<8>>;
+
+__global__ void test_load_f16_8(const __half* in, __half* out)
+{
+  Vec_f16_8 v = simd::unchecked_load<Vec_f16_8>(in, Vec_f16_8::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_f16_8::size(), simd::flag_aligned);
+}
+
+// --- 32-byte tier: __half, N=16 ---
+
+using Vec_f16_16 = simd::basic_vec<__half, simd::fixed_size<16>>;
+
+__global__ void test_load_f16_16(const __half* in, __half* out)
+{
+  Vec_f16_16 v = simd::unchecked_load<Vec_f16_16>(in, Vec_f16_16::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_f16_16::size(), simd::flag_aligned);
+}
+
+/*
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_f16_4{{.*}}(
+; SMXXX: {{.*}}ld.global.{{([bus]64|v4\.[bfus]16|v2\.[bus]32)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{([bus]64|v4\.[bfus]16|v2\.[bus]32)}}{{.*}}
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_f16_8{{.*}}(
+; SMXXX: {{.*}}ld.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+
+; SM100-PLUS-LABEL: .visible .entry {{.*}}test_load_f16_16{{.*}}(
+; SM100-PLUS: {{.*}}ld.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+; SM100-PLUS: {{.*}}st.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+
+*/
+
+#endif // _CCCL_HAS_NVFP16()

--- a/libcudacxx/test/simd_codegen/load_store/load_store_f32.cu
+++ b/libcudacxx/test/simd_codegen/load_store/load_store_f32.cu
@@ -1,0 +1,50 @@
+#include <cuda/std/__simd/load.h>
+#include <cuda/std/__simd/store.h>
+
+namespace simd = cuda::std::simd;
+
+// --- 8-byte tier: float, N=2 ---
+
+using Vec_f32_2 = simd::basic_vec<float, simd::fixed_size<2>>;
+
+__global__ void test_load_f32_2(const float* in, float* out)
+{
+  Vec_f32_2 v = simd::unchecked_load<Vec_f32_2>(in, Vec_f32_2::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_f32_2::size(), simd::flag_aligned);
+}
+
+// --- 16-byte tier: float, N=4 ---
+
+using Vec_f32_4 = simd::basic_vec<float, simd::fixed_size<4>>;
+
+__global__ void test_load_f32_4(const float* in, float* out)
+{
+  Vec_f32_4 v = simd::unchecked_load<Vec_f32_4>(in, Vec_f32_4::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_f32_4::size(), simd::flag_aligned);
+}
+
+// --- 32-byte tier: float, N=8 ---
+
+using Vec_f32_8 = simd::basic_vec<float, simd::fixed_size<8>>;
+
+__global__ void test_load_f32_8(const float* in, float* out)
+{
+  Vec_f32_8 v = simd::unchecked_load<Vec_f32_8>(in, Vec_f32_8::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_f32_8::size(), simd::flag_aligned);
+}
+
+/*
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_f32_2{{.*}}(
+; SMXXX: {{.*}}ld.global.{{([bus]64|v4\.[bus]16|v2\.[bfus]32)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{([bus]64|v4\.[bus]16|v2\.[bfus]32)}}{{.*}}
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_f32_4{{.*}}(
+; SMXXX: {{.*}}ld.global.{{(v4\.[bfus]32|v2\.[bus]64)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{(v4\.[bfus]32|v2\.[bus]64)}}{{.*}}
+
+; SM100-PLUS-LABEL: .visible .entry {{.*}}test_load_f32_8{{.*}}(
+; SM100-PLUS: {{.*}}ld.global.{{(v4\.[bus]64|v8\.[bfus]32)}}{{.*}}
+; SM100-PLUS: {{.*}}st.global.{{(v4\.[bus]64|v8\.[bfus]32)}}{{.*}}
+
+*/

--- a/libcudacxx/test/simd_codegen/load_store/load_store_f64.cu
+++ b/libcudacxx/test/simd_codegen/load_store/load_store_f64.cu
@@ -1,0 +1,37 @@
+#include <cuda/std/__simd/load.h>
+#include <cuda/std/__simd/store.h>
+
+namespace simd = cuda::std::simd;
+
+// --- 16-byte tier: double, N=2 ---
+// 8-byte tier skipped: N=1
+
+using Vec_f64_2 = simd::basic_vec<double, simd::fixed_size<2>>;
+
+__global__ void test_load_f64_2(const double* in, double* out)
+{
+  Vec_f64_2 v = simd::unchecked_load<Vec_f64_2>(in, Vec_f64_2::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_f64_2::size(), simd::flag_aligned);
+}
+
+// --- 32-byte tier: double, N=4 ---
+
+using Vec_f64_4 = simd::basic_vec<double, simd::fixed_size<4>>;
+
+__global__ void test_load_f64_4(const double* in, double* out)
+{
+  Vec_f64_4 v = simd::unchecked_load<Vec_f64_4>(in, Vec_f64_4::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_f64_4::size(), simd::flag_aligned);
+}
+
+/*
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_f64_2{{.*}}(
+; SMXXX: {{.*}}ld.global.{{(v4\.[bus]32|v2\.[bfus]64)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{(v4\.[bus]32|v2\.[bfus]64)}}{{.*}}
+
+; SM100-PLUS-LABEL: .visible .entry {{.*}}test_load_f64_4{{.*}}(
+; SM100-PLUS: {{.*}}ld.global.{{(v4\.[bfus]64|v8\.[bus]32)}}{{.*}}
+; SM100-PLUS: {{.*}}st.global.{{(v4\.[bfus]64|v8\.[bus]32)}}{{.*}}
+
+*/

--- a/libcudacxx/test/simd_codegen/load_store/load_store_i16.cu
+++ b/libcudacxx/test/simd_codegen/load_store/load_store_i16.cu
@@ -1,0 +1,51 @@
+#include <cuda/std/__simd/load.h>
+#include <cuda/std/__simd/store.h>
+#include <cuda/std/cstdint>
+
+namespace simd = cuda::std::simd;
+
+// --- 8-byte tier: int16_t, N=4 ---
+
+using Vec_i16_4 = simd::basic_vec<cuda::std::int16_t, simd::fixed_size<4>>;
+
+__global__ void test_load_i16_4(const cuda::std::int16_t* in, cuda::std::int16_t* out)
+{
+  Vec_i16_4 v = simd::unchecked_load<Vec_i16_4>(in, Vec_i16_4::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i16_4::size(), simd::flag_aligned);
+}
+
+// --- 16-byte tier: int16_t, N=8 ---
+
+using Vec_i16_8 = simd::basic_vec<cuda::std::int16_t, simd::fixed_size<8>>;
+
+__global__ void test_load_i16_8(const cuda::std::int16_t* in, cuda::std::int16_t* out)
+{
+  Vec_i16_8 v = simd::unchecked_load<Vec_i16_8>(in, Vec_i16_8::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i16_8::size(), simd::flag_aligned);
+}
+
+// --- 32-byte tier: int16_t, N=16 ---
+
+using Vec_i16_16 = simd::basic_vec<cuda::std::int16_t, simd::fixed_size<16>>;
+
+__global__ void test_load_i16_16(const cuda::std::int16_t* in, cuda::std::int16_t* out)
+{
+  Vec_i16_16 v = simd::unchecked_load<Vec_i16_16>(in, Vec_i16_16::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i16_16::size(), simd::flag_aligned);
+}
+
+/*
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_i16_4{{.*}}(
+; SMXXX: {{.*}}ld.global.{{([bus]64|v4\.[bus]16|v2\.[bus]32)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{([bus]64|v4\.[bus]16|v2\.[bus]32)}}{{.*}}
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_i16_8{{.*}}(
+; SMXXX: {{.*}}ld.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+
+; SM100-PLUS-LABEL: .visible .entry {{.*}}test_load_i16_16{{.*}}(
+; SM100-PLUS: {{.*}}ld.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+; SM100-PLUS: {{.*}}st.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+
+*/

--- a/libcudacxx/test/simd_codegen/load_store/load_store_i32.cu
+++ b/libcudacxx/test/simd_codegen/load_store/load_store_i32.cu
@@ -1,0 +1,51 @@
+#include <cuda/std/__simd/load.h>
+#include <cuda/std/__simd/store.h>
+#include <cuda/std/cstdint>
+
+namespace simd = cuda::std::simd;
+
+// --- 8-byte tier: int32_t, N=2 ---
+
+using Vec_i32_2 = simd::basic_vec<cuda::std::int32_t, simd::fixed_size<2>>;
+
+__global__ void test_load_i32_2(const cuda::std::int32_t* in, cuda::std::int32_t* out)
+{
+  Vec_i32_2 v = simd::unchecked_load<Vec_i32_2>(in, Vec_i32_2::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i32_2::size(), simd::flag_aligned);
+}
+
+// --- 16-byte tier: int32_t, N=4 ---
+
+using Vec_i32_4 = simd::basic_vec<cuda::std::int32_t, simd::fixed_size<4>>;
+
+__global__ void test_load_i32_4(const cuda::std::int32_t* in, cuda::std::int32_t* out)
+{
+  Vec_i32_4 v = simd::unchecked_load<Vec_i32_4>(in, Vec_i32_4::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i32_4::size(), simd::flag_aligned);
+}
+
+// --- 32-byte tier: int32_t, N=8 ---
+
+using Vec_i32_8 = simd::basic_vec<cuda::std::int32_t, simd::fixed_size<8>>;
+
+__global__ void test_load_i32_8(const cuda::std::int32_t* in, cuda::std::int32_t* out)
+{
+  Vec_i32_8 v = simd::unchecked_load<Vec_i32_8>(in, Vec_i32_8::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i32_8::size(), simd::flag_aligned);
+}
+
+/*
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_i32_2{{.*}}(
+; SMXXX: {{.*}}ld.global.{{([bus]64|v4\.[bus]16|v2\.[bus]32)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{([bus]64|v4\.[bus]16|v2\.[bus]32)}}{{.*}}
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_i32_4{{.*}}(
+; SMXXX: {{.*}}ld.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+
+; SM100-PLUS-LABEL: .visible .entry {{.*}}test_load_i32_8{{.*}}(
+; SM100-PLUS: {{.*}}ld.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+; SM100-PLUS: {{.*}}st.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+
+*/

--- a/libcudacxx/test/simd_codegen/load_store/load_store_i64.cu
+++ b/libcudacxx/test/simd_codegen/load_store/load_store_i64.cu
@@ -1,0 +1,38 @@
+#include <cuda/std/__simd/load.h>
+#include <cuda/std/__simd/store.h>
+#include <cuda/std/cstdint>
+
+namespace simd = cuda::std::simd;
+
+// --- 16-byte tier: int64_t, N=2 ---
+// 8-byte tier skipped: N=1
+
+using Vec_i64_2 = simd::basic_vec<cuda::std::int64_t, simd::fixed_size<2>>;
+
+__global__ void test_load_i64_2(const cuda::std::int64_t* in, cuda::std::int64_t* out)
+{
+  Vec_i64_2 v = simd::unchecked_load<Vec_i64_2>(in, Vec_i64_2::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i64_2::size(), simd::flag_aligned);
+}
+
+// --- 32-byte tier: int64_t, N=4 ---
+
+using Vec_i64_4 = simd::basic_vec<cuda::std::int64_t, simd::fixed_size<4>>;
+
+__global__ void test_load_i64_4(const cuda::std::int64_t* in, cuda::std::int64_t* out)
+{
+  Vec_i64_4 v = simd::unchecked_load<Vec_i64_4>(in, Vec_i64_4::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i64_4::size(), simd::flag_aligned);
+}
+
+/*
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_i64_2{{.*}}(
+; SMXXX: {{.*}}ld.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+
+; SM100-PLUS-LABEL: .visible .entry {{.*}}test_load_i64_4{{.*}}(
+; SM100-PLUS: {{.*}}ld.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+; SM100-PLUS: {{.*}}st.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+
+*/

--- a/libcudacxx/test/simd_codegen/load_store/load_store_i8.cu
+++ b/libcudacxx/test/simd_codegen/load_store/load_store_i8.cu
@@ -1,0 +1,51 @@
+#include <cuda/std/__simd/load.h>
+#include <cuda/std/__simd/store.h>
+#include <cuda/std/cstdint>
+
+namespace simd = cuda::std::simd;
+
+// --- 8-byte tier: int8_t, N=8 ---
+
+using Vec_i8_8 = simd::basic_vec<cuda::std::int8_t, simd::fixed_size<8>>;
+
+__global__ void test_load_i8_8(const cuda::std::int8_t* in, cuda::std::int8_t* out)
+{
+  Vec_i8_8 v = simd::unchecked_load<Vec_i8_8>(in, Vec_i8_8::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i8_8::size(), simd::flag_aligned);
+}
+
+// --- 16-byte tier: int8_t, N=16 ---
+
+using Vec_i8_16 = simd::basic_vec<cuda::std::int8_t, simd::fixed_size<16>>;
+
+__global__ void test_load_i8_16(const cuda::std::int8_t* in, cuda::std::int8_t* out)
+{
+  Vec_i8_16 v = simd::unchecked_load<Vec_i8_16>(in, Vec_i8_16::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i8_16::size(), simd::flag_aligned);
+}
+
+// --- 32-byte tier: int8_t, N=32 ---
+
+using Vec_i8_32 = simd::basic_vec<cuda::std::int8_t, simd::fixed_size<32>>;
+
+__global__ void test_load_i8_32(const cuda::std::int8_t* in, cuda::std::int8_t* out)
+{
+  Vec_i8_32 v = simd::unchecked_load<Vec_i8_32>(in, Vec_i8_32::size(), simd::flag_aligned);
+  simd::unchecked_store(v, out, Vec_i8_32::size(), simd::flag_aligned);
+}
+
+/*
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_i8_8{{.*}}(
+; SMXXX: {{.*}}ld.global.{{([bus]64|v4\.[bus]16|v2\.[bus]32)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{([bus]64|v4\.[bus]16|v2\.[bus]32)}}{{.*}}
+
+; SMXXX-LABEL: .visible .entry {{.*}}test_load_i8_16{{.*}}(
+; SMXXX: {{.*}}ld.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+; SMXXX: {{.*}}st.global.{{(v4\.[bus]32|v2\.[bus]64)}}{{.*}}
+
+; SM100-PLUS-LABEL: .visible .entry {{.*}}test_load_i8_32{{.*}}(
+; SM100-PLUS: {{.*}}ld.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+; SM100-PLUS: {{.*}}st.global.{{(v4\.[bus]64|v8\.[bus]32)}}{{.*}}
+
+*/


### PR DESCRIPTION
## Description

Follow up PR of https://github.com/NVIDIA/cccl/pull/8251

- Add `partial_load`, `unchecked_load`, `partial_store`, `unchecked_store` free functions to `cuda::std::simd`.
- All overloads are provided: range, iterator+count, iterator+sentinel, each with and without mask.

To do:

- [x]  unit test.
