### PR TITLE
[docs] Fix SortKeysCopy code snippet to include d_output_keys parameter

### DIFF
--- a/cub/cub/device/device_merge_sort.cuh
+++ b/cub/cub/device/device_merge_sort.cuh
@@ -806,7 +806,8 @@ public:
    * // Declare, allocate, and initialize device-accessible pointers for
    * // sorting data
    * int  num_items;       // e.g., 7
-   * int  *d_keys;         // e.g., [8, 6, 7, 5, 3, 0, 9]
+   * int  *d_input_keys;   // e.g., [8, 6, 7, 5, 3, 0, 9]
+   * int  *d_output_keys;  // must hold at least num_items elements
    * ...
    *
    * // Initialize comparator
@@ -817,7 +818,7 @@ public:
    * size_t temp_storage_bytes = 0;
    * cub::DeviceMergeSort::SortKeysCopy(
    *   d_temp_storage, temp_storage_bytes,
-   *   d_keys, num_items, custom_op);
+   *   d_input_keys, d_output_keys, num_items, custom_op);
    *
    * // Allocate temporary storage
    * cudaMalloc(&d_temp_storage, temp_storage_bytes);
@@ -825,9 +826,9 @@ public:
    * // Run sorting operation
    * cub::DeviceMergeSort::SortKeysCopy(
    *   d_temp_storage, temp_storage_bytes,
-   *   d_keys, num_items, custom_op);
+   *   d_input_keys, d_output_keys, num_items, custom_op);
    *
-   * // d_keys      <-- [0, 3, 5, 6, 7, 8, 9]
+   * // d_output_keys   <-- [0, 3, 5, 6, 7, 8, 9]
    * @endcode
    *
    * @tparam KeyInputIteratorT


### PR DESCRIPTION
## What

Fix the code snippet in the `cub::DeviceMergeSort::SortKeysCopy` docstring (the `@code`/`@endcode` Doxygen example). The example was using a single `d_keys` pointer for both input and output, but the actual function signature takes separate `d_input_keys` and `d_output_keys` parameters.

**Before (broken):**
```cpp
int  num_items;       // e.g., 7
int  *d_keys;         // e.g., [8, 6, 7, 5, 3, 0, 9]
...
cub::DeviceMergeSort::SortKeysCopy(
  d_temp_storage, temp_storage_bytes,
  d_keys, num_items, custom_op);  // ← missing d_output_keys, wrong argument count
...
// d_keys      <-- [0, 3, 5, 6, 7, 8, 9]
```

**After (correct):**
```cpp
int  num_items;       // e.g., 7
int  *d_input_keys;   // e.g., [8, 6, 7, 5, 3, 0, 9]
int  *d_output_keys;  // must hold at least num_items elements
...
cub::DeviceMergeSort::SortKeysCopy(
  d_temp_storage, temp_storage_bytes,
  d_input_keys, d_output_keys, num_items, custom_op);
...
// d_output_keys   <-- [0, 3, 5, 6, 7, 8, 9]
```

## Why

`SortKeysCopy` (unlike `SortKeys`) is a non-in-place sort: it reads from `d_input_keys` and writes sorted output to `d_output_keys`, leaving the input untouched. The old example passed only 5 arguments to a function that requires 6 (excluding the optional stream), making the snippet non-compilable. Reported in #3116.

## How

Doc-only change. Updated the Doxygen `@code` snippet to match the actual function signature, following the same style as the adjacent `StableSortKeysCopy` example which was already correct.

No API, behavior, or ABI changes.

## Test

- Doc-only change; no runtime behavior affected.
- Verified the corrected call matches the function signature at `SortKeysCopy` (line ~888 in `device_merge_sort.cuh`).

Fixes #3116