### PR TITLE
Ensure `cuda::std::complex` is trivially copyable when possible

### DIFF
--- a/libcudacxx/include/cuda/std/__complex/complex.h
+++ b/libcudacxx/include/cuda/std/__complex/complex.h
@@ -31,6 +31,11 @@
 #include <cuda/std/__type_traits/is_constructible.h>
 #include <cuda/std/__type_traits/is_floating_point.h>
 #include <cuda/std/__type_traits/is_integral.h>
+#include <cuda/std/__type_traits/is_nothrow_copy_assignable.h>
+#include <cuda/std/__type_traits/is_nothrow_copy_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_default_constructible.h>
+#include <cuda/std/__type_traits/is_nothrow_move_assignable.h>
+#include <cuda/std/__type_traits/is_nothrow_move_constructible.h>
 #include <cuda/std/__type_traits/is_same.h>
 #include <cuda/std/cmath>
 #include <cuda/std/cstdint>
@@ -76,10 +81,17 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT _LIBCUDACXX_COMPLEX_ALIGNAS complex
 public:
   using value_type = _Tp;
 
-  _CCCL_API constexpr complex(const value_type& __re = value_type(), const value_type& __im = value_type())
+  _CCCL_API constexpr complex(const value_type& __re = value_type(),
+                              const value_type& __im = value_type()) noexcept(is_nothrow_default_constructible_v<_Tp>)
       : __re_(__re)
       , __im_(__im)
   {}
+
+  _CCCL_HIDE_FROM_ABI constexpr complex(const complex&) noexcept(is_nothrow_copy_constructible_v<_Tp>) = default;
+  _CCCL_HIDE_FROM_ABI constexpr complex(complex&&) noexcept(is_nothrow_move_constructible_v<_Tp>)      = default;
+
+  _CCCL_HIDE_FROM_ABI constexpr complex& operator=(const complex&) noexcept(is_nothrow_copy_assignable_v<_Tp>) = default;
+  _CCCL_HIDE_FROM_ABI constexpr complex& operator=(complex&&) noexcept(is_nothrow_move_assignable_v<_Tp>) = default;
 
   template <class _Up, enable_if_t<__cccl_internal::__is_non_narrowing_convertible<_Tp, _Up>::value, int> = 0>
   _CCCL_API constexpr complex(const complex<_Up>& __c)

--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -114,9 +114,17 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_ALIGNAS(alignof(__nv_bfloat162)) compl
 public:
   using value_type = __nv_bfloat16;
 
-  _CCCL_API inline complex(const value_type& __re = value_type(), const value_type& __im = value_type())
+  _CCCL_API inline complex(const value_type& __re = value_type(), const value_type& __im = value_type()) noexcept
       : __repr_(__re, __im)
   {}
+
+#  if !_CCCL_COMPILER(GCC, <, 8) // Old GCC considers those as deleted
+  _CCCL_HIDE_FROM_ABI complex(const complex&) noexcept = default;
+  _CCCL_HIDE_FROM_ABI complex(complex&&) noexcept      = default;
+
+  _CCCL_HIDE_FROM_ABI complex& operator=(const complex&) noexcept = default;
+  _CCCL_HIDE_FROM_ABI complex& operator=(complex&&) noexcept      = default;
+#  endif // !_CCCL_COMPILER(GCC, <, 8)
 
   template <class _Up, enable_if_t<__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0>
   _CCCL_API inline complex(const complex<_Up>& __c)

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -114,9 +114,17 @@ class _CCCL_TYPE_VISIBILITY_DEFAULT _CCCL_ALIGNAS(alignof(__half2)) complex<__ha
 public:
   using value_type = __half;
 
-  _CCCL_API inline complex(const value_type& __re = value_type(), const value_type& __im = value_type())
+  _CCCL_API inline complex(const value_type& __re = value_type(), const value_type& __im = value_type()) noexcept
       : __repr_(__re, __im)
   {}
+
+#  if !_CCCL_COMPILER(GCC, <, 8) // Old GCC considers those as deleted
+  _CCCL_HIDE_FROM_ABI complex(const complex&) noexcept = default;
+  _CCCL_HIDE_FROM_ABI complex(complex&&) noexcept      = default;
+
+  _CCCL_HIDE_FROM_ABI complex& operator=(const complex&) noexcept = default;
+  _CCCL_HIDE_FROM_ABI complex& operator=(complex&&) noexcept      = default;
+#  endif // !_CCCL_COMPILER(GCC, <, 8)
 
   template <class _Up, enable_if_t<__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0>
   _CCCL_API inline complex(const complex<_Up>& __c)

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex/traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex/traits.pass.cpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2023 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+// <cuda/std/complex>
+
+// template<class T>
+// class complex
+// {
+// public:
+//   using value_type = T;
+//   ...
+// };
+
+#include <cuda/std/complex>
+#include <cuda/std/type_traits>
+
+#include "test_macros.h"
+
+template <class T>
+__host__ __device__ void test()
+{
+  using C = cuda::std::complex<T>;
+
+  static_assert(cuda::std::is_default_constructible_v<C>);
+  static_assert(!cuda::std::is_trivially_default_constructible_v<C>);
+  static_assert(cuda::std::is_nothrow_default_constructible_v<C>);
+
+  static_assert(cuda::std::is_copy_constructible_v<C>);
+  static_assert(cuda::std::is_trivially_copy_constructible_v<C> == cuda::std::is_floating_point_v<T>);
+  static_assert(cuda::std::is_nothrow_copy_constructible_v<C>);
+
+  static_assert(cuda::std::is_move_constructible_v<C>);
+  static_assert(cuda::std::is_trivially_move_constructible_v<C> == cuda::std::is_floating_point_v<T>);
+  static_assert(cuda::std::is_nothrow_move_constructible_v<C>);
+
+  static_assert(cuda::std::is_copy_assignable_v<C>);
+  static_assert(cuda::std::is_trivially_copy_assignable_v<C> == cuda::std::is_floating_point_v<T>);
+  static_assert(cuda::std::is_nothrow_copy_assignable_v<C>);
+
+  static_assert(cuda::std::is_move_assignable_v<C>);
+  static_assert(cuda::std::is_trivially_move_assignable_v<C> == cuda::std::is_floating_point_v<T>);
+  static_assert(cuda::std::is_nothrow_move_assignable_v<C>);
+
+  static_assert(cuda::std::is_trivially_destructible_v<C>);
+  static_assert(cuda::std::is_trivially_copyable_v<C> == cuda::std::is_floating_point_v<T>);
+}
+
+int main(int, char**)
+{
+  test<float>();
+  test<double>();
+#if _CCCL_HAS_LONG_DOUBLE()
+  test<long double>();
+#endif // _CCCL_HAS_LONG_DOUBLE()
+#if !TEST_COMPILER(GCC, <, 8) // Old GCC considers the defaulted constructors as deleted
+#  if _LIBCUDACXX_HAS_NVFP16()
+  test<__half>();
+#  endif // _LIBCUDACXX_HAS_NVFP16()
+#  if _LIBCUDACXX_HAS_NVBF16()
+  test<__nv_bfloat16>();
+#  endif // _LIBCUDACXX_HAS_NVBF16()
+#endif // !TEST_COMPILER(GCC, <, 8)
+
+  return 0;
+}


### PR DESCRIPTION
With C++23  `std::complex` has been changed to be trivially copyable

Adopt those changes for our implementations.

Unfortunately, we cannot make `__half` of `__nv_bfloat16` work because we do not controll those
