### PR TITLE
Disable all LDL and STL sass checks by default

### DIFF
--- a/c/parallel/test/algorithm_execution.h
+++ b/c/parallel/test/algorithm_execution.h
@@ -20,6 +20,8 @@
 #include <c2h/catch2_test_helper.h>
 #include <cccl/c/types.h>
 
+inline constexpr bool check_ldl_stl_in_sass = false;
+
 template <int device_id_ = 0>
 class BuildInformation
 {
@@ -146,10 +148,9 @@ void AlgorithmExecute(std::optional<BuildCache>& cache, const std::optional<KeyT
     }
   }
 
-  const std::string& sass = inspect_sass(build.cubin, build.cubin_size);
-
-  if (build_traits<Build>::should_check_sass(build_info.get_cc_major()))
+  if (check_ldl_stl_in_sass && build_traits<Build>::should_check_sass(build_info.get_cc_major()))
   {
+    const std::string sass = inspect_sass(build.cubin, build.cubin_size);
     REQUIRE(sass.find("LDL") == std::string::npos);
     REQUIRE(sass.find("STL") == std::string::npos);
   }

--- a/c/parallel/test/algorithm_execution.h
+++ b/c/parallel/test/algorithm_execution.h
@@ -148,7 +148,7 @@ void AlgorithmExecute(std::optional<BuildCache>& cache, const std::optional<KeyT
     }
   }
 
-  if (check_ldl_stl_in_sass && build_traits<Build>::should_check_sass(build_info.get_cc_major()))
+  if constexpr (check_ldl_stl_in_sass && build_traits<Build>::should_check_sass(build_info.get_cc_major()))
   {
     const std::string sass = inspect_sass(build.cubin, build.cubin_size);
     REQUIRE(sass.find("LDL") == std::string::npos);

--- a/python/cuda_cccl/tests/compute/conftest.py
+++ b/python/cuda_cccl/tests/compute/conftest.py
@@ -4,7 +4,6 @@ import cupy as cp
 import numpy as np
 import pytest
 
-
 check_ldl_stl_in_sass = False
 
 

--- a/python/cuda_cccl/tests/compute/conftest.py
+++ b/python/cuda_cccl/tests/compute/conftest.py
@@ -5,6 +5,9 @@ import numpy as np
 import pytest
 
 
+check_ldl_stl_in_sass = False
+
+
 # Define a pytest fixture that returns random arrays with different dtypes
 @pytest.fixture(
     params=[
@@ -91,6 +94,10 @@ def cuda_stream() -> Stream:
 @pytest.fixture(scope="function", autouse=True)
 def verify_sass(request, monkeypatch):
     if request.node.get_closest_marker("no_verify_sass"):
+        return
+
+    if not check_ldl_stl_in_sass:
+        print("not checking sass")
         return
 
     import cuda.compute._cccl_interop


### PR DESCRIPTION
This PR removes disables all the checks for LDL and STL instructions in SASS by default. The checks can still be turned on by modifying the flags in the source. We are doing this because these checks fail somewhat randomly and typically block CI, and our default response is to disable them for specific instances.

The reason we are disabling all these checks now is that we have recently added benchmarks to cuda.compute which showed that performance was equivalent to C++ https://github.com/NVIDIA/cccl/pull/7341#issuecomment-4091403018 (except for a few cases for which we opened issues).

In the future, we plan on investigating why LDL and STL instructions appear in our kernels https://github.com/NVIDIA/cccl/issues/7978