### PR TITLE
[cub]: implement utilities for policy selection

### DIFF
--- a/cub/cub/block/block_load_to_shared.cuh
+++ b/cub/cub/block/block_load_to_shared.cuh
@@ -123,11 +123,10 @@ private:
   {
     // Otherwise elect.sync in the last warp with a full mask is UB.
     static_assert(block_threads % cub::detail::warp_threads == 0, "The block size must be a multiple of the warp size");
-    NV_DISPATCH_TARGET(
+    NV_IF_ELSE_TARGET(
       NV_PROVIDES_SM_90,
       ( // Use last warp to try to avoid having the elected thread also working on the peeling in the first warp.
         return (linear_tid >= block_threads - cub::detail::warp_threads) && ::cuda::ptx::elect_sync(~0u);),
-      NV_IS_DEVICE,
       (return linear_tid == 0;));
   }
 
@@ -219,7 +218,7 @@ private:
       (asm volatile("cp.async.wait_group 0;" :: : "memory"); //
        __syncthreads();
        return true;),
-      NV_IS_DEVICE,
+      NV_ANY_TARGET,
       (__syncthreads(); //
        return true;));
   }

--- a/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
+++ b/cub/cub/device/dispatch/dispatch_adjacent_difference.cuh
@@ -18,6 +18,7 @@
 #include <cub/detail/type_traits.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/tuning/tuning_adjacent_difference.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
@@ -62,7 +63,7 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceAdjacentDifferenceDifferenceKernel(
   _CCCL_GRID_CONSTANT const OffsetT num_items)
 {
   static_assert(::cuda::std::is_empty_v<PolicySelector>);
-  static constexpr adjacent_difference_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr adjacent_difference_policy policy = current_policy<PolicySelector>();
   using AdjacentDifferencePolicyT =
     AgentAdjacentDifferencePolicy<policy.block_threads,
                                   policy.items_per_thread,

--- a/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
+++ b/cub/cub/device/dispatch/dispatch_batch_memcpy.cuh
@@ -23,6 +23,7 @@
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/tuning/tuning_batch_memcpy.cuh>
 #include <cub/thread/thread_search.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_ptx.cuh>
@@ -80,7 +81,7 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires batch_memcpy_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_buffer.block_threads))
+__launch_bounds__(int(current_policy<PolicySelector>().large_buffer.block_threads))
   _CCCL_KERNEL_ATTRIBUTES void MultiBlockBatchMemcpyKernel(
     _CCCL_GRID_CONSTANT const InputBufferIt input_buffer_it,
     _CCCL_GRID_CONSTANT const OutputBufferIt output_buffer_it,
@@ -89,7 +90,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large
     TileT buffer_offset_tile,
     _CCCL_GRID_CONSTANT const TileOffsetT last_tile_offset)
 {
-  static constexpr large_buffer_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_buffer;
+  static constexpr large_buffer_policy policy = current_policy<PolicySelector>().large_buffer;
   using StatusWord                            = typename TileT::StatusWord;
   using BufferSizeT                           = it_value_t<BufferSizeIteratorT>;
   /// Internal load/store type. For byte-wise memcpy, a single-byte type
@@ -210,7 +211,7 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires batch_memcpy_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).small_buffer.block_threads))
+__launch_bounds__(int(current_policy<PolicySelector>().small_buffer.block_threads))
   _CCCL_KERNEL_ATTRIBUTES void BatchMemcpyKernel(
     _CCCL_GRID_CONSTANT const InputBufferIt input_buffer_it,
     _CCCL_GRID_CONSTANT const OutputBufferIt output_buffer_it,
@@ -223,7 +224,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).small
     _CCCL_GRID_CONSTANT const BLevBufferOffsetTileState blev_buffer_scan_state,
     _CCCL_GRID_CONSTANT const BLevBlockOffsetTileState blev_block_scan_state)
 {
-  static constexpr small_buffer_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).small_buffer;
+  static constexpr small_buffer_policy policy = current_policy<PolicySelector>().small_buffer;
   // Internal type used for storing a buffer's size
   using BufferSizeT = it_value_t<BufferSizeIteratorT>;
 

--- a/cub/cub/device/dispatch/dispatch_find.cuh
+++ b/cub/cub/device/dispatch/dispatch_find.cuh
@@ -23,6 +23,7 @@
 #include <cub/detail/launcher/cuda_runtime.cuh>
 #include <cub/device/dispatch/tuning/tuning_find.cuh>
 #include <cub/thread/thread_load.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 #include <cub/util_temporary_storage.cuh>
@@ -51,11 +52,10 @@ template <typename PolicySelector, typename IteratorT, typename OffsetT, typenam
 #if _CCCL_HAS_CONCEPTS()
   requires find_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads))
-  _CCCL_KERNEL_ATTRIBUTES void find_kernel(
-    IteratorT d_in, OffsetT num_items, OffsetT* found_pos_ptr, PredicateT predicate)
+__launch_bounds__(int(current_policy<PolicySelector>().block_threads)) _CCCL_KERNEL_ATTRIBUTES void find_kernel(
+  IteratorT d_in, OffsetT num_items, OffsetT* found_pos_ptr, PredicateT predicate)
 {
-  constexpr find_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  constexpr find_policy policy = current_policy<PolicySelector>();
   using agent_find_t =
     agent_t<policy.block_threads,
             policy.items_per_thread,

--- a/cub/cub/device/dispatch/dispatch_merge.cuh
+++ b/cub/cub/device/dispatch/dispatch_merge.cuh
@@ -16,6 +16,7 @@
 #include <cub/agent/agent_merge.cuh>
 #include <cub/detail/arch_dispatch.cuh>
 #include <cub/device/dispatch/tuning/tuning_merge.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_type.cuh>
 #include <cub/util_vsmem.cuh>
@@ -97,7 +98,7 @@ _CCCL_KERNEL_ATTRIBUTES void device_partition_merge_path_kernel(
   // items_per_tile must be the same of the merge kernel later, so we have to consider whether a fallback agent will be
   // selected for the merge agent that changes the tile size
   constexpr int items_per_tile =
-    choose_merge_agent<policy_getter<PolicySelector, ::cuda::arch_id{CUB_PTX_ARCH / 10}>,
+    choose_merge_agent<policy_getter<PolicySelector, current_tuning_arch()>,
                        KeyIt1,
                        ValueIt1,
                        KeyIt2,
@@ -124,7 +125,7 @@ template <typename PolicySelector,
           typename Offset,
           typename CompareOp>
 __launch_bounds__(
-  choose_merge_agent<policy_getter<PolicySelector, ::cuda::arch_id{CUB_PTX_ARCH / 10}>,
+  choose_merge_agent<policy_getter<PolicySelector, current_tuning_arch()>,
                      KeyIt1,
                      ValueIt1,
                      KeyIt2,
@@ -152,7 +153,7 @@ __launch_bounds__(
                 "Comparison operator must be convertible to bool");
 
   using MergeAgent = typename choose_merge_agent<
-    policy_getter<PolicySelector, ::cuda::arch_id{CUB_PTX_ARCH / 10}>,
+    policy_getter<PolicySelector, current_tuning_arch()>,
     KeyIt1,
     ValueIt1,
     KeyIt2,

--- a/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_reduce_by_key.cuh
@@ -26,6 +26,7 @@
 #include <cub/device/dispatch/dispatch_scan.cuh>
 #include <cub/device/dispatch/tuning/tuning_reduce_by_key.cuh>
 #include <cub/thread/thread_operators.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 #include <cub/util_vsmem.cuh>
@@ -187,7 +188,7 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_by_key_policy_selector<PolicySelector>
 #endif
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads))
+__launch_bounds__(int(current_policy<PolicySelector>().block_threads))
   _CCCL_KERNEL_ATTRIBUTES void DeviceReduceByKeyKernel(
     _CCCL_GRID_CONSTANT const KeysInputIteratorT d_keys_in,
     _CCCL_GRID_CONSTANT const UniqueOutputIteratorT d_unique_out,
@@ -202,7 +203,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block
     _CCCL_GRID_CONSTANT const StreamingContextT streaming_context,
     vsmem_t vsmem)
 {
-  static constexpr reduce_by_key_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr reduce_by_key_policy policy = current_policy<PolicySelector>();
   using AgentReduceByKeyPolicyT                = AgentReduceByKeyPolicy<
                    policy.block_threads,
                    policy.items_per_thread,

--- a/cub/cub/device/dispatch/dispatch_rle.cuh
+++ b/cub/cub/device/dispatch/dispatch_rle.cuh
@@ -25,6 +25,7 @@
 #include <cub/device/dispatch/dispatch_scan.cuh>
 #include <cub/device/dispatch/tuning/tuning_rle_non_trivial_runs.cuh>
 #include <cub/thread/thread_operators.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 
@@ -173,7 +174,7 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires non_trivial_runs::rle_non_trivial_runs_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads))
+__launch_bounds__(int(current_policy<PolicySelector>().block_threads))
   _CCCL_KERNEL_ATTRIBUTES void DeviceRleSweepKernel(
     _CCCL_GRID_CONSTANT const InputIteratorT d_in,
     _CCCL_GRID_CONSTANT const OffsetsOutputIteratorT d_offsets_out,
@@ -185,8 +186,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block
     _CCCL_GRID_CONSTANT const int num_tiles,
     _CCCL_GRID_CONSTANT const StreamingContextT streaming_context)
 {
-  static constexpr non_trivial_runs::rle_non_trivial_runs_policy policy =
-    PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr non_trivial_runs::rle_non_trivial_runs_policy policy = current_policy<PolicySelector>();
   using AgentRlePolicyT =
     AgentRlePolicy<policy.block_threads,
                    policy.items_per_thread,

--- a/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
+++ b/cub/cub/device/dispatch/dispatch_scan_by_key.cuh
@@ -24,6 +24,7 @@
 #include <cub/device/dispatch/dispatch_scan.cuh>
 #include <cub/device/dispatch/tuning/tuning_scan_by_key.cuh>
 #include <cub/thread/thread_operators.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
@@ -122,7 +123,7 @@ template <typename PolicySelector,
           typename OffsetT,
           typename AccumT,
           typename KeyT = cub::detail::it_value_t<KeysInputIteratorT>>
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads))
+__launch_bounds__(int(current_policy<PolicySelector>().block_threads))
   _CCCL_KERNEL_ATTRIBUTES void DeviceScanByKeyKernel(
     _CCCL_GRID_CONSTANT const KeysInputIteratorT d_keys_in,
     _CCCL_GRID_CONSTANT KeyT* const d_keys_prev_in,
@@ -135,7 +136,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block
     _CCCL_GRID_CONSTANT const InitValueT init_value,
     _CCCL_GRID_CONSTANT const OffsetT num_items)
 {
-  static constexpr scan_by_key_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr scan_by_key_policy policy = current_policy<PolicySelector>();
 
   using scan_by_key_policy_t = AgentScanByKeyPolicy<
     policy.block_threads,

--- a/cub/cub/device/dispatch/dispatch_select_if.cuh
+++ b/cub/cub/device/dispatch/dispatch_select_if.cuh
@@ -26,6 +26,7 @@
 #include <cub/device/dispatch/dispatch_scan.cuh>
 #include <cub/device/dispatch/tuning/tuning_select_if.cuh>
 #include <cub/thread/thread_operators.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 #include <cub/util_vsmem.cuh>
@@ -335,7 +336,7 @@ template <typename PolicySelectorT,
   requires select_if_policy_selector<PolicySelectorT>
 #endif // _CCCL_HAS_CONCEPTS()
 __launch_bounds__(int(
-  make_vsmem_helper<policy_getter<PolicySelectorT, ::cuda::arch_id{CUB_PTX_ARCH / 10}>,
+  make_vsmem_helper<policy_getter<PolicySelectorT, current_tuning_arch()>,
                     SelectionOpt,
                     InputIteratorT,
                     FlagsInputIteratorT,
@@ -358,7 +359,7 @@ __launch_bounds__(int(
     vsmem_t vsmem)
 {
   using VsmemHelperT = typename make_vsmem_helper<
-    policy_getter<PolicySelectorT, ::cuda::arch_id{CUB_PTX_ARCH / 10}>,
+    policy_getter<PolicySelectorT, current_tuning_arch()>,
     SelectionOpt,
     InputIteratorT,
     FlagsInputIteratorT,

--- a/cub/cub/device/dispatch/dispatch_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_topk.cuh
@@ -21,6 +21,7 @@
 #include <cub/detail/arch_dispatch.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/tuning/tuning_topk.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
 #include <cub/util_math.cuh>
 #include <cub/util_temporary_storage.cuh>
@@ -247,27 +248,26 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires topk_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads))
-  _CCCL_KERNEL_ATTRIBUTES void DeviceTopKKernel(
-    _CCCL_GRID_CONSTANT const KeyInputIteratorT d_keys_in,
-    _CCCL_GRID_CONSTANT const KeyOutputIteratorT d_keys_out,
-    _CCCL_GRID_CONSTANT const ValueInputIteratorT d_values_in,
-    _CCCL_GRID_CONSTANT const ValueOutputIteratorT d_values_out,
-    _CCCL_GRID_CONSTANT KeyInT* const in_buf,
-    _CCCL_GRID_CONSTANT OffsetT* const in_idx_buf,
-    _CCCL_GRID_CONSTANT KeyInT* const out_buf,
-    _CCCL_GRID_CONSTANT OffsetT* const out_idx_buf,
-    Counter<it_value_t<KeyInputIteratorT>, OffsetT, OutOffsetT>* counter,
-    _CCCL_GRID_CONSTANT OffsetT* const histogram,
-    _CCCL_GRID_CONSTANT const OffsetT num_items,
-    _CCCL_GRID_CONSTANT const OutOffsetT k,
-    _CCCL_GRID_CONSTANT const OffsetT buffer_length,
-    ExtractBinOpT extract_bin_op,
-    IdentifyCandidatesOpT identify_candidates_op,
-    _CCCL_GRID_CONSTANT const int pass,
-    _CCCL_GRID_CONSTANT const bool is_last_pass)
+__launch_bounds__(int(current_policy<PolicySelector>().block_threads)) _CCCL_KERNEL_ATTRIBUTES void DeviceTopKKernel(
+  _CCCL_GRID_CONSTANT const KeyInputIteratorT d_keys_in,
+  _CCCL_GRID_CONSTANT const KeyOutputIteratorT d_keys_out,
+  _CCCL_GRID_CONSTANT const ValueInputIteratorT d_values_in,
+  _CCCL_GRID_CONSTANT const ValueOutputIteratorT d_values_out,
+  _CCCL_GRID_CONSTANT KeyInT* const in_buf,
+  _CCCL_GRID_CONSTANT OffsetT* const in_idx_buf,
+  _CCCL_GRID_CONSTANT KeyInT* const out_buf,
+  _CCCL_GRID_CONSTANT OffsetT* const out_idx_buf,
+  Counter<it_value_t<KeyInputIteratorT>, OffsetT, OutOffsetT>* counter,
+  _CCCL_GRID_CONSTANT OffsetT* const histogram,
+  _CCCL_GRID_CONSTANT const OffsetT num_items,
+  _CCCL_GRID_CONSTANT const OutOffsetT k,
+  _CCCL_GRID_CONSTANT const OffsetT buffer_length,
+  ExtractBinOpT extract_bin_op,
+  IdentifyCandidatesOpT identify_candidates_op,
+  _CCCL_GRID_CONSTANT const int pass,
+  _CCCL_GRID_CONSTANT const bool is_last_pass)
 {
-  static constexpr topk_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr topk_policy policy = current_policy<PolicySelector>();
   using agent_topk_policy_t =
     AgentTopKPolicy<policy.block_threads,
                     policy.items_per_thread,
@@ -312,7 +312,7 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires topk_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads))
+__launch_bounds__(int(current_policy<PolicySelector>().block_threads))
   _CCCL_KERNEL_ATTRIBUTES void DeviceTopKHistogramKernel(
     _CCCL_GRID_CONSTANT const KeyInputIteratorT d_keys_in,
     _CCCL_GRID_CONSTANT const KeyOutputIteratorT d_keys_out,
@@ -327,7 +327,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block
     _CCCL_GRID_CONSTANT const int pass,
     _CCCL_GRID_CONSTANT const bool is_last_pass)
 {
-  static constexpr topk_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr topk_policy policy = current_policy<PolicySelector>();
   using agent_topk_policy_t =
     AgentTopKPolicy<policy.block_threads,
                     policy.items_per_thread,
@@ -373,7 +373,7 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires topk_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads))
+__launch_bounds__(int(current_policy<PolicySelector>().block_threads))
   _CCCL_KERNEL_ATTRIBUTES void DeviceTopKLastFilterKernel(
     _CCCL_GRID_CONSTANT const KeyInputIteratorT d_keys_in,
     _CCCL_GRID_CONSTANT const KeyOutputIteratorT d_keys_out,
@@ -388,7 +388,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block
     IdentifyCandidatesOpT identify_candidates_op,
     _CCCL_GRID_CONSTANT const int pass)
 {
-  static constexpr topk_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr topk_policy policy = current_policy<PolicySelector>();
   using agent_topk_policy_t =
     AgentTopKPolicy<policy.block_threads,
                     policy.items_per_thread,

--- a/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_batched_topk.cuh
@@ -35,7 +35,7 @@ struct find_smallest_covering_policy
 {
 private:
   static constexpr ::cuda::std::int64_t max_segment_size = params::static_max_value_v<SegmentSizeParameterT>;
-  static constexpr batched_topk_policy active_policy     = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr batched_topk_policy active_policy     = current_policy<PolicySelector>();
 
   template <int Index>
   [[nodiscard]] static constexpr int find_index()

--- a/cub/cub/device/dispatch/kernels/kernel_for_each.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_for_each.cuh
@@ -17,6 +17,7 @@
 #include <cub/detail/mdspan_utils.cuh> // is_sub_size_static
 #include <cub/detail/type_traits.cuh> // implicit_prom_t
 #include <cub/device/dispatch/tuning/tuning_for.cuh>
+#include <cub/util_arch.cuh>
 
 #include <cuda/std/__type_traits/enable_if.h>
 #include <cuda/std/__type_traits/integral_constant.h>
@@ -92,7 +93,7 @@ template <class PolicySelector, class OffsetT, class OpT>
 #endif // _CCCL_HAS_CONCEPTS()
 _CCCL_KERNEL_ATTRIBUTES void dynamic_kernel(_CCCL_GRID_CONSTANT const OffsetT num_items, OpT op)
 {
-  static constexpr for_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr for_policy policy = current_policy<PolicySelector>();
   using agent_policy_t               = policy_t<policy.block_threads, policy.items_per_thread>;
   using agent_t                      = agent_block_striped_t<agent_policy_t, OffsetT, OpT>;
 
@@ -118,10 +119,10 @@ template <class PolicySelector, class OffsetT, class OpT>
   requires for_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
 _CCCL_KERNEL_ATTRIBUTES //
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads)) //
+__launch_bounds__(int(current_policy<PolicySelector>().block_threads)) //
   void static_kernel(_CCCL_GRID_CONSTANT const OffsetT num_items, OpT op)
 {
-  static constexpr for_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr for_policy policy = current_policy<PolicySelector>();
   using agent_policy_t               = policy_t<policy.block_threads, policy.items_per_thread>;
   using agent_t                      = agent_block_striped_t<agent_policy_t, OffsetT, OpT>;
 

--- a/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_histogram.cuh
@@ -16,6 +16,7 @@
 #include <cub/agent/agent_histogram.cuh>
 #include <cub/device/dispatch/tuning/tuning_histogram.cuh>
 #include <cub/grid/grid_queue.cuh>
+#include <cub/util_arch.cuh>
 
 #include <cuda/std/__numeric/reduce.h>
 
@@ -342,7 +343,7 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceHistogramInitKernel(
   ::cuda::std::array<CounterT*, NumActiveChannels> d_output_histograms_wrapper,
   GridQueue<int> tile_queue)
 {
-  [[maybe_unused]] static constexpr histogram_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  [[maybe_unused]] static constexpr histogram_policy policy = current_policy<PolicySelector>();
   _CCCL_PDL_GRID_DEPENDENCY_SYNC(); // TODO(bgruber): if we had the guarantee that there would be no pending
                                     // writes/reads to the temp storage, we could omit the sync here
 
@@ -452,7 +453,7 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires histogram_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads))
+__launch_bounds__(int(current_policy<PolicySelector>().block_threads))
   _CCCL_KERNEL_ATTRIBUTES void DeviceHistogramSweepKernel(
     _CCCL_GRID_CONSTANT const SampleIteratorT d_samples,
     _CCCL_GRID_CONSTANT const ::cuda::std::array<int, NumActiveChannels> num_output_bins_wrapper,
@@ -467,7 +468,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block
     _CCCL_GRID_CONSTANT const int tiles_per_row,
     GridQueue<int> tile_queue)
 {
-  static constexpr histogram_policy hp = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr histogram_policy hp = current_policy<PolicySelector>();
 
   // Thread block type for compositing input tiles
   using AgentHistogramPolicyT =
@@ -612,7 +613,7 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires histogram_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads))
+__launch_bounds__(int(current_policy<PolicySelector>().block_threads))
   _CCCL_KERNEL_ATTRIBUTES void DeviceHistogramSweepDeviceInitKernel(
     _CCCL_GRID_CONSTANT const SampleIteratorT d_samples,
     ::cuda::std::array<int, NumActiveChannels> num_output_bins_wrapper,
@@ -627,7 +628,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block
     _CCCL_GRID_CONSTANT const int tiles_per_row,
     _CCCL_GRID_CONSTANT const GridQueue<int> tile_queue)
 {
-  static constexpr histogram_policy hp = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr histogram_policy hp = current_policy<PolicySelector>();
 
   OutputDecodeOpT output_decode_op[NumActiveChannels];
   PrivatizedDecodeOpT privatized_decode_op[NumActiveChannels];

--- a/cub/cub/device/dispatch/kernels/kernel_merge_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_merge_sort.cuh
@@ -17,6 +17,7 @@
 #include <cub/detail/arch_dispatch.cuh>
 #include <cub/device/dispatch/tuning/tuning_merge_sort.cuh>
 #include <cub/iterator/cache_modified_input_iterator.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_vsmem.cuh>
 
 CUB_NAMESPACE_BEGIN
@@ -86,7 +87,7 @@ template <typename PolicySelectorT,
           typename KeyT,
           typename ValueT>
 __launch_bounds__(
-  merge_sort_vsmem_helper_t<policy_getter<PolicySelectorT, cuda::arch_id{CUB_PTX_ARCH / 10}>,
+  merge_sort_vsmem_helper_t<policy_getter<PolicySelectorT, current_tuning_arch()>,
                             KeyInputIteratorT,
                             ValueInputIteratorT,
                             KeyIteratorT,
@@ -108,7 +109,7 @@ __launch_bounds__(
     vsmem_t vsmem)
 {
   using vsmem_adapted_agents = merge_sort_vsmem_helper_t<
-    policy_getter<PolicySelectorT, cuda::arch_id{CUB_PTX_ARCH / 10}>,
+    policy_getter<PolicySelectorT, current_tuning_arch()>,
     KeyInputIteratorT,
     ValueInputIteratorT,
     KeyIteratorT,
@@ -186,7 +187,7 @@ template <typename PolicySelectorT,
           typename KeyT,
           typename ValueT>
 __launch_bounds__(
-  merge_sort_vsmem_helper_t<policy_getter<PolicySelectorT, cuda::arch_id{CUB_PTX_ARCH / 10}>,
+  merge_sort_vsmem_helper_t<policy_getter<PolicySelectorT, current_tuning_arch()>,
                             KeyInputIteratorT,
                             ValueInputIteratorT,
                             KeyIteratorT,
@@ -208,7 +209,7 @@ __launch_bounds__(
     vsmem_t vsmem)
 {
   using vsmem_adapted_agents = merge_sort_vsmem_helper_t<
-    policy_getter<PolicySelectorT, cuda::arch_id{CUB_PTX_ARCH / 10}>,
+    policy_getter<PolicySelectorT, current_tuning_arch()>,
     KeyInputIteratorT,
     ValueInputIteratorT,
     KeyIteratorT,

--- a/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_radix_sort.cuh
@@ -22,6 +22,7 @@
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/tuning/tuning_radix_sort.cuh>
 #include <cub/grid/grid_even_share.cuh>
+#include <cub/util_arch.cuh>
 
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__functional/operations.h>
@@ -78,8 +79,8 @@ template <typename PolicySelector,
           typename KeyT,
           typename OffsetT,
           typename DecomposerT = detail::identity_decomposer_t>
-__launch_bounds__(int(ALT_DIGIT_BITS ? PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).alt_upsweep.block_threads
-                                     : PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).upsweep.block_threads))
+__launch_bounds__(int(ALT_DIGIT_BITS ? current_policy<PolicySelector>().alt_upsweep.block_threads
+                                     : current_policy<PolicySelector>().upsweep.block_threads))
   _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortUpsweepKernel(
     _CCCL_GRID_CONSTANT const KeyT* const d_keys,
     _CCCL_GRID_CONSTANT OffsetT* const d_spine,
@@ -89,7 +90,7 @@ __launch_bounds__(int(ALT_DIGIT_BITS ? PolicySelector{}(::cuda::arch_id{CUB_PTX_
     GridEvenShare<OffsetT> even_share,
     _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
-  static constexpr radix_sort_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr radix_sort_policy policy = current_policy<PolicySelector>();
   static constexpr radix_sort_upsweep_policy active_upsweep_policy =
     ALT_DIGIT_BITS ? policy.alt_upsweep : policy.upsweep;
   static constexpr radix_sort_downsweep_policy active_downsweep_policy =
@@ -142,11 +143,11 @@ __launch_bounds__(int(ALT_DIGIT_BITS ? PolicySelector{}(::cuda::arch_id{CUB_PTX_
  *   Total number of bin-counts
  */
 template <typename PolicySelector, typename OffsetT>
-__launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).scan.lookback.block_threads, 1)
+__launch_bounds__(current_policy<PolicySelector>().scan.lookback.block_threads, 1)
   _CCCL_KERNEL_ATTRIBUTES void RadixSortScanBinsKernel(
     _CCCL_GRID_CONSTANT OffsetT* const d_spine, _CCCL_GRID_CONSTANT const int num_counts)
 {
-  static constexpr scan_policy active_policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).scan;
+  static constexpr scan_policy active_policy = current_policy<PolicySelector>().scan;
   static_assert(active_policy.algorithm == scan_algorithm::lookback);
   static constexpr scan_lookback_policy policy = active_policy.lookback;
   using ScanPolicy                             = AgentScanPolicy<
@@ -241,8 +242,8 @@ template <typename PolicySelector,
           typename ValueT,
           typename OffsetT,
           typename DecomposerT = detail::identity_decomposer_t>
-__launch_bounds__(int(ALT_DIGIT_BITS ? PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).alt_downsweep.block_threads
-                                     : PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).downsweep.block_threads))
+__launch_bounds__(int(ALT_DIGIT_BITS ? current_policy<PolicySelector>().alt_downsweep.block_threads
+                                     : current_policy<PolicySelector>().downsweep.block_threads))
   _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortDownsweepKernel(
     _CCCL_GRID_CONSTANT const KeyT* const d_keys_in,
     _CCCL_GRID_CONSTANT KeyT* const d_keys_out,
@@ -255,7 +256,7 @@ __launch_bounds__(int(ALT_DIGIT_BITS ? PolicySelector{}(::cuda::arch_id{CUB_PTX_
     GridEvenShare<OffsetT> even_share,
     _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
-  static constexpr radix_sort_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr radix_sort_policy policy = current_policy<PolicySelector>();
 
   static constexpr radix_sort_upsweep_policy active_upsweep_policy =
     ALT_DIGIT_BITS ? policy.alt_upsweep : policy.upsweep;
@@ -336,7 +337,7 @@ template <typename PolicySelector,
           typename ValueT,
           typename OffsetT,
           typename DecomposerT = identity_decomposer_t>
-__launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).single_tile.block_threads, 1)
+__launch_bounds__(current_policy<PolicySelector>().single_tile.block_threads, 1)
   _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortSingleTileKernel(
     _CCCL_GRID_CONSTANT const KeyT* const d_keys_in,
     _CCCL_GRID_CONSTANT KeyT* const d_keys_out,
@@ -348,7 +349,7 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).single_ti
     _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
   // Constants
-  static constexpr radix_sort_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr radix_sort_policy policy = current_policy<PolicySelector>();
   static constexpr int BLOCK_THREADS        = policy.single_tile.block_threads;
   static constexpr int ITEMS_PER_THREAD     = policy.single_tile.items_per_thread;
   static constexpr bool KEYS_ONLY           = ::cuda::std::is_same_v<ValueT, NullType>;
@@ -452,16 +453,16 @@ template <typename PolicySelector,
           typename KeyT,
           typename OffsetT,
           typename DecomposerT = identity_decomposer_t>
-_CCCL_KERNEL_ATTRIBUTES __launch_bounds__(
-  PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10})
-    .histogram.block_threads) void DeviceRadixSortHistogramKernel(_CCCL_GRID_CONSTANT OffsetT* const d_bins_out,
-                                                                  _CCCL_GRID_CONSTANT const KeyT* const d_keys_in,
-                                                                  _CCCL_GRID_CONSTANT const OffsetT num_items,
-                                                                  _CCCL_GRID_CONSTANT const int start_bit,
-                                                                  _CCCL_GRID_CONSTANT const int end_bit,
-                                                                  _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
+_CCCL_KERNEL_ATTRIBUTES
+__launch_bounds__(current_policy<PolicySelector>().histogram.block_threads) void DeviceRadixSortHistogramKernel(
+  _CCCL_GRID_CONSTANT OffsetT* const d_bins_out,
+  _CCCL_GRID_CONSTANT const KeyT* const d_keys_in,
+  _CCCL_GRID_CONSTANT const OffsetT num_items,
+  _CCCL_GRID_CONSTANT const int start_bit,
+  _CCCL_GRID_CONSTANT const int end_bit,
+  _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
-  static constexpr radix_sort_histogram_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).histogram;
+  static constexpr radix_sort_histogram_policy policy = current_policy<PolicySelector>().histogram;
 
   using HistogramPolicyT =
     AgentRadixSortHistogramPolicy<policy.block_threads, policy.items_per_thread, policy.num_parts, void, policy.radix_bits>;
@@ -479,8 +480,7 @@ template <typename PolicySelector,
           typename PortionOffsetT,
           typename AtomicOffsetT = PortionOffsetT,
           typename DecomposerT   = identity_decomposer_t>
-_CCCL_KERNEL_ATTRIBUTES void
-__launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).onesweep.block_threads)
+_CCCL_KERNEL_ATTRIBUTES void __launch_bounds__(current_policy<PolicySelector>().onesweep.block_threads)
   DeviceRadixSortOnesweepKernel(
     _CCCL_GRID_CONSTANT AtomicOffsetT* const d_lookback,
     _CCCL_GRID_CONSTANT AtomicOffsetT* const d_ctrs,
@@ -495,7 +495,7 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).onesweep.
     _CCCL_GRID_CONSTANT const int num_bits,
     _CCCL_GRID_CONSTANT const DecomposerT decomposer = {})
 {
-  static constexpr radix_sort_onesweep_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).onesweep;
+  static constexpr radix_sort_onesweep_policy policy = current_policy<PolicySelector>().onesweep;
   using OnesweepPolicyT                              = AgentRadixSortOnesweepPolicy<
                                  policy.block_threads,
                                  policy.items_per_thread,
@@ -540,13 +540,12 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).onesweep.
 template <typename PolicySelector, typename OffsetT>
 _CCCL_KERNEL_ATTRIBUTES void DeviceRadixSortExclusiveSumKernel(_CCCL_GRID_CONSTANT OffsetT* const d_bins)
 {
-  static constexpr radix_sort_exclusive_sum_policy policy =
-    PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).exclusive_sum;
-  constexpr int RADIX_BITS      = policy.radix_bits;
-  constexpr int RADIX_DIGITS    = 1 << RADIX_BITS;
-  constexpr int BLOCK_THREADS   = policy.block_threads;
-  constexpr int BINS_PER_THREAD = (RADIX_DIGITS + BLOCK_THREADS - 1) / BLOCK_THREADS;
-  using BlockScan               = cub::BlockScan<OffsetT, BLOCK_THREADS>;
+  static constexpr radix_sort_exclusive_sum_policy policy = current_policy<PolicySelector>().exclusive_sum;
+  constexpr int RADIX_BITS                                = policy.radix_bits;
+  constexpr int RADIX_DIGITS                              = 1 << RADIX_BITS;
+  constexpr int BLOCK_THREADS                             = policy.block_threads;
+  constexpr int BINS_PER_THREAD                           = (RADIX_DIGITS + BLOCK_THREADS - 1) / BLOCK_THREADS;
+  using BlockScan                                         = cub::BlockScan<OffsetT, BLOCK_THREADS>;
   __shared__ typename BlockScan::TempStorage temp_storage;
 
   // load the bins

--- a/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce.cuh
@@ -16,6 +16,7 @@
 #include <cub/agent/agent_reduce.cuh>
 #include <cub/device/dispatch/tuning/tuning_reduce.cuh>
 #include <cub/grid/grid_even_share.cuh>
+#include <cub/util_arch.cuh>
 
 #include <cuda/__device/arch_id.h>
 #include <cuda/atomic>
@@ -130,7 +131,7 @@ template <typename PolicySelector,
   requires reduce_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
 _CCCL_KERNEL_ATTRIBUTES
-__launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).reduce.block_threads)) void DeviceReduceKernel(
+__launch_bounds__(int(current_policy<PolicySelector>().reduce.block_threads)) void DeviceReduceKernel(
   _CCCL_GRID_CONSTANT const InputIteratorT d_in,
   _CCCL_GRID_CONSTANT AccumT* const d_out,
   _CCCL_GRID_CONSTANT const OffsetT num_items,
@@ -138,7 +139,7 @@ __launch_bounds__(int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).reduc
   ReductionOpT reduction_op,
   TransformOpT transform_op)
 {
-  static constexpr agent_reduce_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).reduce;
+  static constexpr agent_reduce_policy policy = current_policy<PolicySelector>().reduce;
   // TODO(bgruber): pass policy directly as template argument to AgentReduce in C++20
   using agent_policy_t =
     AgentReducePolicy<policy.block_threads,
@@ -222,16 +223,16 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires reduce_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-_CCCL_KERNEL_ATTRIBUTES __launch_bounds__(
-  int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).single_tile.block_threads),
-  1) void DeviceReduceSingleTileKernel(_CCCL_GRID_CONSTANT const InputIteratorT d_in,
-                                       OutputIteratorT d_out,
-                                       _CCCL_GRID_CONSTANT const OffsetT num_items,
-                                       ReductionOpT reduction_op,
-                                       _CCCL_GRID_CONSTANT const InitT init,
-                                       TransformOpT transform_op)
+_CCCL_KERNEL_ATTRIBUTES
+__launch_bounds__(int(current_policy<PolicySelector>().single_tile.block_threads), 1) void DeviceReduceSingleTileKernel(
+  _CCCL_GRID_CONSTANT const InputIteratorT d_in,
+  OutputIteratorT d_out,
+  _CCCL_GRID_CONSTANT const OffsetT num_items,
+  ReductionOpT reduction_op,
+  _CCCL_GRID_CONSTANT const InitT init,
+  TransformOpT transform_op)
 {
-  static constexpr agent_reduce_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).single_tile;
+  static constexpr agent_reduce_policy policy = current_policy<PolicySelector>().single_tile;
   // TODO(bgruber): pass policy directly as template argument to AgentReduce in C++20
   using agent_policy_t =
     AgentReducePolicy<policy.block_threads,
@@ -286,7 +287,7 @@ template <typename PolicySelector,
   requires reduce_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
 _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(int(
-  PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10})
+  current_policy<PolicySelector>()
     .reduce_nondeterministic
     .block_threads)) void NondeterministicDeviceReduceAtomicKernel(_CCCL_GRID_CONSTANT const InputIteratorT d_in,
                                                                    _CCCL_GRID_CONSTANT const OutputIteratorT d_out,
@@ -316,8 +317,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(int(
   }
 
   // Thread block type for reducing input tiles
-  static constexpr agent_reduce_policy policy =
-    PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).reduce_nondeterministic;
+  static constexpr agent_reduce_policy policy = current_policy<PolicySelector>().reduce_nondeterministic;
   // TODO(bgruber): pass policy directly as template argument to AgentReduce in C++20
   using agent_policy_t =
     AgentReducePolicy<policy.block_threads,

--- a/cub/cub/device/dispatch/kernels/kernel_reduce_deterministic.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_reduce_deterministic.cuh
@@ -16,6 +16,7 @@
 #include <cub/detail/rfa.cuh>
 #include <cub/device/dispatch/kernels/kernel_reduce.cuh>
 #include <cub/device/dispatch/tuning/tuning_reduce_deterministic.cuh>
+#include <cub/util_arch.cuh>
 
 #include <thrust/type_traits/unwrap_contiguous_iterator.h>
 
@@ -55,16 +56,16 @@ namespace detail::reduce
  *   Binary reduction functor
  */
 template <typename PolicySelector, typename InputIteratorT, typename ReductionOpT, typename AccumT, typename TransformOpT>
-_CCCL_KERNEL_ATTRIBUTES __launch_bounds__(int(
-  PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10})
-    .reduce.block_threads)) void DeterministicDeviceReduceKernel(InputIteratorT d_in,
-                                                                 AccumT* d_out,
-                                                                 int num_items,
-                                                                 ReductionOpT reduction_op,
-                                                                 TransformOpT transform_op,
-                                                                 const int reduce_grid_size)
+_CCCL_KERNEL_ATTRIBUTES
+__launch_bounds__(int(current_policy<PolicySelector>().reduce.block_threads)) void DeterministicDeviceReduceKernel(
+  InputIteratorT d_in,
+  AccumT* d_out,
+  int num_items,
+  ReductionOpT reduction_op,
+  TransformOpT transform_op,
+  const int reduce_grid_size)
 {
-  constexpr rfa::reduce_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).reduce;
+  constexpr rfa::reduce_policy policy = current_policy<PolicySelector>().reduce;
   constexpr int items_per_thread      = policy.items_per_thread;
   constexpr int block_threads         = policy.block_threads;
 
@@ -188,7 +189,7 @@ template <typename PolicySelector,
           typename AccumT,
           typename TransformOpT = ::cuda::std::identity>
 _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(
-  int(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).single_tile.block_threads),
+  int(current_policy<PolicySelector>().single_tile.block_threads),
   1) void DeterministicDeviceReduceSingleTileKernel(InputIteratorT d_in,
                                                     OutputIteratorT d_out,
                                                     int num_items,
@@ -196,7 +197,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(
                                                     InitT init,
                                                     TransformOpT transform_op)
 {
-  constexpr rfa::single_tile_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).single_tile;
+  constexpr rfa::single_tile_policy policy = current_policy<PolicySelector>().single_tile;
   constexpr int block_threads              = policy.block_threads;
 
   using block_reduce_t = BlockReduce<AccumT, block_threads, policy.block_algorithm>;

--- a/cub/cub/device/dispatch/kernels/kernel_scan.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan.cuh
@@ -16,6 +16,7 @@
 #include <cub/agent/agent_scan.cuh>
 #include <cub/detail/warpspeed/look_ahead.cuh>
 #include <cub/device/dispatch/tuning/tuning_scan.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_macro.cuh>
 
 #if _CCCL_CUDACC_AT_LEAST(12, 8)
@@ -65,7 +66,7 @@ _CCCL_KERNEL_ATTRIBUTES __launch_bounds__(128) void DeviceScanInitKernel(
   _CCCL_PDL_TRIGGER_NEXT_LAUNCH(); // beneficial for all problem sizes in cub.bench.scan.exclusive.sum.base
 
 #if _CCCL_CUDACC_AT_LEAST(12, 8)
-  constexpr scan_policy policy = PolicySelectorT{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  constexpr scan_policy policy = current_policy<PolicySelectorT>();
   if constexpr (policy.algorithm == scan_algorithm::warpspeed)
   {
     device_scan_init_warpspeed_body(tile_state.warpspeed, num_tiles);
@@ -114,7 +115,7 @@ _CCCL_KERNEL_ATTRIBUTES void DeviceCompactInitKernel(
 template <typename PolicySelector>
 [[nodiscard]] _CCCL_API _CCCL_CONSTEVAL int get_device_scan_launch_bounds() noexcept
 {
-  constexpr scan_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  constexpr scan_policy policy = current_policy<PolicySelector>();
 #if _CCCL_CUDACC_AT_LEAST(12, 8)
   if constexpr (policy.algorithm == scan_algorithm::warpspeed)
   {
@@ -198,7 +199,7 @@ __launch_bounds__(device_scan_launch_bounds<PolicySelector>, 1) _CCCL_KERNEL_ATT
   _CCCL_GRID_CONSTANT const OffsetT num_items,
   _CCCL_GRID_CONSTANT const int num_stages)
 {
-  static constexpr scan_policy active_policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr scan_policy active_policy = current_policy<PolicySelector>();
   if constexpr (active_policy.algorithm == scan_algorithm::warpspeed)
   {
 #if _CCCL_CUDACC_AT_LEAST(12, 8)

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -24,6 +24,7 @@
 #include <cub/device/dispatch/tuning/tuning_scan.cuh>
 #include <cub/thread/thread_reduce.cuh>
 #include <cub/thread/thread_scan.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/warp/warp_reduce.cuh>
 #include <cub/warp/warp_scan.cuh>
 
@@ -53,7 +54,7 @@ _CCCL_API constexpr int num_total_threads(const scan_warpspeed_policy& policy)
 template <typename PolicySelector>
 _CCCL_DEVICE_API constexpr scan_warpspeed_policy get_warpspeed_policy() noexcept
 {
-  return PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).warpspeed;
+  return current_policy<PolicySelector>().warpspeed;
 }
 
 template <typename InputT, typename OutputT, typename AccumT>

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_radix_sort.cuh
@@ -33,7 +33,7 @@ _CCCL_EXEC_CHECK_DISABLE
 template <typename PolicySelector, bool AltDigitBits>
 _CCCL_API constexpr int segmented_radix_sort_kernel_launch_bounds()
 {
-  constexpr auto policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  constexpr auto policy = current_policy<PolicySelector>();
   return AltDigitBits ? policy.alt_segmented.block_threads : policy.segmented.block_threads;
 }
 
@@ -125,7 +125,7 @@ __launch_bounds__(segmented_radix_sort_kernel_launch_bounds<PolicySelector, AltD
   // Constants
   //
 
-  static constexpr radix_sort_policy policy                  = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr radix_sort_policy policy                  = current_policy<PolicySelector>();
   static constexpr radix_sort_downsweep_policy active_policy = AltDigitBits ? policy.alt_segmented : policy.segmented;
 
   static constexpr int block_threads = active_policy.block_threads;

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_reduce.cuh
@@ -17,6 +17,7 @@
 #include <cub/device/dispatch/kernels/kernel_reduce.cuh> // finalize_and_store_aggregate
 #include <cub/device/dispatch/tuning/tuning_segmented_reduce.cuh>
 #include <cub/iterator/arg_index_input_iterator.cuh>
+#include <cub/util_arch.cuh>
 
 #include <cuda/__device/arch_id.h>
 #include <cuda/__utility/in_range.h>
@@ -109,8 +110,7 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires segmented_reduce_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-_CCCL_KERNEL_ATTRIBUTES
-__launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_reduce.block_threads) //
+_CCCL_KERNEL_ATTRIBUTES __launch_bounds__(current_policy<PolicySelector>().large_reduce.block_threads) //
   void DeviceSegmentedReduceKernel(
     _CCCL_GRID_CONSTANT const InputIteratorT d_in,
     _CCCL_GRID_CONSTANT const OutputIteratorT d_out,
@@ -121,7 +121,7 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_red
     _CCCL_GRID_CONSTANT const InitT init,
     _CCCL_GRID_CONSTANT const size_t max_segment_size)
 {
-  static constexpr segmented_reduce_policy full_policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr segmented_reduce_policy full_policy = current_policy<PolicySelector>();
 
   // Large segment agent (one block per segment)
   static constexpr reduce::agent_reduce_policy large_pol = full_policy.large_reduce;

--- a/cub/cub/device/dispatch/kernels/kernel_segmented_sort.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_segmented_sort.cuh
@@ -18,6 +18,7 @@
 #include <cub/detail/device_double_buffer.cuh>
 #include <cub/device/dispatch/dispatch_common.cuh>
 #include <cub/device/dispatch/tuning/tuning_segmented_sort.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_device.cuh>
 #include <cub/warp/warp_reduce.cuh>
 
@@ -129,7 +130,7 @@ template <SortOrder Order,
 #if _CCCL_HAS_CONCEPTS()
   requires segmented_sort_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_segment.block_threads)
+__launch_bounds__(current_policy<PolicySelector>().large_segment.block_threads)
   _CCCL_KERNEL_ATTRIBUTES void DeviceSegmentedSortFallbackKernel(
     const KeyT* d_keys_in_orig,
     KeyT* d_keys_out_orig,
@@ -140,7 +141,7 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_seg
     _CCCL_GRID_CONSTANT const BeginOffsetIteratorT d_begin_offsets,
     _CCCL_GRID_CONSTANT const EndOffsetIteratorT d_end_offsets)
 {
-  static constexpr segmented_sort_policy active_policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr segmented_sort_policy active_policy = current_policy<PolicySelector>();
   static constexpr auto large_policy                   = active_policy.large_segment;
   using LargeSegmentPolicyT                            = AgentRadixSortDownsweepPolicy<
                                0,
@@ -326,7 +327,7 @@ template <SortOrder Order,
 #if _CCCL_HAS_CONCEPTS()
   requires segmented_sort_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).small_segment.block_threads)
+__launch_bounds__(current_policy<PolicySelector>().small_segment.block_threads)
   _CCCL_KERNEL_ATTRIBUTES void DeviceSegmentedSortKernelSmall(
     _CCCL_GRID_CONSTANT const local_segment_index_t small_segments,
     _CCCL_GRID_CONSTANT const local_segment_index_t medium_segments,
@@ -345,7 +346,7 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).small_seg
   const local_segment_index_t tid = threadIdx.x;
   const local_segment_index_t bid = blockIdx.x;
 
-  static constexpr segmented_sort_policy active_policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr segmented_sort_policy active_policy = current_policy<PolicySelector>();
   static constexpr auto small_policy                   = active_policy.small_segment;
   using SmallPolicyT =
     AgentSubWarpMergeSortPolicy<small_policy.block_threads,
@@ -464,7 +465,7 @@ template <SortOrder Order,
 #if _CCCL_HAS_CONCEPTS()
   requires segmented_sort_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_segment.block_threads)
+__launch_bounds__(current_policy<PolicySelector>().large_segment.block_threads)
   _CCCL_KERNEL_ATTRIBUTES void DeviceSegmentedSortKernelLarge(
     _CCCL_GRID_CONSTANT const local_segment_index_t* const d_segments_indices,
     const KeyT* d_keys_in_orig,
@@ -476,18 +477,17 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_seg
     const _CCCL_GRID_CONSTANT BeginOffsetIteratorT d_begin_offsets,
     const _CCCL_GRID_CONSTANT EndOffsetIteratorT d_end_offsets)
 {
-  static constexpr segmented_radix_sort_policy large_policy =
-    PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).large_segment;
-  using LargeSegmentPolicyT = AgentRadixSortDownsweepPolicy<
-    0,
-    0,
-    void,
-    large_policy.load_algorithm,
-    large_policy.load_modifier,
-    large_policy.rank_algorithm,
-    large_policy.scan_algorithm,
-    large_policy.radix_bits,
-    NoScaling<large_policy.block_threads, large_policy.items_per_thread>>;
+  static constexpr segmented_radix_sort_policy large_policy = current_policy<PolicySelector>().large_segment;
+  using LargeSegmentPolicyT                                 = AgentRadixSortDownsweepPolicy<
+                                    0,
+                                    0,
+                                    void,
+                                    large_policy.load_algorithm,
+                                    large_policy.load_modifier,
+                                    large_policy.rank_algorithm,
+                                    large_policy.scan_algorithm,
+                                    large_policy.radix_bits,
+                                    NoScaling<large_policy.block_threads, large_policy.items_per_thread>>;
 
   using local_segment_index_t = local_segment_index_t;
 

--- a/cub/cub/device/dispatch/kernels/kernel_three_way_partition.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_three_way_partition.cuh
@@ -15,6 +15,7 @@
 
 #include <cub/agent/agent_three_way_partition.cuh>
 #include <cub/device/dispatch/tuning/tuning_three_way_partition.cuh>
+#include <cub/util_arch.cuh>
 
 CUB_NAMESPACE_BEGIN
 
@@ -116,7 +117,7 @@ template <typename PolicySelector,
 #if _CCCL_HAS_CONCEPTS()
   requires three_way_partition_policy_selector<PolicySelector>
 #endif // _CCCL_HAS_CONCEPTS()
-__launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_threads)
+__launch_bounds__(current_policy<PolicySelector>().block_threads)
   _CCCL_KERNEL_ATTRIBUTES void DeviceThreeWayPartitionKernel(
     _CCCL_GRID_CONSTANT const InputIteratorT d_in,
     _CCCL_GRID_CONSTANT const FirstOutputIteratorT d_first_part_out,
@@ -130,7 +131,7 @@ __launch_bounds__(PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10}).block_thr
     _CCCL_GRID_CONSTANT const int num_tiles,
     _CCCL_GRID_CONSTANT const StreamingContextT streaming_context)
 {
-  static constexpr auto active_policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr auto active_policy = current_policy<PolicySelector>();
   using AgentThreeWayPartitionPolicyT = AgentThreeWayPartitionPolicy<
     active_policy.block_threads,
     active_policy.items_per_thread,

--- a/cub/cub/device/dispatch/kernels/kernel_transform.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_transform.cuh
@@ -14,6 +14,7 @@
 #endif // no system header
 
 #include <cub/device/dispatch/tuning/tuning_transform.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_type.cuh>
 #include <cub/util_vsmem.cuh>
 
@@ -993,7 +994,7 @@ _CCCL_HOST_DEVICE auto make_aligned_base_ptr_kernel_arg(It ptr, int alignment) -
 template <typename PolicySelector>
 _CCCL_API constexpr int get_block_threads_helper()
 {
-  constexpr transform_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  constexpr transform_policy policy = current_policy<PolicySelector>();
   if constexpr (policy.algorithm == Algorithm::prefetch)
   {
     return policy.prefetch.block_threads;
@@ -1036,7 +1037,7 @@ __launch_bounds__(get_block_threads<PolicySelector>) _CCCL_KERNEL_ATTRIBUTES voi
 {
   _CCCL_ASSERT(blockDim.y == 1 && blockDim.z == 1, "transform_kernel only supports 1D blocks");
 
-  static constexpr transform_policy policy = PolicySelector{}(::cuda::arch_id{CUB_PTX_ARCH / 10});
+  static constexpr transform_policy policy = current_policy<PolicySelector>();
 
   if constexpr (policy.algorithm == Algorithm::prefetch)
   {

--- a/cub/cub/device/dispatch/kernels/kernel_unique_by_key.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_unique_by_key.cuh
@@ -17,6 +17,7 @@
 #include <cub/detail/arch_dispatch.cuh>
 #include <cub/detail/delay_constructor.cuh>
 #include <cub/device/dispatch/tuning/tuning_unique_by_key.cuh>
+#include <cub/util_arch.cuh>
 #include <cub/util_vsmem.cuh>
 
 #include <cuda/__device/arch_id.h>
@@ -236,7 +237,7 @@ template <typename PolicySelector,
           typename OffsetT>
 __launch_bounds__(
   device_unique_by_key_vsmem_helper_t<
-    device_policy_getter<PolicySelector, cuda::arch_id{CUB_PTX_ARCH / 10}>,
+    device_policy_getter<PolicySelector, current_tuning_arch()>,
     KeyInputIteratorT,
     ValueInputIteratorT,
     KeyOutputIteratorT,
@@ -256,7 +257,7 @@ __launch_bounds__(
     vsmem_t vsmem)
 {
   using vsmem_adapted_agents = device_unique_by_key_vsmem_helper_t<
-    device_policy_getter<PolicySelector, cuda::arch_id{CUB_PTX_ARCH / 10}>,
+    device_policy_getter<PolicySelector, current_tuning_arch()>,
     KeyInputIteratorT,
     ValueInputIteratorT,
     KeyOutputIteratorT,

--- a/cub/cub/util_arch.cuh
+++ b/cub/cub/util_arch.cuh
@@ -25,6 +25,8 @@
 
 #include <cuda/__cmath/ceil_div.h>
 #include <cuda/__cmath/round_up.h>
+#include <cuda/__device/arch_id.h>
+#include <cuda/__device/compute_capability.h>
 #include <cuda/std/__algorithm/clamp.h>
 #include <cuda/std/__algorithm/max.h>
 #include <cuda/std/__algorithm/min.h>
@@ -175,6 +177,45 @@ struct NoScaling
   static constexpr int ITEMS_PER_THREAD = Nominal4ByteItemsPerThread;
   static constexpr int BLOCK_THREADS    = Nominal4ByteBlockThreads;
 };
+
+// Gets the current tuning architecture. Compared to CUB_PTX_ARCH, it can result in arch-specific architecture id. When
+// compiling with nvc++, it always results in ordinary arch id for __NVCOMPILER_CUDA_ARCH__.
+[[nodiscard]] _CCCL_API constexpr ::cuda::arch_id current_tuning_arch() noexcept
+{
+#  if _CCCL_CUDA_COMPILER(NVHPC)
+  return ::cuda::to_arch_id(::cuda::compute_capability(__NVCOMPILER_CUDA_ARCH__ / 10));
+#  elif _CCCL_DEVICE_COMPILATION()
+  return ::cuda::device::current_arch_id();
+#  else // _CCCL_HOST_COMPILATION()
+  return ::cuda::arch_id{};
+#  endif
+}
+
+// Selects the tuning policy for a given architecture id.
+_CCCL_EXEC_CHECK_DISABLE
+template <class PolicySelector>
+[[nodiscard]] _CCCL_API constexpr auto select_policy(::cuda::arch_id arch_id)
+{
+  // todo(dabayer): enable this once current policies are rewritten to work with cuda::compute_capability
+  // if constexpr (::cuda::std::is_invocable_v<PolicySelector, ::cuda::arch_id>)
+  // {
+  //   return PolicySelector{}(arch_id);
+  // }
+  // else
+  // {
+  //   return PolicySelector{}(::cuda::compute_capability{arch_id});
+  // }
+  //
+  // Just convert arch-specific architectures to ordinary archs for now.
+  return PolicySelector{}(::cuda::arch_id{::cuda::compute_capability{arch_id}.get()});
+}
+
+// Selects the tuning policy for the current_tuning_arch() architecture.
+template <class PolicySelector>
+[[nodiscard]] _CCCL_API constexpr auto current_policy()
+{
+  return select_policy<PolicySelector>(current_tuning_arch());
+}
 } // namespace detail
 #endif // Do not document
 

--- a/cub/cub/util_device.cuh
+++ b/cub/cub/util_device.cuh
@@ -17,6 +17,7 @@
 #  pragma system_header
 #endif // no system header
 
+#include <cub/util_arch.cuh>
 #include <cub/util_debug.cuh>
 #include <cub/util_policy_wrapper_t.cuh>
 #include <cub/util_type.cuh>

--- a/python/cuda_cccl/CMakeLists.txt
+++ b/python/cuda_cccl/CMakeLists.txt
@@ -4,6 +4,16 @@
 
 cmake_minimum_required(VERSION 3.21...3.31 FATAL_ERROR)
 
+# Must be set before project() initializes the CUDA language; otherwise CMake
+# < 3.23 defaults to sm_52, which is below CCCL's minimum supported arch.
+include(../../cmake/CCCLCheckCudaArchitectures.cmake)
+set(
+  CMAKE_CUDA_ARCHITECTURES
+  "${minimum_cccl_arch}"
+  CACHE STRING
+  "CUDA architectures for CCCL"
+)
+
 project(cuda_cccl DESCRIPTION "Python package cuda_cccl" LANGUAGES CUDA CXX C)
 
 find_package(CUDAToolkit)


### PR DESCRIPTION
This PR implements several utilities for policy selection. The main advantage is that they can potentially return arch-specific and family-specific architecture ids.