### PR TITLE
Fix typo in cub/.clang-tidy

### DIFF
--- a/cub/.clang-tidy
+++ b/cub/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-IncludeParentConfig: true
+InheritParentConfig: true
 CheckOptions:
  - key:             modernize-loop-convert.MaxCopySize
    value:           '16'

--- a/cub/test/catch2_test_device_segmented_sort_pairs_env_api.cu
+++ b/cub/test/catch2_test_device_segmented_sort_pairs_env_api.cu
@@ -201,7 +201,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairs nonstable env-based API", "[segmen
     stream_ref);
   if (error != cudaSuccess)
   {
-    std::cerr << "cub::DeviceSegmentedSort::SortPairs failed with status: " << error << std::endl;
+    std::cerr << "cub::DeviceSegmentedSort::SortPairs failed with status: " << error << '\n';
   }
 
   thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
@@ -239,7 +239,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable env-based API"
     stream_ref);
   if (error != cudaSuccess)
   {
-    std::cerr << "cub::DeviceSegmentedSort::SortPairsDescending failed with status: " << error << std::endl;
+    std::cerr << "cub::DeviceSegmentedSort::SortPairsDescending failed with status: " << error << '\n';
   }
 
   thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};
@@ -279,7 +279,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairs nonstable DoubleBuffer env-based A
     stream_ref);
   if (error != cudaSuccess)
   {
-    std::cerr << "cub::DeviceSegmentedSort::SortPairs (DoubleBuffer) failed with status: " << error << std::endl;
+    std::cerr << "cub::DeviceSegmentedSort::SortPairs (DoubleBuffer) failed with status: " << error << '\n';
   }
 
   thrust::device_vector<int> expected_keys{6, 7, 8, 0, 3, 5, 9};
@@ -322,8 +322,7 @@ C2H_TEST("cub::DeviceSegmentedSort::SortPairsDescending nonstable DoubleBuffer e
     stream_ref);
   if (error != cudaSuccess)
   {
-    std::cerr
-      << "cub::DeviceSegmentedSort::SortPairsDescending (DoubleBuffer) failed with status: " << error << std::endl;
+    std::cerr << "cub::DeviceSegmentedSort::SortPairsDescending (DoubleBuffer) failed with status: " << error << '\n';
   }
 
   thrust::device_vector<int> expected_keys{8, 7, 6, 9, 5, 3, 0};


### PR DESCRIPTION
## Description

<!-- Every PR should have a corresponding issue that describes and motivates the work done in the PR -->

Not sure why this wasn't causing the original PR to fail.

<!-- Provide a standalone description of changes in this PR. -->

<!-- Note: The pull request title will be included in the CHANGELOG. -->

## Checklist
<!-- TODO: - [ ] I am familiar with the [Contributing Guidelines](). -->
- [ ] New or existing tests cover these changes.
- [ ] The documentation is up to date with these changes.
