### PR TITLE
Switch from pyenv to uv

### DIFF
--- a/c/parallel/src/scan.cu
+++ b/c/parallel/src/scan.cu
@@ -392,6 +392,7 @@ static_assert(device_scan_policy()(::cuda::arch_id{{CUB_PTX_ARCH / 10}}) == {6},
     ctk_path,
     "-rdc=true",
     "-dlto",
+    "-default-device",
     "-DCUB_DISABLE_CDP",
     "-std=c++20"};
 

--- a/ci/build_cuda_cccl_python.sh
+++ b/ci/build_cuda_cccl_python.sh
@@ -77,6 +77,10 @@ done
 
 echo "Merging CUDA wheels..."
 
+# Set up a Python environment for the merge/repair steps.
+source "$ci_dir/pyenv_helper.sh"
+setup_python_env "${py_version}"
+
 # Needed for unpacking and repacking wheels.
 python -m pip install wheel
 

--- a/ci/pyenv_helper.sh
+++ b/ci/pyenv_helper.sh
@@ -5,48 +5,24 @@ setup_python_env() {
     local script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
     source "${script_dir}/pretty_printing.sh"
 
-    begin_group "🐍 Setting up Python ${py_version} (pyenv)"
+    begin_group "🐍 Setting up Python ${py_version} (uv)"
 
-    # check if pyenv is installed
-    if ! command -v pyenv &> /dev/null; then
-        rm -f /pyenv
-        curl -fsSL https://pyenv.run | bash
+    # Install uv if not present
+    if ! command -v uv &> /dev/null; then
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        export PATH="$HOME/.local/bin:$PATH"
     fi
 
-    # Install the build dependencies, check /etc/os-release to see if we are on ubuntu or rocky
-    if [ -f /etc/os-release ]; then
-        source /etc/os-release
-        if [ "$ID" = "ubuntu" ]; then
-            # Use the retry helper to mitigate issues with apt network errors:
-            retry() {
-              "${script_dir}/util/retry.sh" 5 30 "$@"
-            }
+    # Create a venv with the requested Python version.
+    # uv downloads a pre-built CPython binary automatically — no compilation needed.
+    uv venv --seed --python "${py_version}" "${HOME}/.cccl-venv"
 
-            retry sudo apt update
-            retry sudo apt install -y make libssl-dev zlib1g-dev \
-            libbz2-dev libreadline-dev libsqlite3-dev curl git \
-            libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev
-        elif [ "$ID" = "rocky" ]; then
-            # we're inside the rockylinux container, sudo not required/available
-            dnf install -y make patch zlib-devel bzip2 bzip2-devel readline-devel \
-            sqlite sqlite-devel openssl-devel tk-devel libffi-devel xz-devel libuuid-devel \
-            gdbm-libs libnsl2
-        else
-            echo "Unsupported Linux distribution"
-            exit 1
-        fi
+    # Windows venvs use Scripts/, Linux/macOS use bin/
+    if [[ -f "${HOME}/.cccl-venv/Scripts/activate" ]]; then
+        source "${HOME}/.cccl-venv/Scripts/activate"
+    else
+        source "${HOME}/.cccl-venv/bin/activate"
     fi
 
-    # Always set up pyenv environment
-    export PYENV_ROOT="$HOME/.pyenv"
-    [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init - bash)"
-
-    # Using pyenv, install the Python version
-    PYENV_DEBUG=1 pyenv install -v "${py_version}"
-    pyenv local "${py_version}"
-
-    pip install --upgrade pip
-
-    end_group "🐍 Setting up Python ${py_version} (pyenv)"
+    end_group "🐍 Setting up Python ${py_version} (uv)"
 }

--- a/ci/windows/build_common_python.psm1
+++ b/ci/windows/build_common_python.psm1
@@ -23,27 +23,27 @@ function Get-Python {
         $Env:PATH = $uvBin + ";" + $Env:PATH
     }
 
-    Write-Host "Installing Python $Version via uv..."
-    & uv python install $Version
+    Write-Host "Creating Python $Version venv via uv..."
+    $venvDir = Join-Path $HOME '.cccl-venv'
+    & uv venv --seed --python $Version $venvDir
     if ($LASTEXITCODE -ne 0) {
         throw [System.InvalidOperationException]::new(
-            "Failed to install Python $Version via uv."
+            "Failed to create Python $Version venv via uv."
         )
     }
 
-    $exe = (& uv python find $Version 2>&1).Trim()
-    if (-not $exe -or -not (Test-Path $exe)) {
+    $exe = Join-Path $venvDir 'Scripts\python.exe'
+    if (-not (Test-Path $exe)) {
         throw [System.InvalidOperationException]::new(
-            "Could not find Python $Version after uv install. Got: $exe"
+            "Could not find python.exe in venv at $exe"
         )
     }
 
     Write-Host "Python $Version at: $exe"
 
-    # Add python dir and Scripts dir to PATH so bare `python` and `pip` work.
-    $rootDir = Split-Path $exe
-    $scriptsDir = Join-Path $rootDir 'Scripts'
-    $Env:PATH = $rootDir + ";" + $scriptsDir + ";" + $Env:PATH
+    # Add venv Scripts dir to PATH so bare `python` and `pip` work.
+    $scriptsDir = Join-Path $venvDir 'Scripts'
+    $Env:PATH = $scriptsDir + ";" + $Env:PATH
 
     return $exe
 }

--- a/ci/windows/build_common_python.psm1
+++ b/ci/windows/build_common_python.psm1
@@ -1,130 +1,10 @@
-function Get-LatestPythonPatchVersionFromPyEnvWin {
-    <#
-    .SYNOPSIS
-        Resolves the latest patch version for a given Python major.minor (e.g.
-        '3.12') by parsing `pyenv install --list` output on Windows (pyenv-win).
-    .PARAMETER Version
-        A string in the form 'M.m' (e.g., '3.10', '3.11', '3.12').
-    #>
-    [CmdletBinding()]
-    param(
-        [Parameter(Mandatory, Position = 0)]
-        [ValidatePattern('^\d+\.\d+$')]
-        [string]$Version
-    )
-
-    # Verify pyenv exists.
-    if (-not (Get-Command pyenv -ErrorAction SilentlyContinue)) {
-        throw [System.InvalidOperationException]::new(
-            'pyenv-win ("pyenv") not found on PATH.'
-        )
-    }
-
-    $listOutput = & pyenv install --list 2>&1
-    if ($LASTEXITCODE -ne 0 -or -not $listOutput) {
-        $joined = $listOutput -join "`n"
-        throw [System.InvalidOperationException]::new(
-            "Failed to run 'pyenv install --list'. Output:`n$joined"
-        )
-    }
-
-    # Build a list of patch numbers that match the requested minor version.
-    $versionPrefix = "$Version."
-    $patchNumbers = @()
-    foreach ($line in $listOutput) {
-        $candidate = $line.Trim()
-        if (-not $candidate) { continue }
-
-        # Accept any major version; the StartsWith check guarantees we only
-        # keep the wanted minor.
-        if (-not $candidate.StartsWith($versionPrefix)) { continue }
-        if ($candidate -notmatch '^\d+\.\d+\.\d+$') { continue }
-
-        $patchNumbers += [int]($candidate.Split('.')[2])
-    }
-
-    if ($patchNumbers.Count -eq 0) {
-        throw [System.InvalidOperationException]::new(
-            "No installable CPython versions found for prefix " +
-            "'$Version' in pyenv-win list."
-        )
-    }
-
-    $latestPatch = ($patchNumbers | Sort-Object -Descending)[0]
-    return "$Version.$latestPatch"
-}
-
-function Install-PythonViaPyEnvWin {
-    <#
-    .SYNOPSIS
-        Ensures a Python version for the given major.minor exists via
-        pyenv-win, activates it for the current shell, and returns the
-        path to python.exe.
-    .PARAMETER Version
-        A string in the form 'M.m' (e.g., '3.12').
-    #>
-    param(
-        [Parameter(Mandatory, Position = 0)]
-        [ValidatePattern('^\d+\.\d+$')]
-        [string]$Version
-    )
-
-    $fullVersion = Get-LatestPythonPatchVersionFromPyEnvWin `
-        -Version $Version
-
-    Write-Host "Installing Python $fullVersion via pyenv..."
-    Write-Host "pyenv install $fullVersion"
-    ($null = & pyenv install $fullVersion | Out-Host)
-    if ($LASTEXITCODE -ne 0) {
-        throw [System.InvalidOperationException]::new(
-            "Failed to install Python $fullVersion via pyenv."
-        )
-    }
-    Write-Host "Successfully installed Python $fullVersion via pyenv."
-
-    ($null = & pyenv local $fullVersion | Out-Host)
-    if ($LASTEXITCODE -ne 0) {
-        throw [System.InvalidOperationException]::new(
-            "Failed to set Python $fullVersion as local via pyenv."
-        )
-    }
-    Write-Host "Successfully set Python $fullVersion as local via pyenv."
-
-    # Avoid the shim (i.e. shims/python.bat) because it will attempt to set
-    # a codepage via `chcp` that we probably won't have installed on our
-    # Server Core-based image.
-    $exe = (Resolve-Path -LiteralPath $(pyenv which python)).Path
-    Write-Host "python.exe path: $exe"
-
-    # Add the root and Scripts directory to $Env:PATH.
-    $rootDir = $exe.Replace("\python.exe", "")
-    $scriptsDir = $exe.Replace("python.exe", "Scripts")
-    $pathPrefix = $rootDir + ";" + $scriptsDir + ";"
-    $Env:PATH = $pathPrefix + $Env:PATH
-
-    # Upgrade pip using the found exe.  This is necessary because some older
-    # versions of pip (e.g. 23.10) don't support arguments like `--wheeldir`.
-    ($null = & $exe -m pip install --upgrade pip --no-cache-dir | Out-Host)
-    if ($LASTEXITCODE -ne 0) {
-        throw [System.InvalidOperationException]::new("pip upgrade failed")
-    }
-
-    Write-Host "pip successfully upgraded, running pyenv rehash..."
-    ($null = & pyenv rehash | Out-Host)
-    if ($LASTEXITCODE -ne 0) {
-        throw [System.InvalidOperationException]::new("pyenv rehash failed")
-    }
-    Write-Host "Successfully ran pyenv rehash."
-
-    return $exe
-}
-
 function Get-Python {
     <#
     .SYNOPSIS
         Returns the path of the Python interpreter satisfying the supplied
-        version, potentially installing it via pyenv-win if it's not already
-        installed.
+        version, installing it via uv if necessary.
+    .PARAMETER Version
+        A string in the form 'M.m' (e.g., '3.10', '3.13').
     #>
     [CmdletBinding()]
     param(
@@ -133,33 +13,39 @@ function Get-Python {
         [string]$Version
     )
 
-    # Look for a plain 'python.exe' already on the path.
-    try {
-        $candidate = (Get-Command python -ErrorAction Stop).Source
-        $foundVer = & $candidate -c "import sys; print(f'{sys.version_info[0]}.{sys.version_info[1]}')" 2>$null
-        if ($foundVer -eq $Version) {
-            Write-Host "Found matching Python $foundVer at $candidate."
-            return $candidate.Trim()
-        }
-        else {
-            Write-Host "Found python.exe but version $foundVer != requested version $Version."
-        }
-    }
-    catch {
-        Write-Host "Unable to query existing 'python' on PATH: $_"
+    # Install uv if not present. uv downloads pre-built CPython binaries —
+    # no compilation, no build dependencies, no pyenv-win required.
+    if (-not (Get-Command uv -ErrorAction SilentlyContinue)) {
+        Write-Host "Installing uv..."
+        Invoke-RestMethod https://astral.sh/uv/install.ps1 | Invoke-Expression
+        # uv installs to $HOME\.local\bin on Windows
+        $uvBin = Join-Path $HOME '.local\bin'
+        $Env:PATH = $uvBin + ";" + $Env:PATH
     }
 
-    # If we reach here, we'll need to install the requested version via pyenv.
-    try {
-        $exe = Install-PythonViaPyEnvWin -Version $Version
-        return $exe.Trim()
-    }
-    catch {
+    Write-Host "Installing Python $Version via uv..."
+    & uv python install $Version
+    if ($LASTEXITCODE -ne 0) {
         throw [System.InvalidOperationException]::new(
-            "Requested Python $Version not found and installation " +
-            "via pyenv-win failed: $($_.Exception.Message)"
+            "Failed to install Python $Version via uv."
         )
     }
+
+    $exe = (& uv python find $Version 2>&1).Trim()
+    if (-not $exe -or -not (Test-Path $exe)) {
+        throw [System.InvalidOperationException]::new(
+            "Could not find Python $Version after uv install. Got: $exe"
+        )
+    }
+
+    Write-Host "Python $Version at: $exe"
+
+    # Add python dir and Scripts dir to PATH so bare `python` and `pip` work.
+    $rootDir = Split-Path $exe
+    $scriptsDir = Join-Path $rootDir 'Scripts'
+    $Env:PATH = $rootDir + ";" + $scriptsDir + ";" + $Env:PATH
+
+    return $exe
 }
 
 function Get-RepoRoot {

--- a/python/cuda_cccl/merge_cuda_wheels.py
+++ b/python/cuda_cccl/merge_cuda_wheels.py
@@ -68,7 +68,7 @@ def merge_wheels(wheels: List[Path], output_dir: Path) -> Path:
             # Extract wheel - wheel unpack creates the directory itself
             run_command(
                 [
-                    "python",
+                    sys.executable,
                     "-m",
                     "wheel",
                     "unpack",
@@ -125,7 +125,7 @@ def merge_wheels(wheels: List[Path], output_dir: Path) -> Path:
         print(f"Repacking merged wheel as: {base_wheel_name}")
         run_command(
             [
-                "python",
+                sys.executable,
                 "-m",
                 "wheel",
                 "pack",
@@ -182,7 +182,7 @@ def main():
 
     # Check that we have wheel tool available
     try:
-        run_command(["python", "-m", "wheel", "--help"])
+        run_command([sys.executable, "-m", "wheel", "--help"])
     except Exception:
         print("Error: wheel package not available. Install with: pip install wheel")
         sys.exit(1)

--- a/python/cuda_cccl/tests/compute/test_transform.py
+++ b/python/cuda_cccl/tests/compute/test_transform.py
@@ -549,6 +549,9 @@ def test_binary_transform_bool_equal_to():
     np.testing.assert_array_equal(d_output.get(), expected)
 
 
+@pytest.mark.xfail(
+    reason="Disk cache does not distinguish same-bytecode ops with different closed-over state sizes."
+)
 def test_stateful_transform_same_bytecode_different_sizes():
     """
     Test that stateful op with same bytecode, but referencing arrays
@@ -573,6 +576,9 @@ def test_stateful_transform_same_bytecode_different_sizes():
     np.testing.assert_array_equal(np.asarray([False, False, True]), d_out.get())
 
 
+@pytest.mark.xfail(
+    reason="Disk cache conflates ops with identical names referencing different dotted globals (e.g. np.sin vs np.cos)."
+)
 @pytest.mark.no_verify_sass(reason="LDL/STL instructions emitted for this test.")
 def test_transform_caching_with_global_np_ufunc():
     # regression test for a case where if multiple, identically named,

--- a/python/cuda_cccl/tests/compute/test_transform.py
+++ b/python/cuda_cccl/tests/compute/test_transform.py
@@ -549,9 +549,6 @@ def test_binary_transform_bool_equal_to():
     np.testing.assert_array_equal(d_output.get(), expected)
 
 
-@pytest.mark.xfail(
-    reason="Disk cache does not distinguish same-bytecode ops with different closed-over state sizes."
-)
 def test_stateful_transform_same_bytecode_different_sizes():
     """
     Test that stateful op with same bytecode, but referencing arrays
@@ -576,10 +573,6 @@ def test_stateful_transform_same_bytecode_different_sizes():
     np.testing.assert_array_equal(np.asarray([False, False, True]), d_out.get())
 
 
-@pytest.mark.xfail(
-    reason="Disk cache conflates ops with identical names referencing different dotted globals (e.g. np.sin vs np.cos)."
-)
-@pytest.mark.no_verify_sass(reason="LDL/STL instructions emitted for this test.")
 def test_transform_caching_with_global_np_ufunc():
     # regression test for a case where if multiple, identically named,
     # ops referenced dotted globals like `np.<func>` those


### PR DESCRIPTION
## Description

Unlike `pyenv`, which downloads and builds Python from source on each job, `uv` simply downloads pre-built Python binaries. Largely this should improve our CI QOL by having fewer network timeouts etc., There should also be a small improvement in Python CI times (although nothing dramatic).

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
