### PR TITLE
[libcudacxx] Add support for wider types in fill_bytes

### DIFF
--- a/libcudacxx/include/cuda/__algorithm/fill.h
+++ b/libcudacxx/include/cuda/__algorithm/fill.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -36,21 +36,40 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 
 namespace __detail
 {
-template <typename _DstTy, ::cuda::std::size_t _DstSize>
-_CCCL_HOST_API void
-__fill_bytes_impl(stream_ref __stream, ::cuda::std::span<_DstTy, _DstSize> __dst, ::cuda::std::uint8_t __value)
+//! @brief Implementation of fill_bytes for span destinations.
+//!
+//! @tparam _ValueTy The fill value type (1, 2, or 4 bytes).
+//! @param __stream Stream to insert the fill into.
+//! @param __dst Destination span to fill.
+//! @param __value The fill pattern. Each element-sized unit of the destination is set to this value.
+//!
+//! When `sizeof(_ValueTy) > 1`, the destination size in bytes must be a multiple of `sizeof(_ValueTy)`.
+template <typename _ValueTy, typename _DstTy, ::cuda::std::size_t _DstSize>
+_CCCL_HOST_API void __fill_bytes_impl(stream_ref __stream, ::cuda::std::span<_DstTy, _DstSize> __dst, _ValueTy __value)
 {
   static_assert(!::cuda::std::is_const_v<_DstTy>, "Fill destination can't be const");
   static_assert(::cuda::std::is_trivially_copyable_v<_DstTy>);
+  static_assert(sizeof(_ValueTy) == 1 || sizeof(_ValueTy) == 2 || sizeof(_ValueTy) == 4,
+                "Fill value must be 1, 2, or 4 bytes (matching CUDA driver memset support)");
+
+  const auto __size_bytes = __dst.size_bytes();
+  if constexpr (sizeof(_ValueTy) > 1)
+  {
+    if (__size_bytes % sizeof(_ValueTy) != 0)
+    {
+      _CCCL_THROW(::std::invalid_argument,
+                  "fill_bytes destination size in bytes must be a multiple of the fill value size");
+    }
+  }
 
   // TODO do a host callback if not device accessible?
-  ::cuda::__driver::__memsetAsync(__dst.data(), __value, __dst.size_bytes(), __stream.get());
+  ::cuda::__driver::__memsetAsync(__dst.data(), __value, __size_bytes / sizeof(_ValueTy), __stream.get());
 }
 
-template <typename _DstElem, typename _DstExtents, typename _DstLayout, typename _DstAccessor>
-_CCCL_HOST_API void __fill_bytes_impl(stream_ref __stream,
-                                      ::cuda::std::mdspan<_DstElem, _DstExtents, _DstLayout, _DstAccessor> __dst,
-                                      ::cuda::std::uint8_t __value)
+//! @brief Implementation of fill_bytes for mdspan destinations.
+template <typename _ValueTy, typename _DstElem, typename _DstExtents, typename _DstLayout, typename _DstAccessor>
+_CCCL_HOST_API void __fill_bytes_impl(
+  stream_ref __stream, ::cuda::std::mdspan<_DstElem, _DstExtents, _DstLayout, _DstAccessor> __dst, _ValueTy __value)
 {
   // Check if the mdspan is exhaustive
   if (!__dst.is_exhaustive())
@@ -63,19 +82,40 @@ _CCCL_HOST_API void __fill_bytes_impl(stream_ref __stream,
 }
 } // namespace __detail
 
-//! @brief Launches an operation to bytewise fill the memory into the provided stream.
+//! @brief Launches an operation to fill the memory with a repeating pattern into the provided stream.
 //!
 //! The destination needs to be or launch_transform to a `contiguous_range` and convert to `cuda::std::span`.
 //! The element type of the destination is required to be trivially copyable.
 //!
 //! The destination cannot reside in pagable host memory.
 //!
-//! @param __stream Stream that the copy should be inserted into
+//! The fill value can be 1, 2, or 4 bytes wide. The destination size in bytes must be a multiple of
+//! the fill value size.
+//!
+//! @param __stream Stream that the fill should be inserted into
 //! @param __dst Destination memory to fill
-//! @param __value Value to fill into every byte in the destination
+//! @param __value Value to fill into the destination (1, 2, or 4 bytes)
 _CCCL_TEMPLATE(typename _DstTy)
 _CCCL_REQUIRES(__spannable<transformed_device_argument_t<_DstTy>>)
 _CCCL_HOST_API void fill_bytes(stream_ref __stream, _DstTy&& __dst, ::cuda::std::uint8_t __value)
+{
+  ::cuda::__detail::__fill_bytes_impl(
+    __stream, ::cuda::std::span(launch_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))), __value);
+}
+
+//! @overload
+_CCCL_TEMPLATE(typename _DstTy)
+_CCCL_REQUIRES(__spannable<transformed_device_argument_t<_DstTy>>)
+_CCCL_HOST_API void fill_bytes(stream_ref __stream, _DstTy&& __dst, ::cuda::std::uint16_t __value)
+{
+  ::cuda::__detail::__fill_bytes_impl(
+    __stream, ::cuda::std::span(launch_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))), __value);
+}
+
+//! @overload
+_CCCL_TEMPLATE(typename _DstTy)
+_CCCL_REQUIRES(__spannable<transformed_device_argument_t<_DstTy>>)
+_CCCL_HOST_API void fill_bytes(stream_ref __stream, _DstTy&& __dst, ::cuda::std::uint32_t __value)
 {
   ::cuda::__detail::__fill_bytes_impl(
     __stream, ::cuda::std::span(launch_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))), __value);
@@ -86,6 +126,24 @@ _CCCL_HOST_API void fill_bytes(stream_ref __stream, _DstTy&& __dst, ::cuda::std:
 _CCCL_TEMPLATE(typename _DstTy)
 _CCCL_REQUIRES(__mdspannable<transformed_device_argument_t<_DstTy>>)
 _CCCL_HOST_API void fill_bytes(stream_ref __stream, _DstTy&& __dst, ::cuda::std::uint8_t __value)
+{
+  ::cuda::__detail::__fill_bytes_impl(
+    __stream, __as_mdspan(launch_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))), __value);
+}
+
+//! @overload
+_CCCL_TEMPLATE(typename _DstTy)
+_CCCL_REQUIRES(__mdspannable<transformed_device_argument_t<_DstTy>>)
+_CCCL_HOST_API void fill_bytes(stream_ref __stream, _DstTy&& __dst, ::cuda::std::uint16_t __value)
+{
+  ::cuda::__detail::__fill_bytes_impl(
+    __stream, __as_mdspan(launch_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))), __value);
+}
+
+//! @overload
+_CCCL_TEMPLATE(typename _DstTy)
+_CCCL_REQUIRES(__mdspannable<transformed_device_argument_t<_DstTy>>)
+_CCCL_HOST_API void fill_bytes(stream_ref __stream, _DstTy&& __dst, ::cuda::std::uint32_t __value)
 {
   ::cuda::__detail::__fill_bytes_impl(
     __stream, __as_mdspan(launch_transform(__stream, ::cuda::std::forward<_DstTy>(__dst))), __value);

--- a/libcudacxx/include/cuda/__algorithm/fill.h
+++ b/libcudacxx/include/cuda/__algorithm/fill.h
@@ -49,8 +49,6 @@ _CCCL_HOST_API void __fill_bytes_impl(stream_ref __stream, ::cuda::std::span<_Ds
 {
   static_assert(!::cuda::std::is_const_v<_DstTy>, "Fill destination can't be const");
   static_assert(::cuda::std::is_trivially_copyable_v<_DstTy>);
-  static_assert(sizeof(_ValueTy) == 1 || sizeof(_ValueTy) == 2 || sizeof(_ValueTy) == 4,
-                "Fill value must be 1, 2, or 4 bytes (matching CUDA driver memset support)");
 
   const auto __size_bytes = __dst.size_bytes();
   if constexpr (sizeof(_ValueTy) > 1)

--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -392,7 +392,7 @@ _CCCL_HOST_API void __memsetAsync(void* __dst, _Tp __value, ::cuda::std::size_t 
   }
   else
   {
-    static_assert(::cuda::std::__always_false_v<_Tp>, "Unsupported type for memset");
+    static_assert(::cuda::std::__always_false_v<_Tp>, "Unsupported type for memset, must be 1, 2, or 4 bytes");
   }
 }
 

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/fill.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/algorithm/fill.cu
@@ -42,6 +42,62 @@ C2H_CCCLRT_TEST("Fill", "[algorithm]")
   }
 }
 
+template <typename T>
+void check_fill_pattern(cuda::stream_ref stream, const test_buffer<T>& device_buf, T expected)
+{
+  std::vector<T> host_vec(device_buf.size());
+  {
+    cuda::__ensure_current_context ctx_setter{cuda::device_ref{0}};
+    CUDART(
+      cudaMemcpyAsync(host_vec.data(), device_buf.data(), device_buf.size_bytes(), cudaMemcpyDefault, stream.get()));
+  }
+  stream.sync();
+  for (const auto& val : host_vec)
+  {
+    CCCLRT_REQUIRE(val == expected);
+  }
+}
+
+C2H_CCCLRT_TEST("Fill uint16", "[algorithm]")
+{
+  cuda::stream stream{cuda::device_ref{0}};
+  constexpr ::cuda::std::uint16_t pattern = 0xABCD;
+
+  SECTION("Device memory")
+  {
+    test_buffer<::cuda::std::uint16_t> buffer(test_buffer_type::device, buffer_size);
+    cuda::fill_bytes(stream, buffer, pattern);
+    check_fill_pattern(stream, buffer, pattern);
+  }
+
+  SECTION("Pinned memory")
+  {
+    test_buffer<::cuda::std::uint16_t> buffer(test_buffer_type::pinned, buffer_size);
+    cuda::fill_bytes(stream, buffer, pattern);
+    check_fill_pattern(stream, buffer, pattern);
+  }
+}
+
+C2H_CCCLRT_TEST("Fill uint32", "[algorithm]")
+{
+  cuda::stream stream{cuda::device_ref{0}};
+  constexpr ::cuda::std::uint32_t pattern = 0xDEADBEEF;
+
+  SECTION("Device memory")
+  {
+    test_buffer<::cuda::std::uint32_t> buffer(test_buffer_type::device, buffer_size);
+    cuda::fill_bytes(stream, buffer, pattern);
+    check_fill_pattern(stream, buffer, pattern);
+  }
+
+  SECTION("Pinned memory")
+  {
+    test_buffer<::cuda::std::uint32_t> buffer(test_buffer_type::pinned, buffer_size);
+    cuda::fill_bytes(stream, buffer, pattern);
+    check_fill_pattern(stream, buffer, pattern);
+  }
+}
+
 C2H_CCCLRT_TEST("Mdspan Fill", "[algorithm]")
 {
   cuda::stream stream{cuda::device_ref{0}};
@@ -61,6 +117,19 @@ C2H_CCCLRT_TEST("Mdspan Fill", "[algorithm]")
     cuda::fill_bytes(stream, cuda::std::move(mixed_mdspan), fill_byte);
     check_result_and_erase(stream, cuda::std::span(buffer.data(), buffer.size()));
   }
+}
+
+C2H_CCCLRT_TEST("Mdspan Fill uint32", "[algorithm]")
+{
+  cuda::stream stream{cuda::device_ref{0}};
+  constexpr ::cuda::std::uint32_t pattern = 0xCAFEBABE;
+
+  cuda::std::dextents<size_t, 2> extents{4, 8};
+  test_buffer<::cuda::std::uint32_t> buffer(test_buffer_type::pinned, 4 * 8);
+  cuda::std::mdspan<::cuda::std::uint32_t, decltype(extents)> mdspan(buffer.data(), extents);
+
+  cuda::fill_bytes(stream, mdspan, pattern);
+  check_fill_pattern(stream, buffer, pattern);
 }
 
 C2H_CCCLRT_TEST("Non exhaustive mdspan fill_bytes", "[data_manipulation]")


### PR DESCRIPTION
## Summary
- Generalize `fill_bytes` to accept `uint16_t` and `uint32_t` fill values in addition to `uint8_t`, matching the CUDA driver's `cuMemsetD8Async`/`cuMemsetD16Async`/`cuMemsetD32Async` capabilities.
- Template `__fill_bytes_impl` on the fill value type, with a `static_assert` restricting to 1, 2, or 4 byte values.
- For wider fill values, validate that the destination size in bytes is a multiple of the fill value size.

## Test plan
- [ ] Existing `fill_bytes` tests continue to pass (uint8_t path unchanged)
- [ ] Header tests build across all compiler configurations
- [ ] Add tests for `uint16_t` and `uint32_t` fill patterns