### PR TITLE
Port `thrust::min|max_element` to CUB

### DIFF
--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -47,8 +47,8 @@ NVBENCH_DECLARE_TYPE_STRINGS(complex64, "C64", "complex64");
 
 NVBENCH_DECLARE_TYPE_STRINGS(::cuda::std::false_type, "false", "false_type");
 NVBENCH_DECLARE_TYPE_STRINGS(::cuda::std::true_type, "true", "true_type");
-NVBENCH_DECLARE_TYPE_STRINGS(cub::ArgMin, "ArgMin", "cub::ArgMin");
-NVBENCH_DECLARE_TYPE_STRINGS(cub::ArgMax, "ArgMax", "cub::ArgMax");
+NVBENCH_DECLARE_TYPE_STRINGS(cub::detail::arg_min, "arg_min", "cub::detail::arg_min");
+NVBENCH_DECLARE_TYPE_STRINGS(cub::detail::arg_max, "arg_max", "cub::detail::arg_max");
 
 template <typename T, T I>
 struct nvbench::type_strings<::cuda::std::integral_constant<T, I>>

--- a/thrust/benchmarks/bench/extrema/basic.cu
+++ b/thrust/benchmarks/bench/extrema/basic.cu
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/extrema.h>
+
+#include "nvbench_helper.cuh"
+
+template <typename T, typename Func>
+static void bench_extremum(nvbench::state& state, nvbench::type_list<T>, Func func)
+{
+  const auto elements = static_cast<std::size_t>(state.get_int64("Elements"));
+
+  thrust::device_vector<T> in = generate(elements);
+
+  using offset_t = typename decltype(in.cbegin())::difference_type;
+
+  state.add_element_count(elements);
+  state.add_global_memory_reads<T>(elements);
+  state.add_global_memory_writes<offset_t>(1);
+
+  caching_allocator_t alloc;
+  state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch | nvbench::exec_tag::sync,
+             [&](nvbench::launch& launch) {
+               do_not_optimize(func(policy(alloc, launch), in.cbegin(), in.cend()));
+             });
+}
+
+template <typename T>
+static void min_element(nvbench::state& state, nvbench::type_list<T> list)
+{
+  bench_extremum(state, list, [](auto&&... args) {
+    return thrust::min_element(args...);
+  });
+}
+
+NVBENCH_BENCH_TYPES(min_element, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("min_element")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));
+
+template <typename T>
+static void max_element(nvbench::state& state, nvbench::type_list<T> list)
+{
+  bench_extremum(state, list, [](auto&&... args) {
+    return thrust::max_element(args...);
+  });
+}
+
+NVBENCH_BENCH_TYPES(max_element, NVBENCH_TYPE_AXES(fundamental_types))
+  .set_name("max_element")
+  .set_type_axes_names({"T{ct}"})
+  .add_int64_power_of_two_axis("Elements", nvbench::range(16, 28, 4));

--- a/thrust/thrust/system/cuda/detail/extrema.h
+++ b/thrust/thrust/system/cuda/detail/extrema.h
@@ -26,6 +26,7 @@
 #  include <thrust/system/cuda/detail/cdp_dispatch.h>
 #  include <thrust/system/cuda/detail/reduce.h>
 
+#  include <cuda/__iterator/discard_iterator.h>
 #  include <cuda/std/__functional/operations.h>
 #  include <cuda/std/__iterator/distance.h>
 #  include <cuda/std/__utility/pair.h>
@@ -348,8 +349,8 @@ cub_min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, 
     return last;
   }
 
-  size_t tmp_size = 0;
-  auto error      = cub::DeviceReduce::ArgMin(
+  ::cuda::std::size_t tmp_size = 0;
+  auto error                   = cub::DeviceReduce::ArgMin(
     nullptr,
     tmp_size,
     first,
@@ -363,7 +364,7 @@ cub_min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, 
   // We allocate both the temporary storage needed for the algorithm, and a `size_type` to store the result.
   thrust::detail::temporary_array<char, Derived> tmp(policy, sizeof(offset_t) + tmp_size);
   offset_t* index_ptr = thrust::detail::aligned_reinterpret_cast<offset_t*>(tmp.data().get());
-  void* tmp_ptr       = static_cast<void*>(tmp.data().get() + sizeof(offset_t));
+  auto tmp_ptr        = static_cast<void*>(tmp.data().get() + sizeof(offset_t));
 
   error = cub::DeviceReduce::ArgMin(
     tmp_ptr, tmp_size, first, ::cuda::discard_iterator{}, index_ptr, num_items, binary_pred, stream);

--- a/thrust/thrust/system/cuda/detail/extrema.h
+++ b/thrust/thrust/system/cuda/detail/extrema.h
@@ -335,71 +335,67 @@ extrema(execution_policy<Derived>& policy, InputIt first, Size num_items, Binary
   return result;
 }
 
-template <template <class, class, class> class ArgFunctor, class Derived, class ItemsIt, class BinaryPred>
-ItemsIt THRUST_RUNTIME_FUNCTION
-element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred)
+template <class Derived, class ItemsIt, class BinaryPred>
+ItemsIt CUB_RUNTIME_FUNCTION
+cub_min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred)
 {
-  if (first == last)
+  cudaStream_t stream      = cuda_cub::stream(policy);
+  using offset_t           = thrust::detail::it_difference_t<ItemsIt>;
+  const offset_t num_items = ::cuda::std::distance(first, last);
+
+  if (num_items == 0)
   {
     return last;
   }
 
-  using InputType = thrust::detail::it_value_t<ItemsIt>;
-  using IndexType = thrust::detail::it_difference_t<ItemsIt>;
+  size_t tmp_size = 0;
+  auto error      = cub::DeviceReduce::ArgMin(
+    nullptr,
+    tmp_size,
+    first,
+    ::cuda::discard_iterator{},
+    static_cast<offset_t*>(nullptr),
+    num_items,
+    binary_pred,
+    stream);
+  throw_on_error(error, "min_element failed to allocate temporary storages");
 
-  IndexType num_items = static_cast<IndexType>(::cuda::std::distance(first, last));
+  // We allocate both the temporary storage needed for the algorithm, and a `size_type` to store the result.
+  thrust::detail::temporary_array<char, Derived> tmp(policy, sizeof(offset_t) + tmp_size);
+  offset_t* index_ptr = thrust::detail::aligned_reinterpret_cast<offset_t*>(tmp.data().get());
+  void* tmp_ptr       = static_cast<void*>(tmp.data().get() + sizeof(offset_t));
 
-  using iterator_tuple = ::cuda::std::tuple<ItemsIt, counting_iterator<IndexType>>;
-  using zip_iterator   = thrust::zip_iterator<iterator_tuple>;
+  error = cub::DeviceReduce::ArgMin(
+    tmp_ptr, tmp_size, first, ::cuda::discard_iterator{}, index_ptr, num_items, binary_pred, stream);
+  cuda_cub::throw_on_error(error, "min_element failed to launch cub::DeviceReduce::ArgMin");
 
-  iterator_tuple iter_tuple = ::cuda::std::make_tuple(first, counting_iterator<IndexType>(0));
+  cuda_cub::throw_on_error(cuda_cub::synchronize(policy), "min_element failed to synchronize");
 
-  using arg_min_t = ArgFunctor<InputType, IndexType, BinaryPred>;
-  using T         = ::cuda::std::tuple<InputType, IndexType>;
-
-  zip_iterator begin = thrust::make_zip_iterator(iter_tuple);
-
-  T result = extrema(policy, begin, num_items, arg_min_t(binary_pred), (T*) (nullptr));
-  return first + ::cuda::std::get<1>(result);
+  return first + get_value(policy, index_ptr);
 }
 } // namespace __extrema
 
 /// min element
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived, class ItemsIt, class BinaryPred>
+template <class Derived, class ItemsIt, class BinaryPred = ::cuda::std::less<thrust::detail::it_value_t<ItemsIt>>>
 ItemsIt _CCCL_HOST_DEVICE
-min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred)
+min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred = {})
 {
-  THRUST_CDP_DISPATCH((last = __extrema::element<__extrema::arg_min_f>(policy, first, last, binary_pred);),
-                      (last = thrust::min_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);));
-  return last;
-}
-
-template <class Derived, class ItemsIt>
-ItemsIt _CCCL_HOST_DEVICE min_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
-{
-  using value_type = thrust::detail::it_value_t<ItemsIt>;
-  return cuda_cub::min_element(policy, first, last, ::cuda::std::less<value_type>());
+  THRUST_CDP_DISPATCH(({ return __extrema::cub_min_element(policy, first, last, binary_pred); }),
+                      ({ return thrust::min_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred); }));
 }
 
 /// max element
 
 _CCCL_EXEC_CHECK_DISABLE
-template <class Derived, class ItemsIt, class BinaryPred>
+template <class Derived, class ItemsIt, class BinaryPred = ::cuda::std::less<thrust::detail::it_value_t<ItemsIt>>>
 ItemsIt _CCCL_HOST_DEVICE
-max_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred)
+max_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last, BinaryPred binary_pred = {})
 {
-  THRUST_CDP_DISPATCH((last = __extrema::element<__extrema::arg_max_f>(policy, first, last, binary_pred);),
-                      (last = thrust::max_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred);));
-  return last;
-}
-
-template <class Derived, class ItemsIt>
-ItemsIt _CCCL_HOST_DEVICE max_element(execution_policy<Derived>& policy, ItemsIt first, ItemsIt last)
-{
-  using value_type = thrust::detail::it_value_t<ItemsIt>;
-  return cuda_cub::max_element(policy, first, last, ::cuda::std::less<value_type>());
+  THRUST_CDP_DISPATCH(
+    ({ return __extrema::cub_min_element(policy, first, last, cub::detail::swap_args{binary_pred}); }),
+    ({ return thrust::max_element(cvt_to_seq(derived_cast(policy)), first, last, binary_pred); }));
 }
 
 /// minmax element


### PR DESCRIPTION
Pulled out from: #4970

- [x] Merge first: #8285

Added a new thrust benchmark. Performance is overwhelmingly good, except for a few runs.
```
# min_element

## [0] NVIDIA B200

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^16    |  29.767 us |       3.51% |  27.695 us |       2.50% |  -2.072 us |  -6.96% |   FAST   |
|   I8    |    2^20    |  34.445 us |       2.45% |  30.387 us |       3.75% |  -4.057 us | -11.78% |   FAST   |
|   I8    |    2^24    |  48.797 us |       1.97% |  46.842 us |       2.15% |  -1.955 us |  -4.01% |   FAST   |
|   I8    |    2^28    | 232.320 us |       0.71% | 173.622 us |       0.84% | -58.698 us | -25.27% |   FAST   |
|   I16   |    2^16    |  32.439 us |       4.30% |  30.093 us |       7.20% |  -2.347 us |  -7.23% |   FAST   |
|   I16   |    2^20    |  35.631 us |       3.93% |  31.878 us |       3.12% |  -3.753 us | -10.53% |   FAST   |
|   I16   |    2^24    |  52.312 us |       2.39% |  48.735 us |       2.00% |  -3.578 us |  -6.84% |   FAST   |
|   I16   |    2^28    | 237.099 us |       0.81% | 163.475 us |       1.07% | -73.624 us | -31.05% |   FAST   |
|   I32   |    2^16    |  31.905 us |       4.46% |  29.510 us |       3.11% |  -2.395 us |  -7.51% |   FAST   |
|   I32   |    2^20    |  35.995 us |       4.11% |  31.087 us |       3.98% |  -4.907 us | -13.63% |   FAST   |
|   I32   |    2^24    |  52.556 us |       2.99% |  47.221 us |       2.27% |  -5.334 us | -10.15% |   FAST   |
|   I32   |    2^28    | 259.893 us |       0.79% | 202.981 us |       0.83% | -56.913 us | -21.90% |   FAST   |
|   I64   |    2^16    |  31.984 us |       4.34% |  29.859 us |       2.94% |  -2.125 us |  -6.65% |   FAST   |
|   I64   |    2^20    |  35.956 us |       5.26% |  32.477 us |       2.94% |  -3.479 us |  -9.68% |   FAST   |
|   I64   |    2^24    |  63.105 us |       2.19% |  61.777 us |       1.71% |  -1.328 us |  -2.10% |   FAST   |
|   I64   |    2^28    | 363.831 us |       1.16% | 348.154 us |       0.63% | -15.677 us |  -4.31% |   FAST   |
|  I128   |    2^16    |  32.892 us |       5.53% |  30.926 us |       4.51% |  -1.966 us |  -5.98% |   FAST   |
|  I128   |    2^20    |  40.230 us |       4.75% |  39.214 us |       3.15% |  -1.016 us |  -2.53% |   SAME   |
|  I128   |    2^24    |  89.145 us |       1.47% |  92.932 us |       1.49% |   3.786 us |   4.25% |   SLOW   |
|  I128   |    2^28    | 721.795 us |       0.32% | 685.891 us |       1.41% | -35.904 us |  -4.97% |   FAST   |
|   F32   |    2^16    |  32.142 us |       3.67% |  29.304 us |       3.25% |  -2.838 us |  -8.83% |   FAST   |
|   F32   |    2^20    |  35.792 us |       4.37% |  31.437 us |       4.82% |  -4.355 us | -12.17% |   FAST   |
|   F32   |    2^24    |  52.600 us |       2.42% |  47.182 us |       2.07% |  -5.417 us | -10.30% |   FAST   |
|   F32   |    2^28    | 261.674 us |       0.50% | 202.987 us |       0.51% | -58.687 us | -22.43% |   FAST   |
|   F64   |    2^16    |  31.788 us |       4.75% |  29.779 us |       2.33% |  -2.008 us |  -6.32% |   FAST   |
|   F64   |    2^20    |  35.550 us |       4.09% |  32.349 us |       4.18% |  -3.201 us |  -9.00% |   FAST   |
|   F64   |    2^24    |  61.892 us |       2.09% |  61.993 us |       1.65% |   0.101 us |   0.16% |   SAME   |
|   F64   |    2^28    | 353.879 us |       0.40% | 347.793 us |       0.81% |  -6.086 us |  -1.72% |   FAST   |

# max_element

## [0] NVIDIA B200

|  T{ct}  |  Elements  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |    2^16    |  32.616 us |       5.73% |  29.773 us |       4.54% |  -2.842 us |  -8.71% |   FAST   |
|   I8    |    2^20    |  35.695 us |       4.96% |  31.616 us |       3.32% |  -4.080 us | -11.43% |   FAST   |
|   I8    |    2^24    |  48.544 us |       2.74% |  48.531 us |       1.98% |  -0.013 us |  -0.03% |   SAME   |
|   I8    |    2^28    | 230.603 us |       0.62% | 173.792 us |       0.81% | -56.811 us | -24.64% |   FAST   |
|   I16   |    2^16    |  32.419 us |       4.77% |  29.407 us |       3.41% |  -3.011 us |  -9.29% |   FAST   |
|   I16   |    2^20    |  36.012 us |       3.63% |  31.532 us |       3.82% |  -4.480 us | -12.44% |   FAST   |
|   I16   |    2^24    |  49.631 us |       4.07% |  48.665 us |       2.24% |  -0.966 us |  -1.95% |   SAME   |
|   I16   |    2^28    | 232.820 us |       0.73% | 162.812 us |       0.66% | -70.008 us | -30.07% |   FAST   |
|   I32   |    2^16    |  32.406 us |       4.96% |  29.634 us |       3.86% |  -2.772 us |  -8.55% |   FAST   |
|   I32   |    2^20    |  35.590 us |       3.25% |  31.042 us |       3.92% |  -4.548 us | -12.78% |   FAST   |
|   I32   |    2^24    |  51.926 us |       2.57% |  47.256 us |       2.21% |  -4.670 us |  -8.99% |   FAST   |
|   I32   |    2^28    | 257.810 us |       0.51% | 203.083 us |       0.55% | -54.727 us | -21.23% |   FAST   |
|   I64   |    2^16    |  32.068 us |       7.18% |  29.981 us |       4.47% |  -2.086 us |  -6.51% |   FAST   |
|   I64   |    2^20    |  36.542 us |       3.62% |  32.323 us |       3.15% |  -4.219 us | -11.55% |   FAST   |
|   I64   |    2^24    |  61.183 us |       3.07% |  61.967 us |       1.70% |   0.784 us |   1.28% |   SAME   |
|   I64   |    2^28    | 353.614 us |       0.58% | 347.825 us |       0.65% |  -5.790 us |  -1.64% |   FAST   |
|  I128   |    2^16    |  34.014 us |       5.03% |  31.267 us |       4.49% |  -2.747 us |  -8.08% |   FAST   |
|  I128   |    2^20    |  39.949 us |       3.06% |  39.196 us |       3.14% |  -0.752 us |  -1.88% |   SAME   |
|  I128   |    2^24    |  89.703 us |       1.24% |  92.680 us |       1.08% |   2.977 us |   3.32% |   SLOW   |
|  I128   |    2^28    | 733.036 us |       4.12% | 686.048 us |       1.72% | -46.988 us |  -6.41% |   FAST   |
|   F32   |    2^16    |  32.219 us |       4.26% |  29.352 us |       4.45% |  -2.867 us |  -8.90% |   FAST   |
|   F32   |    2^20    |  35.693 us |       3.41% |  31.447 us |       3.32% |  -4.246 us | -11.90% |   FAST   |
|   F32   |    2^24    |  51.790 us |       4.32% |  47.009 us |       2.75% |  -4.780 us |  -9.23% |   FAST   |
|   F32   |    2^28    | 257.314 us |       0.42% | 202.868 us |       0.64% | -54.447 us | -21.16% |   FAST   |
|   F64   |    2^16    |  31.941 us |       4.17% |  29.663 us |       3.68% |  -2.279 us |  -7.13% |   FAST   |
|   F64   |    2^20    |  35.494 us |       3.67% |  32.450 us |       2.87% |  -3.045 us |  -8.58% |   FAST   |
|   F64   |    2^24    |  60.304 us |       2.59% |  62.061 us |       1.88% |   1.757 us |   2.91% |   SLOW   |
|   F64   |    2^28    | 364.362 us |       3.27% | 347.638 us |       0.61% | -16.724 us |  -4.59% |   FAST   |
```

Fixes part of: #1626