### PR TITLE
Fix order of `_CCCL_API` and `CCCL_DEPRECATED`

### DIFF
--- a/libcudacxx/include/cuda/std/__memory/allocator.h
+++ b/libcudacxx/include/cuda/std/__memory/allocator.h
@@ -188,7 +188,7 @@ public:
     return ::cuda::std::addressof(__x);
   }
 
-  [[nodiscard]] _CCCL_API inline CCCL_DEPRECATED _Tp* allocate(size_t __n, const void*)
+  [[nodiscard]] CCCL_DEPRECATED _CCCL_API inline _Tp* allocate(size_t __n, const void*)
   {
     return allocate(__n);
   }
@@ -283,7 +283,7 @@ public:
     return ::cuda::std::addressof(__x);
   }
 
-  [[nodiscard]] _CCCL_API inline CCCL_DEPRECATED const _Tp* allocate(size_t __n, const void*)
+  [[nodiscard]] CCCL_DEPRECATED _CCCL_API inline const _Tp* allocate(size_t __n, const void*)
   {
     return allocate(__n);
   }


### PR DESCRIPTION
NVRTC has issues if `CCCL_DEPRECATED` appears after `_CCCL_API`

Move it to front

Fixes nvbug6066409
