### PR TITLE
Extract first histogram-only pass in `DeviceTopK` into its own kernel

### DIFF
--- a/cub/cub/agent/agent_topk.cuh
+++ b/cub/cub/agent/agent_topk.cuh
@@ -760,7 +760,7 @@ struct AgentTopK
 
     // Early stop means that the bin containing the k-th element has been identified, and all
     // the elements in this bin are exactly the remaining k items we need to find. So we can
-    // stop the process right here.
+    // stop the process after this filtering pass.
     const bool early_stop = (current_len == static_cast<OffsetT>(current_k));
 
     // If previous_len > buffer_length, it means we haven't started writing candidates to out_buf yet,

--- a/cub/cub/device/dispatch/dispatch_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_topk.cuh
@@ -30,7 +30,6 @@
 #include <cuda/std/__algorithm/min.h>
 #include <cuda/std/__type_traits/common_type.h>
 #include <cuda/std/__type_traits/is_same.h>
-#include <cuda/std/__utility/swap.h>
 #include <cuda/std/cstdint>
 
 CUB_NAMESPACE_BEGIN
@@ -644,27 +643,17 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
     }
 
     // Passes 1..num_passes-1: fused filter + histogram kernel
-    // Initialize buffers "one swap ahead" so that the first swap produces the correct assignment for pass 1
-    key_in_t* in_buf     = static_cast<key_in_t*>(allocations[2]);
-    key_in_t* out_buf    = static_cast<key_in_t*>(allocations[3]);
-    OffsetT* in_idx_buf  = nullptr;
-    OffsetT* out_idx_buf = nullptr;
+    // Current() = input buffer (read), Alternate() = output buffer (write)
+    DoubleBuffer<key_in_t> key_bufs(static_cast<key_in_t*>(allocations[3]), static_cast<key_in_t*>(allocations[2]));
+    DoubleBuffer<OffsetT> idx_bufs;
     if constexpr (!keys_only)
     {
-      in_idx_buf  = static_cast<OffsetT*>(allocations[4]);
-      out_idx_buf = static_cast<OffsetT*>(allocations[5]);
+      idx_bufs = DoubleBuffer<OffsetT>(static_cast<OffsetT*>(allocations[5]), static_cast<OffsetT*>(allocations[4]));
     }
 
     int pass = 1;
     for (; pass < num_passes; pass++)
     {
-      using ::cuda::std::swap;
-      swap(in_buf, out_buf);
-      if constexpr (!keys_only)
-      {
-        swap(in_idx_buf, out_idx_buf);
-      }
-
       extract_bin_op extract_op(pass, total_bits, decomposer);
       identify_candidates_op identify_op(&counter->kth_key_bits, pass, total_bits, decomposer);
 
@@ -675,10 +664,10 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
                     d_keys_out,
                     d_values_in,
                     d_values_out,
-                    in_buf,
-                    in_idx_buf,
-                    out_buf,
-                    out_idx_buf,
+                    key_bufs.Current(),
+                    idx_bufs.Current(),
+                    key_bufs.Alternate(),
+                    idx_bufs.Alternate(),
                     counter,
                     histogram,
                     num_items,
@@ -690,6 +679,12 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
                     pass == num_passes - 1)))
       {
         return error;
+      }
+
+      key_bufs.selector ^= 1;
+      if constexpr (!keys_only)
+      {
+        idx_bufs.selector ^= 1;
       }
     }
 
@@ -720,8 +715,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
                   d_keys_out,
                   d_values_in,
                   d_values_out,
-                  out_buf,
-                  out_idx_buf,
+                  key_bufs.Current(),
+                  idx_bufs.Current(),
                   counter,
                   num_items,
                   k,


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
This PR extracts the first-pass histogram-only code path from the fused filter+histogram kernel into a dedicated DeviceTopKHistogramKernel, removing the IsFirstPass template parameter and simplifying the fused kernel.

**Background:**

- `DeviceTopK` works in passes. With each pass, we "partition" items into "selected", "candidates", and "rejected". 
  - "selected" are definitely amongst the top-k, 
  - "candidates" may or may not end up amongst the top-k (these need further refinement in subsequent passes)
  - "rejected" are definitely not amongst the top-k items
 - A pass consists of 
   - Computing the histogram over the current radix digit
   - Computing the prefix sum over such histogram
   - Identifying the buckets that are "selected", "candidates", and "rejected"
   - Writing out "selected" items to the given output iterator
   - Writing out "candidates" to a buffer for further refinement
 - **Note:** Writing out "candidates" to a buffer for further refinement can be fused with the histogram computation of the next pass. That's what `DeviceTopK` does. However, for the very first pass, there's just a stand-alone histogram computation. This PR extracts this histogram-only computation into its own kernel.

Partially addresses https://github.com/NVIDIA/cccl/issues/6191

Open tasks:
- [x] Benchmark changes