### PR TITLE
Cleanup `thrust::pointer_traits` a bit more

### DIFF
--- a/thrust/thrust/detail/allocator/copy_construct_range.h
+++ b/thrust/thrust/detail/allocator/copy_construct_range.h
@@ -16,7 +16,6 @@
 #include <thrust/detail/allocator/allocator_system.h>
 #include <thrust/detail/copy.h>
 #include <thrust/detail/execution_policy.h>
-#include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/for_each.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/iterator/zip_iterator.h>
@@ -25,6 +24,7 @@
 #include <cuda/std/__iterator/advance.h>
 #include <cuda/std/__iterator/distance.h>
 #include <cuda/std/__memory/allocator_traits.h>
+#include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/__type_traits/is_convertible.h>
 #include <cuda/std/__type_traits/is_trivially_copy_constructible.h>
 #include <cuda/std/tuple>
@@ -151,7 +151,8 @@ template <typename System, typename Allocator, typename InputIterator, typename 
 _CCCL_HOST_DEVICE Pointer copy_construct_range(
   thrust::execution_policy<System>& from_system, Allocator& a, InputIterator first, InputIterator last, Pointer result)
 {
-  if constexpr (needs_copy_construct_via_allocator<Allocator, typename pointer_element<Pointer>::type>)
+  if constexpr (needs_copy_construct_via_allocator<Allocator,
+                                                   typename ::cuda::std::pointer_traits<Pointer>::element_type>)
   {
     return uninitialized_copy_with_allocator(a, from_system, allocator_system<Allocator>::get(a), first, last, result);
   }
@@ -166,7 +167,8 @@ template <typename System, typename Allocator, typename InputIterator, typename 
 _CCCL_HOST_DEVICE Pointer copy_construct_range_n(
   thrust::execution_policy<System>& from_system, Allocator& a, InputIterator first, Size n, Pointer result)
 {
-  if constexpr (needs_copy_construct_via_allocator<Allocator, typename pointer_element<Pointer>::type>)
+  if constexpr (needs_copy_construct_via_allocator<Allocator,
+                                                   typename ::cuda::std::pointer_traits<Pointer>::element_type>)
   {
     return uninitialized_copy_with_allocator_n(a, from_system, allocator_system<Allocator>::get(a), first, n, result);
   }

--- a/thrust/thrust/detail/allocator/destroy_range.h
+++ b/thrust/thrust/detail/allocator/destroy_range.h
@@ -15,11 +15,11 @@
 
 #include <thrust/detail/allocator/allocator_system.h>
 #include <thrust/detail/allocator/destroy_range.h>
-#include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/for_each.h>
 
 #include <cuda/std/__host_stdlib/memory>
 #include <cuda/std/__memory/allocator_traits.h>
+#include <cuda/std/__memory/pointer_traits.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -65,7 +65,7 @@ template <typename Allocator, typename Pointer, typename Size>
 _CCCL_HOST_DEVICE void
 destroy_range([[maybe_unused]] Allocator& a, [[maybe_unused]] Pointer p, [[maybe_unused]] Size n) noexcept
 {
-  using pe_t = typename pointer_element<Pointer>::type;
+  using pe_t = typename ::cuda::std::pointer_traits<Pointer>::element_type;
 
   // case 1: destroy via allocator
   if constexpr (has_effectful_member_destroy<Allocator, pe_t>)

--- a/thrust/thrust/detail/allocator/fill_construct_range.h
+++ b/thrust/thrust/detail/allocator/fill_construct_range.h
@@ -15,12 +15,12 @@
 
 #include <thrust/detail/allocator/allocator_system.h>
 #include <thrust/detail/type_traits.h>
-#include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/for_each.h>
 #include <thrust/uninitialized_fill.h>
 
 #include <cuda/std/__host_stdlib/memory>
 #include <cuda/std/__memory/allocator_traits.h>
+#include <cuda/std/__memory/pointer_traits.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -53,7 +53,7 @@ struct construct2_via_allocator
 template <typename Allocator, typename Pointer, typename Size, typename T>
 _CCCL_HOST_DEVICE void fill_construct_range(Allocator& a, Pointer p, Size n, const T& value)
 {
-  if constexpr (has_effectful_member_construct2<Allocator, typename pointer_element<Pointer>::type, T>)
+  if constexpr (has_effectful_member_construct2<Allocator, typename ::cuda::std::pointer_traits<Pointer>::element_type, T>)
   {
     thrust::for_each_n(allocator_system<Allocator>::get(a), p, n, construct2_via_allocator<Allocator, T>{a, value});
   }

--- a/thrust/thrust/detail/allocator/value_initialize_range.h
+++ b/thrust/thrust/detail/allocator/value_initialize_range.h
@@ -15,11 +15,11 @@
 
 #include <thrust/detail/allocator/allocator_system.h>
 #include <thrust/detail/type_traits.h>
-#include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/for_each.h>
 #include <thrust/uninitialized_fill.h>
 
 #include <cuda/std/__memory/allocator_traits.h>
+#include <cuda/std/__memory/pointer_traits.h>
 
 THRUST_NAMESPACE_BEGIN
 namespace detail
@@ -52,13 +52,15 @@ inline constexpr bool needs_default_construct_via_allocator<std::allocator<U>, T
 template <typename Allocator, typename Pointer, typename Size>
 _CCCL_HOST_DEVICE void value_initialize_range(Allocator& a, Pointer p, Size n)
 {
-  if constexpr (needs_default_construct_via_allocator<Allocator, typename pointer_element<Pointer>::type>)
+  if constexpr (needs_default_construct_via_allocator<Allocator,
+                                                      typename ::cuda::std::pointer_traits<Pointer>::element_type>)
   {
     thrust::for_each_n(allocator_system<Allocator>::get(a), p, n, construct1_via_allocator<Allocator>{a});
   }
   else
   {
-    thrust::uninitialized_fill_n(allocator_system<Allocator>::get(a), p, n, typename pointer_element<Pointer>::type());
+    thrust::uninitialized_fill_n(
+      allocator_system<Allocator>::get(a), p, n, typename ::cuda::std::pointer_traits<Pointer>::element_type());
   }
 }
 } // namespace detail

--- a/thrust/thrust/detail/execute_with_allocator.h
+++ b/thrust/thrust/detail/execute_with_allocator.h
@@ -15,10 +15,10 @@
 
 #include <thrust/detail/execute_with_allocator_fwd.h>
 #include <thrust/detail/raw_pointer_cast.h>
-#include <thrust/detail/type_traits/pointer_traits.h>
 
 #include <cuda/__cmath/ceil_div.h>
 #include <cuda/std/__memory/allocator_traits.h>
+#include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/__utility/pair.h>
 
 THRUST_NAMESPACE_BEGIN
@@ -54,7 +54,7 @@ _CCCL_HOST void return_temporary_buffer(
   using pointer         = typename alloc_traits::pointer;
   using size_type       = typename alloc_traits::size_type;
   using value_type      = typename alloc_traits::value_type;
-  using T               = typename thrust::detail::pointer_traits<Pointer>::element_type;
+  using T               = typename ::cuda::std::pointer_traits<Pointer>::element_type;
 
   size_type num_elements = ::cuda::ceil_div(sizeof(T) * n, sizeof(value_type));
 

--- a/thrust/thrust/detail/get_iterator_value.h
+++ b/thrust/thrust/detail/get_iterator_value.h
@@ -13,10 +13,11 @@
 #  pragma system_header
 #endif // no system header
 
-#include <thrust/detail/type_traits/pointer_traits.h>
 #include <thrust/execution_policy.h>
 #include <thrust/iterator/iterator_traits.h>
 #include <thrust/system/detail/generic/memory.h> // for get_value()
+
+#include <cuda/std/__memory/pointer_traits.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -38,7 +39,7 @@ _CCCL_HOST_DEVICE it_value_t<Iterator> get_iterator_value(thrust::execution_poli
 // we use get_value(exec,pointer*) function
 // to perform a dereferencing consistent with the execution policy
 template <typename DerivedPolicy, typename Pointer>
-_CCCL_HOST_DEVICE typename thrust::detail::pointer_traits<Pointer*>::element_type
+_CCCL_HOST_DEVICE typename ::cuda::std::pointer_traits<Pointer*>::element_type
 get_iterator_value(thrust::execution_policy<DerivedPolicy>& exec, Pointer* ptr)
 {
   return get_value(derived_cast(exec), ptr);

--- a/thrust/thrust/detail/raw_pointer_cast.h
+++ b/thrust/thrust/detail/raw_pointer_cast.h
@@ -12,7 +12,10 @@
 #elif defined(_CCCL_IMPLICIT_SYSTEM_HEADER_MSVC)
 #  pragma system_header
 #endif // no system header
+
 #include <thrust/detail/type_traits/pointer_traits.h>
+
+#include <cuda/std/__memory/pointer_traits.h>
 
 THRUST_NAMESPACE_BEGIN
 
@@ -25,14 +28,14 @@ _CCCL_HOST_DEVICE typename thrust::detail::pointer_traits<Pointer>::raw_pointer 
 template <typename ToPointer, typename FromPointer>
 _CCCL_HOST_DEVICE ToPointer reinterpret_pointer_cast(FromPointer ptr)
 {
-  using to_element = typename thrust::detail::pointer_element<ToPointer>::type;
+  using to_element = typename ::cuda::std::pointer_traits<ToPointer>::element_type;
   return ToPointer(reinterpret_cast<to_element*>(thrust::raw_pointer_cast(ptr)));
 }
 
 template <typename ToPointer, typename FromPointer>
 _CCCL_HOST_DEVICE ToPointer static_pointer_cast(FromPointer ptr)
 {
-  using to_element = typename thrust::detail::pointer_element<ToPointer>::type;
+  using to_element = typename ::cuda::std::pointer_traits<ToPointer>::element_type;
   return ToPointer(static_cast<to_element*>(thrust::raw_pointer_cast(ptr)));
 }
 

--- a/thrust/thrust/detail/raw_reference_cast.h
+++ b/thrust/thrust/detail/raw_reference_cast.h
@@ -17,6 +17,7 @@
 #include <thrust/detail/type_traits.h>
 #include <thrust/detail/type_traits/has_nested_type.h>
 
+#include <cuda/std/__memory/pointer_traits.h>
 #include <cuda/std/__tuple_dir/apply.h>
 #include <cuda/std/__type_traits/add_lvalue_reference.h>
 #include <cuda/std/__type_traits/enable_if.h>
@@ -62,7 +63,7 @@ struct raw_reference_impl : ::cuda::std::add_lvalue_reference<T>
 
 template <typename T>
 struct raw_reference_impl<T, ::cuda::std::enable_if_t<is_wrapped_reference<::cuda::std::remove_cv_t<T>>::value>>
-    : ::cuda::std::add_lvalue_reference<typename pointer_element<typename T::pointer>::type>
+    : ::cuda::std::add_lvalue_reference<typename ::cuda::std::pointer_traits<typename T::pointer>::element_type>
 {};
 
 template <typename T>

--- a/thrust/thrust/detail/type_traits/pointer_traits.h
+++ b/thrust/thrust/detail/type_traits/pointer_traits.h
@@ -30,33 +30,6 @@
 THRUST_NAMESPACE_BEGIN
 namespace detail
 {
-template <typename Ptr>
-struct pointer_element;
-
-template <template <typename...> class Ptr, typename FirstArg, typename... Args>
-struct pointer_element<Ptr<FirstArg, Args...>>
-{
-  using type = FirstArg;
-};
-
-template <typename T>
-struct pointer_element<T*>
-{
-  using type = T;
-};
-
-template <typename Ptr>
-struct pointer_difference
-{
-  using type = typename Ptr::difference_type;
-};
-
-template <typename T>
-struct pointer_difference<T*>
-{
-  using type = ::cuda::std::ptrdiff_t;
-};
-
 template <typename Ptr, typename T>
 struct rebind_pointer;
 
@@ -161,8 +134,8 @@ struct pointer_traits
 {
   using pointer         = Ptr;
   using reference       = typename Ptr::reference;
-  using element_type    = typename pointer_element<Ptr>::type;
-  using difference_type = typename pointer_difference<Ptr>::type;
+  using element_type    = typename ::cuda::std::pointer_traits<pointer>::element_type;
+  using difference_type = typename ::cuda::std::pointer_traits<pointer>::difference_type;
 
   template <typename U>
   struct rebind
@@ -195,7 +168,7 @@ struct pointer_traits<T*>
   using pointer         = T*;
   using reference       = T&;
   using element_type    = T;
-  using difference_type = typename pointer_difference<T*>::type;
+  using difference_type = typename ::cuda::std::pointer_traits<pointer>::difference_type;
 
   template <typename U>
   struct rebind
@@ -224,7 +197,7 @@ struct pointer_traits<void*>
   using pointer         = void*;
   using reference       = void;
   using element_type    = void;
-  using difference_type = pointer_difference<void*>::type;
+  using difference_type = typename ::cuda::std::pointer_traits<pointer>::difference_type;
 
   template <typename U>
   struct rebind
@@ -252,7 +225,7 @@ struct pointer_traits<const void*>
   using pointer         = const void*;
   using reference       = const void;
   using element_type    = const void;
-  using difference_type = pointer_difference<const void*>::type;
+  using difference_type = typename ::cuda::std::pointer_traits<pointer>::difference_type;
 
   template <typename U>
   struct rebind
@@ -280,12 +253,13 @@ inline constexpr bool is_pointer_system_convertible_v =
 
 template <typename FromPtr, typename ToPtr>
 inline constexpr bool is_pointer_convertible_v =
-  ::cuda::std::is_convertible_v<typename pointer_element<FromPtr>::type*, typename pointer_element<ToPtr>::type*>
+  ::cuda::std::is_convertible_v<typename ::cuda::std::pointer_traits<FromPtr>::element_type*,
+                                typename ::cuda::std::pointer_traits<ToPtr>::element_type*>
   && is_pointer_system_convertible_v<FromPtr, ToPtr>;
 
 template <typename FromPtr, typename ToPtr>
 inline constexpr bool is_void_pointer_system_convertible_v =
-  ::cuda::std::is_void_v<typename pointer_element<FromPtr>::type> //
+  ::cuda::std::is_void_v<typename ::cuda::std::pointer_traits<FromPtr>::element_type> //
   && is_pointer_system_convertible_v<FromPtr, ToPtr>;
 
 // avoid inspecting traits of the arguments if they aren't known to be pointers

--- a/thrust/thrust/mr/allocator.h
+++ b/thrust/thrust/mr/allocator.h
@@ -24,6 +24,7 @@
 #include <thrust/mr/polymorphic_adaptor.h>
 #include <thrust/mr/validator.h>
 
+#include <cuda/std/__iterator/iterator_traits.h>
 #include <cuda/std/limits>
 
 THRUST_NAMESPACE_BEGIN
@@ -57,9 +58,9 @@ public:
   /*! The pointer to const type. Equivalent to a pointer type of \p MR rebound to <tt>const T</tt>. */
   using const_pointer = typename thrust::detail::pointer_traits<void_pointer>::template rebind<const T>::other;
   /*! The reference to the type allocated by this allocator. Supports smart references. */
-  using reference = typename thrust::detail::pointer_traits<pointer>::reference;
+  using reference = typename ::cuda::std::iterator_traits<pointer>::reference;
   /*! The const reference to the type allocated by this allocator. Supports smart references. */
-  using const_reference = typename thrust::detail::pointer_traits<const_pointer>::reference;
+  using const_reference = typename ::cuda::std::iterator_traits<const_pointer>::reference;
   /*! The size type of this allocator. Always \p std::size_t. */
   using size_type = std::size_t;
   /*! The difference type between pointers allocated by this allocator. */


### PR DESCRIPTION
We can rely on the standard `cuda::std::pointer_traits` for `element_type` and `difference_type`
