### PR TITLE
[CUB] Replace Shuffle(Up|Down|Index) with cuda::device::warp_shuffle - WarpScan only 

### DIFF
--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -32,6 +32,13 @@ benchmarks:
       # Examples:
       # - '^cub\.bench\.for_each\.base'
       # - '^cub\.bench\.reduce\.(sum|min)\.'
+      - '^cub\.bench\.scan\.exclusive\.sum\.'
+      - '^cub\.bench\.scan\.exclusive\.by_key\.'
+      - '^cub\.bench\.scan\.exclusive\.sum\.warpspeed\.'
+      - '^cub\.bench\.select\.if\.'
+      - '^cub\.bench\.reduce\.by_key\.'
+      - '^cub\.bench\.topk\.keys\.'
+      - '^cub\.bench\.run_length_encode\.encode\.'
 
     # Python benchmark filters (regex matched against paths under benchmarks/).
     python:
@@ -44,11 +51,11 @@ benchmarks:
   gpus:
     # - "t4"         # sm_75, 16 GB
     # - "rtx2080"    # sm_75,  8 GB
-    # - "rtxa6000"   # sm_86, 48 GB
+    - "rtxa6000"   # sm_86, 48 GB
     # - "l4"         # sm_89, 24 GB
     # - "rtx4090"    # sm_89, 24 GB
-    # - "h100"       # sm_90, 80 GB
-    # - "rtxpro6000" # sm_120
+    - "h100"       # sm_90, 80 GB
+    - "rtxpro6000" # sm_120
 
   # Extra .devcontainer/launch.sh -d args
   # launch_args: "--cuda 13.1 --host gcc14"
@@ -59,7 +66,7 @@ benchmarks:
   test_ref: "HEAD"
   arch: "native"
   nvbench_args: >-
-    --timeout 30
+    --timeout 300
     --skip-time 15e-6
     --stopping-criterion entropy
     --throttle-threshold 90

--- a/cub/cub/warp/specializations/warp_scan_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_scan_shfl.cuh
@@ -381,7 +381,7 @@ struct WarpScanShfl
   template <typename _Tp, typename ScanOpT>
   _CCCL_DEVICE _CCCL_FORCEINLINE _Tp InclusiveScanStep(_Tp input, ScanOpT scan_op, int first_lane, int offset)
   {
-    _Tp temp = ShuffleUp<LOGICAL_WARP_THREADS>(input, offset, first_lane, member_mask);
+    _Tp temp = ::cuda::device::warp_shuffle_up<LOGICAL_WARP_THREADS>(input, offset, member_mask);
 
     // Perform scan op if from a valid peer
     _Tp output = scan_op(temp, input);
@@ -501,7 +501,7 @@ struct WarpScanShfl
    */
   _CCCL_DEVICE _CCCL_FORCEINLINE T Broadcast(T input, int src_lane)
   {
-    return ShuffleIndex<LOGICAL_WARP_THREADS>(input, src_lane, member_mask);
+    return ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(input, src_lane, member_mask);
   }
 
   //---------------------------------------------------------------------
@@ -592,7 +592,7 @@ struct WarpScanShfl
   {
     inclusive_output = input;
 
-    KeyT pred_key = ShuffleUp<LOGICAL_WARP_THREADS>(inclusive_output.key, 1, 0, member_mask);
+    KeyT pred_key = ::cuda::device::warp_shuffle_up<LOGICAL_WARP_THREADS>(inclusive_output.key, 1, member_mask);
 
     unsigned int ballot = __ballot_sync(member_mask, (pred_key != inclusive_output.key));
 
@@ -636,7 +636,8 @@ struct WarpScanShfl
     InclusiveScan(input, inclusive_output, scan_op);
 
     // Grab aggregate from last warp lane
-    warp_aggregate = ShuffleIndex<LOGICAL_WARP_THREADS>(inclusive_output, LOGICAL_WARP_THREADS - 1, member_mask);
+    warp_aggregate =
+      ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive_output, LOGICAL_WARP_THREADS - 1, member_mask);
   }
 
   /**
@@ -691,7 +692,7 @@ struct WarpScanShfl
   Update(T /*input*/, T& inclusive, T& exclusive, ScanOpT /*scan_op*/, IsIntegerT /*is_integer*/)
   {
     // initial value unknown
-    exclusive = ShuffleUp<LOGICAL_WARP_THREADS>(inclusive, 1, 0, member_mask);
+    exclusive = ::cuda::device::warp_shuffle_up<LOGICAL_WARP_THREADS>(inclusive, 1, member_mask);
   }
 
   /**
@@ -714,7 +715,7 @@ struct WarpScanShfl
   Update(T /*input*/, T& inclusive, T& exclusive, ScanOpT scan_op, T initial_value, IsIntegerT /*is_integer*/)
   {
     inclusive = scan_op(initial_value, inclusive);
-    exclusive = ShuffleUp<LOGICAL_WARP_THREADS>(inclusive, 1, 0, member_mask);
+    exclusive = ::cuda::device::warp_shuffle_up<LOGICAL_WARP_THREADS>(inclusive, 1, member_mask);
 
     if (lane_id == 0)
     {
@@ -745,7 +746,8 @@ struct WarpScanShfl
   _CCCL_DEVICE _CCCL_FORCEINLINE void
   Update(T input, T& inclusive, T& exclusive, T& warp_aggregate, ScanOpT scan_op, IsIntegerT is_integer)
   {
-    warp_aggregate = ShuffleIndex<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
+    warp_aggregate =
+      ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
     Update(input, inclusive, exclusive, scan_op, is_integer);
   }
 
@@ -757,7 +759,8 @@ struct WarpScanShfl
   _CCCL_DEVICE _CCCL_FORCEINLINE void Update(
     T input, T& inclusive, T& exclusive, T& warp_aggregate, ScanOpT scan_op, T initial_value, IsIntegerT is_integer)
   {
-    warp_aggregate = ShuffleIndex<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
+    warp_aggregate =
+      ::cuda::device::warp_shuffle_idx<LOGICAL_WARP_THREADS>(inclusive, LOGICAL_WARP_THREADS - 1, member_mask);
     Update(input, inclusive, exclusive, scan_op, initial_value, is_integer);
   }
 


### PR DESCRIPTION
## Description

Split

- https://github.com/NVIDIA/cccl/pull/8159

The change only affects WarpScan routines. This helps to isolate potential performance regressions