### PR TITLE
Fix `cuda::constant_iterator` return value

### DIFF
--- a/libcudacxx/include/cuda/__iterator/constant_iterator.h
+++ b/libcudacxx/include/cuda/__iterator/constant_iterator.h
@@ -130,14 +130,14 @@ public:
     return static_cast<difference_type>(__index());
   }
 
-  //! @brief Returns a const reference to the stored value
-  [[nodiscard]] _CCCL_API constexpr const _Tp& operator*() const noexcept
+  //! @brief Returns the stored value
+  [[nodiscard]] _CCCL_API constexpr reference operator*() const noexcept
   {
     return __value();
   }
 
-  //! @brief Returns a const reference to the stored value
-  [[nodiscard]] _CCCL_API constexpr const _Tp& operator[](difference_type) const noexcept
+  //! @brief Returns the stored value
+  [[nodiscard]] _CCCL_API constexpr reference operator[](difference_type) const noexcept
   {
     return __value();
   }

--- a/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/star.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/star.pass.cpp
@@ -27,14 +27,14 @@ __host__ __device__ constexpr void test(T value)
     }
 
     static_assert(noexcept(*iter));
-    static_assert(cuda::std::is_same_v<decltype(*iter), const T&>);
+    static_assert(cuda::std::is_same_v<decltype(*iter), T>);
   }
 
   {
     const cuda::constant_iterator iter{value, 42};
     assert(*iter == value);
     static_assert(noexcept(*iter));
-    static_assert(cuda::std::is_same_v<decltype(*iter), const T&>);
+    static_assert(cuda::std::is_same_v<decltype(*iter), T>);
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/subscript.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/iterators/constant_iterator/subscript.pass.cpp
@@ -27,7 +27,7 @@ __host__ __device__ constexpr void test(T value)
     }
 
     static_assert(noexcept(iter[42]));
-    static_assert(cuda::std::is_same_v<decltype(iter[42]), const T&>);
+    static_assert(cuda::std::is_same_v<decltype(iter[42]), T>);
   }
 
   {
@@ -37,7 +37,7 @@ __host__ __device__ constexpr void test(T value)
       assert(iter[i] == value);
     }
     static_assert(noexcept(iter[42]));
-    static_assert(cuda::std::is_same_v<decltype(iter[42]), const T&>);
+    static_assert(cuda::std::is_same_v<decltype(iter[42]), T>);
   }
 }
 


### PR DESCRIPTION
We incorrectly returned `const _Tp&` from `operator*` and `operator[]`

This can lead to dangling references in pretty common code, such as `cuda::std::reverse_iterator` which does a `return *::cuda::std::prev(__current_);`

The temporary created by `::cuda::std::prev(__current_)` is then dangling because we returned a reference to the value stored in the temporary iterator

Found during investigation of issues in #5649