### PR TITLE
Don't guard [[assume]] behind C++23

### DIFF
--- a/libcudacxx/include/cuda/std/__cccl/attributes.h
+++ b/libcudacxx/include/cuda/std/__cccl/attributes.h
@@ -78,7 +78,7 @@
 // NVCC does not properly respect [[assume()]], so use __builtin_assume, see nvbug5458663
 #if _CCCL_CUDA_COMPILER(NVCC) && _CCCL_DEVICE_COMPILATION()
 #  define _CCCL_ASSUME(...) __builtin_assume(__VA_ARGS__)
-#elif _CCCL_HAS_CPP_ATTRIBUTE(assume) && (_CCCL_STD_VER >= 2023)
+#elif _CCCL_HAS_CPP_ATTRIBUTE(assume)
 #  define _CCCL_ASSUME(...) [[assume(__VA_ARGS__)]]
 #else
 #  define _CCCL_ASSUME(...) _CCCL_BUILTIN_ASSUME(__VA_ARGS__)


### PR DESCRIPTION
Only quite old or technically unsupported clangs warn for it.

## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
