### PR TITLE
Replace `detail::merge::dispatch` by CUB's public API

### DIFF
--- a/cub/benchmarks/bench/merge/keys.cu
+++ b/cub/benchmarks/bench/merge/keys.cu
@@ -49,7 +49,7 @@ void keys(nvbench::state& state, nvbench::type_list<KeyT>)
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::__tune(policy_selector<key_t, value_t, offset_t>{})
+      cuda::execution::__tune(bench_policy_selector<key_t>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/merge/keys.cu
+++ b/cub/benchmarks/bench/merge/keys.cu
@@ -18,24 +18,10 @@
 // %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1
 // %RANGE% TUNE_THREADS_PER_BLOCK_POW2 tpb 6:10:1
 
-#if !TUNE_BASE
-struct bench_policy_selector
+template <typename KeyT>
+void keys(nvbench::state& state, nvbench::type_list<KeyT>)
 {
-  _CCCL_API constexpr auto operator()(::cuda::arch_id /*arch*/) const -> cub::detail::merge::merge_policy
-  {
-    return cub::detail::merge::merge_policy{
-      TUNE_THREADS_PER_BLOCK,
-      cub::Nominal4BItemsToItems<KeyT>(TUNE_ITEMS_PER_THREAD),
-      TUNE_LOAD_MODIFIER,
-      TUNE_STORE_ALGORITHM,
-      TUNE_USE_BL2SH};
-  }
-};
-#endif // !TUNE_BASE
-
-template <typename KeyT, typename OffsetT>
-void keys(nvbench::state& state, nvbench::type_list<KeyT, OffsetT>)
-{
+  using offset_t     = int64_t;
   using compare_op_t = less_t;
 
   // Retrieve axis parameters
@@ -46,7 +32,7 @@ void keys(nvbench::state& state, nvbench::type_list<KeyT, OffsetT>)
   const auto num_items_rhs  = elements - num_items_lhs;
   auto [keys_lhs, keys_rhs] = generate_lhs_rhs<KeyT>(num_items_lhs, num_items_rhs, entropy);
 
-  thrust::device_vector<KeyT> keys_out(elements);
+  thrust::device_vector<KeyT> keys_out(elements, thrust::no_init);
   KeyT* d_keys_lhs = thrust::raw_pointer_cast(keys_lhs.data());
   KeyT* d_keys_rhs = thrust::raw_pointer_cast(keys_rhs.data());
   KeyT* d_keys_out = thrust::raw_pointer_cast(keys_out.data());
@@ -56,51 +42,26 @@ void keys(nvbench::state& state, nvbench::type_list<KeyT, OffsetT>)
   state.add_global_memory_reads<KeyT>(elements);
   state.add_global_memory_writes<KeyT>(elements);
 
-  auto value_nullptr = static_cast<cub::NullType*>(nullptr);
-
-  // Allocate temporary storage:
-  std::size_t temp_size{};
-  cub::detail::merge::dispatch(
-    nullptr,
-    temp_size,
-    d_keys_lhs,
-    value_nullptr,
-    static_cast<OffsetT>(num_items_lhs),
-    d_keys_rhs,
-    value_nullptr,
-    static_cast<OffsetT>(num_items_rhs),
-    d_keys_out,
-    value_nullptr,
-    compare_op_t{},
-    cudaStream_t{}
-#if !TUNE_BASE
-    ,
-    bench_policy_selector{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::merge::dispatch(
-      temp_storage,
-      temp_size,
-      d_keys_lhs,
-      value_nullptr,
-      static_cast<OffsetT>(num_items_lhs),
-      d_keys_rhs,
-      value_nullptr,
-      static_cast<OffsetT>(num_items_rhs),
-      d_keys_out,
-      value_nullptr,
-      compare_op_t{},
-      launch.get_stream()
+    auto env = cub_bench_env(
+      alloc,
+      launch
 #if !TUNE_BASE
-        ,
-      bench_policy_selector{}
+      ,
+      cuda::execution::__tune(policy_selector<key_t, value_t, offset_t>{})
 #endif // !TUNE_BASE
     );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceMerge::MergeKeys,
+      "MergePairs failed",
+      d_keys_lhs,
+      static_cast<offset_t>(num_items_lhs),
+      d_keys_rhs,
+      static_cast<offset_t>(num_items_rhs),
+      d_keys_out,
+      compare_op_t{},
+      env);
   });
 }
 
@@ -110,8 +71,8 @@ using key_types = nvbench::type_list<TUNE_KeyT>;
 using key_types = fundamental_types;
 #endif // TUNE_KeyT
 
-NVBENCH_BENCH_TYPES(keys, NVBENCH_TYPE_AXES(key_types, offset_types))
+NVBENCH_BENCH_TYPES(keys, NVBENCH_TYPE_AXES(key_types))
   .set_name("base")
-  .set_type_axes_names({"KeyT{ct}", "OffsetT{ct}"})
+  .set_type_axes_names({"KeyT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
   .add_string_axis("Entropy", {"1.000", "0.201"});

--- a/cub/benchmarks/bench/merge/merge_common.cuh
+++ b/cub/benchmarks/bench/merge/merge_common.cuh
@@ -13,13 +13,6 @@
 #include <nvbench_helper.cuh>
 
 #if !TUNE_BASE
-#  define TUNE_THREADS_PER_BLOCK (1 << TUNE_THREADS_PER_BLOCK_POW2)
-#  if TUNE_TRANSPOSE == 0
-#    define TUNE_STORE_ALGORITHM cub::BLOCK_STORE_DIRECT
-#  else // TUNE_TRANSPOSE == 1
-#    define TUNE_STORE_ALGORITHM cub::BLOCK_STORE_WARP_TRANSPOSE
-#  endif // TUNE_TRANSPOSE
-
 #  if TUNE_LOAD == 0
 #    define TUNE_LOAD_MODIFIER cub::LOAD_DEFAULT
 #    define TUNE_USE_BL2SH     false
@@ -35,19 +28,17 @@
 #  endif // TUNE_LOAD
 
 template <typename KeyT>
-struct policy_hub_t
+struct bench_policy_selector
 {
-  struct policy_t : cub::ChainedPolicy<500, policy_t, policy_t>
+  _CCCL_API constexpr auto operator()(::cuda::arch_id /*arch*/) const -> cub::detail::merge::merge_policy
   {
-    using merge_policy =
-      cub::agent_policy_t<TUNE_THREADS_PER_BLOCK,
-                          cub::Nominal4BItemsToItems<KeyT>(TUNE_ITEMS_PER_THREAD),
-                          TUNE_LOAD_MODIFIER,
-                          TUNE_STORE_ALGORITHM,
-                          TUNE_USE_BL2SH>;
-  };
-
-  using MaxPolicy = policy_t;
+    return cub::detail::merge::merge_policy{
+      (1 << TUNE_THREADS_PER_BLOCK_POW2),
+      cub::Nominal4BItemsToItems<KeyT>(TUNE_ITEMS_PER_THREAD),
+      TUNE_LOAD_MODIFIER,
+      TUNE_TRANSPOSE == 0 ? cub::BLOCK_STORE_DIRECT : cub::BLOCK_STORE_WARP_TRANSPOSE,
+      TUNE_USE_BL2SH};
+  }
 };
 #endif // TUNE_BASE
 

--- a/cub/benchmarks/bench/merge/pairs.cu
+++ b/cub/benchmarks/bench/merge/pairs.cu
@@ -59,7 +59,7 @@ void pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT>)
       launch
 #if !TUNE_BASE
       ,
-      cuda::execution::__tune(policy_selector<key_t, value_t, offset_t>{})
+      cuda::execution::__tune(bench_policy_selector<key_t>{})
 #endif // !TUNE_BASE
     );
     _CCCL_TRY_CUDA_API(

--- a/cub/benchmarks/bench/merge/pairs.cu
+++ b/cub/benchmarks/bench/merge/pairs.cu
@@ -18,24 +18,10 @@
 // %RANGE% TUNE_ITEMS_PER_THREAD ipt 7:24:1
 // %RANGE% TUNE_THREADS_PER_BLOCK_POW2 tpb 6:10:1
 
-#if !TUNE_BASE
-struct bench_policy_selector
+template <typename KeyT, typename ValueT>
+void pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT>)
 {
-  _CCCL_API constexpr auto operator()(::cuda::arch_id /*arch*/) const -> cub::detail::merge::merge_policy
-  {
-    return cub::detail::merge::merge_policy{
-      TUNE_THREADS_PER_BLOCK,
-      cub::Nominal4BItemsToItems<KeyT>(TUNE_ITEMS_PER_THREAD),
-      TUNE_LOAD_MODIFIER,
-      TUNE_STORE_ALGORITHM,
-      TUNE_USE_BL2SH};
-  }
-};
-#endif // !TUNE_BASE
-
-template <typename KeyT, typename ValueT, typename OffsetT>
-void pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
-{
+  using offset_t     = int64_t;
   using compare_op_t = less_t;
 
   // Retrieve axis parameters
@@ -45,10 +31,10 @@ void pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
   const auto num_items_lhs = elements / 2;
   const auto num_items_rhs = elements - num_items_lhs;
 
-  thrust::device_vector<KeyT> keys_out(elements);
-  thrust::device_vector<ValueT> values_lhs(num_items_lhs);
-  thrust::device_vector<ValueT> values_rhs(num_items_rhs);
-  thrust::device_vector<ValueT> values_out(elements);
+  thrust::device_vector<KeyT> keys_out(elements, thrust::no_init);
+  thrust::device_vector<ValueT> values_lhs(num_items_lhs, thrust::no_init);
+  thrust::device_vector<ValueT> values_rhs(num_items_rhs, thrust::no_init);
+  thrust::device_vector<ValueT> values_out(elements, thrust::no_init);
 
   auto [keys_lhs, keys_rhs] = generate_lhs_rhs<KeyT>(num_items_lhs, num_items_rhs, entropy);
 
@@ -66,49 +52,29 @@ void pairs(nvbench::state& state, nvbench::type_list<KeyT, ValueT, OffsetT>)
   state.add_global_memory_writes<KeyT>(elements);
   state.add_global_memory_writes<ValueT>(elements);
 
-  // Allocate temporary storage:
-  std::size_t temp_size{};
-  cub::detail::merge::dispatch(
-    nullptr,
-    temp_size,
-    d_keys_lhs,
-    d_values_lhs,
-    static_cast<OffsetT>(num_items_lhs),
-    d_keys_rhs,
-    d_values_rhs,
-    static_cast<OffsetT>(num_items_rhs),
-    d_keys_out,
-    d_values_out,
-    compare_op_t{},
-    cudaStream_t{}
-#if !TUNE_BASE
-    ,
-    bench_policy_selector{}
-#endif // !TUNE_BASE
-  );
-
-  thrust::device_vector<nvbench::uint8_t> temp(temp_size);
-  auto* temp_storage = thrust::raw_pointer_cast(temp.data());
-
+  caching_allocator_t alloc;
   state.exec(nvbench::exec_tag::gpu | nvbench::exec_tag::no_batch, [&](nvbench::launch& launch) {
-    cub::detail::merge::dispatch(
-      temp_storage,
-      temp_size,
+    auto env = cub_bench_env(
+      alloc,
+      launch
+#if !TUNE_BASE
+      ,
+      cuda::execution::__tune(policy_selector<key_t, value_t, offset_t>{})
+#endif // !TUNE_BASE
+    );
+    _CCCL_TRY_CUDA_API(
+      cub::DeviceMerge::MergePairs,
+      "MergePairs failed",
       d_keys_lhs,
       d_values_lhs,
-      static_cast<OffsetT>(num_items_lhs),
+      static_cast<offset_t>(num_items_lhs),
       d_keys_rhs,
       d_values_rhs,
-      static_cast<OffsetT>(num_items_rhs),
+      static_cast<offset_t>(num_items_rhs),
       d_keys_out,
       d_values_out,
       compare_op_t{},
-      launch.get_stream()
-#if !TUNE_BASE
-        ,
-      bench_policy_selector{}
-#endif // !TUNE_BASE
-    );
+      env);
   });
 }
 
@@ -130,8 +96,8 @@ using value_types = nvbench::type_list<int8_t, int16_t, int32_t, int64_t
                                        >;
 #endif // TUNE_ValueT
 
-NVBENCH_BENCH_TYPES(pairs, NVBENCH_TYPE_AXES(key_types, value_types, offset_types))
+NVBENCH_BENCH_TYPES(pairs, NVBENCH_TYPE_AXES(key_types, value_types))
   .set_name("base")
-  .set_type_axes_names({"KeyT{ct}", "ValueT{ct}", "OffsetT{ct}"})
+  .set_type_axes_names({"KeyT{ct}", "ValueT{ct}"})
   .add_int64_power_of_two_axis("Elements{io}", nvbench::range(16, 28, 4))
   .add_string_axis("Entropy", {"1.000", "0.201"});

--- a/cub/cub/detail/env_dispatch.cuh
+++ b/cub/cub/detail/env_dispatch.cuh
@@ -74,6 +74,18 @@ CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env(EnvT env, AlgorithmCal
   return (error != cudaSuccess) ? error : deallocate_error;
 }
 //! @endcond
+
+template <typename DefaultPolicySelector, typename EnvT, typename AlgorithmCallable>
+CUB_RUNTIME_FUNCTION static cudaError_t dispatch_with_env_and_tuning(EnvT env, AlgorithmCallable&& algorithm_callable)
+{
+  return detail::dispatch_with_env(
+    env, [&]([[maybe_unused]] auto tuning_env, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+      using policy_t = decltype(DefaultPolicySelector{}(::cuda::arch_id{}));
+      using policy_selector =
+        ::cuda::std::execution::__query_result_or_t<decltype(tuning_env), policy_t, DefaultPolicySelector>;
+      return algorithm_callable(policy_selector{}, d_temp_storage, temp_storage_bytes, stream);
+    });
+}
 } // namespace detail
 
 CUB_NAMESPACE_END

--- a/cub/cub/device/device_merge.cuh
+++ b/cub/cub/device/device_merge.cuh
@@ -192,8 +192,10 @@ struct DeviceMerge
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceMerge::MergeKeys");
 
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using default_policy_selector =
+      detail::merge::policy_selector_from_types<detail::it_value_t<KeyIteratorIn1>, NullType, int64_t>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::merge::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -206,7 +208,8 @@ struct DeviceMerge
           keys_out,
           static_cast<NullType*>(nullptr),
           compare_op,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 
@@ -413,9 +416,10 @@ struct DeviceMerge
     EnvT env             = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceMerge::MergePairs");
-
-    return detail::dispatch_with_env(
-      env, [&]([[maybe_unused]] auto tuning, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
+    using default_policy_selector = detail::merge::
+      policy_selector_from_types<detail::it_value_t<KeyIteratorIn1>, detail::it_value_t<ValueIteratorIn1>, int64_t>;
+    return detail::dispatch_with_env_and_tuning<default_policy_selector>(
+      env, [&](auto policy_selector, void* d_temp_storage, size_t& temp_storage_bytes, cudaStream_t stream) {
         return detail::merge::dispatch(
           d_temp_storage,
           temp_storage_bytes,
@@ -428,7 +432,8 @@ struct DeviceMerge
           keys_out,
           values_out,
           compare_op,
-          stream);
+          stream,
+          policy_selector);
       });
   }
 };

--- a/cub/test/catch2_test_device_merge_env.cu
+++ b/cub/test/catch2_test_device_merge_env.cu
@@ -24,6 +24,31 @@ DECLARE_LAUNCH_WRAPPER(cub::DeviceMerge::MergePairs, merge_pairs);
 
 namespace stdexec = cuda::std::execution;
 
+struct block_size_extracting_less_t
+{
+  int* ptr;
+
+  __device__ bool operator()(const int& lhs, const int& rhs) const
+  {
+    if (threadIdx.x == 0)
+    {
+      atomicMin(ptr, blockDim.x);
+    }
+    return lhs < rhs;
+  }
+};
+
+template <int BlockThreads>
+struct merge_tuning
+{
+  _CCCL_API constexpr auto operator()(cuda::arch_id /*arch*/) const -> cub::detail::merge::merge_policy
+  {
+    return {BlockThreads, 1, cub::LOAD_DEFAULT, cub::BLOCK_STORE_WARP_TRANSPOSE, false};
+  }
+};
+
+using block_sizes = c2h::type_list<cuda::std::integral_constant<int, 64>, cuda::std::integral_constant<int, 128>>;
+
 #if TEST_LAUNCH == 0
 
 TEST_CASE("DeviceMerge::MergeKeys works with default environment", "[merge][device]")
@@ -70,6 +95,70 @@ TEST_CASE("DeviceMerge::MergePairs works with default environment", "[merge][dev
 }
 
 #endif
+
+C2H_TEST("DeviceMerge::MergeKeys can be tuned", "[merge][device]", block_sizes)
+{
+  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  auto keys1                      = c2h::device_vector<int>{0, 2, 5};
+  auto keys2                      = c2h::device_vector<int>{0, 3, 3, 4};
+  auto result                     = c2h::device_vector<int>(7);
+  auto d_block_size               = c2h::device_vector<int>(1, 2048);
+
+  block_size_extracting_less_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+
+  auto env = cuda::execution::__tune(merge_tuning<target_block_size>{});
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceMerge::MergeKeys(
+      keys1.begin(),
+      static_cast<int>(keys1.size()),
+      keys2.begin(),
+      static_cast<int>(keys2.size()),
+      result.begin(),
+      block_size_check,
+      env));
+
+  c2h::device_vector<int> expected{0, 0, 2, 3, 3, 4, 5};
+  REQUIRE(result == expected);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
+
+C2H_TEST("DeviceMerge::MergePairs can be tuned", "[merge][device]", block_sizes)
+{
+  constexpr int target_block_size = c2h::get<0, TestType>::value;
+  auto keys1                      = c2h::device_vector<int>{0, 2, 5};
+  auto values1                    = c2h::device_vector<char>{'a', 'b', 'c'};
+  auto keys2                      = c2h::device_vector<int>{0, 3, 3, 4};
+  auto values2                    = c2h::device_vector<char>{'A', 'B', 'C', 'D'};
+  auto result_keys                = c2h::device_vector<int>(7);
+  auto result_values              = c2h::device_vector<char>(7);
+  auto d_block_size               = c2h::device_vector<int>(1, 2048);
+
+  block_size_extracting_less_t block_size_check{thrust::raw_pointer_cast(d_block_size.data())};
+
+  auto env = cuda::execution::__tune(merge_tuning<target_block_size>{});
+
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceMerge::MergePairs(
+      keys1.begin(),
+      values1.begin(),
+      static_cast<int>(keys1.size()),
+      keys2.begin(),
+      values2.begin(),
+      static_cast<int>(keys2.size()),
+      result_keys.begin(),
+      result_values.begin(),
+      block_size_check,
+      env));
+
+  c2h::device_vector<int> expected_keys{0, 0, 2, 3, 3, 4, 5};
+  c2h::device_vector<char> expected_values{'a', 'A', 'b', 'B', 'C', 'D', 'c'};
+  REQUIRE(result_keys == expected_keys);
+  REQUIRE(result_values == expected_values);
+  REQUIRE(d_block_size[0] == target_block_size);
+}
 
 C2H_TEST("DeviceMerge::MergeKeys uses environment", "[merge][device]")
 {

--- a/cub/test/catch2_test_device_merge_no_unroll.cu
+++ b/cub/test/catch2_test_device_merge_no_unroll.cu
@@ -88,6 +88,7 @@ C2H_TEST("DeviceMerge::MergeKeys large key types", "[merge][device]", c2h::type_
     6346,
     cuda::std::less<key_t>{},
     [](const key_t* k1, offset_t s1, const key_t* k2, offset_t s2, key_t* r, cuda::std::less<key_t> co) {
-      REQUIRE(cub::DeviceMerge::MergeKeys(k1, s1, k2, s2, r, co, fixed_policy_selector{}) == cudaSuccess);
+      REQUIRE(cub::DeviceMerge::MergeKeys(k1, s1, k2, s2, r, co, cuda::execution::__tune(fixed_policy_selector{}))
+              == cudaSuccess);
     });
 }

--- a/cub/test/catch2_test_device_merge_no_unroll.cu
+++ b/cub/test/catch2_test_device_merge_no_unroll.cu
@@ -88,37 +88,6 @@ C2H_TEST("DeviceMerge::MergeKeys large key types", "[merge][device]", c2h::type_
     6346,
     cuda::std::less<key_t>{},
     [](const key_t* k1, offset_t s1, const key_t* k2, offset_t s2, key_t* r, cuda::std::less<key_t> co) {
-      std::size_t temp_storage_bytes = 0;
-      auto value_nullptr             = static_cast<cub::NullType*>(nullptr);
-      cub::detail::merge::dispatch(
-        nullptr,
-        temp_storage_bytes,
-        k1,
-        value_nullptr,
-        s1,
-        k2,
-        value_nullptr,
-        s2,
-        r,
-        value_nullptr,
-        co,
-        cudaStream_t{0},
-        fixed_policy_selector{});
-
-      c2h::device_vector<char> temp_storage(temp_storage_bytes);
-      cub::detail::merge::dispatch(
-        thrust::raw_pointer_cast(temp_storage.data()),
-        temp_storage_bytes,
-        k1,
-        value_nullptr,
-        s1,
-        k2,
-        value_nullptr,
-        s2,
-        r,
-        value_nullptr,
-        co,
-        cudaStream_t{0},
-        fixed_policy_selector{});
+      REQUIRE(cub::DeviceMerge::MergeKeys(k1, s1, k2, s2, r, co, fixed_policy_selector{}) == cudaSuccess);
     });
 }

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -47,18 +47,6 @@ struct block_size_check_t
   }
 };
 
-struct block_size_retreiver_t
-{
-  int* ptr;
-
-  template <class ActivePolicyT>
-  cudaError_t Invoke()
-  {
-    *ptr = ActivePolicyT::SingleTilePolicy::BLOCK_THREADS;
-    return cudaSuccess;
-  }
-};
-
 TEST_CASE("Device reduce works with default environment", "[reduce][device]")
 {
   using num_items_t = int;

--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -18,10 +18,6 @@
 #  include <cuda/stream>
 #endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 
-#include <cuda/__memory_resource/any_resource.h>
-#include <cuda/__stream/stream_ref.h>
-#include <cuda/std/__execution/env.h>
-
 #include <map>
 #include <stdexcept>
 

--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -712,6 +712,7 @@ auto policy(caching_allocator_t&, nvbench::launch&)
 }
 #endif
 
+#if THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 // Returns an environment for benchmarking using alloc as MR, launch's stream, and any additional envs passed in.
 template <typename... MoreEnvs>
 auto cub_bench_env(caching_allocator_t& alloc, nvbench::launch& launch, MoreEnvs... envs)
@@ -721,4 +722,5 @@ auto cub_bench_env(caching_allocator_t& alloc, nvbench::launch& launch, MoreEnvs
     ::cuda::std::execution::prop{cuda::mr::get_memory_resource, ::cuda::mr::resource_ref<>{alloc}},
     envs...};
 }
+#endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 } // namespace

--- a/nvbench_helper/nvbench_helper/nvbench_helper.cuh
+++ b/nvbench_helper/nvbench_helper/nvbench_helper.cuh
@@ -18,6 +18,10 @@
 #  include <cuda/stream>
 #endif // THRUST_DEVICE_SYSTEM == THRUST_DEVICE_SYSTEM_CUDA
 
+#include <cuda/__memory_resource/any_resource.h>
+#include <cuda/__stream/stream_ref.h>
+#include <cuda/std/__execution/env.h>
+
 #include <map>
 #include <stdexcept>
 
@@ -711,4 +715,14 @@ auto policy(caching_allocator_t&, nvbench::launch&)
   return thrust::device;
 }
 #endif
+
+// Returns an environment for benchmarking using alloc as MR, launch's stream, and any additional envs passed in.
+template <typename... MoreEnvs>
+auto cub_bench_env(caching_allocator_t& alloc, nvbench::launch& launch, MoreEnvs... envs)
+{
+  return cuda::std::execution::env{
+    ::cuda::stream_ref{launch.get_stream().get_stream()},
+    ::cuda::std::execution::prop{cuda::mr::get_memory_resource, ::cuda::mr::resource_ref<>{alloc}},
+    envs...};
+}
 } // namespace

--- a/thrust/thrust/system/cuda/detail/merge.h
+++ b/thrust/thrust/system/cuda/detail/merge.h
@@ -51,47 +51,23 @@ merge(execution_policy<Derived>& policy,
         return result_begin;
       }
 
-      auto value_nullptr = static_cast<cub::NullType*>(nullptr);
-      const auto stream  = cuda_cub::stream(policy);
-      cudaError_t status;
+      const auto stream   = cuda_cub::stream(policy);
       size_t storage_size = 0;
-      THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
-        status,
-        cub::detail::merge::dispatch,
-        num_keys1,
-        num_keys2,
-        (nullptr,
-         storage_size,
-         keys1_begin,
-         value_nullptr,
-         num_keys1_fixed,
-         keys2_begin,
-         value_nullptr,
-         num_keys2_fixed,
-         result_begin,
-         value_nullptr,
-         compare_op,
-         stream));
+      cudaError_t status  = cub::DeviceMerge::MergeKeys(
+        nullptr, storage_size, keys1_begin, num_keys1, keys2_begin, num_keys2, result_begin, compare_op, stream);
       throw_on_error(status, "merge: failed on 1st step");
 
       thrust::detail::temporary_array<char, Derived> temp_storage(policy, storage_size);
-      THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
-        status,
-        cub::detail::merge::dispatch,
+      status = cub::DeviceMerge::MergeKeys(
+        temp_storage.data().get(),
+        storage_size,
+        keys1_begin,
         num_keys1,
+        keys2_begin,
         num_keys2,
-        (temp_storage.data().get(),
-         storage_size,
-         keys1_begin,
-         value_nullptr,
-         num_keys1_fixed,
-         keys2_begin,
-         value_nullptr,
-         num_keys2_fixed,
-         result_begin,
-         value_nullptr,
-         compare_op,
-         stream));
+        result_begin,
+        compare_op,
+        stream);
       throw_on_error(status, "merge: failed on 2nd step");
 
       status = cuda_cub::synchronize_optional(policy);
@@ -137,46 +113,37 @@ template <class Derived,
                           return {keys_out_begin, items_out_begin};
                         }
 
-                        const auto stream = cuda_cub::stream(policy);
-                        cudaError_t status;
+                        const auto stream   = cuda_cub::stream(policy);
                         size_t storage_size = 0;
-                        THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
-                          status,
-                          cub::detail::merge::dispatch,
+                        cudaError_t status  = cub::DeviceMerge::MergePairs(
+                          nullptr,
+                          storage_size,
+                          keys1_begin,
+                          items1_begin,
                           num_keys1,
+                          keys2_begin,
+                          items2_begin,
                           num_keys2,
-                          (nullptr,
-                           storage_size,
-                           keys1_begin,
-                           items1_begin,
-                           num_keys1_fixed,
-                           keys2_begin,
-                           items2_begin,
-                           num_keys2_fixed,
-                           keys_out_begin,
-                           items_out_begin,
-                           compare_op,
-                           stream));
+                          keys_out_begin,
+                          items_out_begin,
+                          compare_op,
+                          stream);
                         throw_on_error(status, "merge: failed on 1st step");
 
                         thrust::detail::temporary_array<char, Derived> temp_storage(policy, storage_size);
-                        THRUST_DOUBLE_INDEX_TYPE_DISPATCH(
-                          status,
-                          cub::detail::merge::dispatch,
+                        status = cub::DeviceMerge::MergePairs(
+                          temp_storage.data().get(),
+                          storage_size,
+                          keys1_begin,
+                          items1_begin,
                           num_keys1,
+                          keys2_begin,
+                          items2_begin,
                           num_keys2,
-                          (temp_storage.data().get(),
-                           storage_size,
-                           keys1_begin,
-                           items1_begin,
-                           num_keys1_fixed,
-                           keys2_begin,
-                           items2_begin,
-                           num_keys2_fixed,
-                           keys_out_begin,
-                           items_out_begin,
-                           compare_op,
-                           stream));
+                          keys_out_begin,
+                          items_out_begin,
+                          compare_op,
+                          stream);
                         throw_on_error(status, "merge: failed on 2nd step");
 
                         status = cuda_cub::synchronize_optional(policy);


### PR DESCRIPTION
* Use the new tuning API internally where possible
* Drop 32 bit offset types in benchmarks (public API just uses int64)
* Drop index type dispatch in Thrust (public API just uses int64)

This PR does change the SASS of `cub.bench.merge.pairs.base` (tested on SM120), but this is expected since we discard all 32-bit offset type benchmarks. Those are not needed, since the public API does not allow to compile a 32-bit kernel.

This PR will also take away Thrust's ability to compile a 32-bit offset type kernel, which is not needed since the 64-bit offset type version is on par: #3530

Fixes: #7955