### PR TITLE
Recover `warp_shuffle` original behavior (revert #8210)

### DIFF
--- a/libcudacxx/include/cuda/__warp/warp_shuffle.h
+++ b/libcudacxx/include/cuda/__warp/warp_shuffle.h
@@ -31,6 +31,7 @@
 #    include <cuda/std/__memory/addressof.h>
 #    include <cuda/std/__type_traits/enable_if.h>
 #    include <cuda/std/__type_traits/integral_constant.h>
+#    include <cuda/std/__type_traits/is_default_constructible.h>
 #    include <cuda/std/__type_traits/is_pointer.h>
 #    include <cuda/std/cstdint>
 
@@ -55,6 +56,7 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 [[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up> warp_shuffle_idx(
   const _Tp& __data, int __src_lane, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
+  static_assert(::cuda::std::is_default_constructible_v<_Tp>, "_Tp must be default constructible");
   constexpr auto __warp_size   = 32u;
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
   static_assert(!::cuda::std::is_pointer_v<_Up> || __is_void_ptr,
@@ -99,6 +101,7 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 [[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Tp> warp_shuffle_up(
   const _Tp& __data, int __delta, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
+  static_assert(::cuda::std::is_default_constructible_v<_Tp>, "_Tp must be default constructible");
   constexpr auto __warp_size   = 32u;
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
   static_assert(!::cuda::std::is_pointer_v<_Up> || __is_void_ptr,
@@ -147,6 +150,7 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 [[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up> warp_shuffle_down(
   const _Tp& __data, int __delta, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
+  static_assert(::cuda::std::is_default_constructible_v<_Tp>, "_Tp must be default constructible");
   constexpr auto __warp_size   = 32u;
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
   static_assert(!::cuda::std::is_pointer_v<_Up> || __is_void_ptr,
@@ -195,6 +199,7 @@ template <int _Width = 32, typename _Tp, typename _Up = ::cuda::std::remove_cv_t
 [[nodiscard]] _CCCL_DEVICE_API warp_shuffle_result<_Up> warp_shuffle_xor(
   const _Tp& __data, int __xor_mask, uint32_t __lane_mask = 0xFFFFFFFF, ::cuda::std::integral_constant<int, _Width> = {})
 {
+  static_assert(::cuda::std::is_default_constructible_v<_Tp>, "_Tp must be default constructible");
   constexpr auto __warp_size   = 32u;
   constexpr bool __is_void_ptr = ::cuda::std::is_same_v<_Up, void*> || ::cuda::std::is_same_v<_Up, const void*>;
   static_assert(!::cuda::std::is_pointer_v<_Up> || __is_void_ptr,


### PR DESCRIPTION
## Description

#8210 enforces additional constraints to the type allowed in `cuda::device::warp_shuffle_*`, namely default contractible and trivially copyable.  

While this is conceptually correct, the new constraints prevent using warp shuffle instructions with types that practically satisfy these property but where the type traits fail, e.g. `__half`, `__nv_bfloat16`, other reduced precision floating-point types, composition of them like array and structures. Enforcing such constraints prevent using them in many context, e.g. CUB.

This PR reverts the original behavior until we don't find a reliable way to prevent the problem.