### PR TITLE
Fix typo in .clang-tidy that left noexcept-swap disabled

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -21,7 +21,6 @@ Checks:
   # TODO: BEGIN REMOVE ME
   - '-*'
   - 'performance-*'
-  - '-performance-noexcept-swap'
   - '-performance-enum-size'
   - '-performance-unnecessary-value-param'
   # END REMOVE ME


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->
closes <!-- Link issue here -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
