### PR TITLE
[libcu++] Make memory resources work with get_memory_resource when wrapped in environment

### DIFF
--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "insert_nested_NVTX_range_guard.h"
@@ -10,8 +10,10 @@
 #include <cuda/__execution/determinism.h>
 #include <cuda/__execution/require.h>
 #include <cuda/devices>
+#include <cuda/std/__execution/env.h>
 #include <cuda/stream>
 
+#include "catch2_test_memory_resources.h"
 #include <c2h/catch2_test_helper.h>
 
 C2H_TEST("cub::DeviceReduce::Reduce accepts run_to_run determinism requirements", "[reduce][env]")
@@ -619,4 +621,26 @@ C2H_TEST("cub::DeviceReduce::ReduceByKey accepts stream", "[reduce][env]")
   aggregates_out.resize(5);
   REQUIRE(unique_keys_out == expected_keys);
   REQUIRE(aggregates_out == expected_aggregates);
+}
+
+C2H_TEST("cub::DeviceReduce::Sum queries both stream and resource from composed env", "[reduce][env]")
+{
+  auto input  = thrust::device_vector<int>{1, 2, 3, 4, 5};
+  auto output = thrust::device_vector<int>(1);
+
+  cuda::stream stream{cuda::devices[0]};
+
+  size_t bytes_allocated{};
+  size_t bytes_deallocated{};
+  auto mr = device_memory_resource{stream.get(), &bytes_allocated, &bytes_deallocated};
+
+  auto env = cuda::std::execution::env{cuda::stream_ref{stream}, mr};
+
+  auto error = cub::DeviceReduce::Sum(input.begin(), output.begin(), static_cast<int>(input.size()), env);
+
+  stream.sync();
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output[0] == 15);
+  REQUIRE(bytes_allocated > 0);
+  REQUIRE(bytes_deallocated == bytes_allocated);
 }

--- a/cub/test/catch2_test_env_launch_helper.h
+++ b/cub/test/catch2_test_env_launch_helper.h
@@ -9,6 +9,7 @@
 
 #include <cuda/std/optional>
 
+#include "catch2_test_memory_resources.h"
 #include <c2h/catch2_test_helper.h>
 
 //! @file
@@ -233,169 +234,6 @@ struct kernel_scope
   }
 };
 
-struct device_memory_resource : cub::detail::device_memory_resource
-{
-  cudaStream_t target_stream = nullptr;
-  size_t* bytes_allocated    = nullptr;
-  size_t* bytes_deallocated  = nullptr;
-
-  void* allocate_sync(size_t /* bytes */, size_t /* alignment */)
-  {
-    FAIL("CUB shouldn't use synchronous allocation");
-    return nullptr;
-  }
-
-  void deallocate_sync(void* /* ptr */, size_t /* bytes */, size_t /* alignment */)
-  {
-    FAIL("CUB shouldn't use synchronous deallocation");
-  }
-
-  void* allocate(cuda::stream_ref stream, size_t bytes, size_t /* alignment */)
-  {
-    return allocate(stream, bytes);
-  }
-
-  void* allocate(cuda::stream_ref stream, size_t bytes)
-  {
-    REQUIRE(target_stream == stream.get());
-
-    if (bytes_allocated)
-    {
-      *bytes_allocated += bytes;
-    }
-    return cub::detail::device_memory_resource::allocate(stream, bytes);
-  }
-
-  void deallocate(const cuda::stream_ref stream, void* ptr, size_t bytes, size_t /* alignment */)
-  {
-    deallocate(stream, ptr, bytes);
-  }
-
-  void deallocate(const cuda::stream_ref stream, void* ptr, size_t bytes)
-  {
-    REQUIRE(target_stream == stream.get());
-
-    if (bytes_deallocated)
-    {
-      *bytes_deallocated += bytes;
-    }
-    cub::detail::device_memory_resource::deallocate(stream, ptr, bytes);
-  }
-
-  bool operator==(const device_memory_resource& rhs) const
-  {
-    return target_stream == rhs.target_stream && bytes_allocated == rhs.bytes_allocated
-        && bytes_deallocated == rhs.bytes_deallocated;
-  }
-  bool operator!=(const device_memory_resource& rhs) const
-  {
-    return !(*this == rhs);
-  }
-};
-static_assert(::cuda::mr::resource<device_memory_resource>);
-
-struct throwing_memory_resource
-{
-  void* allocate_sync(size_t /* bytes */, size_t /* alignment */)
-  {
-    FAIL("CUB shouldn't use synchronous allocation");
-    return nullptr;
-  }
-
-  void deallocate_sync(void* /* ptr */, size_t /* bytes */, size_t /* alignment */)
-  {
-    FAIL("CUB shouldn't use synchronous deallocation");
-  }
-
-  void* allocate(cuda::stream_ref /* stream */, size_t /* bytes */, size_t /* alignment */)
-  {
-    throw "test";
-  }
-
-  void* allocate(cuda::stream_ref /* stream */, size_t /* bytes */)
-  {
-    throw "test";
-  }
-
-  void deallocate(cuda::stream_ref /* stream */, void* /* ptr */, size_t /* bytes */, size_t /* alignment*/)
-  {
-    throw "test";
-  }
-
-  void deallocate(cuda::stream_ref /* stream */, void* /* ptr */, size_t /* bytes */)
-  {
-    throw "test";
-  }
-
-  bool operator==(const throwing_memory_resource&) const
-  {
-    return true;
-  }
-  bool operator!=(const throwing_memory_resource&) const
-  {
-    return false;
-  }
-};
-static_assert(::cuda::mr::resource<throwing_memory_resource>);
-
-struct device_side_memory_resource
-{
-  void* ptr{};
-  size_t* bytes_allocated   = nullptr;
-  size_t* bytes_deallocated = nullptr;
-
-  __host__ __device__ void* allocate_sync(size_t /* bytes */, size_t /* alignment */)
-  {
-    cuda::std::terminate();
-  }
-
-  __host__ __device__ void deallocate_sync(void* /* ptr */, size_t /* bytes */, size_t /* alignment */)
-  {
-    cuda::std::terminate();
-  }
-
-  __host__ __device__ void* allocate(cuda::stream_ref stream, size_t bytes, size_t /* alignment */)
-  {
-    return allocate(stream, bytes);
-  }
-
-  __host__ __device__ void* allocate(cuda::stream_ref /* stream */, size_t bytes)
-  {
-    if (bytes_allocated)
-    {
-      *bytes_allocated += bytes;
-    }
-    return static_cast<void*>(static_cast<char*>(ptr) + *bytes_allocated);
-  }
-
-  __host__ __device__ void deallocate(const cuda::stream_ref /* stream */, void* /* ptr */, size_t bytes)
-  {
-    if (bytes_deallocated)
-    {
-      *bytes_deallocated += bytes;
-    }
-  }
-
-  __host__ __device__ void
-  deallocate(const cuda::stream_ref /* stream */, void* /* ptr */, size_t bytes, size_t /* alignment */)
-  {
-    if (bytes_deallocated)
-    {
-      *bytes_deallocated += bytes;
-    }
-  }
-
-  bool operator==(const device_side_memory_resource& rhs) const
-  {
-    return ptr == rhs.ptr && bytes_allocated == rhs.bytes_allocated && bytes_deallocated == rhs.bytes_deallocated;
-  }
-  bool operator!=(const device_side_memory_resource& rhs) const
-  {
-    return !(*this == rhs);
-  }
-};
-static_assert(::cuda::mr::resource<device_side_memory_resource>);
-
 template <size_t... Is, class TplT, class EnvT>
 auto replace_back(cuda::std::integer_sequence<size_t, Is...>, TplT tpl, EnvT env)
 {
@@ -472,7 +310,7 @@ void launch(ActionT action, Args... args)
 
   static_assert(!cuda::std::execution::__queryable_with<env_t, cuda::mr::__get_memory_resource_t>,
                 "Don't specify memory resource for launch tests.");
-  auto mr         = device_memory_resource{{}, stream, &bytes_allocated, &bytes_deallocated};
+  auto mr         = device_memory_resource{stream, &bytes_allocated, &bytes_deallocated};
   auto mr_env     = cuda::std::execution::prop{cuda::mr::__get_memory_resource_t{}, mr};
   auto stream_env = cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{stream}};
   auto fixed_env  = cuda::std::execution::env{mr_env, stream_env, env};
@@ -638,7 +476,7 @@ void launch(ActionT action, Args... args)
       fixed_args);
   }
 
-  auto mr         = device_memory_resource{{}, stream, &bytes_allocated, &bytes_deallocated};
+  auto mr         = device_memory_resource{stream, &bytes_allocated, &bytes_deallocated};
   auto mr_env     = cuda::std::execution::prop{cuda::mr::__get_memory_resource_t{}, mr};
   auto stream_env = cuda::std::execution::prop{cuda::get_stream_t{}, cuda::stream_ref{stream}};
   auto fixed_env  = cuda::std::execution::env{mr_env, stream_env, env};

--- a/cub/test/catch2_test_memory_resources.h
+++ b/cub/test/catch2_test_memory_resources.h
@@ -15,7 +15,7 @@ struct device_memory_resource
     : cub::detail::device_memory_resource
     , ::cuda::mr::memory_resource_base<device_memory_resource>
 {
-  cudaStream_t target_stream = 0;
+  cudaStream_t target_stream = nullptr;
   size_t* bytes_allocated    = nullptr;
   size_t* bytes_deallocated  = nullptr;
 

--- a/cub/test/catch2_test_memory_resources.h
+++ b/cub/test/catch2_test_memory_resources.h
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cub/detail/device_memory_resource.cuh>
+
+#include <cuda/__memory_resource/memory_resource_base.h>
+#include <cuda/__memory_resource/resource.h>
+#include <cuda/__stream/stream_ref.h>
+
+#include <c2h/catch2_test_helper.h>
+
+struct device_memory_resource
+    : cub::detail::device_memory_resource
+    , ::cuda::mr::memory_resource_base<device_memory_resource>
+{
+  cudaStream_t target_stream = 0;
+  size_t* bytes_allocated    = nullptr;
+  size_t* bytes_deallocated  = nullptr;
+
+  device_memory_resource() = default;
+
+  device_memory_resource(cudaStream_t stream, size_t* alloc, size_t* dealloc)
+      : target_stream(stream)
+      , bytes_allocated(alloc)
+      , bytes_deallocated(dealloc)
+  {}
+
+  void* allocate_sync(size_t /* bytes */, size_t /* alignment */)
+  {
+    FAIL("CUB shouldn't use synchronous allocation");
+    return nullptr;
+  }
+
+  void deallocate_sync(void* /* ptr */, size_t /* bytes */, size_t /* alignment */)
+  {
+    FAIL("CUB shouldn't use synchronous deallocation");
+  }
+
+  void* allocate(cuda::stream_ref stream, size_t bytes, size_t /* alignment */)
+  {
+    return allocate(stream, bytes);
+  }
+
+  void* allocate(cuda::stream_ref stream, size_t bytes)
+  {
+    REQUIRE(target_stream == stream.get());
+
+    if (bytes_allocated)
+    {
+      *bytes_allocated += bytes;
+    }
+    return cub::detail::device_memory_resource::allocate(stream, bytes);
+  }
+
+  void deallocate(const cuda::stream_ref stream, void* ptr, size_t bytes, size_t /* alignment */)
+  {
+    deallocate(stream, ptr, bytes);
+  }
+
+  void deallocate(const cuda::stream_ref stream, void* ptr, size_t bytes)
+  {
+    REQUIRE(target_stream == stream.get());
+
+    if (bytes_deallocated)
+    {
+      *bytes_deallocated += bytes;
+    }
+    cub::detail::device_memory_resource::deallocate(stream, ptr, bytes);
+  }
+
+  bool operator==(const device_memory_resource& rhs) const
+  {
+    return target_stream == rhs.target_stream && bytes_allocated == rhs.bytes_allocated
+        && bytes_deallocated == rhs.bytes_deallocated;
+  }
+  bool operator!=(const device_memory_resource& rhs) const
+  {
+    return !(*this == rhs);
+  }
+};
+static_assert(::cuda::mr::resource<device_memory_resource>);
+
+struct throwing_memory_resource
+{
+  void* allocate_sync(size_t /* bytes */, size_t /* alignment */)
+  {
+    FAIL("CUB shouldn't use synchronous allocation");
+    return nullptr;
+  }
+
+  void deallocate_sync(void* /* ptr */, size_t /* bytes */, size_t /* alignment */)
+  {
+    FAIL("CUB shouldn't use synchronous deallocation");
+  }
+
+  void* allocate(cuda::stream_ref /* stream */, size_t /* bytes */, size_t /* alignment */)
+  {
+    throw "test";
+  }
+
+  void* allocate(cuda::stream_ref /* stream */, size_t /* bytes */)
+  {
+    throw "test";
+  }
+
+  void deallocate(cuda::stream_ref /* stream */, void* /* ptr */, size_t /* bytes */, size_t /* alignment*/)
+  {
+    throw "test";
+  }
+
+  void deallocate(cuda::stream_ref /* stream */, void* /* ptr */, size_t /* bytes */)
+  {
+    throw "test";
+  }
+
+  bool operator==(const throwing_memory_resource&) const
+  {
+    return true;
+  }
+  bool operator!=(const throwing_memory_resource&) const
+  {
+    return false;
+  }
+};
+static_assert(::cuda::mr::resource<throwing_memory_resource>);
+
+struct device_side_memory_resource
+{
+  void* ptr{};
+  size_t* bytes_allocated   = nullptr;
+  size_t* bytes_deallocated = nullptr;
+
+  __host__ __device__ void* allocate_sync(size_t /* bytes */, size_t /* alignment */)
+  {
+    cuda::std::terminate();
+  }
+
+  __host__ __device__ void deallocate_sync(void* /* ptr */, size_t /* bytes */, size_t /* alignment */)
+  {
+    cuda::std::terminate();
+  }
+
+  __host__ __device__ void* allocate(cuda::stream_ref stream, size_t bytes, size_t /* alignment */)
+  {
+    return allocate(stream, bytes);
+  }
+
+  __host__ __device__ void* allocate(cuda::stream_ref /* stream */, size_t bytes)
+  {
+    if (bytes_allocated)
+    {
+      *bytes_allocated += bytes;
+    }
+    return static_cast<void*>(static_cast<char*>(ptr) + *bytes_allocated);
+  }
+
+  __host__ __device__ void deallocate(const cuda::stream_ref /* stream */, void* /* ptr */, size_t bytes)
+  {
+    if (bytes_deallocated)
+    {
+      *bytes_deallocated += bytes;
+    }
+  }
+
+  __host__ __device__ void
+  deallocate(const cuda::stream_ref /* stream */, void* /* ptr */, size_t bytes, size_t /* alignment */)
+  {
+    if (bytes_deallocated)
+    {
+      *bytes_deallocated += bytes;
+    }
+  }
+
+  bool operator==(const device_side_memory_resource& rhs) const
+  {
+    return ptr == rhs.ptr && bytes_allocated == rhs.bytes_allocated && bytes_deallocated == rhs.bytes_deallocated;
+  }
+  bool operator!=(const device_side_memory_resource& rhs) const
+  {
+    return !(*this == rhs);
+  }
+};
+static_assert(::cuda::mr::resource<device_side_memory_resource>);

--- a/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/device_memory_pool.h
@@ -25,6 +25,7 @@
 
 #  include <cuda/__memory_pool/memory_pool_base.h>
 #  include <cuda/__memory_resource/get_property.h>
+#  include <cuda/__memory_resource/memory_resource_base.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__runtime/api_wrapper.h>
 #  include <cuda/std/__concepts/concept_macros.h>
@@ -60,7 +61,9 @@ _CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
 //!    exceeds the lifetime of the ``device_memory_pool_ref``.
 //!
 //! @endrst
-class device_memory_pool_ref : public __memory_pool_base
+class device_memory_pool_ref
+    : public __memory_pool_base
+    , public ::cuda::mr::memory_resource_base<device_memory_pool_ref>
 {
 public:
   //! @brief  Constructs the device_memory_pool_ref from a \c cudaMemPool_t.

--- a/libcudacxx/include/cuda/__memory_pool/managed_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/managed_memory_pool.h
@@ -24,6 +24,7 @@
 #if _CCCL_CTK_AT_LEAST(13, 0)
 
 #  include <cuda/__memory_pool/memory_pool_base.h>
+#  include <cuda/__memory_resource/memory_resource_base.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/std/__concepts/concept_macros.h>
 
@@ -58,7 +59,9 @@ _CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
 //!    exceeds the lifetime of the ``managed_memory_pool_ref``.
 //!
 //! @endrst
-class managed_memory_pool_ref : public __memory_pool_base
+class managed_memory_pool_ref
+    : public __memory_pool_base
+    , public ::cuda::mr::memory_resource_base<managed_memory_pool_ref>
 {
 public:
   //! @brief  Constructs the managed_memory_pool_ref from a \c cudaMemPool_t.

--- a/libcudacxx/include/cuda/__memory_pool/pinned_memory_pool.h
+++ b/libcudacxx/include/cuda/__memory_pool/pinned_memory_pool.h
@@ -25,6 +25,7 @@
 
 #  include <cuda/__device/all_devices.h>
 #  include <cuda/__memory_pool/memory_pool_base.h>
+#  include <cuda/__memory_resource/memory_resource_base.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/std/__concepts/concept_macros.h>
 
@@ -62,7 +63,9 @@ _CCCL_DIAG_SUPPRESS_CLANG("-Wmissing-braces")
 //!    exceeds the lifetime of the ``pinned_memory_pool_ref``.
 //!
 //! @endrst
-class pinned_memory_pool_ref : public __memory_pool_base
+class pinned_memory_pool_ref
+    : public __memory_pool_base
+    , public ::cuda::mr::memory_resource_base<pinned_memory_pool_ref>
 {
 public:
   //! @brief  Constructs the pinned_memory_pool_ref from a \c cudaMemPool_t.

--- a/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
@@ -37,18 +37,35 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_MR
 
 template <class _Tp>
+_CCCL_CONCEPT __has_get_memory_resource_method =
+  _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)(__t.get_memory_resource());
+
+template <class _Tp>
+_CCCL_CONCEPT __is_synchronous_resource_env = synchronous_resource<_Tp> && !__has_get_memory_resource_method<_Tp>;
+
+template <class _Tp>
 _CCCL_CONCEPT __has_member_get_resource = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)(
+  requires(!__is_synchronous_resource_env<_Tp>),
   requires(resource<::cuda::std::remove_cvref_t<decltype(__t.get_memory_resource())>>));
 
 template <class _Env>
 _CCCL_CONCEPT __has_query_get_memory_resource = _CCCL_REQUIRES_EXPR(
-  (_Env))(requires(!__has_member_get_resource<_Env>),
+  (_Env))(requires(!__is_synchronous_resource_env<_Env>),
+          requires(!__has_member_get_resource<_Env>),
           requires(::cuda::std::execution::__queryable_with<const _Env&, __get_memory_resource_t>));
 
 //! @brief `__get_memory_resource_t` is a customization point object that queries a type `T` for an associated memory
 //! resource
 struct __get_memory_resource_t
 {
+  _CCCL_EXEC_CHECK_DISABLE
+  _CCCL_TEMPLATE(class _Tp)
+  _CCCL_REQUIRES(__is_synchronous_resource_env<_Tp>)
+  [[nodiscard]] _CCCL_API constexpr _Tp& operator()(_Tp& __t) const noexcept
+  {
+    return __t;
+  }
+
   _CCCL_EXEC_CHECK_DISABLE
   _CCCL_TEMPLATE(class _Tp)
   _CCCL_REQUIRES(__has_member_get_resource<_Tp>)

--- a/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/get_memory_resource.h
@@ -37,8 +37,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_MR
 
 template <class _Tp>
-_CCCL_CONCEPT __has_get_memory_resource_method =
-  _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)(__t.get_memory_resource());
+_CCCL_CONCEPT __has_get_memory_resource_method = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& __t)(__t.get_memory_resource());
 
 template <class _Tp>
 _CCCL_CONCEPT __is_synchronous_resource_env = synchronous_resource<_Tp> && !__has_get_memory_resource_method<_Tp>;
@@ -49,10 +48,10 @@ _CCCL_CONCEPT __has_member_get_resource = _CCCL_REQUIRES_EXPR((_Tp), const _Tp& 
   requires(resource<::cuda::std::remove_cvref_t<decltype(__t.get_memory_resource())>>));
 
 template <class _Env>
-_CCCL_CONCEPT __has_query_get_memory_resource = _CCCL_REQUIRES_EXPR(
-  (_Env))(requires(!__is_synchronous_resource_env<_Env>),
-          requires(!__has_member_get_resource<_Env>),
-          requires(::cuda::std::execution::__queryable_with<const _Env&, __get_memory_resource_t>));
+_CCCL_CONCEPT __has_query_get_memory_resource = _CCCL_REQUIRES_EXPR((_Env))(
+  requires(!__is_synchronous_resource_env<_Env>),
+  requires(!__has_member_get_resource<_Env>),
+  requires(::cuda::std::execution::__queryable_with<const _Env&, __get_memory_resource_t>));
 
 //! @brief `__get_memory_resource_t` is a customization point object that queries a type `T` for an associated memory
 //! resource

--- a/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_managed_memory_resource.h
@@ -25,6 +25,7 @@
 
 #  include <cuda/__memory_resource/any_resource.h>
 #  include <cuda/__memory_resource/get_property.h>
+#  include <cuda/__memory_resource/memory_resource_base.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__memory_resource/resource.h>
 #  include <cuda/__runtime/api_wrapper.h>
@@ -40,7 +41,7 @@
 _CCCL_BEGIN_NAMESPACE_CUDA_MR
 
 //! @brief \c managed_memory_resource uses `cudaMallocManaged` / `cudaFree` for allocation / deallocation.
-class legacy_managed_memory_resource
+class legacy_managed_memory_resource : public memory_resource_base<legacy_managed_memory_resource>
 {
 private:
   unsigned int __flags_ = cudaMemAttachGlobal;

--- a/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/legacy_pinned_memory_resource.h
@@ -24,6 +24,7 @@
 #if _CCCL_HAS_CTK()
 
 #  include <cuda/__device/device_ref.h>
+#  include <cuda/__memory_resource/memory_resource_base.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__memory_resource/resource.h>
 #  include <cuda/__runtime/api_wrapper.h>
@@ -41,7 +42,7 @@ _CCCL_BEGIN_NAMESPACE_CUDA_MR
 //! @brief legacy_pinned_memory_resource uses `cudaMallocHost` / `cudaFreeAsync` for allocation / deallocation.
 //! @note This memory resource will be deprecated in the future. For CUDA 12.9 and above, use
 //! `cuda::pinned_memory_resource` instead, which is the long-term replacement.
-class legacy_pinned_memory_resource
+class legacy_pinned_memory_resource : public memory_resource_base<legacy_pinned_memory_resource>
 {
 public:
   //! @brief Construct a new legacy_pinned_memory_resource.

--- a/libcudacxx/include/cuda/__memory_resource/memory_resource_base.h
+++ b/libcudacxx/include/cuda/__memory_resource/memory_resource_base.h
@@ -1,0 +1,53 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of libcu++, the C++ Standard Library for your entire system,
+// under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef _CUDA___MEMORY_RESOURCE_MEMORY_RESOURCE_BASE_H
+#define _CUDA___MEMORY_RESOURCE_MEMORY_RESOURCE_BASE_H
+
+#include <cuda/std/detail/__config>
+
+#if defined(_CCCL_IMPLICIT_SYSTEM_HEADER_GCC)
+#  pragma GCC system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_CLANG)
+#  pragma clang system_header
+#elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
+#  pragma system_header
+#endif // no system header
+
+#if _CCCL_HAS_CTK()
+
+#  include <cuda/__fwd/get_memory_resource.h>
+
+#  include <cuda/std/__cccl/prologue.h>
+
+_CCCL_BEGIN_NAMESPACE_CUDA_MR
+
+//! @brief CRTP base class for memory resources.
+//!
+//! When a resource inherits from `memory_resource_base<Derived>`, it provides a
+//! `query(get_memory_resource_t)` method that returns a const reference to itself.
+//! This enables the resource to be discovered inside a composed
+//! `cuda::std::execution::env` by the `get_memory_resource` customization point.
+template <class _Derived>
+struct memory_resource_base
+{
+  [[nodiscard]] _CCCL_API constexpr const _Derived& query(const __get_memory_resource_t&) const noexcept
+  {
+    return static_cast<const _Derived&>(*this);
+  }
+};
+
+_CCCL_END_NAMESPACE_CUDA_MR
+
+#  include <cuda/std/__cccl/epilogue.h>
+
+#endif // _CCCL_HAS_CTK()
+
+#endif // _CUDA___MEMORY_RESOURCE_MEMORY_RESOURCE_BASE_H

--- a/libcudacxx/include/cuda/__memory_resource/shared_resource.h
+++ b/libcudacxx/include/cuda/__memory_resource/shared_resource.h
@@ -23,6 +23,7 @@
 
 #if _CCCL_HAS_CTK()
 
+#  include <cuda/__memory_resource/memory_resource_base.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__memory_resource/resource.h>
 #  include <cuda/std/__new_>
@@ -55,6 +56,7 @@ template <class _Resource>
 struct shared_resource
     : ::cuda::mr::__copy_default_queries<_Resource>
     , ::cuda::forward_property<shared_resource<_Resource>, _Resource>
+    , ::cuda::mr::memory_resource_base<shared_resource<_Resource>>
 {
   static_assert(::cuda::mr::synchronous_resource<_Resource>);
 

--- a/libcudacxx/include/cuda/__memory_resource/synchronous_resource_adapter.h
+++ b/libcudacxx/include/cuda/__memory_resource/synchronous_resource_adapter.h
@@ -24,6 +24,7 @@
 #if _CCCL_HAS_CTK()
 
 #  include <cuda/__memory_resource/get_property.h>
+#  include <cuda/__memory_resource/memory_resource_base.h>
 #  include <cuda/__memory_resource/properties.h>
 #  include <cuda/__memory_resource/resource.h>
 #  include <cuda/std/__concepts/concept_macros.h>
@@ -54,6 +55,7 @@ template <class _Resource>
 struct synchronous_resource_adapter
     : ::cuda::mr::__copy_default_queries<_Resource>
     , ::cuda::forward_property<synchronous_resource_adapter<_Resource>, _Resource>
+    , ::cuda::mr::memory_resource_base<synchronous_resource_adapter<_Resource>>
 {
   _CCCL_HOST_API synchronous_resource_adapter(const _Resource& __resource) noexcept
       : __resource(__resource)

--- a/libcudacxx/test/libcudacxx/cuda/memory_resource/get_memory_resource/get_memory_resource.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/memory_resource/get_memory_resource/get_memory_resource.pass.cpp
@@ -191,6 +191,89 @@ TEST_FUNC void test()
     assert(val.res_ == res_query);
   }
 
+  { // Can call get_memory_resource directly on a synchronous_resource (returns ref to itself)
+    struct sync_only_resource
+    {
+      __host__ __device__ void* allocate_sync(std::size_t, std::size_t)
+      {
+        return nullptr;
+      }
+
+      __host__ __device__ void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+
+      __host__ __device__ bool operator==(const sync_only_resource&) const noexcept
+      {
+        return true;
+      }
+
+      __host__ __device__ bool operator!=(const sync_only_resource&) const noexcept
+      {
+        return false;
+      }
+    };
+    static_assert(::cuda::mr::synchronous_resource<sync_only_resource>);
+    static_assert(::cuda::std::is_invocable_v<::cuda::mr::get_memory_resource_t, sync_only_resource&>);
+
+    sync_only_resource val{};
+    auto&& res = ::cuda::mr::get_memory_resource(val);
+    static_assert(cuda::std::is_same_v<decltype(res), sync_only_resource&>);
+    assert(&res == &val);
+  }
+
+  { // Can call get_memory_resource directly on a full async resource (returns ref to itself)
+    static_assert(::cuda::mr::resource<test_resource>);
+    static_assert(::cuda::std::is_invocable_v<::cuda::mr::get_memory_resource_t, test_resource&>);
+
+    test_resource val{};
+    auto&& res = ::cuda::mr::get_memory_resource(val);
+    static_assert(cuda::std::is_same_v<decltype(res), test_resource&>);
+    assert(&res == &val);
+  }
+
+  { // A resource with get_memory_resource method uses the method, not the direct path
+    struct resource_with_method
+    {
+      test_resource inner_{};
+
+      __host__ __device__ void* allocate_sync(std::size_t, std::size_t)
+      {
+        return nullptr;
+      }
+
+      __host__ __device__ void deallocate_sync(void*, std::size_t, std::size_t) noexcept {}
+
+      __host__ __device__ void* allocate(cuda::stream_ref, std::size_t, std::size_t)
+      {
+        return nullptr;
+      }
+
+      __host__ __device__ void deallocate(cuda::stream_ref, void*, std::size_t, std::size_t) noexcept {}
+
+      __host__ __device__ bool operator==(const resource_with_method&) const noexcept
+      {
+        return true;
+      }
+
+      __host__ __device__ bool operator!=(const resource_with_method&) const noexcept
+      {
+        return false;
+      }
+
+      __host__ __device__ const test_resource& get_memory_resource() const noexcept
+      {
+        return inner_;
+      }
+    };
+    static_assert(::cuda::mr::resource<resource_with_method>);
+    static_assert(::cuda::std::is_invocable_v<::cuda::mr::get_memory_resource_t, const resource_with_method&>);
+
+    resource_with_method val{};
+    auto&& res = ::cuda::mr::get_memory_resource(val);
+    // Should return the inner resource via get_memory_resource(), not val itself
+    static_assert(cuda::std::is_same_v<decltype(res), const test_resource&>);
+    assert(&res == &val.inner_);
+  }
+
   { // Cannot call get_memory_resource on an env with a non-async resource
     struct with_get_resource_non_async
     {


### PR DESCRIPTION
Right now when an API takes an environment, in order to use `get_memory_resource` on that environment it needs to be wrapped in `cuda::std::execution::prop`. It would be nice to put the resource directly into it, to make it work this PR adds a CRTP base class for resources that implements `query(get_memory_resource)` that allows it to work with the environment machinery.