### PR TITLE
[`cuda::ptx`] `cta_group` error workaround

### DIFF
--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor.h
@@ -14,7 +14,7 @@
 // Because `fn_ptr` is possibly visible outside this translation unit, the
 // compiler must compile all the functions which are stored.
 
-__global__ void test_cp_async_bulk_tensor(void** fn_ptr)
+__global__ void test_cp_async_bulk_tensor_cta_group_1(void** fn_ptr)
 {
 #if __cccl_ptx_isa >= 800
   NV_IF_TARGET(
@@ -121,84 +121,6 @@ __global__ void test_cp_async_bulk_tensor(void** fn_ptr)
           static_cast<void (*)(cuda::ptx::space_shared_t,
                                cuda::ptx::space_global_t,
                                cuda::ptx::cta_group_1_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
                                void*,
                                const void*,
                                const cuda::std::int32_t (&)[1],
@@ -327,84 +249,6 @@ __global__ void test_cp_async_bulk_tensor(void** fn_ptr)
                                const void*,
                                const cuda::std::int32_t (&)[2],
                                cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 800
@@ -525,84 +369,6 @@ __global__ void test_cp_async_bulk_tensor(void** fn_ptr)
           static_cast<void (*)(cuda::ptx::space_shared_t,
                                cuda::ptx::space_global_t,
                                cuda::ptx::cta_group_1_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
                                void*,
                                const void*,
                                const cuda::std::int32_t (&)[3],
@@ -731,84 +497,6 @@ __global__ void test_cp_async_bulk_tensor(void** fn_ptr)
                                const void*,
                                const cuda::std::int32_t (&)[4],
                                cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 800
@@ -933,6 +621,551 @@ __global__ void test_cp_async_bulk_tensor(void** fn_ptr)
                                const void*,
                                const cuda::std::int32_t (&)[5],
                                cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.5d.global.shared::cta.tile.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+}
+
+__global__ void test_cp_async_bulk_tensor_cta_group_2(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.1d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.1d.global.shared::cta.tile.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.2d.global.shared::cta.tile.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.3d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.3d.global.shared::cta.tile.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.4d.shared::cta.global.tile.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.4d.global.shared::cta.tile.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_90,
+    (
+        // cp.async.bulk.tensor.5d.shared::cta.global.tile.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor_gather_scatter.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor_gather_scatter.h
@@ -14,7 +14,7 @@
 // Because `fn_ptr` is possibly visible outside this translation unit, the
 // compiler must compile all the functions which are stored.
 
-__global__ void test_cp_async_bulk_tensor_gather_scatter(void** fn_ptr)
+__global__ void test_cp_async_bulk_tensor_gather_scatter_cta_group_1(void** fn_ptr)
 {
 #if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
@@ -110,84 +110,6 @@ __global__ void test_cp_async_bulk_tensor_gather_scatter(void** fn_ptr)
                                const void*,
                                const cuda::std::int32_t (&)[5],
                                cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[5],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[5],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[5],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[5],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[5],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
-        // [tensorMap, tensorCoords], [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_shared_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[5],
-                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
@@ -356,6 +278,252 @@ __global__ void test_cp_async_bulk_tensor_gather_scatter(void** fn_ptr)
                                const cuda::std::int32_t (&)[5],
                                cuda::std::uint64_t*,
                                const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.2d.global.shared::cta.tile::scatter4.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor_tile_scatter4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.2d.global.shared::cta.tile::scatter4.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor_tile_scatter4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.2d.global.shared::cta.tile::scatter4.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor_tile_scatter4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.2d.global.shared::cta.tile::scatter4.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor_tile_scatter4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.2d.global.shared::cta.tile::scatter4.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor_tile_scatter4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.2d.global.shared::cta.tile::scatter4.bulk_group [tensorMap, tensorCoords], [srcMem];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_global_t,
+                               cuda::ptx::space_shared_t,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               const void*)>(cuda::ptx::cp_async_bulk_tensor_tile_scatter4));));
+#endif // __cccl_ptx_isa >= 860
+}
+
+__global__ void test_cp_async_bulk_tensor_gather_scatter_cta_group_2(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_PROVIDES_SM_100,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes [dstMem], [tensorMap,
+        // tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4.mbarrier::complete_tx::bytes.cta_group::2 [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_shared_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile::gather4.mbarrier::complete_tx::bytes.multicast::cluster
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor_tile_gather4));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor_multicast.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/cp_async_bulk_tensor_multicast.h
@@ -14,7 +14,7 @@
 // Because `fn_ptr` is possibly visible outside this translation unit, the
 // compiler must compile all the functions which are stored.
 
-__global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
+__global__ void test_cp_async_bulk_tensor_multicast_cta_group_1(void** fn_ptr)
 {
 #if __cccl_ptx_isa >= 800
   NV_IF_TARGET(
@@ -195,90 +195,6 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                const cuda::std::int32_t (&)[1],
                                cuda::std::uint64_t*,
                                const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[1],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
 #endif // __cccl_ptx_isa >= 800
 
 #if __cccl_ptx_isa >= 800
@@ -455,90 +371,6 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
           static_cast<void (*)(cuda::ptx::space_cluster_t,
                                cuda::ptx::space_global_t,
                                cuda::ptx::cta_group_1_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[2],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
                                void*,
                                const void*,
                                const cuda::std::int32_t (&)[2],
@@ -725,90 +557,6 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                const cuda::std::int32_t (&)[3],
                                cuda::std::uint64_t*,
                                const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[3],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
 #endif // __cccl_ptx_isa >= 800
 
 #if __cccl_ptx_isa >= 800
@@ -985,90 +733,6 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
           static_cast<void (*)(cuda::ptx::space_cluster_t,
                                cuda::ptx::space_global_t,
                                cuda::ptx::cta_group_1_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
-                               void*,
-                               const void*,
-                               const cuda::std::int32_t (&)[4],
-                               cuda::std::uint64_t*,
-                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
-        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::space_cluster_t,
-                               cuda::ptx::space_global_t,
-                               cuda::ptx::cta_group_2_t,
                                void*,
                                const void*,
                                const cuda::std::int32_t (&)[4],
@@ -1255,6 +919,830 @@ __global__ void test_cp_async_bulk_tensor_multicast(void** fn_ptr)
                                const cuda::std::int32_t (&)[5],
                                cuda::std::uint64_t*,
                                const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+}
+
+__global__ void test_cp_async_bulk_tensor_multicast_cta_group_2(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_90a,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.1d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[1],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_90a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.2d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[2],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_90a,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.3d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[3],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_90a,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.4d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster.cta_group::2
+        // [dstMem], [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               cuda::ptx::cta_group_2_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[4],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_90a,
+    (
+        // cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // cp.async.bulk.tensor.5d.shared::cluster.global.tile.mbarrier::complete_tx::bytes.multicast::cluster [dstMem],
+        // [tensorMap, tensorCoords], [smem_bar], ctaMask;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::space_cluster_t,
+                               cuda::ptx::space_global_t,
+                               void*,
+                               const void*,
+                               const cuda::std::int32_t (&)[5],
+                               cuda::std::uint64_t*,
+                               const cuda::std::uint16_t&)>(cuda::ptx::cp_async_bulk_tensor));));
+#endif // __cccl_ptx_isa >= 800
+
+#if __cccl_ptx_isa >= 800
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_alloc.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_alloc.h
@@ -14,7 +14,7 @@
 // Because `fn_ptr` is possibly visible outside this translation unit, the
 // compiler must compile all the functions which are stored.
 
-__global__ void test_tcgen05_alloc(void** fn_ptr)
+__global__ void test_tcgen05_alloc_cta_group_1(void** fn_ptr)
 {
 #if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
@@ -59,48 +59,6 @@ __global__ void test_tcgen05_alloc(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
             cuda::ptx::tcgen05_alloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_alloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_alloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_alloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_alloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_alloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_alloc));));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
@@ -145,48 +103,6 @@ __global__ void test_tcgen05_alloc(void** fn_ptr)
         // tcgen05.dealloc.cta_group::1.sync.aligned.b32 taddr, nCols;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_dealloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_dealloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_dealloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_dealloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_dealloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
-            cuda::ptx::tcgen05_dealloc));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
             cuda::ptx::tcgen05_dealloc));));
 #endif // __cccl_ptx_isa >= 860
 
@@ -221,6 +137,102 @@ __global__ void test_tcgen05_alloc(void** fn_ptr)
                    // tcgen05.relinquish_alloc_permit.cta_group::1.sync.aligned;
                    * fn_ptr++ = reinterpret_cast<void*>(
                      static_cast<void (*)(cuda::ptx::cta_group_1_t)>(cuda::ptx::tcgen05_relinquish_alloc_permit));));
+#endif // __cccl_ptx_isa >= 860
+}
+
+__global__ void test_tcgen05_alloc_cta_group_2(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_alloc));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_alloc));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_alloc));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_alloc));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_alloc));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.alloc.cta_group::2.sync.aligned.shared::cta.b32 [dst], nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t*, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_alloc));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_dealloc));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_dealloc));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_dealloc));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_dealloc));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_dealloc));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.dealloc.cta_group::2.sync.aligned.b32 taddr, nCols;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, const cuda::std::uint32_t&)>(
+            cuda::ptx::tcgen05_dealloc));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(NV_HAS_FEATURE_SM_100a,
                (
                    // tcgen05.relinquish_alloc_permit.cta_group::2.sync.aligned;

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_commit.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_commit.h
@@ -14,7 +14,7 @@
 // Because `fn_ptr` is possibly visible outside this translation unit, the
 // compiler must compile all the functions which are stored.
 
-__global__ void test_tcgen05_commit(void** fn_ptr)
+__global__ void test_tcgen05_commit_cta_group_1(void** fn_ptr)
 {
 #if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
@@ -53,42 +53,6 @@ __global__ void test_tcgen05_commit(void** fn_ptr)
         // tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
@@ -134,6 +98,51 @@ __global__ void test_tcgen05_commit(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint64_t*, cuda::std::uint16_t)>(
             cuda::ptx::tcgen05_commit_multicast));));
+#endif // __cccl_ptx_isa >= 860
+}
+
+__global__ void test_tcgen05_commit_cta_group_2(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.commit.cta_group::2.mbarrier::arrive::one.shared::cluster.b64 [smem_bar];
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint64_t*)>(cuda::ptx::tcgen05_commit));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_cp.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_cp.h
@@ -14,7 +14,7 @@
 // Because `fn_ptr` is possibly visible outside this translation unit, the
 // compiler must compile all the functions which are stored.
 
-__global__ void test_tcgen05_cp(void** fn_ptr)
+__global__ void test_tcgen05_cp_cta_group_1(void** fn_ptr)
 {
 #if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
@@ -59,6 +59,777 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
             cuda::ptx::tcgen05_cp_128x256b));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
+            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
+#endif // __cccl_ptx_isa >= 860
+}
+
+__global__ void test_tcgen05_cp_cta_group_2(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -107,48 +878,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.4x256b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.cp.cta_group::2.4x256b [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
@@ -191,48 +920,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.128x128b [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -281,48 +968,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.cp.cta_group::2.64x128b.warpx2::02_13 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
@@ -365,48 +1010,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -455,48 +1058,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.cp.cta_group::2.32x128b.warpx4 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
@@ -539,48 +1100,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b6x16_p32));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -629,48 +1148,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.cp.cta_group::2.4x256b.b8x16.b6x16_p32 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
@@ -713,48 +1190,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b6x16_p32));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -803,48 +1238,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.cp.cta_group::2.64x128b.warpx2::02_13.b8x16.b6x16_p32 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
@@ -887,48 +1280,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b6x16_p32));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -977,48 +1328,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b6x16_p32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.cp.cta_group::2.32x128b.warpx4.b8x16.b6x16_p32 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
@@ -1061,48 +1370,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.128x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x256b_b8x16_b4x16_p64));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -1151,48 +1418,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_4x256b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.cp.cta_group::2.4x256b.b8x16.b4x16_p64 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
@@ -1235,48 +1460,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.128x128b.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_128x128b_b8x16_b4x16_p64));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -1325,48 +1508,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_02_13_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.cp.cta_group::2.64x128b.warpx2::02_13.b8x16.b4x16_p64 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
@@ -1412,48 +1553,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_64x128b_warpx2_01_23_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.cp.cta_group::2.64x128b.warpx2::01_23.b8x16.b4x16_p64 [taddr], s_desc;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_2_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
@@ -1496,48 +1595,6 @@ __global__ void test_tcgen05_cp(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.cp.cta_group::1.32x128b.warpx4.b8x16.b4x16_p64 [taddr], s_desc;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t, cuda::std::uint64_t)>(
-            cuda::ptx::tcgen05_cp_32x128b_warpx4_b8x16_b4x16_p64));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_mma.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_mma.h
@@ -14,7 +14,7 @@
 // Because `fn_ptr` is possibly visible outside this translation unit, the
 // compiler must compile all the functions which are stored.
 
-__global__ void test_tcgen05_mma(void** fn_ptr)
+__global__ void test_tcgen05_mma_cta_group_1(void** fn_ptr)
 {
 #if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
@@ -143,129 +143,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-#endif // __cccl_ptx_isa >= 860
-
-#if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f16_t,
@@ -529,269 +406,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_i8_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_i8_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool)>(cuda::ptx::tcgen05_mma));));
-#endif // __cccl_ptx_isa >= 860
-
-#if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f16_t,
@@ -844,58 +458,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_tf32_t,
@@ -939,58 +501,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_tf32_t,
                                cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -1075,78 +585,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_tf32_t,
@@ -1219,78 +657,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
@@ -1355,78 +721,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
                                cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_2_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -1456,30 +750,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                cuda::std::uint64_t,
                                cuda::std::uint32_t,
                                bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_i8_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_i8_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma));));
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
@@ -1601,129 +871,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
                                cuda::std::uint64_t,
                                cuda::std::uint32_t,
                                const cuda::std::uint32_t (&)[4],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-#endif // __cccl_ptx_isa >= 860
-
-#if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
-        // scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               const cuda::std::uint32_t (&)[8],
                                bool,
                                cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
 #endif // __cccl_ptx_isa >= 860
@@ -1995,6 +1142,6768 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
+        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_i8_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_i8_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
+        // [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
+        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], [a_tmem],
+        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
+#endif // __cccl_ptx_isa >= 880
+
+#if __cccl_ptx_isa >= 880
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
+        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
+                               cuda::ptx::cta_group_1_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
+#endif // __cccl_ptx_isa >= 880
+}
+
+__global__ void test_tcgen05_mma_cta_group_2(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_i8_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, disable_output_lane, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_i8_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool)>(cuda::ptx::tcgen05_mma));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d, scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_i8_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_110a,
+    (
+        // tcgen05.mma.cta_group::2.kind::i8 [d_tmem], a_desc, b_desc, idesc, enable_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_i8_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               bool)>(cuda::ptx::tcgen05_mma));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_f16_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103a,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_103f,
+    (
+        // tcgen05.mma.cta_group::2.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d,
+        // scale_input_d;
+        * fn_ptr++ = reinterpret_cast<void*>(
+          static_cast<void (*)(cuda::ptx::kind_tf32_t,
+                               cuda::ptx::cta_group_2_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint32_t,
+                               cuda::std::uint64_t,
+                               cuda::std::uint32_t,
+                               const cuda::std::uint32_t (&)[8],
+                               bool,
+                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
+#endif // __cccl_ptx_isa >= 860
+
+#if __cccl_ptx_isa >= 860
+  NV_IF_TARGET(
+    NV_HAS_FEATURE_SM_100a,
+    (
         // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, disable_output_lane, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f16_t,
@@ -2258,58 +8167,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f16_t,
@@ -2353,58 +8210,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f16_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool,
-                               cuda::ptx::n32_t<0>)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d, scale_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -2469,78 +8274,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f16_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::f16 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f16_t,
@@ -2605,78 +8338,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f16_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::tf32 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_tf32_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -2757,78 +8418,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::f8f6f4 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
@@ -2893,30 +8482,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_f8f6f4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_i8_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::i8 [d_tmem], [a_tmem], b_desc, idesc, enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_i8_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -2952,51 +8517,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -3045,51 +8565,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -3125,51 +8600,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -3228,51 +8658,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -3318,96 +8703,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 880
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -3504,96 +8799,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
         // [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -3684,96 +8889,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
         // [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -3854,96 +8969,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], a_desc, b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -4047,51 +9072,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X [d_tmem], [a_tmem], b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -4140,51 +9120,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -4220,51 +9155,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -4323,51 +9213,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X [d_tmem], [a_tmem], b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -4413,96 +9258,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 880
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -4599,96 +9354,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -4779,96 +9444,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
-        // [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc, [scale_A_tmem],
         // [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -4949,96 +9524,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32 [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -5142,51 +9627,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -5235,51 +9675,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -5315,51 +9710,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -5418,51 +9768,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -5508,96 +9813,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 880
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_fill));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -5694,96 +9909,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -5874,96 +9999,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -6044,96 +10079,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -6237,51 +10182,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::fill [d_tmem], [a_tmem],
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -6330,51 +10230,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem], b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -6410,51 +10265,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::fill [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -6513,51 +10323,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::fill [d_tmem], [a_tmem],
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -6603,96 +10368,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 880
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_fill));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -6789,96 +10464,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -6969,96 +10554,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -7139,96 +10634,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_fill));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::fill [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -7332,51 +10737,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -7425,51 +10785,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -7505,51 +10820,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -7608,51 +10878,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -7698,96 +10923,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 880
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_use));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -7884,96 +11019,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -8064,96 +11109,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -8234,96 +11189,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -8427,51 +11292,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::use [d_tmem], [a_tmem],
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -8520,51 +11340,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem], b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -8600,51 +11375,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::use [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -8703,51 +11433,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::use [d_tmem], [a_tmem],
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -8793,96 +11478,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 880
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_use));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -8979,96 +11574,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -9159,96 +11664,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
-        // [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc, idesc,
         // [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -9329,96 +11744,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_use));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::use [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -9522,51 +11847,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -9615,51 +11895,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -9695,51 +11930,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -9798,51 +11988,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -9888,96 +12033,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 880
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_lastuse));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -10074,96 +12129,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -10254,96 +12219,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -10424,96 +12299,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -10617,51 +12402,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::lastuse [d_tmem], [a_tmem],
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -10710,51 +12450,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -10790,51 +12485,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -10893,51 +12543,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::lastuse [d_tmem], [a_tmem],
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -10983,96 +12588,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 880
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_lastuse));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -11169,96 +12684,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -11349,96 +12774,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -11519,96 +12854,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_lastuse));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::lastuse [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -11712,51 +12957,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -11805,51 +13005,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -11885,51 +13040,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -11988,51 +13098,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], a_desc,
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -12078,96 +13143,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 880
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_collector_a_discard));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -12264,96 +13239,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -12444,96 +13329,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -12614,96 +13409,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], a_desc, b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
                                cuda::std::uint64_t,
@@ -12807,51 +13512,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_1x_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.scale_vec::1X.collector::a::discard [d_tmem], [a_tmem],
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -12900,51 +13560,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
         // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -12980,51 +13595,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_2_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::2X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,
@@ -13080,51 +13650,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 860
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.scale_vec::4X.collector::a::discard [d_tmem], [a_tmem],
-        // b_desc, idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_vec_4x_tmem_a_collector_a_discard));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -13173,96 +13698,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
 #endif // __cccl_ptx_isa >= 860
 
 #if __cccl_ptx_isa >= 880
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block16.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block16_tmem_a_collector_a_discard));));
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
@@ -13359,96 +13794,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf8f6f4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf8f6f4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -13539,96 +13884,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
         // tcgen05.mma.cta_group::2.kind::mxf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
         // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
         * fn_ptr++ = reinterpret_cast<void*>(
@@ -13709,96 +13964,6 @@ __global__ void test_tcgen05_mma(void** fn_ptr)
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::kind_mxf4_t,
                                cuda::ptx::cta_group_2_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110a,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_100f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_103f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint64_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               cuda::std::uint32_t,
-                               bool)>(cuda::ptx::tcgen05_mma_block_scale_block32_tmem_a_collector_a_discard));));
-  NV_IF_TARGET(
-    NV_HAS_FEATURE_SM_110f,
-    (
-        // tcgen05.mma.cta_group::1.kind::mxf4nvf4.block_scale.block32.collector::a::discard [d_tmem], [a_tmem], b_desc,
-        // idesc, [scale_A_tmem], [scale_B_tmem], enable_input_d;
-        * fn_ptr++ = reinterpret_cast<void*>(
-          static_cast<void (*)(cuda::ptx::kind_mxf4nvf4_t,
-                               cuda::ptx::cta_group_1_t,
                                cuda::std::uint32_t,
                                cuda::std::uint32_t,
                                cuda::std::uint64_t,

--- a/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_shift.h
+++ b/libcudacxx/test/libcudacxx/cuda/ptx/generated/tcgen05_shift.h
@@ -14,7 +14,7 @@
 // Because `fn_ptr` is possibly visible outside this translation unit, the
 // compiler must compile all the functions which are stored.
 
-__global__ void test_tcgen05_shift(void** fn_ptr)
+__global__ void test_tcgen05_shift_cta_group_1(void** fn_ptr)
 {
 #if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
@@ -35,6 +35,12 @@ __global__ void test_tcgen05_shift(void** fn_ptr)
         // tcgen05.shift.cta_group::1.down [taddr];
         * fn_ptr++ = reinterpret_cast<void*>(
           static_cast<void (*)(cuda::ptx::cta_group_1_t, cuda::std::uint32_t)>(cuda::ptx::tcgen05_shift_down));));
+#endif // __cccl_ptx_isa >= 860
+}
+
+__global__ void test_tcgen05_shift_cta_group_2(void** fn_ptr)
+{
+#if __cccl_ptx_isa >= 860
   NV_IF_TARGET(
     NV_HAS_FEATURE_SM_100a,
     (


### PR DESCRIPTION
## Description

Recent versions of the CUDA toolkit raise an error when compiling ptx instructions with both `cta_group::1` and `cta_group::2` in the same kernel. Currently, the test code for `cuda::ptx` includes both cta group in a single kernel. The PR provides a temporary workaround until we don't fully generate a new version of the instructions.

The workaround consists in splitting the kernels containing the two instructions. The code has been only moved, not modified.