### PR TITLE
Apply some random warpspeed tunings

### DIFF
--- a/cub/cub/device/dispatch/tuning/tuning_scan.cuh
+++ b/cub/cub/device/dispatch/tuning/tuning_scan.cuh
@@ -873,63 +873,87 @@ struct policy_selector
   // TODO(griwes): remove this field before policy_selector is publicly exposed
   bool benchmark_match;
 
+  _CCCL_API constexpr auto get_sm100_fallback_warpspeed_policy() const -> scan_warpspeed_policy
+  {
+    scan_warpspeed_policy warpspeed_policy{};
+
+    // TODO(bgruber): tune this
+#if _CCCL_COMPILER(NVHPC)
+    // need to reduce the number of threads to <= 256, so each thread can use up to 255 registers. This avoids an
+    // error in ptxas, see also: https://github.com/NVIDIA/cccl/issues/7700.
+    warpspeed_policy.num_reduce_and_scan_warps = 2;
+#else // _CCCL_COMPILER(NVHPC)
+    warpspeed_policy.num_reduce_and_scan_warps = 4;
+#endif // _CCCL_COMPILER(NVHPC)
+
+    // TODO(bgruber): 5 is a bit better for complex<float>
+    warpspeed_policy.look_ahead_items_per_thread = accum_size == 2 ? 3 : 4;
+
+    // manual tuning based on cub.bench.scan.exclusive.sum.base
+    // 256 / sizeof(InputValueT) - 1 should minimize bank conflicts (and fits into 48KiB SMEM)
+    // 2-byte types and double needed special handling
+    warpspeed_policy.items_per_thread = ::cuda::std::max(256 / (input_value_size == 2 ? 2 : accum_size) - 1, 1);
+    // TODO(bgruber): the special handling of double below is a LOT faster on B200, but exceeds 48KiB SMEM
+    // clang-format off
+      // |   F64   |      I64      |     72576      |  12.301 us |       8.18% |  12.987 us |       5.75% |     0.686 us |   5.58% |   SAME   |
+      // |   F64   |      I64      |    1056384     |  16.775 us |       5.70% |  16.091 us |       6.14% |    -0.684 us |  -4.08% |   SAME   |
+      // |   F64   |      I64      |    16781184    |  66.970 us |       1.41% |  58.024 us |       3.17% |    -8.946 us | -13.36% |   FAST   |
+      // |   F64   |      I64      |   268442496    | 863.826 us |       0.23% | 676.465 us |       0.98% |  -187.360 us | -21.69% |   FAST   |
+      // |   F64   |      I64      |   1073745792   |   3.419 ms |       0.11% |   2.664 ms |       0.48% |  -755.409 us | -22.09% |   FAST   |
+      // |   F64   |      I64      |   4294975104   |  13.641 ms |       0.05% |  10.575 ms |       0.24% | -3065.815 us | -22.48% |   FAST   |
+    // clang-format on
+    // (256 / (sizeof(InputValueT) == 2 ? 2 : (::cuda::std::is_same_v<InputValueT, double> ? 4 : sizeof(AccumT))) -
+    // 1);
+
+    return warpspeed_policy;
+  }
+
+  _CCCL_API constexpr auto get_sm120_fallback_warpspeed_policy() const -> scan_warpspeed_policy
+  {
+    auto policy = get_sm100_fallback_warpspeed_policy();
+    if (operation_t == op_kind_t::other && is_arithmetic_type(input_type))
+    {
+      if (input_value_size == 4 || input_value_size == 8)
+      {
+        policy.items_per_thread = 127;
+      }
+      else
+      {
+        policy.items_per_thread = ::cuda::std::min(policy.items_per_thread, input_value_size <= 2 ? 63 : 127);
+      }
+    }
+    return policy;
+  }
+
   _CCCL_API constexpr auto get_warpspeed_policy(::cuda::arch_id arch) const
     -> ::cuda::std::optional<scan_warpspeed_policy>
   {
+    if (arch >= ::cuda::arch_id::sm_120)
+    {
+      return get_sm120_fallback_warpspeed_policy();
+    }
     if (arch >= ::cuda::arch_id::sm_100)
     {
-      scan_warpspeed_policy warpspeed_policy{};
-
-      // TODO(bgruber): tune this
-#if _CCCL_COMPILER(NVHPC)
-      // need to reduce the number of threads to <= 256, so each thread can use up to 255 registers. This avoids an
-      // error in ptxas, see also: https://github.com/NVIDIA/cccl/issues/7700.
-      warpspeed_policy.num_reduce_and_scan_warps = 2;
-#else // _CCCL_COMPILER(NVHPC)
-      warpspeed_policy.num_reduce_and_scan_warps = 4;
-#endif // _CCCL_COMPILER(NVHPC)
-
-      // TODO(bgruber): 5 is a bit better for complex<float>
-      warpspeed_policy.look_ahead_items_per_thread = accum_size == 2 ? 3 : 4;
-
-      // manual tuning based on cub.bench.scan.exclusive.sum.base
-      // 256 / sizeof(InputValueT) - 1 should minimize bank conflicts (and fits into 48KiB SMEM)
-      // 2-byte types and double needed special handling
-      auto items_per_thread = ::cuda::std::max(256 / (input_value_size == 2 ? 2 : accum_size) - 1, 1);
-      // TODO(bgruber): the special handling of double below is a LOT faster on B200, but exceeds 48KiB SMEM
-      // clang-format off
-    // |   F64   |      I32      |     72576      |  11.295 us |       2.44% |  11.917 us |       8.02% |     0.622 us |   5.50% |   SLOW   |
-    // |   F64   |      I32      |    1056384     |  16.162 us |       6.24% |  15.847 us |       5.57% |    -0.315 us |  -1.95% |   SAME   |
-    // |   F64   |      I32      |    16781184    |  65.696 us |       1.64% |  60.650 us |       3.37% |    -5.046 us |  -7.68% |   FAST   |
-    // |   F64   |      I32      |   268442496    | 863.896 us |       0.22% | 679.100 us |       0.93% |  -184.796 us | -21.39% |   FAST   |
-    // |   F64   |      I32      |   1073745792   |   3.418 ms |       0.12% |   2.662 ms |       0.46% |  -755.740 us | -22.11% |   FAST   |
-    // |   F64   |      I64      |     72576      |  12.301 us |       8.18% |  12.987 us |       5.75% |     0.686 us |   5.58% |   SAME   |
-    // |   F64   |      I64      |    1056384     |  16.775 us |       5.70% |  16.091 us |       6.14% |    -0.684 us |  -4.08% |   SAME   |
-    // |   F64   |      I64      |    16781184    |  66.970 us |       1.41% |  58.024 us |       3.17% |    -8.946 us | -13.36% |   FAST   |
-    // |   F64   |      I64      |   268442496    | 863.826 us |       0.23% | 676.465 us |       0.98% |  -187.360 us | -21.69% |   FAST   |
-    // |   F64   |      I64      |   1073745792   |   3.419 ms |       0.11% |   2.664 ms |       0.48% |  -755.409 us | -22.09% |   FAST   |
-    // |   F64   |      I64      |   4294975104   |  13.641 ms |       0.05% |  10.575 ms |       0.24% | -3065.815 us | -22.48% |   FAST   |
-      // clang-format on
-      // (256 / (sizeof(InputValueT) == 2 ? 2 : (::cuda::std::is_same_v<InputValueT, double> ? 4 : sizeof(AccumT))) -
-      // 1);
-
-      if (arch >= ::cuda::arch_id::sm_120 && operation_t == op_kind_t::other && is_arithmetic_type(input_type))
+      // tunings from cub/benchmarks/bench/scan/exclusive/sum.warpspeed.cu
+      if (operation_t == op_kind_t::plus && accum_is_primitive_or_trivially_copy_constructible)
       {
-        if (input_value_size == 4 || input_value_size == 8)
+        switch (input_value_size)
         {
-          items_per_thread = 127;
-        }
-        else
-        {
-          items_per_thread = ::cuda::std::min(items_per_thread, input_value_size <= 2 ? 63 : 127);
+          case 1:
+            // wrps_4.lbi_8.ipt_160 ()  1.264254  1.264254  1.264254  1.264254
+            return scan_warpspeed_policy{4, 8, 160 - 1};
+          case 2:
+            // wrps_6.lbi_2.ipt_96 ()  1.167633  1.167633  1.167633  1.167633
+            return scan_warpspeed_policy{6, 2, 96 - 1};
+
+            // TODO(bgruber): tune for more data types
+          default:
+            break;
         }
       }
 
-      warpspeed_policy.items_per_thread = items_per_thread;
-
-      return warpspeed_policy;
+      return get_sm100_fallback_warpspeed_policy();
     }
-
     return {};
   }
 


### PR DESCRIPTION
Works towards: #8348. Those are not the result of serious tuning, just me testing the random tuning search to proof that we are ready for *real* tuning.

`cub.bench.scan.exclusive.sum.warpspeed.base` on B200:
```
## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |        Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|-------------|---------|----------|
|   I8    |      I64      |      2^16      |   9.485 us |       7.39% |  11.264 us |       0.84% |    1.779 us |  18.76% |   SLOW   |
|   I8    |      I64      |      2^20      |  12.832 us |       7.97% |  13.283 us |       3.96% |    0.451 us |   3.52% |   SAME   |
|   I8    |      I64      |      2^24      |  32.877 us |       3.49% |  28.341 us |       3.49% |   -4.536 us | -13.80% |   FAST   |
|   I8    |      I64      |      2^28      | 260.388 us |       0.38% | 207.747 us |       0.60% |  -52.641 us | -20.22% |   FAST   |
|   I8    |      I64      |      2^32      |   3.949 ms |       0.05% |   3.123 ms |       0.27% | -826.017 us | -20.92% |   FAST   |
|   I16   |      I64      |      2^16      |  11.209 us |       0.74% |  11.210 us |       0.63% |    0.001 us |   0.01% |   SAME   |
|   I16   |      I64      |      2^20      |  13.103 us |       4.64% |  12.509 us |       7.98% |   -0.595 us |  -4.54% |   SAME   |
|   I16   |      I64      |      2^24      |  30.882 us |       5.62% |  28.447 us |       3.77% |   -2.435 us |  -7.88% |   FAST   |
|   I16   |      I64      |      2^28      | 248.879 us |       0.61% | 211.693 us |       0.60% |  -37.186 us | -14.94% |   FAST   |
|   I16   |      I64      |      2^32      |   3.743 ms |       0.18% |   3.195 ms |       1.08% | -547.339 us | -14.62% |   FAST   |
|   I32   |      I64      |      2^16      |   9.832 us |       9.57% |  10.203 us |      10.05% |    0.371 us |   3.77% |   SAME   |
|   I32   |      I64      |      2^20      |  13.531 us |       5.06% |  13.477 us |       5.19% |   -0.054 us |  -0.40% |   SAME   |
|   I32   |      I64      |      2^24      |  37.159 us |       4.95% |  37.201 us |       5.08% |    0.043 us |   0.11% |   SAME   |
|   I32   |      I64      |      2^28      | 320.292 us |       0.62% | 320.278 us |       0.57% |   -0.014 us |  -0.00% |   SAME   |
|   I32   |      I64      |      2^32      |   5.087 ms |       1.24% |   5.091 ms |       1.16% |    4.720 us |   0.09% |   SAME   |
|   I64   |      I64      |      2^16      |  11.357 us |       3.96% |  11.752 us |       7.34% |    0.395 us |   3.48% |   SAME   |
|   I64   |      I64      |      2^20      |  15.355 us |       1.69% |  15.500 us |       3.44% |    0.145 us |   0.94% |   SAME   |
|   I64   |      I64      |      2^24      |  58.876 us |       1.70% |  59.171 us |       1.81% |    0.295 us |   0.50% |   SAME   |
|   I64   |      I64      |      2^28      | 694.527 us |       0.17% | 694.738 us |       0.16% |    0.211 us |   0.03% |   SAME   |
|   I64   |      I64      |      2^32      |  11.253 ms |       0.71% |  11.250 ms |       0.82% |   -3.704 us |  -0.03% |   SAME   |
|  I128   |      I64      |      2^16      |  12.987 us |       5.64% |  12.420 us |       8.16% |   -0.567 us |  -4.36% |   SAME   |
|  I128   |      I64      |      2^20      |  23.506 us |       1.93% |  23.504 us |       1.53% |   -0.002 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^24      | 171.297 us |       0.64% | 171.405 us |       0.62% |    0.107 us |   0.06% |   SAME   |
|  I128   |      I64      |      2^28      |   2.511 ms |       0.10% |   2.511 ms |       0.10% |   -0.186 us |  -0.01% |   SAME   |
|  I128   |      I64      |      2^32      |  40.023 ms |       0.02% |  40.022 ms |       0.02% |   -1.429 us |  -0.00% |   SAME   |
|   F32   |      I64      |      2^16      |  10.354 us |      10.64% |  10.203 us |      10.12% |   -0.151 us |  -1.45% |   SAME   |
|   F32   |      I64      |      2^20      |  14.010 us |       7.01% |  13.993 us |       7.08% |   -0.017 us |  -0.12% |   SAME   |
|   F32   |      I64      |      2^24      |  39.498 us |       4.42% |  39.362 us |       4.24% |   -0.137 us |  -0.35% |   SAME   |
|   F32   |      I64      |      2^28      | 345.532 us |       0.50% | 345.276 us |       0.49% |   -0.256 us |  -0.07% |   SAME   |
|   F32   |      I64      |      2^32      |   5.239 ms |       0.49% |   5.239 ms |       0.56% |    0.235 us |   0.00% |   SAME   |
|   F64   |      I64      |      2^16      |  10.928 us |       7.10% |  10.605 us |       9.03% |   -0.323 us |  -2.95% |   SAME   |
|   F64   |      I64      |      2^20      |  15.370 us |       1.09% |  15.346 us |       1.61% |   -0.024 us |  -0.16% |   SAME   |
|   F64   |      I64      |      2^24      |  63.947 us |       1.60% |  63.637 us |       1.69% |   -0.310 us |  -0.49% |   SAME   |
|   F64   |      I64      |      2^28      | 785.046 us |       0.12% | 784.668 us |       0.14% |   -0.378 us |  -0.05% |   SAME   |
|   F64   |      I64      |      2^32      |  12.338 ms |       0.01% |  12.338 ms |       0.01% |    0.050 us |   0.00% |   SAME   |
|   C32   |      I64      |      2^16      |  10.804 us |       7.83% |  10.517 us |       9.41% |   -0.286 us |  -2.65% |   SAME   |
|   C32   |      I64      |      2^20      |  15.296 us |       2.31% |  15.277 us |       2.68% |   -0.019 us |  -0.12% |   SAME   |
|   C32   |      I64      |      2^24      |  59.842 us |       1.75% |  59.816 us |       1.91% |   -0.026 us |  -0.04% |   SAME   |
|   C32   |      I64      |      2^28      | 682.702 us |       0.17% | 682.236 us |       0.17% |   -0.466 us |  -0.07% |   SAME   |
|   C32   |      I64      |      2^32      |  10.659 ms |       0.02% |  10.660 ms |       0.02% |    0.158 us |   0.00% |   SAME   |
```
The regression for tiny `I8` problems is a bit sad, but not an issue, since warpspeed scan has not shipped publicly yet. Since this PR only changes tunings, it's not a regression in the kernel's code.

`I8` and `I16` absolute results after this PR:
```
| T{ct} | OffsetT{ct} |   Elements{io}    |    Size     | Samples |  CPU Time  |  Noise  |  GPU Time  | Noise  |  Elem/s  | GlobalMem BW | BWUtil |
|-------|-------------|-------------------|-------------|---------|------------|---------|------------|--------|----------|--------------|--------|
|    I8 |         I64 |      2^16 = 65536 |  64.000 KiB |    398x |  49.706 us | 416.15% |  11.264 us |  0.84% |   5.818G |  11.636 GB/s |  0.15% |
|    I8 |         I64 |    2^20 = 1048576 |   1.000 MiB |    372x |  41.686 us |   3.69% |  13.283 us |  3.96% |  78.943G | 157.885 GB/s |  2.06% |
|    I8 |         I64 |   2^24 = 16777216 |  16.000 MiB |    354x |  57.191 us |   2.91% |  28.341 us |  3.49% | 591.985G |   1.184 TB/s | 15.43% |
|    I8 |         I64 |  2^28 = 268435456 | 256.000 MiB |    396x | 237.714 us |   0.71% | 207.747 us |  0.60% |   1.292T |   2.584 TB/s | 33.68% |
|    I8 |         I64 | 2^32 = 4294967296 |   4.000 GiB |    370x |   3.155 ms |   0.26% |   3.123 ms |  0.27% |   1.375T |   2.750 TB/s | 35.85% |
|   I16 |         I64 |      2^16 = 65536 | 128.000 KiB |    382x |  42.885 us |   3.69% |  11.210 us |  0.63% |   5.846G |  23.385 GB/s |  0.30% |
|   I16 |         I64 |    2^20 = 1048576 |   2.000 MiB |    380x |  44.050 us |   4.26% |  12.509 us |  7.98% |  83.829G | 335.315 GB/s |  4.37% |
|   I16 |         I64 |   2^24 = 16777216 |  32.000 MiB |    360x |  59.403 us |   2.54% |  28.447 us |  3.77% | 589.765G |   2.359 TB/s | 30.75% |
|   I16 |         I64 |  2^28 = 268435456 | 512.000 MiB |    498x | 242.576 us |   0.86% | 211.693 us |  0.60% |   1.268T |   5.072 TB/s | 66.11% |
|   I16 |         I64 | 2^32 = 4294967296 |   8.000 GiB |    750x |   3.226 ms |   1.07% |   3.195 ms |  1.08% |   1.344T |   5.377 TB/s | 70.08% |
```
This makes it 3x faster than the old scan implementation.