### PR TITLE
Disable optimizer workaround for newer nvcc

### DIFF
--- a/cub/cub/detail/warpspeed/squad/load_store.cuh
+++ b/cub/cub/detail/warpspeed/squad/load_store.cuh
@@ -224,11 +224,13 @@ squadStoreBulkSync(Squad squad, CpAsyncOobInfo<OutputT> cpAsyncOobInfo, const ::
     // Perform fence.proxy.async with full warp to avoid BSSY+BSYNC
     ::cuda::ptx::fence_proxy_async(::cuda::ptx::space_shared);
 
-    // FIXME(bgruber): for some reason the optimizer propagates some information from the computation of
+#  if _CCCL_CUDA_COMPILER(NVCC, <, 13, 3)
+    // for some reason the optimizer propagates some information from the computation of
     // overCopySizeBytes to the masked bulk copy below and generates an unaligned access error.
     // The artificial read modification of overCopySizeBytes prevents the propagation here works around this.
     // It also solves the issue described in nvbug 5848313 by accident on nvcc 13.2+
     asm volatile("" : "+r"(cpAsyncOobInfo.overCopySizeBytes));
+#  endif // _CCCL_CUDA_COMPILER(NVCC, <, 13, 3)
 
     const bool doStartCopy  = cpAsyncOobInfo.smemStartSkipBytes > 0;
     const bool doEndCopy    = cpAsyncOobInfo.smemEndBytesAfter16BBoundary > 0;


### PR DESCRIPTION
This works now on some future nvcc. Related nvbug: 5848313