### PR TITLE
CUB] Replace Shuffle(Up|Down|Index) with cuda::device::warp_shuffle - WarpReduce only

### DIFF
--- a/ci/bench.yaml
+++ b/ci/bench.yaml
@@ -32,6 +32,14 @@ benchmarks:
       # Examples:
       # - '^cub\.bench\.for_each\.base'
       # - '^cub\.bench\.reduce\.(sum|min)\.'
+      - '^cub\.bench\.reduce\.sum\.'
+      - '^cub\.bench\.reduce\.deterministic\.'
+      - '^cub\.bench\.reduce\.by_key\.'
+      - '^cub\.bench\.reduce\.warp_reduce_sum\.'
+      - '^cub\.bench\.scan\.exclusive\.sum\.'
+      - '^cub\.bench\.scan\.exclusive\.sum\.warpspeed\.'
+      - '^cub\.bench\.select\.if\.'
+      - '^cub\.bench\.radix_sort\.keys\.'
 
     # Python benchmark filters (regex matched against paths under benchmarks/).
     python:
@@ -44,11 +52,11 @@ benchmarks:
   gpus:
     # - "t4"         # sm_75, 16 GB
     # - "rtx2080"    # sm_75,  8 GB
-    # - "rtxa6000"   # sm_86, 48 GB
+    - "rtxa6000"   # sm_86, 48 GB
     # - "l4"         # sm_89, 24 GB
     # - "rtx4090"    # sm_89, 24 GB
-    # - "h100"       # sm_90, 80 GB
-    # - "rtxpro6000" # sm_120
+    - "h100"       # sm_90, 80 GB
+    - "rtxpro6000" # sm_120
 
   # Extra .devcontainer/launch.sh -d args
   # launch_args: "--cuda 13.1 --host gcc14"
@@ -59,7 +67,7 @@ benchmarks:
   test_ref: "HEAD"
   arch: "native"
   nvbench_args: >-
-    --timeout 30
+    --timeout 600
     --skip-time 15e-6
     --stopping-criterion entropy
     --throttle-threshold 90

--- a/cub/cub/warp/specializations/warp_reduce_shfl.cuh
+++ b/cub/cub/warp/specializations/warp_reduce_shfl.cuh
@@ -28,6 +28,7 @@
 #include <cuda/__functional/maximum.h>
 #include <cuda/__functional/minimum.h>
 #include <cuda/__ptx/instructions/get_sreg.h>
+#include <cuda/__warp/warp_shuffle.h>
 #include <cuda/std/__bit/countr.h>
 #include <cuda/std/__functional/operations.h>
 #include <cuda/std/__type_traits/conditional.h>
@@ -360,7 +361,7 @@ struct WarpReduceShfl
   {
     KeyValuePair<KeyT, ValueT> output;
 
-    KeyT other_key = ShuffleDown<LOGICAL_WARP_THREADS>(input.key, offset, last_lane, member_mask);
+    KeyT other_key = ::cuda::device::warp_shuffle_down<LOGICAL_WARP_THREADS>(input.key, offset, member_mask);
 
     output.key   = input.key;
     output.value = ReduceStep(input.value, ::cuda::std::plus<>{}, last_lane, offset);
@@ -429,7 +430,7 @@ struct WarpReduceShfl
   {
     _Tp output = input;
 
-    _Tp temp = ShuffleDown<LOGICAL_WARP_THREADS>(output, offset, last_lane, member_mask);
+    _Tp temp = ::cuda::device::warp_shuffle_down<LOGICAL_WARP_THREADS>(output, offset, member_mask);
 
     // Perform reduction op if valid
     if (offset + lane_id <= last_lane)


### PR DESCRIPTION
## Description

Split

- https://github.com/NVIDIA/cccl/pull/8159
- 
The change only affects WarpReduce routines. This helps to isolate potential performance regressions
