### PR TITLE
Remove taplo-pre-commit hook (no aarch64 wheels)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,16 +59,6 @@ repos:
     - id: ruff  # linter
     - id: ruff-format  # formatter
 
-  # TOML lint & format
-  - repo: https://github.com/ComPWA/taplo-pre-commit
-    rev: v0.9.3
-    hooks:
-      # See https://github.com/NVIDIA/cccl/issues/3426
-      # - id: taplo-lint
-      #   exclude: "^docs/"
-      - id: taplo-format
-        exclude: "^docs/"
-
   # CMake formatting
   - repo: https://github.com/BlankSpruce/gersemi
     rev: 0.23.1


### PR DESCRIPTION
## Description

closes #8345

`taplo-pre-commit` (v0.9.3) does not ship pre-built wheels for Linux aarch64. When `pre-commit run -a` is invoked on an aarch64 host, the hook falls back to building from source — automatically installing a Rust toolchain — then fails because the source tarball is incomplete. This removes the hook entirely, relying on the existing `check-toml` hook for TOML syntax validation.

## Checklist
- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.