### PR TITLE
Fix gcc 9 thinking complex<__half> is not copy constructible

### DIFF
--- a/libcudacxx/include/cuda/std/__complex/nvbf16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvbf16.h
@@ -118,27 +118,27 @@ public:
       : __repr_(__re, __im)
   {}
 
-#  if !_CCCL_COMPILER(GCC, <, 8) // Old GCC considers those as deleted
+#  if !_CCCL_COMPILER(GCC, <, 10) // Old GCC considers those as deleted
   _CCCL_HIDE_FROM_ABI complex(const complex&) noexcept = default;
   _CCCL_HIDE_FROM_ABI complex(complex&&) noexcept      = default;
 
   _CCCL_HIDE_FROM_ABI complex& operator=(const complex&) noexcept = default;
   _CCCL_HIDE_FROM_ABI complex& operator=(complex&&) noexcept      = default;
-#  endif // !_CCCL_COMPILER(GCC, <, 8)
+#  endif // !_CCCL_COMPILER(GCC, <, 10)
 
   template <class _Up, enable_if_t<__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0>
-  _CCCL_API inline complex(const complex<_Up>& __c)
+  _CCCL_API inline complex(const complex<_Up>& __c) noexcept
       : __repr_(__convert_to_bfloat16(__c.real()), __convert_to_bfloat16(__c.imag()))
   {}
 
   template <class _Up,
             enable_if_t<!__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0,
             enable_if_t<is_constructible_v<value_type, _Up>, int>                                      = 0>
-  _CCCL_API inline explicit complex(const complex<_Up>& __c)
+  _CCCL_API inline explicit complex(const complex<_Up>& __c) noexcept
       : __repr_(__convert_to_bfloat16(__c.real()), __convert_to_bfloat16(__c.imag()))
   {}
 
-  _CCCL_API inline complex& operator=(const value_type& __re)
+  _CCCL_API inline complex& operator=(const value_type& __re) noexcept
   {
     __repr_.x = __re;
     __repr_.y = value_type();
@@ -146,7 +146,7 @@ public:
   }
 
   template <class _Up>
-  _CCCL_API inline complex& operator=(const complex<_Up>& __c)
+  _CCCL_API inline complex& operator=(const complex<_Up>& __c) noexcept
   {
     __repr_.x = __convert_to_bfloat16(__c.real());
     __repr_.y = __convert_to_bfloat16(__c.imag());
@@ -155,19 +155,19 @@ public:
 
 #  if !_CCCL_COMPILER(NVRTC)
   template <class _Up>
-  _CCCL_API inline complex(const ::std::complex<_Up>& __other)
+  _CCCL_API inline complex(const ::std::complex<_Up>& __other) noexcept
       : __repr_(_LIBCUDACXX_ACCESS_STD_COMPLEX_REAL(__other), _LIBCUDACXX_ACCESS_STD_COMPLEX_IMAG(__other))
   {}
 
   template <class _Up>
-  _CCCL_API inline complex& operator=(const ::std::complex<_Up>& __other)
+  _CCCL_API inline complex& operator=(const ::std::complex<_Up>& __other) noexcept
   {
     __repr_.x = _LIBCUDACXX_ACCESS_STD_COMPLEX_REAL(__other);
     __repr_.y = _LIBCUDACXX_ACCESS_STD_COMPLEX_IMAG(__other);
     return *this;
   }
 
-  _CCCL_HOST_API operator ::std::complex<value_type>() const
+  _CCCL_HOST_API operator ::std::complex<value_type>() const noexcept
   {
     return {__repr_.x, __repr_.y};
   }

--- a/libcudacxx/include/cuda/std/__complex/nvfp16.h
+++ b/libcudacxx/include/cuda/std/__complex/nvfp16.h
@@ -118,13 +118,13 @@ public:
       : __repr_(__re, __im)
   {}
 
-#  if !_CCCL_COMPILER(GCC, <, 8) // Old GCC considers those as deleted
+#  if !_CCCL_COMPILER(GCC, <, 10) // Old GCC considers those as deleted
   _CCCL_HIDE_FROM_ABI complex(const complex&) noexcept = default;
   _CCCL_HIDE_FROM_ABI complex(complex&&) noexcept      = default;
 
   _CCCL_HIDE_FROM_ABI complex& operator=(const complex&) noexcept = default;
   _CCCL_HIDE_FROM_ABI complex& operator=(complex&&) noexcept      = default;
-#  endif // !_CCCL_COMPILER(GCC, <, 8)
+#  endif // !_CCCL_COMPILER(GCC, <, 10)
 
   template <class _Up, enable_if_t<__cccl_internal::__is_non_narrowing_convertible<value_type, _Up>::value, int> = 0>
   _CCCL_API inline complex(const complex<_Up>& __c)

--- a/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex/traits.pass.cpp
+++ b/libcudacxx/test/libcudacxx/std/numerics/complex.number/complex/traits.pass.cpp
@@ -58,14 +58,14 @@ int main(int, char**)
 #if _CCCL_HAS_LONG_DOUBLE()
   test<long double>();
 #endif // _CCCL_HAS_LONG_DOUBLE()
-#if !TEST_COMPILER(GCC, <, 8) // Old GCC considers the defaulted constructors as deleted
+#if !TEST_COMPILER(GCC, <, 10) // Old GCC considers the defaulted constructors as deleted
 #  if _LIBCUDACXX_HAS_NVFP16()
   test<__half>();
 #  endif // _LIBCUDACXX_HAS_NVFP16()
 #  if _LIBCUDACXX_HAS_NVBF16()
   test<__nv_bfloat16>();
 #  endif // _LIBCUDACXX_HAS_NVBF16()
-#endif // !TEST_COMPILER(GCC, <, 8)
+#endif // !TEST_COMPILER(GCC, <, 01)
 
   return 0;
 }


### PR DESCRIPTION
Looks like it incorrectly deduces that the copy constructor is deleted

CI only catched GCC7 :shrug: