### PR TITLE
Remove `NumItemsT` and hardcocde it for `DeviceSegmentedRadixSort`

### DIFF
--- a/cub/cub/device/device_segmented_radix_sort.cuh
+++ b/cub/cub/device/device_segmented_radix_sort.cuh
@@ -433,7 +433,7 @@ public:
   //!
   //! This is an environment-based API that allows customization of:
   //!
-  //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
+  //! - a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! - The contents of the input data are not altered by the sorting operation.
   //! - When input a contiguous sequence of segments, a single sequence
@@ -471,9 +471,6 @@ public:
   //! @tparam ValueT
   //!   **[inferred]** Value type
   //!
-  //! @tparam NumItemsT
-  //!   **[inferred]** Type of num_items
-  //!
   //! @tparam BeginOffsetIteratorT
   //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets @iterator
   //!
@@ -484,61 +481,61 @@ public:
   //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
   //!
   //! @param[in] d_keys_in
-  //!   Pointer to the input data of key data to sort
+  //!   Device-accessible pointer to the input data of key data to sort
   //!
   //! @param[out] d_keys_out
-  //!   Pointer to the sorted output sequence of key data
+  //!   Device-accessible pointer to the sorted output sequence of key data
   //!
   //! @param[in] d_values_in
-  //!   Pointer to the corresponding input sequence of associated value items
+  //!   Device-accessible pointer to the corresponding input sequence of
+  //!   associated value items
   //!
   //! @param[out] d_values_out
-  //!   Pointer to the correspondingly-reordered output sequence of associated value items
+  //!   Device-accessible pointer to the correspondingly-reordered output
+  //!   sequence of associated value items
   //!
   //! @param[in] num_items
-  //!   The total number of items within the segmented array
+  //!   The total number of items within the segmented array, including items not
+  //!   covered by segments. `num_items` should match the largest element within
+  //!   the range `[d_end_offsets, d_end_offsets + num_segments)`.
   //!
   //! @param[in] num_segments
   //!   The number of segments that comprise the sorting data
   //!
   //! @param[in] d_begin_offsets
-  //!   @rst
   //!   Random-access input iterator to the sequence of beginning offsets of
-  //!   length ``num_segments``, such that ``d_begin_offsets[i]`` is the first
-  //!   element of the *i*\ :sup:`th` data segment in ``d_keys_*`` and ``d_values_*``
-  //!   @endrst
+  //!   length `num_segments`, such that `d_begin_offsets[i]` is the first
+  //!   element of the *i*<sup>th</sup> data segment in `d_keys_*` and `d_values_*`
   //!
   //! @param[in] d_end_offsets
   //!   @rst
   //!   Random-access input iterator to the sequence of ending offsets of length
   //!   ``num_segments``, such that ``d_end_offsets[i] - 1`` is the last element of
-  //!   the *i*\ :sup:`th` data segment in ``d_keys_*`` and ``d_values_*``.
-  //!   If ``d_end_offsets[i] - 1 <= d_begin_offsets[i]``, the *i*\ :sup:`th` is considered empty.
+  //!   the *i*\ :sup:`th` data segment in ``d_keys_*`` and ``d_values_*``. If
+  //!   ``d_end_offsets[i] - 1 <= d_begin_offsets[i]``, the *i*\ :sup:`th` is considered empty.
   //!   @endrst
   //!
   //! @param[in] begin_bit
-  //!   The least-significant bit index (inclusive) needed for key comparison
+  //!    **[optional]** The least-significant bit index (inclusive) needed for key comparison
   //!
   //! @param[in] end_bit
-  //!   The most-significant bit index (exclusive) needed for key comparison
-  //!   (e.g., ``sizeof(unsigned int) * 8``)
+  //!   **[optional]** The most-significant bit index (exclusive) needed for key
+  //!   comparison (e.g., `sizeof(unsigned int) * 8`)
   //!
   //! @param[in] env
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   template <typename KeyT,
             typename ValueT,
-            typename NumItemsT,
             typename BeginOffsetIteratorT,
             typename EndOffsetIteratorT,
-            typename EnvT                                                        = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SortPairs(
     const KeyT* d_keys_in,
     KeyT* d_keys_out,
     const ValueT* d_values_in,
     ValueT* d_values_out,
-    NumItemsT num_items,
-    NumItemsT num_segments,
+    ::cuda::std::int64_t num_items,
+    ::cuda::std::int64_t num_segments,
     BeginOffsetIteratorT d_begin_offsets,
     EndOffsetIteratorT d_end_offsets,
     int begin_bit = 0,
@@ -942,7 +939,7 @@ public:
   //!
   //! This is an environment-based API that allows customization of:
   //!
-  //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
+  //! - a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! - The contents of the input data are not altered by the sorting operation.
   //! - When input a contiguous sequence of segments, a single sequence
@@ -980,9 +977,6 @@ public:
   //! @tparam ValueT
   //!   **[inferred]** Value type
   //!
-  //! @tparam NumItemsT
-  //!   **[inferred]** Type of num_items
-  //!
   //! @tparam BeginOffsetIteratorT
   //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets @iterator
   //!
@@ -993,19 +987,21 @@ public:
   //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
   //!
   //! @param[in] d_keys_in
-  //!   Pointer to the input data of key data to sort
+  //!   Device-accessible pointer to the input data of key data to sort
   //!
   //! @param[out] d_keys_out
-  //!   Pointer to the sorted output sequence of key data
+  //!   Device-accessible pointer to the sorted output sequence of key data
   //!
   //! @param[in] d_values_in
-  //!   Pointer to the corresponding input sequence of associated value items
+  //!   Device-accessible pointer to the corresponding input sequence of associated value items
   //!
   //! @param[out] d_values_out
-  //!   Pointer to the correspondingly-reordered output sequence of associated value items
+  //!   Device-accessible pointer to the correspondingly-reordered output sequence of associated value items
   //!
   //! @param[in] num_items
-  //!   The total number of items within the segmented array
+  //!   The total number of items within the segmented array, including items not
+  //!   covered by segments. `num_items` should match the largest element within
+  //!   the range `[d_end_offsets, d_end_offsets + num_segments)`.
   //!
   //! @param[in] num_segments
   //!   The number of segments that comprise the sorting data
@@ -1026,28 +1022,26 @@ public:
   //!   @endrst
   //!
   //! @param[in] begin_bit
-  //!   The least-significant bit index (inclusive) needed for key comparison
+  //!   **[optional]** The least-significant bit index (inclusive) needed for key comparison
   //!
   //! @param[in] end_bit
-  //!   The most-significant bit index (exclusive) needed for key comparison
+  //!   **[optional]** The most-significant bit index (exclusive) needed for key comparison
   //!   (e.g., ``sizeof(unsigned int) * 8``)
   //!
   //! @param[in] env
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   template <typename KeyT,
             typename ValueT,
-            typename NumItemsT,
             typename BeginOffsetIteratorT,
             typename EndOffsetIteratorT,
-            typename EnvT                                                        = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SortPairsDescending(
     const KeyT* d_keys_in,
     KeyT* d_keys_out,
     const ValueT* d_values_in,
     ValueT* d_values_out,
-    NumItemsT num_items,
-    NumItemsT num_segments,
+    ::cuda::std::int64_t num_items,
+    ::cuda::std::int64_t num_segments,
     BeginOffsetIteratorT d_begin_offsets,
     EndOffsetIteratorT d_end_offsets,
     int begin_bit = 0,
@@ -1067,8 +1061,8 @@ public:
         bytes,
         d_keys,
         d_values,
-        static_cast<::cuda::std::int64_t>(num_items),
-        static_cast<::cuda::std::int64_t>(num_segments),
+        num_items,
+        num_segments,
         d_begin_offsets,
         d_end_offsets,
         begin_bit,
@@ -1426,16 +1420,16 @@ public:
   //!
   //! This is an environment-based API that allows customization of:
   //!
-  //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
+  //! - a specific stream or cuda memory resource through the ``env`` parameter.
   //!
-  //! - The contents of the input data are not altered by the sorting operation.
+  //! - The contents of the input data are not altered by the sorting operation
+  //! - An optional bit subrange ``[begin_bit, end_bit)`` of differentiating key
+  //!   bits can be specified. This can reduce overall sorting overhead and
+  //!   yield a corresponding performance improvement.
   //! - When input a contiguous sequence of segments, a single sequence
   //!   ``segment_offsets`` (of length ``num_segments + 1``) can be aliased for both
   //!   the ``d_begin_offsets`` and ``d_end_offsets`` parameters (where the latter
   //!   is specified as ``segment_offsets + 1``).
-  //! - An optional bit subrange ``[begin_bit, end_bit)`` of differentiating key
-  //!   bits can be specified. This can reduce overall sorting overhead and
-  //!   yield a corresponding performance improvement.
   //! - The range ``[d_keys_out, d_keys_out + num_items)`` shall not overlap
   //!   ``[d_keys_in, d_keys_in + num_items)``,
   //!   ``[d_begin_offsets, d_begin_offsets + num_segments)`` nor
@@ -1460,26 +1454,27 @@ public:
   //! @tparam KeyT
   //!   **[inferred]** Key type
   //!
-  //! @tparam NumItemsT
-  //!   **[inferred]** Type of num_items
-  //!
   //! @tparam BeginOffsetIteratorT
-  //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets @iterator
+  //!   **[inferred]** Random-access input iterator type for reading segment
+  //!   beginning offsets @iterator
   //!
   //! @tparam EndOffsetIteratorT
-  //!   **[inferred]** Random-access input iterator type for reading segment ending offsets @iterator
+  //!   **[inferred]** Random-access input iterator type for reading segment
+  //!   ending offsets @iterator
   //!
   //! @tparam EnvT
   //!   **[inferred]** Environment type (e.g., ``cuda::std::execution::env<...>``)
   //!
   //! @param[in] d_keys_in
-  //!   Pointer to the input data of key data to sort
+  //!   Device-accessible pointer to the input data of key data to sort
   //!
   //! @param[out] d_keys_out
-  //!   Pointer to the sorted output sequence of key data
+  //!   Device-accessible pointer to the sorted output sequence of key data
   //!
   //! @param[in] num_items
-  //!   The total number of items within the segmented array
+  //!   The total number of items within the segmented array, including items not
+  //!   covered by segments. `num_items` should match the largest element within
+  //!   the range `[d_end_offsets, d_end_offsets + num_segments)`.
   //!
   //! @param[in] num_segments
   //!   The number of segments that comprise the sorting data
@@ -1500,25 +1495,23 @@ public:
   //!   @endrst
   //!
   //! @param[in] begin_bit
-  //!   The least-significant bit index (inclusive) needed for key comparison
+  //!   **[optional]** The least-significant bit index (inclusive) needed for key comparison
   //!
   //! @param[in] end_bit
-  //!   The most-significant bit index (exclusive) needed for key comparison
-  //!   (e.g., ``sizeof(unsigned int) * 8``)
+  //!   **[optional]** The most-significant bit index (exclusive) needed for key
+  //!   comparison (e.g., `sizeof(unsigned int) * 8`)
   //!
   //! @param[in] env
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   template <typename KeyT,
-            typename NumItemsT,
             typename BeginOffsetIteratorT,
             typename EndOffsetIteratorT,
-            typename EnvT                                                        = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SortKeys(
     const KeyT* d_keys_in,
     KeyT* d_keys_out,
-    NumItemsT num_items,
-    NumItemsT num_segments,
+    ::cuda::std::int64_t num_items,
+    ::cuda::std::int64_t num_segments,
     BeginOffsetIteratorT d_begin_offsets,
     EndOffsetIteratorT d_end_offsets,
     int begin_bit = 0,
@@ -1538,8 +1531,8 @@ public:
         bytes,
         d_keys,
         d_values,
-        static_cast<::cuda::std::int64_t>(num_items),
-        static_cast<::cuda::std::int64_t>(num_segments),
+        num_items,
+        num_segments,
         d_begin_offsets,
         d_end_offsets,
         begin_bit,
@@ -1891,7 +1884,7 @@ public:
   //!
   //! This is an environment-based API that allows customization of:
   //!
-  //! - Can use a specific stream or cuda memory resource through the ``env`` parameter.
+  //! - a specific stream or cuda memory resource through the ``env`` parameter.
   //!
   //! - The contents of the input data are not altered by the sorting operation.
   //! - When input a contiguous sequence of segments, a single sequence
@@ -1925,9 +1918,6 @@ public:
   //! @tparam KeyT
   //!   **[inferred]** Key type
   //!
-  //! @tparam NumItemsT
-  //!   **[inferred]** Type of num_items
-  //!
   //! @tparam BeginOffsetIteratorT
   //!   **[inferred]** Random-access input iterator type for reading segment beginning offsets @iterator
   //!
@@ -1941,10 +1931,12 @@ public:
   //!   Pointer to the input data of key data to sort
   //!
   //! @param[out] d_keys_out
-  //!   Pointer to the sorted output sequence of key data
+  //!   Device-accessible pointer to the sorted output sequence of key data
   //!
   //! @param[in] num_items
-  //!   The total number of items within the segmented array
+  //!   The total number of items within the segmented array, including items not
+  //!   covered by segments. `num_items` should match the largest element within
+  //!   the range `[d_end_offsets, d_end_offsets + num_segments)`.
   //!
   //! @param[in] num_segments
   //!   The number of segments that comprise the sorting data
@@ -1965,25 +1957,23 @@ public:
   //!   @endrst
   //!
   //! @param[in] begin_bit
-  //!   The least-significant bit index (inclusive) needed for key comparison
+  //!   **[optional]** The least-significant bit index (inclusive) needed for key comparison
   //!
   //! @param[in] end_bit
-  //!   The most-significant bit index (exclusive) needed for key comparison
+  //!   **[optional]** The most-significant bit index (exclusive) needed for key comparison
   //!   (e.g., ``sizeof(unsigned int) * 8``)
   //!
   //! @param[in] env
   //!   **[optional]** Execution environment. Default is ``cuda::std::execution::env{}``.
   template <typename KeyT,
-            typename NumItemsT,
             typename BeginOffsetIteratorT,
             typename EndOffsetIteratorT,
-            typename EnvT                                                        = ::cuda::std::execution::env<>,
-            ::cuda::std::enable_if_t<::cuda::std::is_integral_v<NumItemsT>, int> = 0>
+            typename EnvT = ::cuda::std::execution::env<>>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t SortKeysDescending(
     const KeyT* d_keys_in,
     KeyT* d_keys_out,
-    NumItemsT num_items,
-    NumItemsT num_segments,
+    ::cuda::std::int64_t num_items,
+    ::cuda::std::int64_t num_segments,
     BeginOffsetIteratorT d_begin_offsets,
     EndOffsetIteratorT d_end_offsets,
     int begin_bit = 0,
@@ -2003,8 +1993,8 @@ public:
         bytes,
         d_keys,
         d_values,
-        static_cast<::cuda::std::int64_t>(num_items),
-        static_cast<::cuda::std::int64_t>(num_segments),
+        num_items,
+        num_segments,
         d_begin_offsets,
         d_end_offsets,
         begin_bit,


### PR DESCRIPTION
Slip ups from https://github.com/NVIDIA/cccl/pull/7999

This one removes `NumItemsT` form the template list of `DeviceSegmentedRadixSort` env overloads in order to conform to the non-env overloads. Removes the SFINAE associated with it along the way.

_this regards the non-DoubleBuffer overloads_