### PR TITLE
Fix typo: `[[maybe_unsused]]` -> `[[maybe_unused]]`

### DIFF
--- a/cub/cub/agent/agent_merge.cuh
+++ b/cub/cub/agent/agent_merge.cuh
@@ -249,7 +249,7 @@ struct agent_t
     {
       // Both of these are only needed when either keys or items or both use BlockLoadToShared introducing padding (that
       // can differ between the keys and items)
-      [[maybe_unsused]] const auto translate_indices = [&](int items2_offset) -> void {
+      [[maybe_unused]] const auto translate_indices = [&](int items2_offset) -> void {
         const int diff = items2_offset - keys2_offset;
         _CCCL_PRAGMA_UNROLL_FULL()
         for (int i = 0; i < ItemsPerThread; ++i)


### PR DESCRIPTION
## Description

Closes https://github.com/NVIDIA/cccl/issues/8321, fixes a typo from https://github.com/NVIDIA/cccl/pull/6077.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.
