### PR TITLE
Warpspeed micro optimizations

### DIFF
--- a/cub/cub/detail/warpspeed/squad/load_store.cuh
+++ b/cub/cub/detail/warpspeed/squad/load_store.cuh
@@ -234,7 +234,7 @@ squadStoreBulkSync(Squad squad, CpAsyncOobInfo<OutputT> cpAsyncOobInfo, const ::
 
     const bool doStartCopy  = cpAsyncOobInfo.smemStartSkipBytes > 0;
     const bool doEndCopy    = cpAsyncOobInfo.smemEndBytesAfter16BBoundary > 0;
-    const bool doMiddleCopy = cpAsyncOobInfo.ptrGmemStartAlignUp != cpAsyncOobInfo.ptrGmemEndAlignUp;
+    const bool doMiddleCopy = cpAsyncOobInfo.ptrGmemStartAlignUp < cpAsyncOobInfo.ptrGmemEndAlignDown;
 
     constexpr ::cuda::std::uint16_t byteMask  = 0xFFFF;
     const ::cuda::std::uint16_t byteMaskStart = byteMask << cpAsyncOobInfo.smemStartSkipBytes;

--- a/cub/cub/detail/warpspeed/squad/load_store.cuh
+++ b/cub/cub/detail/warpspeed/squad/load_store.cuh
@@ -234,7 +234,7 @@ squadStoreBulkSync(Squad squad, CpAsyncOobInfo<OutputT> cpAsyncOobInfo, const ::
 
     const bool doStartCopy  = cpAsyncOobInfo.smemStartSkipBytes > 0;
     const bool doEndCopy    = cpAsyncOobInfo.smemEndBytesAfter16BBoundary > 0;
-    const bool doMiddleCopy = cpAsyncOobInfo.ptrGmemStartAlignUp < cpAsyncOobInfo.ptrGmemEndAlignDown;
+    const bool doMiddleCopy = cpAsyncOobInfo.ptrGmemStartAlignUp != cpAsyncOobInfo.ptrGmemEndAlignUp;
 
     constexpr ::cuda::std::uint16_t byteMask  = 0xFFFF;
     const ::cuda::std::uint16_t byteMaskStart = byteMask << cpAsyncOobInfo.smemStartSkipBytes;

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -299,13 +299,13 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void kernelBody(
   ////////////////////////////////////////////////////////////////////////////////
   // Resources
   ////////////////////////////////////////////////////////////////////////////////
-  warpspeed::SyncHandler syncHandler{};
-  warpspeed::SmemAllocator smemAllocator{};
-
-  ScanResources<PolicySelector, InputT, OutputT, AccumT> res =
-    allocResources<PolicySelector, InputT, OutputT, AccumT>(syncHandler, smemAllocator, params.numStages);
-
-  syncHandler.clusterInitSync(specialRegisters);
+  ScanResources<PolicySelector, InputT, OutputT, AccumT> res = [&] {
+    warpspeed::SyncHandler syncHandler{};
+    warpspeed::SmemAllocator smemAllocator{};
+    auto r = allocResources<PolicySelector, InputT, OutputT, AccumT>(syncHandler, smemAllocator, params.numStages);
+    syncHandler.clusterInitSync(specialRegisters);
+    return r;
+  }();
 
   // Inclusive scan if no init_value type is provided
   static constexpr bool hasInit     = !::cuda::std::is_same_v<RealInitValueT, NullType>;

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -277,7 +277,8 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void kernelBody(
   warpspeed::SpecialRegisters specialRegisters,
   const scanKernelParams<InputT, OutputT, AccumT>& params,
   ScanOpT scan_op,
-  RealInitValueT real_init_value)
+  RealInitValueT real_init_value,
+  ScanResources<PolicySelector, InputT, OutputT, AccumT>& res)
 {
   static constexpr scan_warpspeed_policy policy        = get_warpspeed_policy<PolicySelector>();
   static constexpr warpspeed::SquadDesc squadReduce    = squad_reduce(policy);
@@ -296,17 +297,6 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void kernelBody(
   // Inclusive scan if no init_value type is provided
   static constexpr bool hasInit     = !::cuda::std::is_same_v<RealInitValueT, NullType>;
   static constexpr bool isInclusive = ForceInclusive || !hasInit;
-
-  ////////////////////////////////////////////////////////////////////////////////
-  // Resources
-  ////////////////////////////////////////////////////////////////////////////////
-  ScanResources<PolicySelector, InputT, OutputT, AccumT> res = [&] {
-    warpspeed::SyncHandler syncHandler{};
-    warpspeed::SmemAllocator smemAllocator{};
-    auto r = allocResources<PolicySelector, InputT, OutputT, AccumT>(syncHandler, smemAllocator, params.numStages);
-    syncHandler.clusterInitSync(specialRegisters);
-    return r;
-  }();
 
   ////////////////////////////////////////////////////////////////////////////////
   // Pre-loop
@@ -822,10 +812,18 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_lookahead_body(
     squad_lookback(policy),
   };
 
+  ScanResources<PolicySelector, InputT, OutputT, AccumT> res = [&] {
+    warpspeed::SyncHandler syncHandler{};
+    warpspeed::SmemAllocator smemAllocator{};
+    auto r = allocResources<PolicySelector, InputT, OutputT, AccumT>(syncHandler, smemAllocator, params.numStages);
+    syncHandler.clusterInitSync(specialRegisters);
+    return r;
+  }();
+
   // we need to force inline the lambda, but clang in CUDA mode only likes the GNU syntax
   warpspeed::squadDispatch(specialRegisters, scanSquads, [&](warpspeed::Squad squad) _CCCL_FORCEINLINE_LAMBDA {
     kernelBody<PolicySelector, InputT, OutputT, AccumT, ScanOpT, RealInitValueT, ForceInclusive>(
-      squad, specialRegisters, params, ::cuda::std::move(scan_op), static_cast<RealInitValueT>(init_value));
+      squad, specialRegisters, params, ::cuda::std::move(scan_op), static_cast<RealInitValueT>(init_value), res);
   });
 #endif // __cccl_ptx_isa >= 860
 }

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -279,9 +279,6 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void kernelBody(
   ScanOpT scan_op,
   RealInitValueT real_init_value)
 {
-  ////////////////////////////////////////////////////////////////////////////////
-  // Tuning dependent variables
-  ////////////////////////////////////////////////////////////////////////////////
   static constexpr scan_warpspeed_policy policy        = get_warpspeed_policy<PolicySelector>();
   static constexpr warpspeed::SquadDesc squadReduce    = squad_reduce(policy);
   static constexpr warpspeed::SquadDesc squadScanStore = squad_scan_store(policy);
@@ -289,12 +286,16 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void kernelBody(
   static constexpr warpspeed::SquadDesc squadSched     = squad_sched(policy);
   static constexpr warpspeed::SquadDesc squadLookback  = squad_lookback(policy);
 
-  constexpr int tile_size                   = policy.tile_size();
-  constexpr int look_ahead_items_per_thread = policy.look_ahead_items_per_thread;
+  static constexpr int tile_size                   = policy.tile_size();
+  static constexpr int look_ahead_items_per_thread = policy.look_ahead_items_per_thread;
 
-  // We might try to instantiate the kernel with hughe types which would lead to a small tile size. Ensure its never 0
-  constexpr int elemPerThread = policy.items_per_thread;
+  // We might try to instantiate the kernel with huge types which would lead to a small tile size. Ensure its never 0
+  static constexpr int elemPerThread = policy.items_per_thread;
   static_assert(elemPerThread * squadReduce.threadCount() == tile_size, "Invalid tuning policy");
+
+  // Inclusive scan if no init_value type is provided
+  static constexpr bool hasInit     = !::cuda::std::is_same_v<RealInitValueT, NullType>;
+  static constexpr bool isInclusive = ForceInclusive || !hasInit;
 
   ////////////////////////////////////////////////////////////////////////////////
   // Resources
@@ -306,10 +307,6 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void kernelBody(
     syncHandler.clusterInitSync(specialRegisters);
     return r;
   }();
-
-  // Inclusive scan if no init_value type is provided
-  static constexpr bool hasInit     = !::cuda::std::is_same_v<RealInitValueT, NullType>;
-  static constexpr bool isInclusive = ForceInclusive || !hasInit;
 
   ////////////////////////////////////////////////////////////////////////////////
   // Pre-loop


### PR DESCRIPTION
Adds two micro optimizations

* ~~Avoids a bulk copy for storing of zero size~~ (reverted, causes a bug)
* limits the scope of the `SyncHandler` and `SmemAllocator`
* setup scan resources before dispatch

And a bonus refactoring of some constants at the kernel start.

The SASS changes a bit, the kernel now has a few instructions less.
```
## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I64      |      2^16      |  11.229 us |       3.26% |  11.284 us |       4.37% |   0.056 us |   0.50% |   SAME   |
|   I8    |      I64      |      2^20      |  12.645 us |       6.92% |  12.637 us |       6.95% |  -0.008 us |  -0.06% |   SAME   |
|   I8    |      I64      |      2^24      |  27.022 us |       3.55% |  27.189 us |       2.98% |   0.167 us |   0.62% |   SAME   |
|   I8    |      I64      |      2^28      | 217.644 us |       0.52% | 216.046 us |       0.50% |  -1.598 us |  -0.73% |   FAST   |
|   I8    |      I64      |      2^32      |   3.258 ms |       0.23% |   3.228 ms |       0.22% | -30.251 us |  -0.93% |   FAST   |
|   I16   |      I64      |      2^16      |  11.096 us |       0.94% |  11.099 us |       0.85% |   0.003 us |   0.03% |   SAME   |
|   I16   |      I64      |      2^20      |  13.219 us |       3.12% |  13.233 us |       3.21% |   0.014 us |   0.11% |   SAME   |
|   I16   |      I64      |      2^24      |  31.853 us |       5.01% |  31.521 us |       5.19% |  -0.331 us |  -1.04% |   SAME   |
|   I16   |      I64      |      2^28      | 213.988 us |       0.63% | 214.188 us |       0.67% |   0.200 us |   0.09% |   SAME   |
|   I16   |      I64      |      2^32      |   3.233 ms |       1.20% |   3.237 ms |       1.39% |   3.535 us |   0.11% |   SAME   |
|   I32   |      I64      |      2^16      |   9.747 us |       9.91% |   9.707 us |       9.89% |  -0.041 us |  -0.42% |   SAME   |
|   I32   |      I64      |      2^20      |  13.457 us |       6.09% |  13.705 us |       6.52% |   0.248 us |   1.84% |   SAME   |
|   I32   |      I64      |      2^24      |  38.227 us |       3.92% |  38.102 us |       4.68% |  -0.125 us |  -0.33% |   SAME   |
|   I32   |      I64      |      2^28      | 321.791 us |       0.55% | 321.954 us |       0.55% |   0.162 us |   0.05% |   SAME   |
|   I32   |      I64      |      2^32      |   5.102 ms |       1.13% |   5.091 ms |       1.21% | -11.281 us |  -0.22% |   SAME   |
|   I64   |      I64      |      2^16      |  11.258 us |       2.17% |  11.283 us |       1.20% |   0.025 us |   0.22% |   SAME   |
|   I64   |      I64      |      2^20      |  15.440 us |       3.81% |  15.473 us |       4.21% |   0.033 us |   0.21% |   SAME   |
|   I64   |      I64      |      2^24      |  60.081 us |       1.87% |  60.226 us |       2.01% |   0.145 us |   0.24% |   SAME   |
|   I64   |      I64      |      2^28      | 686.874 us |       0.17% | 688.208 us |       0.18% |   1.334 us |   0.19% |   SLOW   |
|   I64   |      I64      |      2^32      |  11.260 ms |       0.91% |  11.264 ms |       0.82% |   4.273 us |   0.04% |   SAME   |
|  I128   |      I64      |      2^16      |  13.035 us |       4.73% |  13.072 us |       4.17% |   0.038 us |   0.29% |   SAME   |
|  I128   |      I64      |      2^20      |  25.355 us |       3.60% |  25.119 us |       4.18% |  -0.236 us |  -0.93% |   SAME   |
|  I128   |      I64      |      2^24      | 173.144 us |       0.73% | 172.993 us |       0.66% |  -0.152 us |  -0.09% |   SAME   |
|  I128   |      I64      |      2^28      |   2.521 ms |       0.10% |   2.521 ms |       0.09% |   0.282 us |   0.01% |   SAME   |
|  I128   |      I64      |      2^32      |  40.175 ms |       0.02% |  40.173 ms |       0.02% |  -2.604 us |  -0.01% |   SAME   |
|   F32   |      I64      |      2^16      |  10.074 us |      10.46% |  10.094 us |      10.29% |   0.020 us |   0.20% |   SAME   |
|   F32   |      I64      |      2^20      |  14.327 us |       7.49% |  14.279 us |       7.19% |  -0.048 us |  -0.34% |   SAME   |
|   F32   |      I64      |      2^24      |  41.153 us |       3.55% |  41.303 us |       3.51% |   0.150 us |   0.37% |   SAME   |
|   F32   |      I64      |      2^28      | 345.244 us |       0.44% | 345.811 us |       0.44% |   0.567 us |   0.16% |   SAME   |
|   F32   |      I64      |      2^32      |   5.216 ms |       0.41% |   5.222 ms |       0.39% |   6.299 us |   0.12% |   SAME   |
|   F64   |      I64      |      2^16      |  11.054 us |       2.08% |  11.045 us |       2.02% |  -0.009 us |  -0.08% |   SAME   |
|   F64   |      I64      |      2^20      |  15.546 us |       3.82% |  15.549 us |       3.84% |   0.003 us |   0.02% |   SAME   |
|   F64   |      I64      |      2^24      |  64.794 us |       1.50% |  65.203 us |       1.66% |   0.409 us |   0.63% |   SAME   |
|   F64   |      I64      |      2^28      | 778.715 us |       0.14% | 779.808 us |       0.15% |   1.093 us |   0.14% |   SAME   |
|   F64   |      I64      |      2^32      |  12.223 ms |       0.01% |  12.233 ms |       0.01% |   9.897 us |   0.08% |   SLOW   |
|   C32   |      I64      |      2^16      |  10.818 us |       7.21% |  10.791 us |       7.36% |  -0.027 us |  -0.25% |   SAME   |
|   C32   |      I64      |      2^20      |  15.224 us |       2.23% |  15.241 us |       1.60% |   0.017 us |   0.11% |   SAME   |
|   C32   |      I64      |      2^24      |  59.083 us |       2.06% |  59.184 us |       2.01% |   0.101 us |   0.17% |   SAME   |
|   C32   |      I64      |      2^28      | 682.631 us |       0.17% | 682.193 us |       0.17% |  -0.438 us |  -0.06% |   SAME   |
|   C32   |      I64      |      2^32      |  10.670 ms |       0.02% |  10.662 ms |       0.02% |  -8.215 us |  -0.08% |   FAST   |

```