### PR TITLE
[docs] Update cuda::maximum/minimum signatures to match actual API

### DIFF
--- a/docs/libcudacxx/extended_api/functional/maximum_minimum.rst
+++ b/docs/libcudacxx/extended_api/functional/maximum_minimum.rst
@@ -3,39 +3,46 @@
 ``cuda::maximum`` and ``cuda::minimum``
 =======================================
 
+Defined in the header ``<cuda/functional>``.
+
 .. code:: cuda
 
     template <typename T>
     struct maximum {
-        [[nodiscard]] __host__ __device__ inline
-        T operator()(T a, T b) const;
+        [[nodiscard]] __host__ __device__ constexpr
+        T operator()(const T& a, const T& b) const noexcept(/* see below */);
     };
 
     template <>
     struct maximum<void> {
         template <typename T1, typename T2>
-        [[nodiscard]] __host__ __device__ inline
-        cuda::std::common_type_t<T1, T2> operator()(T1 a, T2 b) const;
+        [[nodiscard]] __host__ __device__ constexpr
+        cuda::std::common_type_t<T1, T2> operator()(const T1& a, const T2& b) const noexcept(/* see below */);
     };
 
     template <typename T>
     struct minimum {
-        [[nodiscard]] __host__ __device__ inline
-        T operator()(T a, T b) const;
+        [[nodiscard]] __host__ __device__ constexpr
+        T operator()(const T& a, const T& b) const noexcept(/* see below */);
     };
 
     template <>
     struct minimum<void> {
         template <typename T1, typename T2>
-        [[nodiscard]] __host__ __device__ inline
-        cuda::std::common_type_t<T1, T2> operator()(T1 a, T2 b) const;
+        [[nodiscard]] __host__ __device__ constexpr
+        cuda::std::common_type_t<T1, T2> operator()(const T1& a, const T2& b) const noexcept(/* see below */);
     };
 
-Function objects for performing maximum and minimum. The functions behave as ``noexcept`` when the comparison between the values is also ``noexcept``.
+Function objects for performing maximum and minimum operations. The ``operator()`` is ``noexcept`` when the comparison between the values is also ``noexcept``.
 
 .. note::
 
     Differently from ``std::plus`` and other functional operators, ``cuda::maximum`` and ``cuda::minimum`` specialized for ``void`` returns ``cuda::std::common_type_t`` and not the implicit promotion
+
+Floating-Point Behavior
+-----------------------
+
+For floating-point types (and extended floating-point types), ``cuda::maximum`` uses ``cuda::std::fmax`` and ``cuda::minimum`` uses ``cuda::std::fmin`` instead of the comparison operator. This means that ``NaN`` arguments are treated as missing data: ``cuda::maximum{}(NaN, 1.0)`` returns ``1.0``, and ``cuda::minimum{}(NaN, 1.0)`` returns ``1.0``.
 
 Example
 -------

--- a/docs/libcudacxx/extended_api/functional/maximum_minimum.rst
+++ b/docs/libcudacxx/extended_api/functional/maximum_minimum.rst
@@ -42,7 +42,9 @@ Function objects for performing maximum and minimum operations. The ``operator()
 Floating-Point Behavior
 -----------------------
 
-For floating-point types (and extended floating-point types), ``cuda::maximum`` uses ``cuda::std::fmax`` and ``cuda::minimum`` uses ``cuda::std::fmin`` instead of the comparison operator. This means that ``NaN`` arguments are treated as missing data: ``cuda::maximum{}(NaN, 1.0)`` returns ``1.0``, and ``cuda::minimum{}(NaN, 1.0)`` returns ``1.0``.
+For floating-point types (and extended floating-point types), ``cuda::maximum`` uses ``cuda::std::fmax`` and ``cuda::minimum`` uses ``cuda::std::fmin`` instead of the comparison operator, following the ``std::fmax``/``std::fmin`` specification for handling special values such as ``NaN``.
+
+This also makes ``cuda::maximum`` and ``cuda::minimum`` commutative for floating-point types, unlike a plain comparison-based approach.
 
 Example
 -------


### PR DESCRIPTION
## Description

closes #8350

The documentation for `cuda::maximum` and `cuda::minimum` did not match the actual API in several ways:

| | Docs (before) | Actual API |
|---|---|---|
| Parameters | by value (`T a, T b`) | by const reference (`const T& a, const T& b`) |
| Qualifier | `inline` | `constexpr` |
| Exception spec | *(not shown)* | `noexcept(/* conditional */)` |
| FP behavior | *(not documented)* | Uses `fmax`/`fmin` (NaN = missing data) |

**Changes:**

- Updated all four `operator()` signatures (typed + `void` specializations, for both `maximum` and `minimum`) to use `const T&` params, `constexpr`, and `noexcept(/* see below */)`
- Added "Defined in the header" line (consistent with other docs in this directory)
- Added "Floating-Point Behavior" section explaining that `fmax`/`fmin` is used for floating-point types, as requested by @fbusato in the issue comments

## Checklist

- [x] New or existing tests cover these changes.
- [x] The documentation is up to date with these changes.