### PR TITLE
Refactor and improve `extents_as` queries

### DIFF
--- a/cudax/include/cuda/experimental/__hierarchy/synchronizers.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/synchronizers.cuh
@@ -164,17 +164,12 @@ struct __synchronizer_select
   using type = __barrier_synchronizer<_Unit, _Level, _Mapping>;
 };
 
-template <::cuda::std::size_t _Np>
-struct __synchronizer_select<thread_level, warp_level, group_by<_Np>>
-{
-  using type = __syncwarp_synchronizer<thread_level, warp_level, group_by<_Np>>;
-};
-
 template <class _Level, ::cuda::std::size_t _Np>
-struct __synchronizer_select<thread_level,
-                             _Level,
-                             group_by<_Np>,
-                             ::cuda::std::enable_if_t<(::cuda::is_power_of_two(_Np) && _Np <= 32)>>
+struct __synchronizer_select<
+  thread_level,
+  _Level,
+  group_by<_Np>,
+  ::cuda::std::enable_if_t<::cuda::std::is_same_v<_Level, warp_level> || (::cuda::is_power_of_two(_Np) && _Np <= 32)>>
 {
   using type = __syncwarp_synchronizer<thread_level, _Level, group_by<_Np>>;
 };

--- a/cudax/include/cuda/experimental/__hierarchy/this_group.cuh
+++ b/cudax/include/cuda/experimental/__hierarchy/this_group.cuh
@@ -104,14 +104,14 @@ public:
     !::cuda::std::is_same_v<_Level2, grid_level>))
   [[nodiscard]] _CCCL_DEVICE_API constexpr _Tp count_as(const _InLevel& __in_level) const noexcept
   {
-    return _Level{}.template count_as<_Tp>(__in_level);
+    return _Level{}.template count_as<_Tp>(__in_level, __hier_);
   }
 
   _CCCL_TEMPLATE(class _InLevel, class _Level2 = _Level)
   _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel> _CCCL_AND(!::cuda::std::is_same_v<_Level2, grid_level>))
   [[nodiscard]] _CCCL_DEVICE_API constexpr auto count(const _InLevel& __in_level) const noexcept
   {
-    return _Level{}.count(__in_level);
+    return _Level{}.count(__in_level, __hier_);
   }
 
 #  if _CCCL_CUDA_COMPILATION()
@@ -120,14 +120,16 @@ public:
     !::cuda::std::is_same_v<_Level2, grid_level>))
   [[nodiscard]] _CCCL_DEVICE_API _Tp rank_as(const _InLevel& __in_level) const noexcept
   {
-    return _Level{}.template rank_as<_Tp>(__in_level);
+    // todo: pass hierarchy to query
+    return _Level{}.template rank_as<_Tp>(__in_level /*, __hier_*/);
   }
 
   _CCCL_TEMPLATE(class _InLevel, class _Level2 = _Level)
   _CCCL_REQUIRES(__is_hierarchy_level_v<_InLevel> _CCCL_AND(!::cuda::std::is_same_v<_Level2, grid_level>))
   [[nodiscard]] _CCCL_DEVICE_API auto rank(const _InLevel& __in_level) const noexcept
   {
-    return _Level{}.rank(__in_level);
+    // todo: pass hierarchy to query
+    return _Level{}.rank(__in_level /*, __hier_*/);
   }
 #  endif // _CCCL_CUDA_COMPILATION()
 };

--- a/libcudacxx/include/cuda/__fwd/hierarchy.h
+++ b/libcudacxx/include/cuda/__fwd/hierarchy.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2024 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -71,6 +71,12 @@ class hierarchy_level_desc;
 
 template <class _Tp>
 inline constexpr bool __is_hierarchy_level_desc_v = ::cuda::std::is_base_of_v<__hierarchy_level_desc_base, _Tp>;
+
+template <class _Unit, class _Level>
+struct __extents_query_native;
+
+template <class _Unit, class _Level>
+struct __extents_query;
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/__hierarchy/block_level.h
+++ b/libcudacxx/include/cuda/__hierarchy/block_level.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -44,22 +44,12 @@ struct _CCCL_DECLSPEC_EMPTY_BASES block_level : __native_hierarchy_level_base<bl
 
   using __base_type = __native_hierarchy_level_base<block_level>;
   using __base_type::count_as;
-  using __base_type::extents_as;
 
 #  if _CCCL_CUDA_COMPILATION()
   using __base_type::index_as;
   using __base_type::rank_as;
 
   // interactions with cluster level
-
-  _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
-  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, _Tp> extents_as(const cluster_level&) noexcept
-  {
-    ::dim3 __dims{1u, 1u, 1u};
-    NV_IF_TARGET(NV_PROVIDES_SM_90, (__dims = ::__clusterDim();))
-    return ::cuda::std::dims<3, _Tp>{static_cast<_Tp>(__dims.x), static_cast<_Tp>(__dims.y), static_cast<_Tp>(__dims.z)};
-  }
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
@@ -89,14 +79,6 @@ struct _CCCL_DECLSPEC_EMPTY_BASES block_level : __native_hierarchy_level_base<bl
   }
 
   // interactions with grid level
-
-  _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
-  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, _Tp> extents_as(const grid_level&) noexcept
-  {
-    return ::cuda::std::dims<3, _Tp>{
-      static_cast<_Tp>(gridDim.x), static_cast<_Tp>(gridDim.y), static_cast<_Tp>(gridDim.z)};
-  }
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)

--- a/libcudacxx/include/cuda/__hierarchy/cluster_level.h
+++ b/libcudacxx/include/cuda/__hierarchy/cluster_level.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -43,21 +43,11 @@ struct _CCCL_DECLSPEC_EMPTY_BASES cluster_level : __native_hierarchy_level_base<
   using __next_native_level = grid_level;
 
   using __base_type = __native_hierarchy_level_base<cluster_level>;
-  using __base_type::extents_as;
 
 #  if _CCCL_CUDA_COMPILATION()
   using __base_type::index_as;
 
   // interactions with grid level
-
-  _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
-  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, _Tp> extents_as(const grid_level&) noexcept
-  {
-    ::dim3 __dims{gridDim};
-    NV_IF_TARGET(NV_PROVIDES_SM_90, (__dims = ::__clusterGridDimInClusters();))
-    return ::cuda::std::dims<3, _Tp>{static_cast<_Tp>(__dims.x), static_cast<_Tp>(__dims.y), static_cast<_Tp>(__dims.z)};
-  }
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)

--- a/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/hierarchy_level_base.h
@@ -25,15 +25,12 @@
 
 #  include <cuda/__fwd/hierarchy.h>
 #  include <cuda/__hierarchy/hierarchy_query_result.h>
+#  include <cuda/__hierarchy/queries/extents.h>
 #  include <cuda/__hierarchy/traits.h>
-#  include <cuda/std/__algorithm/max.h>
 #  include <cuda/std/__concepts/concept_macros.h>
 #  include <cuda/std/__cstddef/types.h>
-#  include <cuda/std/__functional/operations.h>
 #  include <cuda/std/__mdspan/extents.h>
 #  include <cuda/std/__type_traits/is_integer.h>
-#  include <cuda/std/__utility/integer_sequence.h>
-#  include <cuda/std/array>
 
 #  if defined(_CUDAX_HIERARCHY)
 #    include <cuda/experimental/__hierarchy/fwd.cuh>
@@ -42,83 +39,6 @@
 #  include <cuda/std/__cccl/prologue.h>
 
 _CCCL_BEGIN_NAMESPACE_CUDA
-
-[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL ::cuda::std::size_t
-__hierarchy_static_extents_mul_helper(::cuda::std::size_t __lhs, ::cuda::std::size_t __rhs) noexcept
-{
-  if (__lhs == ::cuda::std::dynamic_extent || __rhs == ::cuda::std::dynamic_extent)
-  {
-    return ::cuda::std::dynamic_extent;
-  }
-  else
-  {
-    return __lhs * __rhs;
-  }
-}
-
-template <class _ResultIndex, class _LhsExts, class _RhsExts, ::cuda::std::size_t... _Is>
-[[nodiscard]] _CCCL_API constexpr auto __hierarchy_static_extents_mul(::cuda::std::index_sequence<_Is...>) noexcept
-{
-  return ::cuda::std::extents<
-    _ResultIndex,
-    ::cuda::__hierarchy_static_extents_mul_helper((_Is < _LhsExts::rank()) ? _LhsExts::static_extent(_Is) : 1,
-                                                  (_Is < _RhsExts::rank()) ? _RhsExts::static_extent(_Is) : 1)...>{};
-}
-
-//! @brief Multiplies 2 extents in column major order together, returning a new extents type. If the ranks don't match,
-//!        the extent with lower rank is padded with 1s on the right to match the rank of the other.
-//!
-//! @param __lhs The left hand side extents to multiply.
-//! @param __rhs The right hand side extents to multiply.
-//!
-//! @return The result of multiplying the extents together.
-template <class _Index, ::cuda::std::size_t... _LhsExts, ::cuda::std::size_t... _RhsExts>
-[[nodiscard]] _CCCL_API constexpr auto
-__hierarchy_extents_mul(const ::cuda::std::extents<_Index, _LhsExts...>& __lhs,
-                        const ::cuda::std::extents<_Index, _RhsExts...>& __rhs) noexcept
-{
-  using _Lhs = ::cuda::std::extents<_Index, _LhsExts...>;
-  using _Rhs = ::cuda::std::extents<_Index, _RhsExts...>;
-
-  constexpr auto __rank = ::cuda::std::max(_Lhs::rank(), _Rhs::rank());
-  using _Ret =
-    decltype(::cuda::__hierarchy_static_extents_mul<_Index, _Lhs, _Rhs>(::cuda::std::make_index_sequence<__rank>{}));
-
-  ::cuda::std::array<_Index, __rank> __ret{};
-  for (::cuda::std::size_t __i = 0; __i < __rank; ++__i)
-  {
-    if (_Ret::static_extent(__i) == ::cuda::std::dynamic_extent)
-    {
-      __ret[__i] = static_cast<_Index>((__i < _Lhs::rank()) ? __lhs.extent(__i) : 1)
-                 * static_cast<_Index>((__i < _Rhs::rank()) ? __rhs.extent(__i) : 1);
-    }
-    else
-    {
-      __ret[__i] = static_cast<_Index>(_Ret::static_extent(__i));
-    }
-  }
-  return _Ret{__ret};
-}
-
-template <class _Index, class _OrgIndex, ::cuda::std::size_t... _StaticExts>
-[[nodiscard]] _CCCL_API constexpr ::cuda::std::extents<_Index, _StaticExts...>
-__hierarchy_extents_cast(::cuda::std::extents<_OrgIndex, _StaticExts...> __org_exts) noexcept
-{
-  using _OrgExts = ::cuda::std::extents<_OrgIndex, _StaticExts...>;
-  ::cuda::std::array<_Index, _OrgExts::rank()> __ret{};
-  for (::cuda::std::size_t __i = 0; __i < _OrgExts::rank(); ++__i)
-  {
-    if (_OrgExts::static_extent(__i) == ::cuda::std::dynamic_extent)
-    {
-      __ret[__i] = static_cast<_Index>(__org_exts.extent(__i));
-    }
-    else
-    {
-      __ret[__i] = static_cast<_Index>(_OrgExts::static_extent(__i));
-    }
-  }
-  return ::cuda::std::extents<_Index, _StaticExts...>{__ret};
-}
 
 // Used to either pass-through the hierarchy argument or unpack it from launch configuration
 _CCCL_TEMPLATE(class _Type)
@@ -214,33 +134,9 @@ struct hierarchy_level_base
   _CCCL_TEMPLATE(class _Tp, class _InLevel, class _Hierarchy)
   _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp> _CCCL_AND __is_hierarchy_level_v<_InLevel> _CCCL_AND
                    __is_or_has_hierarchy_member_v<_Hierarchy>)
-  [[nodiscard]] _CCCL_API static constexpr auto extents_as(const _InLevel& __in_level, const _Hierarchy& __hier) noexcept
+  [[nodiscard]] _CCCL_API static constexpr auto extents_as(const _InLevel&, const _Hierarchy& __hier) noexcept
   {
-    auto& __hier_unpacked    = ::cuda::__unpack_hierarchy_if_needed(__hier);
-    using _HierarchyUnpacked = ::cuda::std::remove_cvref_t<decltype(__hier_unpacked)>;
-    static_assert(__has_bottom_unit_or_level_v<_Level, _HierarchyUnpacked>, "_Hierarchy doesn't contain _Level");
-    static_assert(_HierarchyUnpacked::template has_level<_InLevel>(), "_Hierarchy doesn't contain _InLevel");
-
-    using _NextLevel = __next_hierarchy_level_t<_Level, _HierarchyUnpacked>;
-    using _CurrExts  = decltype(::cuda::__hierarchy_extents_cast<_Tp>(__hier_unpacked.level(_NextLevel{}).extents()));
-
-    // Remove dependency on runtime storage. This makes the queries work for hierarchy levels with all static extents
-    // in constant evaluated context.
-    _CurrExts __curr_exts{};
-    if constexpr (_CurrExts::rank_dynamic() > 0)
-    {
-      __curr_exts = ::cuda::__hierarchy_extents_cast<_Tp>(__hier_unpacked.level(_NextLevel{}).extents());
-    }
-
-    if constexpr (!::cuda::std::is_same_v<_NextLevel, _InLevel>)
-    {
-      const auto __next_exts = _NextLevel::template extents_as<_Tp>(__in_level, __hier_unpacked);
-      return ::cuda::__hierarchy_extents_mul(__curr_exts, __next_exts);
-    }
-    else
-    {
-      return __curr_exts;
-    }
+    return __extents_query<_Level, _InLevel>::template __call<_Tp>(::cuda::__unpack_hierarchy_if_needed(__hier));
   }
 
   _CCCL_TEMPLATE(class _Tp, class _InLevel, class _Hierarchy)
@@ -340,8 +236,7 @@ struct hierarchy_level_base
     }
     else
     {
-      // todo: Pass __group.hierarchy() to the query.
-      return _Level::template count_as<_Tp>(typename _Group::level_type{} /*, __group.hierarchy()*/);
+      return _Level::template count_as<_Tp>(typename _Group::level_type{}, __group.hierarchy());
     }
   }
 
@@ -355,8 +250,7 @@ struct hierarchy_level_base
     }
     else
     {
-      // todo: Pass __group.hierarchy() to the query.
-      return _Level::count(typename _Group::level_type{} /*, __group.hierarchy()*/);
+      return _Level::count(typename _Group::level_type{}, __group.hierarchy());
     }
   }
 

--- a/libcudacxx/include/cuda/__hierarchy/native_hierarchy_level_base.h
+++ b/libcudacxx/include/cuda/__hierarchy/native_hierarchy_level_base.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -26,6 +26,7 @@
 #  include <cuda/__fwd/hierarchy.h>
 #  include <cuda/__hierarchy/hierarchy_level_base.h>
 #  include <cuda/__hierarchy/hierarchy_query_result.h>
+#  include <cuda/__hierarchy/queries/extents.h>
 #  include <cuda/__hierarchy/traits.h>
 #  include <cuda/std/__concepts/concept_macros.h>
 #  include <cuda/std/__cstddef/types.h>
@@ -134,13 +135,7 @@ struct _CCCL_DECLSPEC_EMPTY_BASES __native_hierarchy_level_base : hierarchy_leve
   _CCCL_REQUIRES(__is_native_hierarchy_level_v<_InLevel>)
   [[nodiscard]] _CCCL_DEVICE_API static auto extents_as(const _InLevel& __level) noexcept
   {
-    static_assert(__is_natively_reachable_hierarchy_level_v<_Level, _InLevel>,
-                  "_InLevel must be reachable from _Level");
-
-    using _NextLevel = typename _Level::__next_native_level;
-    auto __next_exts = _NextLevel::template extents_as<_Tp>(__level);
-    auto __curr_exts = _Level::template extents_as<_Tp>(_NextLevel{});
-    return ::cuda::__hierarchy_extents_mul(__curr_exts, __next_exts);
+    return __extents_query_native<_Level, _InLevel>::template __call<_Tp>();
   }
 
   _CCCL_TEMPLATE(class _Tp, class _InLevel)

--- a/libcudacxx/include/cuda/__hierarchy/queries/extents.h
+++ b/libcudacxx/include/cuda/__hierarchy/queries/extents.h
@@ -1,0 +1,359 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___HIERARCHY_QUERIES_EXTENTS_H
+#define _CUDA___HIERARCHY_QUERIES_EXTENTS_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_CTK()
+
+#  include <cuda/__cmath/ceil_div.h>
+#  include <cuda/__fwd/hierarchy.h>
+#  include <cuda/__hierarchy/traits.h>
+#  include <cuda/std/__algorithm/max.h>
+#  include <cuda/std/__cstddef/types.h>
+#  include <cuda/std/__mdspan/extents.h>
+#  include <cuda/std/__utility/integer_sequence.h>
+#  include <cuda/std/array>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA
+
+// helpers
+
+[[nodiscard]] _CCCL_API _CCCL_CONSTEVAL ::cuda::std::size_t
+__hierarchy_static_extents_mul_helper(::cuda::std::size_t __lhs, ::cuda::std::size_t __rhs) noexcept
+{
+  if (__lhs == ::cuda::std::dynamic_extent || __rhs == ::cuda::std::dynamic_extent)
+  {
+    return ::cuda::std::dynamic_extent;
+  }
+  else
+  {
+    return __lhs * __rhs;
+  }
+}
+
+template <class _ResultIndex, class _LhsExts, class _RhsExts, ::cuda::std::size_t... _Is>
+[[nodiscard]] _CCCL_API constexpr auto __hierarchy_static_extents_mul(::cuda::std::index_sequence<_Is...>) noexcept
+{
+  return ::cuda::std::extents<
+    _ResultIndex,
+    ::cuda::__hierarchy_static_extents_mul_helper((_Is < _LhsExts::rank()) ? _LhsExts::static_extent(_Is) : 1,
+                                                  (_Is < _RhsExts::rank()) ? _RhsExts::static_extent(_Is) : 1)...>{};
+}
+
+//! @brief Multiplies 2 extents in column major order together, returning a new extents type. If the ranks don't match,
+//!        the extent with lower rank is padded with 1s on the right to match the rank of the other.
+//!
+//! @param __lhs The left hand side extents to multiply.
+//! @param __rhs The right hand side extents to multiply.
+//!
+//! @return The result of multiplying the extents together.
+template <class _Index, ::cuda::std::size_t... _LhsExts, ::cuda::std::size_t... _RhsExts>
+[[nodiscard]] _CCCL_API constexpr auto
+__hierarchy_extents_mul(const ::cuda::std::extents<_Index, _LhsExts...>& __lhs,
+                        const ::cuda::std::extents<_Index, _RhsExts...>& __rhs) noexcept
+{
+  using _Lhs = ::cuda::std::extents<_Index, _LhsExts...>;
+  using _Rhs = ::cuda::std::extents<_Index, _RhsExts...>;
+
+  constexpr auto __rank = ::cuda::std::max(_Lhs::rank(), _Rhs::rank());
+  using _Ret =
+    decltype(::cuda::__hierarchy_static_extents_mul<_Index, _Lhs, _Rhs>(::cuda::std::make_index_sequence<__rank>{}));
+
+  ::cuda::std::array<_Index, __rank> __ret{};
+  for (::cuda::std::size_t __i = 0; __i < __rank; ++__i)
+  {
+    if (_Ret::static_extent(__i) == ::cuda::std::dynamic_extent)
+    {
+      __ret[__i] = static_cast<_Index>((__i < _Lhs::rank()) ? __lhs.extent(__i) : 1)
+                 * static_cast<_Index>((__i < _Rhs::rank()) ? __rhs.extent(__i) : 1);
+    }
+    else
+    {
+      __ret[__i] = static_cast<_Index>(_Ret::static_extent(__i));
+    }
+  }
+  return _Ret{__ret};
+}
+
+template <class _Index, class _OrgIndex, ::cuda::std::size_t... _StaticExts>
+[[nodiscard]] _CCCL_API constexpr ::cuda::std::extents<_Index, _StaticExts...>
+__hierarchy_extents_cast(::cuda::std::extents<_OrgIndex, _StaticExts...> __org_exts) noexcept
+{
+  using _OrgExts = ::cuda::std::extents<_OrgIndex, _StaticExts...>;
+  ::cuda::std::array<_Index, _OrgExts::rank()> __ret{};
+  for (::cuda::std::size_t __i = 0; __i < _OrgExts::rank(); ++__i)
+  {
+    if (_OrgExts::static_extent(__i) == ::cuda::std::dynamic_extent)
+    {
+      __ret[__i] = static_cast<_Index>(__org_exts.extent(__i));
+    }
+    else
+    {
+      __ret[__i] = static_cast<_Index>(_OrgExts::static_extent(__i));
+    }
+  }
+  return ::cuda::std::extents<_Index, _StaticExts...>{__ret};
+}
+
+template <class _Tp, class _Unit, class _Level, class _Hierarchy>
+[[nodiscard]] _CCCL_API constexpr auto __extents_query_generic(const _Hierarchy& __hier) noexcept
+{
+  static_assert(__has_bottom_unit_or_level_v<_Unit, _Hierarchy> || __is_native_hierarchy_level_v<_Unit>,
+                "_Hierarchy doesn't contain _Unit");
+  static_assert(_Hierarchy::has_level(_Level{}) || __is_native_hierarchy_level_v<_Level>,
+                "_Hierarchy doesn't contain _Level");
+
+  using _NextLevel = __next_hierarchy_level_t<_Unit, _Hierarchy>;
+  using _CurrExts  = decltype(::cuda::__hierarchy_extents_cast<_Tp>(__hier.level(_NextLevel{}).extents()));
+
+  // Remove dependency on runtime storage. This makes the queries work for hierarchy levels with all static extents
+  // in constant evaluated context.
+  _CurrExts __curr_exts{};
+  if constexpr (_CurrExts::rank_dynamic() > 0)
+  {
+    __curr_exts = ::cuda::__hierarchy_extents_cast<_Tp>(__hier.level(_NextLevel{}).extents());
+  }
+
+  if constexpr (!::cuda::std::is_same_v<_NextLevel, _Level>)
+  {
+    const auto __next_exts = __extents_query<_NextLevel, _Level>::template __call<_Tp>(__hier);
+    return ::cuda::__hierarchy_extents_mul(__curr_exts, __next_exts);
+  }
+  else
+  {
+    return __curr_exts;
+  }
+}
+
+// native hierarchy queries
+
+#  if _CCCL_CUDA_COMPILATION()
+
+// cudafe++ makes the queries (that are device only) return void when compiling for host, which causes host compilers
+// to warn about applying [[nodiscard]] to a function that returns void.
+_CCCL_DIAG_PUSH
+_CCCL_DIAG_SUPPRESS_NVHPC(nodiscard_doesnt_apply)
+#    if _CCCL_CUDA_COMPILER(NVCC, <, 13, 0)
+_CCCL_DIAG_SUPPRESS_GCC("-Wattributes")
+_CCCL_DIAG_SUPPRESS_CLANG("-Wignored-attributes")
+#    endif // _CCCL_CUDA_COMPILER(NVCC, <, 13, 0)
+
+template <class _Unit, class _Level>
+struct __extents_query_native
+{
+  template <class _Tp>
+  [[nodiscard]] _CCCL_DEVICE_API static auto __call() noexcept
+  {
+    static_assert(__is_natively_reachable_hierarchy_level_v<_Unit, _Level>, "_Level must be reachable from _Unit");
+
+    using _NextLevel       = typename _Unit::__next_native_level;
+    const auto __next_exts = __extents_query_native<_NextLevel, _Level>::template __call<_Tp>();
+    const auto __curr_exts = __extents_query_native<_Unit, _NextLevel>::template __call<_Tp>();
+    return ::cuda::__hierarchy_extents_mul(__curr_exts, __next_exts);
+  }
+};
+
+template <>
+struct __extents_query_native<thread_level, warp_level>
+{
+  template <class _Tp>
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::extents<_Tp, 32> __call() noexcept
+  {
+    return {};
+  }
+};
+
+template <>
+struct __extents_query_native<thread_level, block_level>
+{
+  template <class _Tp>
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, _Tp> __call() noexcept
+  {
+    return ::cuda::std::dims<3, _Tp>{
+      static_cast<_Tp>(blockDim.x), static_cast<_Tp>(blockDim.y), static_cast<_Tp>(blockDim.z)};
+  }
+};
+
+template <>
+struct __extents_query_native<warp_level, block_level>
+{
+  template <class _Tp>
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<1, _Tp> __call() noexcept
+  {
+    const auto __thread_count = blockDim.x * blockDim.y * blockDim.z;
+    return ::cuda::std::dims<1, _Tp>{static_cast<_Tp>(::cuda::ceil_div(__thread_count, 32))};
+  }
+};
+
+template <>
+struct __extents_query_native<block_level, cluster_level>
+{
+  template <class _Tp>
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, _Tp> __call() noexcept
+  {
+    ::dim3 __dims{1u, 1u, 1u};
+    NV_IF_TARGET(NV_PROVIDES_SM_90, (__dims = ::__clusterDim();))
+    return ::cuda::std::dims<3, _Tp>{static_cast<_Tp>(__dims.x), static_cast<_Tp>(__dims.y), static_cast<_Tp>(__dims.z)};
+  }
+};
+
+template <>
+struct __extents_query_native<block_level, grid_level>
+{
+  template <class _Tp>
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, _Tp> __call() noexcept
+  {
+    return ::cuda::std::dims<3, _Tp>{
+      static_cast<_Tp>(gridDim.x), static_cast<_Tp>(gridDim.y), static_cast<_Tp>(gridDim.z)};
+  }
+};
+
+template <>
+struct __extents_query_native<cluster_level, grid_level>
+{
+  template <class _Tp>
+  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, _Tp> __call() noexcept
+  {
+    ::dim3 __dims{gridDim};
+    NV_IF_TARGET(NV_PROVIDES_SM_90, (__dims = ::__clusterGridDimInClusters();))
+    return ::cuda::std::dims<3, _Tp>{static_cast<_Tp>(__dims.x), static_cast<_Tp>(__dims.y), static_cast<_Tp>(__dims.z)};
+  }
+};
+
+_CCCL_DIAG_POP
+#  endif // _CCCL_CUDA_COMPILATION()
+
+// hierarchy queries
+
+template <class _Unit, class _Level>
+struct __extents_query
+{
+  template <class _Tp, class _Hierarchy>
+  [[nodiscard]] _CCCL_API static constexpr auto __call(const _Hierarchy& __hier) noexcept
+  {
+    return ::cuda::__extents_query_generic<_Tp, _Unit, _Level>(__hier);
+  }
+};
+
+template <>
+struct __extents_query<thread_level, warp_level>
+{
+  template <class _Tp, class _Hierarchy>
+  [[nodiscard]] _CCCL_API static constexpr ::cuda::std::extents<_Tp, 32> __call(const _Hierarchy&) noexcept
+  {
+    static_assert(__has_bottom_unit_or_level_v<thread_level, _Hierarchy>, "_Hierarchy doesn't contain thread_level");
+    static_assert(_Hierarchy::template has_level<block_level>(), "_Hierarchy doesn't contain block_level");
+    return {};
+  }
+};
+
+template <class _Level>
+struct __extents_query<warp_level, _Level>
+{
+  template <class _Tp, class _Hierarchy>
+  [[nodiscard]] _CCCL_API static constexpr auto __call(const _Hierarchy& __hier) noexcept
+  {
+    auto __block_exts = __extents_query<thread_level, block_level>::template __call<_Tp>(__hier);
+    using _BlockExts  = decltype(__block_exts);
+
+    if constexpr (_BlockExts::rank_dynamic() == 0)
+    {
+      constexpr auto __static_thread_count =
+        _BlockExts::static_extent(0) * _BlockExts::static_extent(1) * _BlockExts::static_extent(2);
+      static_assert(__static_thread_count >= 32, "_Hierarchy doesn't contain enough threads to fill a single warp");
+
+      constexpr auto __static_warp_count = ::cuda::ceil_div(__static_thread_count, 32);
+      ::cuda::std::extents<_Tp, __static_warp_count> __curr_exts{};
+      if constexpr (::cuda::std::is_same_v<_Level, block_level>)
+      {
+        return __curr_exts;
+      }
+      else
+      {
+        const auto __next_exts = __extents_query<block_level, _Level>::template __call<_Tp>(__hier);
+        return ::cuda::__hierarchy_extents_mul(__curr_exts, __next_exts);
+      }
+    }
+    else
+    {
+      const auto __thread_count = __block_exts.extent(0) * __block_exts.extent(1) * __block_exts.extent(2);
+      _CCCL_ASSERT(__thread_count >= 32, "_Hierarchy doesn't contain enough threads to fill a single warp");
+
+      const auto __warp_count = static_cast<_Tp>(::cuda::ceil_div(__thread_count, 32));
+      ::cuda::std::dims<1, _Tp> __curr_exts{__warp_count};
+      if constexpr (::cuda::std::is_same_v<_Level, block_level>)
+      {
+        return __curr_exts;
+      }
+      else
+      {
+        const auto __next_exts = __extents_query<block_level, _Level>::template __call<_Tp>(__hier);
+        return ::cuda::__hierarchy_extents_mul(__curr_exts, __next_exts);
+      }
+    }
+  }
+};
+
+template <>
+struct __extents_query<block_level, cluster_level>
+{
+  template <class _Tp, class _Hierarchy>
+  [[nodiscard]] _CCCL_API static constexpr auto __call(const _Hierarchy& __hier) noexcept
+  {
+    if constexpr (_Hierarchy::template has_level<cluster_level>())
+    {
+      return ::cuda::__extents_query_generic<_Tp, block_level, cluster_level>(__hier);
+    }
+    else
+    {
+      static_assert(__has_bottom_unit_or_level_v<block_level, _Hierarchy>, "_Hierarchy doesn't contain block_level");
+      static_assert(_Hierarchy::template has_level<grid_level>(), "_Hierarchy doesn't contain grid_level");
+      return ::cuda::std::extents<_Tp, 1, 1, 1>{};
+    }
+  }
+};
+
+template <>
+struct __extents_query<cluster_level, grid_level>
+{
+  template <class _Tp, class _Hierarchy>
+  [[nodiscard]] _CCCL_API static constexpr auto __call(const _Hierarchy& __hier) noexcept
+  {
+    if constexpr (_Hierarchy::template has_level<cluster_level>())
+    {
+      return ::cuda::__extents_query_generic<_Tp, cluster_level, grid_level>(__hier);
+    }
+    else
+    {
+      return __extents_query<block_level, grid_level>::template __call<_Tp>(__hier);
+    }
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HAS_CTK()
+
+#endif // _CUDA___HIERARCHY_QUERIES_EXTENTS_H

--- a/libcudacxx/include/cuda/__hierarchy/thread_level.h
+++ b/libcudacxx/include/cuda/__hierarchy/thread_level.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -47,7 +47,6 @@ struct _CCCL_DECLSPEC_EMPTY_BASES thread_level : __native_hierarchy_level_base<t
   using __next_native_level = block_level;
 
   using __base_type = __native_hierarchy_level_base<thread_level>;
-  using __base_type::extents_as;
 
 #  if _CCCL_CUDA_COMPILATION()
   using __base_type::index_as;
@@ -57,28 +56,12 @@ struct _CCCL_DECLSPEC_EMPTY_BASES thread_level : __native_hierarchy_level_base<t
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
-  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<3, _Tp> extents_as(const block_level&) noexcept
-  {
-    return ::cuda::std::dims<3, _Tp>{
-      static_cast<_Tp>(blockDim.x), static_cast<_Tp>(blockDim.y), static_cast<_Tp>(blockDim.z)};
-  }
-
-  _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
   [[nodiscard]] _CCCL_DEVICE_API static hierarchy_query_result<_Tp> index_as(const block_level&) noexcept
   {
     return {static_cast<_Tp>(threadIdx.x), static_cast<_Tp>(threadIdx.y), static_cast<_Tp>(threadIdx.z)};
   }
 
   // interactions with warp level
-
-  _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
-  [[nodiscard]]
-  _CCCL_DEVICE_API static constexpr ::cuda::std::extents<_Tp, 32> extents_as(const warp_level&) noexcept
-  {
-    return {};
-  }
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)

--- a/libcudacxx/include/cuda/__hierarchy/warp_level.h
+++ b/libcudacxx/include/cuda/__hierarchy/warp_level.h
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -42,17 +42,9 @@ struct _CCCL_DECLSPEC_EMPTY_BASES warp_level : __native_hierarchy_level_base<war
   using __next_native_level = block_level;
 
   using __base_type = __native_hierarchy_level_base<warp_level>;
-  using __base_type::extents_as;
 
 #  if _CCCL_CUDA_COMPILATION()
   using __base_type::index_as;
-
-  _CCCL_TEMPLATE(class _Tp)
-  _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)
-  [[nodiscard]] _CCCL_DEVICE_API static ::cuda::std::dims<1, _Tp> extents_as(const block_level&) noexcept
-  {
-    return ::cuda::std::dims<1, _Tp>{static_cast<_Tp>((gpu_thread.count(block) + 31) / 32)};
-  }
 
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(::cuda::std::__cccl_is_integer_v<_Tp>)

--- a/libcudacxx/include/cuda/hierarchy
+++ b/libcudacxx/include/cuda/hierarchy
@@ -4,7 +4,7 @@
 // under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -31,6 +31,7 @@
 #include <cuda/__hierarchy/hierarchy_query_result.h>
 #include <cuda/__hierarchy/level_dimensions.h>
 #include <cuda/__hierarchy/native_hierarchy_level_base.h>
+#include <cuda/__hierarchy/queries/extents.h>
 #include <cuda/__hierarchy/thread_level.h>
 #include <cuda/__hierarchy/traits.h>
 #include <cuda/__hierarchy/warp_level.h>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/block_level/hierarchy_query_signatures.compile.pass.cpp
@@ -3,7 +3,7 @@
 // Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -42,14 +42,17 @@ __device__ void test_query_signatures(const Level& level, const Hierarchy& hier)
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::block_level::count(level, hier))>);
   static_assert(noexcept(cuda::block_level::count(level, hier)));
 
-  // 6. Test cuda::block_level::index(x, hier) signature.
-  static_assert(
-    cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::block_level::index(level, hier))>);
-  static_assert(noexcept(cuda::block_level::index(level, hier)));
+  if constexpr (Hierarchy::has_level(cuda::cluster))
+  {
+    // 6. Test cuda::block_level::index(x, hier) signature.
+    static_assert(
+      cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::block_level::index(level, hier))>);
+    static_assert(noexcept(cuda::block_level::index(level, hier)));
 
-  // 7. Test cuda::block_level::rank(x, hier) signature.
-  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::block_level::rank(level, hier))>);
-  static_assert(noexcept(cuda::block_level::rank(level, hier)));
+    // 7. Test cuda::block_level::rank(x, hier) signature.
+    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::block_level::rank(level, hier))>);
+    static_assert(noexcept(cuda::block_level::rank(level, hier)));
+  }
 }
 
 template <class T, class Level, class Hierarchy>
@@ -70,14 +73,17 @@ __device__ void test_query_as_signatures(const Level& level, const Hierarchy& hi
   static_assert(cuda::std::is_same_v<T, decltype(cuda::block_level::count_as<T>(level, hier))>);
   static_assert(noexcept(cuda::block_level::count_as<T>(level, hier)));
 
-  // 4. Test cuda::block_level::index_as(x, hier) signature.
-  static_assert(
-    cuda::std::is_same_v<cuda::hierarchy_query_result<T>, decltype(cuda::block_level::index_as<T>(level, hier))>);
-  static_assert(noexcept(cuda::block_level::index_as<T>(level, hier)));
+  if constexpr (Hierarchy::has_level(cuda::cluster))
+  {
+    // 4. Test cuda::block_level::index_as(x, hier) signature.
+    static_assert(
+      cuda::std::is_same_v<cuda::hierarchy_query_result<T>, decltype(cuda::block_level::index_as<T>(level, hier))>);
+    static_assert(noexcept(cuda::block_level::index_as<T>(level, hier)));
 
-  // 5. Test cuda::block_level::rank_as(x, hier) signature.
-  static_assert(cuda::std::is_same_v<T, decltype(cuda::block_level::rank_as<T>(level, hier))>);
-  static_assert(noexcept(cuda::block_level::rank_as<T>(level, hier)));
+    // 5. Test cuda::block_level::rank_as(x, hier) signature.
+    static_assert(cuda::std::is_same_v<T, decltype(cuda::block_level::rank_as<T>(level, hier))>);
+    static_assert(noexcept(cuda::block_level::rank_as<T>(level, hier)));
+  }
 }
 
 template <class InLevel, class Hierarchy>
@@ -95,10 +101,7 @@ __device__ void test(const InLevel& in_level, const Hierarchy& hier)
 template <class Hierarchy>
 __device__ void test(const Hierarchy& hier)
 {
-  if constexpr (Hierarchy::has_level(cuda::cluster))
-  {
-    test(cuda::cluster, hier);
-  }
+  test(cuda::cluster, hier);
   test(cuda::grid, hier);
 }
 
@@ -112,18 +115,18 @@ __global__ void test_kernel(Hierarchy hier)
   template __global__ void test_kernel<decltype(cuda::make_hierarchy(__VA_ARGS__))>( \
     decltype(cuda::make_hierarchy(__VA_ARGS__)))
 
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::block_dims(dim3{}));
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::block_dims(dim3{}));
 
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims<1>(), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims<1>(), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims<1>(), cuda::block_dims(dim3{}));
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims(dim3{}), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims(dim3{}), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims(dim3{}), cuda::block_dims(dim3{}));
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims<1>(), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims<1>(), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims<1>(), cuda::block_dims(dim3{}));
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims(dim3{}), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims(dim3{}), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims(dim3{}), cuda::block_dims(dim3{}));
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/cluster_level/hierarchy_queries.pass.cpp
@@ -3,7 +3,7 @@
 // Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -54,9 +54,13 @@ __device__ void test_cluster(const Hierarchy& hier, const GridExts& grid_exts, c
   test_count(cuda::std::size_t{dims.z} * dims.y * dims.x, cuda::cluster, cuda::grid, hier);
 
   // 6. test cuda::cluster.index(x, hier)
-  test_index(index, cuda::cluster, cuda::grid, hier);
+  if constexpr (Hierarchy::has_level(cuda::cluster))
+  {
+    test_index(index, cuda::cluster, cuda::grid, hier);
+  }
 
   // 7. Test cuda::cluster.rank(x, hier)
+  if constexpr (Hierarchy::has_level(cuda::cluster))
   {
     const cuda::std::size_t exp = (index.z * dims.y + index.y) * dims.x + index.x;
     test_rank(exp, cuda::cluster, cuda::grid, hier);

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/hierarchy_objects.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/hierarchy_objects.compile.pass.cpp
@@ -3,7 +3,7 @@
 // Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -16,6 +16,7 @@
 static_assert(cuda::std::is_same_v<cuda::thread_level, cuda::std::remove_const_t<decltype(cuda::gpu_thread)>>);
 static_assert(cuda::std::is_same_v<cuda::warp_level, cuda::std::remove_const_t<decltype(cuda::warp)>>);
 static_assert(cuda::std::is_same_v<cuda::block_level, cuda::std::remove_const_t<decltype(cuda::block)>>);
+static_assert(cuda::std::is_same_v<cuda::cluster_level, cuda::std::remove_const_t<decltype(cuda::cluster)>>);
 static_assert(cuda::std::is_same_v<cuda::grid_level, cuda::std::remove_const_t<decltype(cuda::grid)>>);
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_queries.pass.cpp
@@ -3,7 +3,7 @@
 // Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -23,8 +23,8 @@ __device__ void test_thread(
   const Hierarchy& hier, const GridExts& grid_exts, const ClusterExts& cluster_exts, const BlockExts& block_exts)
 {
   // 1. Test cuda::gpu_thread.dims(x, hier)
+  test_dims(uint3{static_cast<unsigned>(warpSize), 1u, 1u}, cuda::gpu_thread, cuda::warp, hier);
   test_dims(blockDim, cuda::gpu_thread, cuda::block, hier);
-  if constexpr (Hierarchy::has_level(cuda::cluster))
   {
     uint3 exp = blockDim;
     NV_IF_TARGET(NV_PROVIDES_SM_90, ({
@@ -40,11 +40,11 @@ __device__ void test_thread(
   }
 
   // 2. Test cuda::gpu_thread.static_dims(x, hier)
+  test_static_dims(ulonglong3{cuda::std::size_t{32}, 1, 1}, cuda::gpu_thread, cuda::warp, hier);
   test_static_dims(ulonglong3{BlockExts::static_extent(0), BlockExts::static_extent(1), BlockExts::static_extent(2)},
                    cuda::gpu_thread,
                    cuda::block,
                    hier);
-  if constexpr (Hierarchy::has_level(cuda::cluster))
   {
     const ulonglong3 exp{
       mul_static_extents(ClusterExts::static_extent(0), BlockExts::static_extent(0)),
@@ -63,8 +63,8 @@ __device__ void test_thread(
   }
 
   // 3. Test cuda::gpu_thread.extents(x)
+  test_extents(cuda::std::extents<unsigned, 32>{}, cuda::gpu_thread, cuda::warp, hier);
   test_extents(block_exts, cuda::gpu_thread, cuda::block, hier);
-  if constexpr (Hierarchy::has_level(cuda::cluster))
   {
     uint3 dims = blockDim;
     NV_IF_TARGET(NV_PROVIDES_SM_90, ({
@@ -92,16 +92,14 @@ __device__ void test_thread(
   }
 
   // 4. Test cuda::gpu_thread.static_count(x, hier)
+  test_static_count(cuda::gpu_thread, cuda::warp, hier);
   test_static_count(cuda::gpu_thread, cuda::block, hier);
-  if constexpr (Hierarchy::has_level(cuda::cluster))
-  {
-    test_static_count(cuda::gpu_thread, cuda::cluster, hier);
-  }
+  test_static_count(cuda::gpu_thread, cuda::cluster, hier);
   test_static_count(cuda::gpu_thread, cuda::grid, hier);
 
   // 5. Test cuda::gpu_thread.count(x, hier)
+  test_count(32, cuda::gpu_thread, cuda::warp, hier);
   test_count(cuda::std::size_t{blockDim.z} * blockDim.y * blockDim.x, cuda::gpu_thread, cuda::block, hier);
-  if constexpr (Hierarchy::has_level(cuda::cluster))
   {
     uint3 exp = blockDim;
     NV_IF_TARGET(NV_PROVIDES_SM_90, ({
@@ -117,6 +115,7 @@ __device__ void test_thread(
   }
 
   // 6. test cuda::gpu_thread.index(x, hier)
+  // test_index(uint3{cuda::ptx::get_sreg_laneid(), 0, 0}, cuda::gpu_thread, cuda::warp, hier);
   test_index(threadIdx, cuda::gpu_thread, cuda::block, hier);
   if constexpr (Hierarchy::has_level(cuda::cluster))
   {
@@ -138,6 +137,7 @@ __device__ void test_thread(
   }
 
   // 7. Test cuda::gpu_thread.rank(x, hier)
+  // test_rank(cuda::ptx::get_sreg_laneid(), cuda::gpu_thread, cuda::warp, hier);
   test_rank((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x, cuda::gpu_thread, cuda::block, hier);
   if constexpr (Hierarchy::has_level(cuda::cluster))
   {
@@ -271,8 +271,8 @@ void test()
   const bool enable_clusters = cc_major >= 9;
 
   test_launch(cuda::std::extents<unsigned, 1, 1, 1>{}, cuda::std::extents<unsigned, 128, 1, 1>{});
-  test_launch(cuda::std::extents<unsigned, 128, 1, 1>{}, cuda::std::extents<unsigned, 1, 1, 1>{});
-  test_launch(cuda::std::extents<unsigned, 2, 3, 1>{}, cuda::std::extents<unsigned, 4, 2, 1>{});
+  test_launch(cuda::std::extents<unsigned, 128, 1, 1>{}, cuda::std::extents<unsigned, 32, 1, 1>{});
+  test_launch(cuda::std::extents<unsigned, 2, 3, 1>{}, cuda::std::extents<unsigned, 7, 5, 1>{});
   test_launch(cuda::std::extents<unsigned, 2, 3, 4>{}, cuda::std::extents<unsigned, 4, 2, 8>{});
 
   if (enable_clusters)

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/thread_level/hierarchy_query_signatures.compile.pass.cpp
@@ -3,7 +3,7 @@
 // Part of the libcu++ Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// SPDX-FileCopyrightText: Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES.
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
 //
 //===----------------------------------------------------------------------===//
 
@@ -42,14 +42,17 @@ __device__ void test_query_signatures(const Level& level, const Hierarchy& hier)
   static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::count(level, hier))>);
   static_assert(noexcept(cuda::thread_level::count(level, hier)));
 
-  // 6. Test cuda::thread_level::index(x, hier) signature.
-  static_assert(
-    cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::thread_level::index(level, hier))>);
-  static_assert(noexcept(cuda::thread_level::index(level, hier)));
+  if constexpr (Hierarchy::has_level(Level{}))
+  {
+    // 6. Test cuda::thread_level::index(x, hier) signature.
+    static_assert(
+      cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::thread_level::index(level, hier))>);
+    static_assert(noexcept(cuda::thread_level::index(level, hier)));
 
-  // 7. Test cuda::thread_level::rank(x, hier) signature.
-  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::rank(level, hier))>);
-  static_assert(noexcept(cuda::thread_level::rank(level, hier)));
+    // 7. Test cuda::thread_level::rank(x, hier) signature.
+    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::thread_level::rank(level, hier))>);
+    static_assert(noexcept(cuda::thread_level::rank(level, hier)));
+  }
 }
 
 template <class T, class Level, class Hierarchy>
@@ -70,14 +73,17 @@ __device__ void test_query_as_signatures(const Level& level, const Hierarchy& hi
   static_assert(cuda::std::is_same_v<T, decltype(cuda::thread_level::count_as<T>(level, hier))>);
   static_assert(noexcept(cuda::thread_level::count_as<T>(level, hier)));
 
-  // 4. Test cuda::thread_level::index_as(x, hier) signature.
-  static_assert(
-    cuda::std::is_same_v<cuda::hierarchy_query_result<T>, decltype(cuda::thread_level::index_as<T>(level, hier))>);
-  static_assert(noexcept(cuda::thread_level::index_as<T>(level, hier)));
+  if constexpr (Hierarchy::has_level(Level{}))
+  {
+    // 4. Test cuda::thread_level::index_as(x, hier) signature.
+    static_assert(
+      cuda::std::is_same_v<cuda::hierarchy_query_result<T>, decltype(cuda::thread_level::index_as<T>(level, hier))>);
+    static_assert(noexcept(cuda::thread_level::index_as<T>(level, hier)));
 
-  // 5. Test cuda::thread_level::rank_as(x, hier) signature.
-  static_assert(cuda::std::is_same_v<T, decltype(cuda::thread_level::rank_as<T>(level, hier))>);
-  static_assert(noexcept(cuda::thread_level::rank_as<T>(level, hier)));
+    // 5. Test cuda::thread_level::rank_as(x, hier) signature.
+    static_assert(cuda::std::is_same_v<T, decltype(cuda::thread_level::rank_as<T>(level, hier))>);
+    static_assert(noexcept(cuda::thread_level::rank_as<T>(level, hier)));
+  }
 }
 
 template <class InLevel, class Hierarchy>
@@ -95,11 +101,9 @@ __device__ void test(const InLevel& in_level, const Hierarchy& hier)
 template <class Hierarchy>
 __device__ void test(const Hierarchy& hier)
 {
+  test(cuda::warp, hier);
   test(cuda::block, hier);
-  if constexpr (Hierarchy::has_level(cuda::cluster))
-  {
-    test(cuda::cluster, hier);
-  }
+  test(cuda::cluster, hier);
   test(cuda::grid, hier);
 }
 
@@ -113,18 +117,18 @@ __global__ void test_kernel(Hierarchy hier)
   template __global__ void test_kernel<decltype(cuda::make_hierarchy(__VA_ARGS__))>( \
     decltype(cuda::make_hierarchy(__VA_ARGS__)))
 
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::block_dims(dim3{}));
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::block_dims(dim3{}));
 
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims<1>(), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims<1>(), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims<1>(), cuda::block_dims(dim3{}));
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims(dim3{}), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims(dim3{}), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims<1>(), cuda::cluster_dims(dim3{}), cuda::block_dims(dim3{}));
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims<1>(), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims<1>(), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims<1>(), cuda::block_dims(dim3{}));
-TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims(dim3{}), cuda::block_dims<1>());
+TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims(dim3{}), cuda::block_dims<32>());
 TEST_KERNEL_INSTANTIATE(cuda::grid_dims(dim3{}), cuda::cluster_dims(dim3{}), cuda::block_dims(dim3{}));
 
 int main(int, char**)

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/hierarchy_queries.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/hierarchy_queries.pass.cpp
@@ -19,94 +19,140 @@
 #include <cuda/std/type_traits>
 
 template <class Hierarchy, class GridExts, class ClusterExts, class BlockExts>
-__device__ void test_block(
+__device__ void test_warp(
   const Hierarchy& hier, const GridExts& grid_exts, const ClusterExts& cluster_exts, const BlockExts& block_exts)
 {
-  // 1. Test cuda::block.dims(x, hier)
-  {
-    uint3 exp{1, 1, 1};
-    NV_IF_TARGET(NV_PROVIDES_SM_90, (exp = __clusterDim();))
-    test_dims(exp, cuda::block, cuda::cluster, hier);
-  }
-  test_dims(gridDim, cuda::block, cuda::grid, hier);
+  constexpr cuda::std::size_t dext = cuda::std::dynamic_extent;
 
-  // 2. Test cuda::block.static_dims(x, hier)
+  constexpr auto static_count_in_block =
+    (BlockExts::rank_dynamic() == 0)
+      ? (BlockExts::static_extent(0) * BlockExts::static_extent(1) * BlockExts::static_extent(2) + 32 - 1) / 32
+      : dext;
+
+  const unsigned count_in_block = (blockDim.x * blockDim.y * blockDim.z + warpSize - 1) / warpSize;
+  // const unsigned rank_in_block  = ((threadIdx.z * blockDim.y + threadIdx.y) * blockDim.x + threadIdx.x) / warpSize;
+  const uint3 dims_in_block{count_in_block, 1, 1};
+  // const uint3 index_in_block{rank_in_block, 0, 0};
+
+  // 1. Test cuda::warp.dims(x, hier)
+  test_dims(dims_in_block, cuda::warp, cuda::block, hier);
+  {
+    uint3 exp = dims_in_block;
+    NV_IF_TARGET(NV_PROVIDES_SM_90, ({
+                   exp.x *= __clusterDim().x;
+                   exp.y *= __clusterDim().y;
+                   exp.z *= __clusterDim().z;
+                 }))
+    test_dims(exp, cuda::warp, cuda::cluster, hier);
+  }
+  test_dims({count_in_block * gridDim.x, gridDim.y, gridDim.z}, cuda::warp, cuda::grid, hier);
+
+  // 2. Test cuda::warp.static_dims(x, hier)
+  test_static_dims(ulonglong3{static_count_in_block, 1, 1}, cuda::warp, cuda::block, hier);
   {
     const ulonglong3 exp{
-      ClusterExts::static_extent(0),
+      mul_static_extents(ClusterExts::static_extent(0), static_count_in_block),
       ClusterExts::static_extent(1),
       ClusterExts::static_extent(2),
     };
-    test_static_dims(exp, cuda::block, cuda::cluster, hier);
+    test_static_dims(exp, cuda::warp, cuda::cluster, hier);
   }
   {
     const ulonglong3 exp{
-      mul_static_extents(GridExts::static_extent(0), ClusterExts::static_extent(0)),
+      mul_static_extents(GridExts::static_extent(0), ClusterExts::static_extent(0), static_count_in_block),
       mul_static_extents(GridExts::static_extent(1), ClusterExts::static_extent(1)),
       mul_static_extents(GridExts::static_extent(2), ClusterExts::static_extent(2)),
     };
-    test_static_dims(exp, cuda::block, cuda::grid, hier);
+    test_static_dims(exp, cuda::warp, cuda::grid, hier);
   }
 
-  // 3. Test cuda::block.extents(x)
+  // 3. Test cuda::warp.extents(x, hier)
+  test_extents(cuda::std::extents<unsigned, static_count_in_block>{count_in_block}, cuda::warp, cuda::block, hier);
   {
-    uint3 dims{1, 1, 1};
-    NV_IF_TARGET(NV_PROVIDES_SM_90, (dims = __clusterDim();))
-    const cuda::std::
-      extents<unsigned, ClusterExts::static_extent(0), ClusterExts::static_extent(1), ClusterExts::static_extent(2)>
-        exp{dims.x, dims.y, dims.z};
+    uint3 dims = dims_in_block;
+    NV_IF_TARGET(NV_PROVIDES_SM_90, ({
+                   dims.x *= __clusterDim().x;
+                   dims.y *= __clusterDim().y;
+                   dims.z *= __clusterDim().z;
+                 }))
 
-    test_extents(exp, cuda::block, cuda::cluster, hier);
-  }
-  {
     const cuda::std::extents<unsigned,
-                             mul_static_extents(GridExts::static_extent(0), ClusterExts::static_extent(0)),
-                             mul_static_extents(GridExts::static_extent(1), ClusterExts::static_extent(1)),
-                             mul_static_extents(GridExts::static_extent(2), ClusterExts::static_extent(2))>
-      exp{gridDim.x, gridDim.y, gridDim.z};
-    test_extents(exp, cuda::block, cuda::grid, hier);
+                             mul_static_extents(ClusterExts::static_extent(0), static_count_in_block),
+                             ClusterExts::static_extent(1),
+                             ClusterExts::static_extent(2)>
+      exp{dims.x, dims.y, dims.z};
+    test_extents(exp, cuda::warp, cuda::cluster, hier);
+  }
+  {
+    const cuda::std::extents<
+      unsigned,
+      mul_static_extents(GridExts::static_extent(0), ClusterExts::static_extent(0), static_count_in_block),
+      mul_static_extents(GridExts::static_extent(1), ClusterExts::static_extent(1)),
+      mul_static_extents(GridExts::static_extent(2), ClusterExts::static_extent(2))>
+      exp{count_in_block * gridDim.x, gridDim.y, gridDim.z};
+    test_extents(exp, cuda::warp, cuda::grid, hier);
   }
 
-  // 4. Test cuda::block.static_count(x, hier)
-  test_static_count(cuda::block, cuda::cluster, hier);
-  test_static_count(cuda::block, cuda::grid, hier);
+  // 4. Test cuda::warp.static_count(x, hier)
+  test_static_count(cuda::warp, cuda::block, hier);
+  test_static_count(cuda::warp, cuda::cluster, hier);
+  test_static_count(cuda::warp, cuda::grid, hier);
 
-  // 5. Test cuda::block.count(x, hier)
+  // 5. Test cuda::warp.count(x, hier)
+  test_count(count_in_block, cuda::warp, cuda::block, hier);
   {
-    cuda::std::size_t exp = 1;
+    uint3 exp = dims_in_block;
     NV_IF_TARGET(NV_PROVIDES_SM_90, ({
-                   exp *= __clusterDim().x;
-                   exp *= __clusterDim().y;
-                   exp *= __clusterDim().z;
+                   exp.x *= __clusterDim().x;
+                   exp.y *= __clusterDim().y;
+                   exp.z *= __clusterDim().z;
                  }))
-    test_count(exp, cuda::block, cuda::cluster, hier);
+    test_count(cuda::std::size_t{exp.z} * exp.y * exp.x, cuda::warp, cuda::cluster, hier);
   }
-  test_count(cuda::std::size_t{gridDim.z} * gridDim.y * gridDim.x, cuda::block, cuda::grid, hier);
+  {
+    const uint3 exp{count_in_block * gridDim.x, gridDim.y, gridDim.z};
+    test_count(cuda::std::size_t{exp.z} * exp.y * exp.x, cuda::warp, cuda::grid, hier);
+  }
 
-  // 6. test cuda::block.index(x, hier)
-  if constexpr (Hierarchy::has_level(cuda::cluster))
-  {
-    uint3 exp{0, 0, 0};
-    NV_IF_TARGET(NV_PROVIDES_SM_90, (exp = __clusterRelativeBlockIdx();))
-    test_index(exp, cuda::block, cuda::cluster, hier);
-  }
-  test_index(blockIdx, cuda::block, cuda::grid, hier);
+  // 6. test cuda::warp.index(x, hier)
+  // test_index(index_in_block, cuda::warp, cuda::block, hier);
+  // {
+  //   uint3 exp = index_in_block;
+  //   NV_IF_TARGET(NV_PROVIDES_SM_90, ({
+  //                  exp.x += count_in_block * __clusterRelativeBlockIdx().x;
+  //                  exp.y += __clusterRelativeBlockIdx().y;
+  //                  exp.z += __clusterRelativeBlockIdx().z;
+  //                }))
+  //   test_index(exp, cuda::warp, cuda::cluster, hier);
+  // }
+  // {
+  //   const uint3 exp{
+  //     rank_in_block + count_in_block * blockIdx.x,
+  //     blockIdx.y,
+  //     blockIdx.z,
+  //   };
+  //   test_index(exp, cuda::warp, cuda::grid, hier);
+  // }
 
-  // 7. Test cuda::block.rank(x, hier)
-  if constexpr (Hierarchy::has_level(cuda::cluster))
-  {
-    cuda::std::size_t exp = 0;
-    NV_IF_TARGET(NV_PROVIDES_SM_90, ({
-                   exp = ((__clusterRelativeBlockIdx().z * __clusterDim().y) + __clusterRelativeBlockIdx().y)
-                         * __clusterDim().x
-                       + __clusterRelativeBlockIdx().x;
-                 }))
-    test_rank(exp, cuda::block, cuda::cluster, hier);
-  }
-  {
-    const cuda::std::size_t exp = (blockIdx.z * gridDim.y + blockIdx.y) * gridDim.x + blockIdx.x;
-    test_rank(exp, cuda::block, cuda::grid, hier);
-  }
+  // 7. Test cuda::warp.rank(x, hier)
+  // test_rank(rank_in_block, cuda::warp, cuda::block, hier);
+  // {
+  //   cuda::std::size_t exp = 0;
+  //   NV_IF_ELSE_TARGET(NV_PROVIDES_SM_90,
+  //                     ({
+  //                       exp = (__clusterRelativeBlockIdx().z * __clusterDim().y + __clusterRelativeBlockIdx().y)
+  //                             * __clusterDim().x * count_in_block
+  //                           + __clusterRelativeBlockIdx().x * count_in_block + rank_in_block;
+  //                     }),
+  //                     ({ exp = rank_in_block; }))
+  //   test_rank(exp, cuda::warp, cuda::cluster, hier);
+  // }
+  // {
+  //   const cuda::std::size_t exp =
+  //     (blockIdx.z * gridDim.y + blockIdx.y) * gridDim.x * count_in_block + blockIdx.x * count_in_block +
+  //     rank_in_block;
+  //   test_rank(exp, cuda::warp, cuda::grid, hier);
+  // }
 }
 
 __device__ void test_device()
@@ -119,13 +165,13 @@ __device__ void test_device()
 template <class Hierarchy, class GridExts, class BlockExts>
 __global__ void test_kernel(Hierarchy hier, GridExts grid_exts, BlockExts block_exts)
 {
-  test_block(hier, grid_exts, cuda::std::extents<unsigned, 1, 1, 1>{}, block_exts);
+  test_warp(hier, grid_exts, cuda::std::extents<unsigned, 1, 1, 1>{}, block_exts);
 }
 
 template <class Hierarchy, class GridExts, class ClusterExts, class BlockExts>
 __global__ void test_kernel(Hierarchy hier, GridExts grid_exts, ClusterExts cluster_exts, BlockExts block_exts)
 {
-  test_block(hier, grid_exts, cluster_exts, block_exts);
+  test_warp(hier, grid_exts, cluster_exts, block_exts);
 }
 
 template <class GridExts, class BlockExts>

--- a/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/hierarchy_query_signatures.compile.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/hierarchy/warp_level/hierarchy_query_signatures.compile.pass.cpp
@@ -18,72 +18,69 @@
 template <class Level, class Hierarchy>
 __device__ void test_query_signatures(const Level& level, const Hierarchy& hier)
 {
-  // 1. Test cuda::cluster_level::dims(x, hier) signature.
+  // 1. Test cuda::warp_level::dims(x, hier) signature.
   static_assert(
-    cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::cluster_level::dims(level, hier))>);
-  static_assert(noexcept(cuda::cluster_level::dims(level, hier)));
+    cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::warp_level::dims(level, hier))>);
+  static_assert(noexcept(cuda::warp_level::dims(level, hier)));
 
-  // 2. Test cuda::cluster_level::static_dims(x, hier) signature.
+  // 2. Test cuda::warp_level::static_dims(x, hier) signature.
   static_assert(cuda::std::is_same_v<cuda::hierarchy_query_result<cuda::std::size_t>,
-                                     decltype(cuda::cluster_level::static_dims(level, hier))>);
-  static_assert(noexcept(cuda::cluster_level::static_dims(level, hier)));
+                                     decltype(cuda::warp_level::static_dims(level, hier))>);
+  static_assert(noexcept(cuda::warp_level::static_dims(level, hier)));
 
-  // 3. Test cuda::cluster_level::extents(x, hier) signature.
-  using ExtentsResult = decltype(cuda::cluster_level::extents(level, hier));
+  // 3. Test cuda::warp_level::extents(x, hier) signature.
+  using ExtentsResult = decltype(cuda::warp_level::extents(level, hier));
   static_assert(cuda::std::__is_cuda_std_extents_v<ExtentsResult>);
   static_assert(cuda::std::is_same_v<unsigned, typename ExtentsResult::index_type>);
-  static_assert(noexcept(cuda::cluster_level::extents(level, hier)));
+  static_assert(noexcept(cuda::warp_level::extents(level, hier)));
+  static_assert(ExtentsResult::rank() == ((cuda::std::is_same_v<Level, cuda::block_level>) ? 1 : 3));
 
-  // 4. Test cuda::cluster_level::static_count(x, hier) signature.
-  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::cluster_level::static_count(level, hier))>);
-  static_assert(noexcept(cuda::cluster_level::static_count(level, hier)));
+  // 4. Test cuda::warp_level::static_count(x, hier) signature.
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::warp_level::static_count(level, hier))>);
+  static_assert(noexcept(cuda::warp_level::static_count(level, hier)));
 
-  // 5. Test cuda::cluster_level::count(x, hier) signature.
-  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::cluster_level::count(level, hier))>);
-  static_assert(noexcept(cuda::cluster_level::count(level, hier)));
+  // 5. Test cuda::warp_level::count(x, hier) signature.
+  static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::warp_level::count(level, hier))>);
+  static_assert(noexcept(cuda::warp_level::count(level, hier)));
 
   if constexpr (Hierarchy::has_level(cuda::cluster))
   {
-    // 6. Test cuda::cluster_level::index(x, hier) signature.
-    static_assert(
-      cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>, decltype(cuda::cluster_level::index(level, hier))>);
-    static_assert(noexcept(cuda::cluster_level::index(level, hier)));
+    // 6. Test cuda::warp_level::index(x, hier) signature.
+    // static_assert(cuda::std::is_same_v<cuda::hierarchy_query_result<unsigned>,
+    // decltype(cuda::warp_level::index(level, hier))>); static_assert(noexcept(cuda::warp_level::index(level, hier)));
 
-    // 7. Test cuda::cluster_level::rank(x, hier) signature.
-    static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::cluster_level::rank(level, hier))>);
-    static_assert(noexcept(cuda::cluster_level::rank(level, hier)));
+    // 7. Test cuda::warp_level::rank(x, hier) signature.
+    // static_assert(cuda::std::is_same_v<cuda::std::size_t, decltype(cuda::warp_level::rank(level, hier))>);
+    // static_assert(noexcept(cuda::warp_level::rank(level, hier)));
   }
 }
 
 template <class T, class Level, class Hierarchy>
 __device__ void test_query_as_signatures(const Level& level, const Hierarchy& hier)
 {
-  // 1. Test cuda::cluster_level::dims_as(x, hier) signature.
+  // 1. Test cuda::warp_level::dims(x, hier) signature.
   static_assert(
-    cuda::std::is_same_v<cuda::hierarchy_query_result<T>, decltype(cuda::cluster_level::dims_as<T>(level, hier))>);
-  static_assert(noexcept(cuda::cluster_level::dims_as<T>(level, hier)));
+    cuda::std::is_same_v<cuda::hierarchy_query_result<T>, decltype(cuda::warp_level::dims_as<T>(level, hier))>);
+  static_assert(noexcept(cuda::warp_level::dims_as<T>(level, hier)));
 
-  // 2. Test cuda::cluster_level::extents_as(x, hier) signature.
-  using ExtentsResult = decltype(cuda::cluster_level::extents_as<T>(level, hier));
+  // 2. Test cuda::warp_level::extents(x, hier) signature.
+  using ExtentsResult = decltype(cuda::warp_level::extents_as<T>(level, hier));
   static_assert(cuda::std::__is_cuda_std_extents_v<ExtentsResult>);
   static_assert(cuda::std::is_same_v<T, typename ExtentsResult::index_type>);
-  static_assert(noexcept(cuda::cluster_level::extents_as<T>(level, hier)));
+  static_assert(noexcept(cuda::warp_level::extents_as<T>(level, hier)));
+  static_assert(ExtentsResult::rank() == ((cuda::std::is_same_v<Level, cuda::block_level>) ? 1 : 3));
 
-  // 3. Test cuda::cluster_level::count_as(x, hier) signature.
-  static_assert(cuda::std::is_same_v<T, decltype(cuda::cluster_level::count_as<T>(level, hier))>);
-  static_assert(noexcept(cuda::cluster_level::count_as<T>(level, hier)));
+  // 3. Test cuda::warp_level::count(x, hier) signature.
+  static_assert(cuda::std::is_same_v<T, decltype(cuda::warp_level::count_as<T>(level, hier))>);
+  static_assert(noexcept(cuda::warp_level::count_as<T>(level, hier)));
 
-  if constexpr (Hierarchy::has_level(cuda::cluster))
-  {
-    // 4. Test cuda::cluster_level::index_as(x, hier) signature.
-    static_assert(
-      cuda::std::is_same_v<cuda::hierarchy_query_result<T>, decltype(cuda::cluster_level::index_as<T>(level, hier))>);
-    static_assert(noexcept(cuda::cluster_level::index_as<T>(level, hier)));
+  // 4. Test cuda::warp_level::index(x, hier) signature.
+  // static_assert(cuda::std::is_same_v<cuda::hierarchy_query_result<T>, decltype(cuda::warp_level::index_as<T>(level,
+  // hier))>); static_assert(noexcept(cuda::warp_level::index_as<T>(level, hier)));
 
-    // 5. Test cuda::cluster_level::rank_as(x, hier) signature.
-    static_assert(cuda::std::is_same_v<T, decltype(cuda::cluster_level::rank_as<T>(level, hier))>);
-    static_assert(noexcept(cuda::cluster_level::rank_as<T>(level, hier)));
-  }
+  // 5. Test cuda::warp_level::rank(x, hier) signature.
+  // static_assert(cuda::std::is_same_v<T, decltype(cuda::warp_level::rank_as<T>(level, hier))>);
+  // static_assert(noexcept(cuda::warp_level::rank_as<T>(level, hier)));
 }
 
 template <class InLevel, class Hierarchy>
@@ -101,6 +98,8 @@ __device__ void test(const InLevel& in_level, const Hierarchy& hier)
 template <class Hierarchy>
 __device__ void test(const Hierarchy& hier)
 {
+  test(cuda::block, hier);
+  test(cuda::cluster, hier);
   test(cuda::grid, hier);
 }
 


### PR DESCRIPTION
This PR refactors the `extents_as` implementation and adds additional support for `warp_level` queries in a hierarchy and `cluster_level` queries in a hierarchy when `cluster_level` is not part of the hierarchy. This change allows us to use queries with hierarchy parameter inside groups implementation.

Partially implements #8310. 2 more PRs will follow with `index` and `rank` implementations.