### PR TITLE
Fixes determining keys_only-code path in `DeviceTopK`

### DIFF
--- a/cub/cub/agent/agent_topk.cuh
+++ b/cub/cub/agent/agent_topk.cuh
@@ -241,7 +241,8 @@ struct AgentTopK
   // Types and constants
   //---------------------------------------------------------------------
   // The key and value type
-  using key_in_t = it_value_t<KeyInputIteratorT>;
+  using key_in_t   = it_value_t<KeyInputIteratorT>;
+  using value_in_t = it_value_t<ValueInputIteratorT>;
 
   static constexpr int block_threads    = AgentTopKPolicyT::block_threads;
   static constexpr int items_per_thread = AgentTopKPolicyT::items_per_thread;
@@ -249,7 +250,7 @@ struct AgentTopK
   static constexpr int tile_items       = block_threads * items_per_thread;
   static constexpr int num_buckets      = 1 << bits_per_pass;
 
-  static constexpr bool keys_only      = ::cuda::std::is_same_v<ValueInputIteratorT, NullType*>;
+  static constexpr bool keys_only      = ::cuda::std::is_same_v<value_in_t, NullType>;
   static constexpr int bins_per_thread = ::cuda::ceil_div(num_buckets, block_threads);
 
   // Parameterized BlockLoad type for input data

--- a/cub/cub/device/dispatch/dispatch_topk.cuh
+++ b/cub/cub/device/dispatch/dispatch_topk.cuh
@@ -482,7 +482,8 @@ CUB_RUNTIME_FUNCTION _CCCL_FORCEINLINE cudaError_t dispatch(
   return dispatch_arch(policy_selector, arch_id, [&](auto policy_getter) {
     static constexpr topk_policy active_policy = policy_getter();
     using key_in_t                             = it_value_t<KeyInputIteratorT>;
-    static constexpr bool keys_only            = ::cuda::std::is_same_v<ValueInputIteratorT, NullType*>;
+    using value_in_t                           = it_value_t<ValueInputIteratorT>;
+    static constexpr bool keys_only            = ::cuda::std::is_same_v<value_in_t, NullType>;
 
     // atomicAdd does not implement overloads for all integer types, so we limit OffsetT to uint32_t or unsigned long
     // long


### PR DESCRIPTION
## Description

Fixes determining whether we're in a keys-only `DeviceTopK` code path. Previosuly, we may have failed to do so for, e.g., `pointer-to-const-NullType`.
