### PR TITLE
[libcu++] Add support for family-specific architectures

### DIFF
--- a/libcudacxx/include/cuda/__device/arch_id.h
+++ b/libcudacxx/include/cuda/__device/arch_id.h
@@ -37,29 +37,41 @@ _CCCL_BEGIN_NAMESPACE_CUDA
 //! capability. For example, sm_90 and sm_90a have the same compute capability, but the identifier is different.
 enum class arch_id : int
 {
-#define _CCCL_DEFINE_ARCH_ID(_CC)          sm_##_CC = _CC,
-#define _CCCL_DEFINE_ARCH_SPECIFIC_ID(_CC) sm_##_CC##a = _CC * __arch_specific_id_multiplier,
+#define _CCCL_DEFINE_ARCH_ID(_CC)            sm_##_CC = _CC,
+#define _CCCL_DEFINE_FAMILY_SPECIFIC_ID(_CC) sm_##_CC##f = _CC + __family_specific_id_offset,
+#define _CCCL_DEFINE_ARCH_SPECIFIC_ID(_CC)   sm_##_CC##a = _CC + __arch_specific_id_offset,
   _CCCL_PP_FOR_EACH(_CCCL_DEFINE_ARCH_ID, _CCCL_KNOWN_CUDA_ARCH_LIST)
-    _CCCL_PP_FOR_EACH(_CCCL_DEFINE_ARCH_SPECIFIC_ID, _CCCL_KNOWN_CUDA_ARCH_SPECIFIC_LIST)
+    _CCCL_PP_FOR_EACH(_CCCL_DEFINE_FAMILY_SPECIFIC_ID, _CCCL_KNOWN_CUDA_FAMILY_SPECIFIC_LIST)
+      _CCCL_PP_FOR_EACH(_CCCL_DEFINE_ARCH_SPECIFIC_ID, _CCCL_KNOWN_CUDA_ARCH_SPECIFIC_LIST)
 #undef _CCCL_DEFINE_ARCH_ID
+#undef _CCCL_DEFINE_FAMILY_SPECIFIC_ID
 #undef _CCCL_DEFINE_ARCH_SPECIFIC_ID
 };
 
 [[nodiscard]] _CCCL_API constexpr auto __all_arch_ids() noexcept
 {
   return ::cuda::std::array{
-#define _CCCL_MAKE_ARCH_ID(_CC)          arch_id::sm_##_CC,
-#define _CCCL_MAKE_ARCH_SPECIFIC_ID(_CC) arch_id::sm_##_CC##a,
+#define _CCCL_MAKE_ARCH_ID(_CC)            arch_id::sm_##_CC,
+#define _CCCL_MAKE_FAMILY_SPECIFIC_ID(_CC) arch_id::sm_##_CC##f,
+#define _CCCL_MAKE_ARCH_SPECIFIC_ID(_CC)   arch_id::sm_##_CC##a,
     _CCCL_PP_FOR_EACH(_CCCL_MAKE_ARCH_ID, _CCCL_KNOWN_CUDA_ARCH_LIST)
-      _CCCL_PP_FOR_EACH(_CCCL_MAKE_ARCH_SPECIFIC_ID, _CCCL_KNOWN_CUDA_ARCH_SPECIFIC_LIST)
+      _CCCL_PP_FOR_EACH(_CCCL_MAKE_FAMILY_SPECIFIC_ID, _CCCL_KNOWN_CUDA_FAMILY_SPECIFIC_LIST)
+        _CCCL_PP_FOR_EACH(_CCCL_MAKE_ARCH_SPECIFIC_ID, _CCCL_KNOWN_CUDA_ARCH_SPECIFIC_LIST)
 #undef _CCCL_MAKE_ARCH_ID
+#undef _CCCL_MAKE_FAMILY_SPECIFIC_ID
 #undef _CCCL_MAKE_ARCH_SPECIFIC_ID
   };
 }
 
-[[nodiscard]] _CCCL_API constexpr bool __is_specific_arch(arch_id __arch) noexcept
+[[nodiscard]] _CCCL_API constexpr bool __is_family_specific(arch_id __arch) noexcept
 {
-  return ::cuda::std::to_underlying(__arch) > __arch_specific_id_multiplier;
+  return ::cuda::std::to_underlying(__arch) > __family_specific_id_offset
+      && ::cuda::std::to_underlying(__arch) < __arch_specific_id_offset;
+}
+
+[[nodiscard]] _CCCL_API constexpr bool __is_arch_specific(arch_id __arch) noexcept
+{
+  return ::cuda::std::to_underlying(__arch) > __arch_specific_id_offset;
 }
 
 [[nodiscard]] _CCCL_API constexpr bool __has_known_arch(compute_capability __cc) noexcept
@@ -75,7 +87,20 @@ enum class arch_id : int
   }
 }
 
-[[nodiscard]] _CCCL_API constexpr bool __has_known_specific_arch(compute_capability __cc) noexcept
+[[nodiscard]] _CCCL_API constexpr bool __has_known_family_specific_arch(compute_capability __cc) noexcept
+{
+  switch (__cc.get())
+  {
+#define _CCCL_HAS_KNOWN_FAMILY_SPECFIC_ARCH_CASE(_CC) case _CC:
+    _CCCL_PP_FOR_EACH(_CCCL_HAS_KNOWN_FAMILY_SPECFIC_ARCH_CASE, _CCCL_KNOWN_CUDA_FAMILY_SPECIFIC_LIST)
+#undef _CCCL_HAS_KNOWN_FAMILY_SPECFIC_ARCH_CASE
+    return true;
+    default:
+      return false;
+  }
+}
+
+[[nodiscard]] _CCCL_API constexpr bool __has_known_arch_specific_arch(compute_capability __cc) noexcept
 {
   switch (__cc.get())
   {
@@ -99,6 +124,18 @@ enum class arch_id : int
   return static_cast<arch_id>(__cc.get());
 }
 
+//! @brief Converts the compute capability to the family specific id.
+//!
+//! @param __cc The compute capability. Must have a corresponding family specific id.
+//!
+//! @returns The architecture specific id.
+[[nodiscard]] _CCCL_API constexpr arch_id to_family_specific_id(compute_capability __cc) noexcept
+{
+  _CCCL_ASSERT(::cuda::__has_known_family_specific_arch(__cc),
+               "this compute capability cannot be converted to arch specific id");
+  return static_cast<arch_id>(__cc.get() + __family_specific_id_offset);
+}
+
 //! @brief Converts the compute capability to the architecture specific id.
 //!
 //! @param __cc The compute capability. Must have a corresponding architecture specific id.
@@ -106,9 +143,9 @@ enum class arch_id : int
 //! @returns The architecture specific id.
 [[nodiscard]] _CCCL_API constexpr arch_id to_arch_specific_id(compute_capability __cc) noexcept
 {
-  _CCCL_ASSERT(::cuda::__has_known_specific_arch(__cc),
+  _CCCL_ASSERT(::cuda::__has_known_arch_specific_arch(__cc),
                "this compute capability cannot be converted to arch specific id");
-  return static_cast<arch_id>(__cc.get() * __arch_specific_id_multiplier);
+  return static_cast<arch_id>(__cc.get() + __arch_specific_id_offset);
 }
 
 _CCCL_END_NAMESPACE_CUDA
@@ -134,9 +171,13 @@ struct formatter<::cuda::arch_id, _CharT> : private formatter<::cuda::compute_ca
     *__it++   = _CharT{'_'};
     __ctx.advance_to(__it);
     __it = formatter<::cuda::compute_capability, _CharT>::format(::cuda::compute_capability{__arch}, __ctx);
-    if (::cuda::__is_specific_arch(__arch))
+    if (::cuda::__is_arch_specific(__arch))
     {
       *__it++ = _CharT{'a'};
+    }
+    else if (::cuda::__is_family_specific(__arch))
+    {
+      *__it++ = _CharT{'f'};
     }
     return __it;
   }
@@ -177,14 +218,19 @@ template <class _Dummy = void>
 #  elif _CCCL_DEVICE_COMPILATION()
   constexpr auto __cc = ::cuda::device::current_compute_capability();
 #    if defined(__CUDA_ARCH_SPECIFIC__)
-  constexpr auto __is_known_cc = ::cuda::std::__always_false_v<_Dummy> || ::cuda::__has_known_specific_arch(__cc);
-  static_assert(__is_known_cc, "unknown CUDA specific architecture");
+  constexpr auto __is_known_cc = ::cuda::std::__always_false_v<_Dummy> || ::cuda::__has_known_arch_specific_arch(__cc);
+  static_assert(__is_known_cc, "unknown CUDA arch-specific architecture");
   return ::cuda::to_arch_specific_id(__cc);
-#    else // ^^^ __CUDA_ARCH_SPECIFIC__ ^^^ / vvv !__CUDA_ARCH_SPECIFIC__ vvv
+#    elif defined(__CUDA_FAMILY_SPECIFIC__)
+  constexpr auto __is_known_cc =
+    ::cuda::std::__always_false_v<_Dummy> || ::cuda::__has_known_family_specific_arch(__cc);
+  static_assert(__is_known_cc, "unknown CUDA family-specific architecture");
+  return ::cuda::to_family_specific_id(__cc);
+#    else // ^^^ family specific arch ^^^ / vvv ordinary arch vvv
   constexpr auto __is_known_cc = ::cuda::std::__always_false_v<_Dummy> || ::cuda::__has_known_arch(__cc);
   static_assert(__is_known_cc, "unknown CUDA architecture");
   return ::cuda::to_arch_id(__cc);
-#    endif // ^^^ __CUDA_ARCH_SPECIFIC__ ^^^
+#    endif // ^^^ ordinary arch ^^^
 #  else
   return {};
 #  endif // ^^^ single-pass cuda compiler ^^^

--- a/libcudacxx/include/cuda/__device/arch_traits.h
+++ b/libcudacxx/include/cuda/__device/arch_traits.h
@@ -366,6 +366,14 @@ template <>
 };
 
 template <>
+[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_100f>() noexcept
+{
+  auto __traits    = ::cuda::arch_traits<arch_id::sm_100>();
+  __traits.arch_id = arch_id::sm_100f;
+  return __traits;
+};
+
+template <>
 [[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_100a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_100>();
@@ -381,6 +389,14 @@ template <>
   __traits.compute_capability_major = 10;
   __traits.compute_capability_minor = 3;
   __traits.compute_capability       = compute_capability{103};
+  return __traits;
+};
+
+template <>
+[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_103f>() noexcept
+{
+  auto __traits    = ::cuda::arch_traits<arch_id::sm_103>();
+  __traits.arch_id = arch_id::sm_103f;
   return __traits;
 };
 
@@ -407,6 +423,14 @@ template <>
 };
 
 template <>
+[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_110f>() noexcept
+{
+  auto __traits    = ::cuda::arch_traits<arch_id::sm_110>();
+  __traits.arch_id = arch_id::sm_110f;
+  return __traits;
+};
+
+template <>
 [[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_110a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_110>();
@@ -424,6 +448,14 @@ template <>
   __traits.max_warps_per_multiprocessor         = __traits.max_threads_per_multiprocessor / __traits.warp_size;
   __traits.max_shared_memory_per_block_optin =
     __traits.max_shared_memory_per_multiprocessor - __traits.reserved_shared_memory_per_block;
+  return __traits;
+};
+
+template <>
+[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_120f>() noexcept
+{
+  auto __traits    = ::cuda::arch_traits<arch_id::sm_120>();
+  __traits.arch_id = arch_id::sm_120f;
   return __traits;
 };
 
@@ -447,6 +479,14 @@ template <>
 };
 
 template <>
+[[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_121f>() noexcept
+{
+  auto __traits    = ::cuda::arch_traits<arch_id::sm_121>();
+  __traits.arch_id = arch_id::sm_121f;
+  return __traits;
+};
+
+template <>
 [[nodiscard]] _CCCL_API constexpr arch_traits_t arch_traits<arch_id::sm_121a>() noexcept
 {
   auto __traits    = ::cuda::arch_traits<arch_id::sm_121>();
@@ -464,13 +504,18 @@ template <>
 #define _CCCL_ARCH_TRAITS_FOR_CASE(_CC) \
   case arch_id::sm_##_CC:               \
     return ::cuda::arch_traits<arch_id::sm_##_CC>();
-#define _CCCL_ARCH_TRAITS_FOR_SPECIFIC_CASE(_CC) \
-  case arch_id::sm_##_CC##a:                     \
+#define _CCCL_ARCH_TRAITS_FOR_FAMILY_SPECIFIC_CASE(_CC) \
+  case arch_id::sm_##_CC##f:                            \
+    return ::cuda::arch_traits<arch_id::sm_##_CC##f>();
+#define _CCCL_ARCH_TRAITS_FOR_ARCH_SPECIFIC_CASE(_CC) \
+  case arch_id::sm_##_CC##a:                          \
     return ::cuda::arch_traits<arch_id::sm_##_CC##a>();
     _CCCL_PP_FOR_EACH(_CCCL_ARCH_TRAITS_FOR_CASE, _CCCL_KNOWN_CUDA_ARCH_LIST)
-    _CCCL_PP_FOR_EACH(_CCCL_ARCH_TRAITS_FOR_SPECIFIC_CASE, _CCCL_KNOWN_CUDA_ARCH_SPECIFIC_LIST)
+    _CCCL_PP_FOR_EACH(_CCCL_ARCH_TRAITS_FOR_FAMILY_SPECIFIC_CASE, _CCCL_KNOWN_CUDA_FAMILY_SPECIFIC_LIST)
+    _CCCL_PP_FOR_EACH(_CCCL_ARCH_TRAITS_FOR_ARCH_SPECIFIC_CASE, _CCCL_KNOWN_CUDA_ARCH_SPECIFIC_LIST)
 #undef _CCCL_ARCH_TRAITS_FOR_CASE
-#undef _CCCL_ARCH_TRAITS_FOR_SPECIFIC_CASE
+#undef _CCCL_ARCH_TRAITS_FOR_FAMILY_SPECIFIC_CASE
+#undef _CCCL_ARCH_TRAITS_FOR_ARCH_SPECIFIC_CASE
     default:
 #if _CCCL_HAS_CTK()
       _CCCL_THROW(::cuda::cuda_error, ::cudaErrorInvalidValue, "Traits requested for an unknown architecture");

--- a/libcudacxx/include/cuda/__device/compute_capability.h
+++ b/libcudacxx/include/cuda/__device/compute_capability.h
@@ -62,9 +62,13 @@ public:
   _CCCL_API explicit constexpr compute_capability(arch_id __arch_id) noexcept
   {
     const auto __val = ::cuda::std::to_underlying(__arch_id);
-    if (__val > __arch_specific_id_multiplier)
+    if (__val > __arch_specific_id_offset)
     {
-      __cc_ = __val / __arch_specific_id_multiplier;
+      __cc_ = __val - __arch_specific_id_offset;
+    }
+    else if (__val > __family_specific_id_offset)
+    {
+      __cc_ = __val - __family_specific_id_offset;
     }
     else
     {

--- a/libcudacxx/include/cuda/__fwd/devices.h
+++ b/libcudacxx/include/cuda/__fwd/devices.h
@@ -38,7 +38,8 @@ struct arch_traits_t;
 class compute_capability;
 enum class arch_id : int;
 
-inline constexpr int __arch_specific_id_multiplier = 100000;
+inline constexpr int __family_specific_id_offset = 1000;
+inline constexpr int __arch_specific_id_offset   = 100'000;
 
 _CCCL_END_NAMESPACE_CUDA
 

--- a/libcudacxx/include/cuda/std/__cccl/execution_space.h
+++ b/libcudacxx/include/cuda/std/__cccl/execution_space.h
@@ -68,6 +68,9 @@
 //! @brief List of all known PTX architectures supported by this CCCL version.
 #define _CCCL_KNOWN_CUDA_ARCH_LIST 60, 61, 62, 70, 75, 80, 86, 87, 88, 89, 90, 100, 103, 110, 120, 121
 
+//! @brief List of all known family specific architectures supported by this CCCL version.
+#define _CCCL_KNOWN_CUDA_FAMILY_SPECIFIC_LIST 100, 103, 110, 120, 121
+
 //! @brief List of all known architecture specific architectures supported by this CCCL version.
 #define _CCCL_KNOWN_CUDA_ARCH_SPECIFIC_LIST 90, 100, 103, 110, 120, 121
 

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/all_arch_ids.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/all_arch_ids.pass.cpp
@@ -39,6 +39,11 @@ __host__ __device__ constexpr bool test()
   assert(all_arch_ids[i++] == cuda::arch_id::sm_110);
   assert(all_arch_ids[i++] == cuda::arch_id::sm_120);
   assert(all_arch_ids[i++] == cuda::arch_id::sm_121);
+  assert(all_arch_ids[i++] == cuda::arch_id::sm_100f);
+  assert(all_arch_ids[i++] == cuda::arch_id::sm_103f);
+  assert(all_arch_ids[i++] == cuda::arch_id::sm_110f);
+  assert(all_arch_ids[i++] == cuda::arch_id::sm_120f);
+  assert(all_arch_ids[i++] == cuda::arch_id::sm_121f);
   assert(all_arch_ids[i++] == cuda::arch_id::sm_90a);
   assert(all_arch_ids[i++] == cuda::arch_id::sm_100a);
   assert(all_arch_ids[i++] == cuda::arch_id::sm_103a);

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id.pass.cpp
@@ -46,6 +46,18 @@ __device__ void test_current()
     (assert(arch == cuda::arch_id::sm_121a); return;))
 
   NV_DISPATCH_TARGET(
+    NV_HAS_FEATURE_SM_100f,
+    (assert(arch == cuda::arch_id::sm_100f); return;),
+    NV_HAS_FEATURE_SM_103f,
+    (assert(arch == cuda::arch_id::sm_103f); return;),
+    NV_HAS_FEATURE_SM_110f,
+    (assert(arch == cuda::arch_id::sm_110f); return;),
+    NV_HAS_FEATURE_SM_120f,
+    (assert(arch == cuda::arch_id::sm_120f); return;),
+    NV_HAS_FEATURE_SM_121f,
+    (assert(arch == cuda::arch_id::sm_121f); return;))
+
+  NV_DISPATCH_TARGET(
     NV_IS_EXACTLY_SM_60,
     (assert(arch == cuda::arch_id::sm_60); return;),
     NV_IS_EXACTLY_SM_61,
@@ -105,12 +117,17 @@ __host__ __device__ constexpr bool test()
   static_assert(cuda::std::to_underlying(cuda::arch_id::sm_110) == 110);
   static_assert(cuda::std::to_underlying(cuda::arch_id::sm_120) == 120);
   static_assert(cuda::std::to_underlying(cuda::arch_id::sm_121) == 121);
-  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_90a) == 90 * 100000);
-  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_100a) == 100 * 100000);
-  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_103a) == 103 * 100000);
-  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_110a) == 110 * 100000);
-  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_120a) == 120 * 100000);
-  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_121a) == 121 * 100000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_100f) == 100 + 1000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_103f) == 103 + 1000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_110f) == 110 + 1000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_120f) == 120 + 1000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_121f) == 121 + 1000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_90a) == 90 + 100000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_100a) == 100 + 100000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_103a) == 103 + 100000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_110a) == 110 + 100000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_120a) == 120 + 100000);
+  static_assert(cuda::std::to_underlying(cuda::arch_id::sm_121a) == 121 + 100000);
 
   // 2. Test cuda::to_arch_id(cuda::compute_capability).
   {
@@ -123,7 +140,19 @@ __host__ __device__ constexpr bool test()
     assert(id_highest == cuda::arch_id::sm_120);
   }
 
-  // 3. Test cuda::to_arch_specific_id(cuda::compute_capability).
+  // 3. Test cuda::to_family_specific_id(cuda::compute_capability).
+  {
+    static_assert(
+      cuda::std::is_same_v<cuda::arch_id, decltype(cuda::to_family_specific_id(cuda::compute_capability{}))>);
+    static_assert(noexcept(cuda::to_family_specific_id(cuda::compute_capability{})));
+
+    cuda::arch_id id_lowest = cuda::to_family_specific_id(cuda::compute_capability{100});
+    assert(id_lowest == cuda::arch_id::sm_100f);
+    cuda::arch_id id_highest = cuda::to_family_specific_id(cuda::compute_capability{120});
+    assert(id_highest == cuda::arch_id::sm_120f);
+  }
+
+  // 4. Test cuda::to_arch_specific_id(cuda::compute_capability).
   {
     static_assert(cuda::std::is_same_v<cuda::arch_id, decltype(cuda::to_arch_specific_id(cuda::compute_capability{}))>);
     static_assert(noexcept(cuda::to_arch_specific_id(cuda::compute_capability{})));

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id_fmt.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_id_fmt.pass.cpp
@@ -36,6 +36,11 @@ void test()
   assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_110) == TEST_STRLIT(C, "sm_110"));
   assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_120) == TEST_STRLIT(C, "sm_120"));
   assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_121) == TEST_STRLIT(C, "sm_121"));
+  assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_100f) == TEST_STRLIT(C, "sm_100f"));
+  assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_103f) == TEST_STRLIT(C, "sm_103f"));
+  assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_110f) == TEST_STRLIT(C, "sm_110f"));
+  assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_120f) == TEST_STRLIT(C, "sm_120f"));
+  assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_121f) == TEST_STRLIT(C, "sm_121f"));
   assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_90a) == TEST_STRLIT(C, "sm_90a"));
   assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_100a) == TEST_STRLIT(C, "sm_100a"));
   assert(std::format(TEST_STRLIT(C, "{}"), cuda::arch_id::sm_103a) == TEST_STRLIT(C, "sm_103a"));

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_traits.c2h.cu
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/arch_traits.c2h.cu
@@ -66,6 +66,11 @@ template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_110>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_120>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_121>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_100f>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_103f>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_110f>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_120f>();
+template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_121f>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_90a>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_100a>();
 template __global__ void arch_specific_kernel_mock_do_not_launch<cuda::arch_id::sm_103a>();

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/compute_capability.pass.cpp
@@ -103,8 +103,10 @@ __host__ __device__ constexpr bool test()
 
     cuda::compute_capability cc1{cuda::arch_id::sm_100};
     assert(cc1.get() == 100);
-    cuda::compute_capability cc2{cuda::arch_id::sm_100a};
+    cuda::compute_capability cc2{cuda::arch_id::sm_100f};
     assert(cc2.get() == 100);
+    cuda::compute_capability cc3{cuda::arch_id::sm_100a};
+    assert(cc3.get() == 100);
   }
 
   // 5. Test copy constructor.

--- a/libcudacxx/test/libcudacxx/cuda/ccclrt/device/is_specific_arch.pass.cpp
+++ b/libcudacxx/test/libcudacxx/cuda/ccclrt/device/is_specific_arch.pass.cpp
@@ -17,32 +17,68 @@
 __host__ __device__ constexpr bool test()
 {
   // 1. Test signature.
-  static_assert(cuda::std::is_same_v<bool, decltype(cuda::__is_specific_arch(cuda::arch_id{}))>);
-  static_assert(noexcept(cuda::__is_specific_arch(cuda::arch_id{})));
+  static_assert(cuda::std::is_same_v<bool, decltype(cuda::__is_family_specific(cuda::arch_id{}))>);
+  static_assert(noexcept(cuda::__is_family_specific(cuda::arch_id{})));
+
+  static_assert(cuda::std::is_same_v<bool, decltype(cuda::__is_arch_specific(cuda::arch_id{}))>);
+  static_assert(noexcept(cuda::__is_arch_specific(cuda::arch_id{})));
 
   // 2. Test values.
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_60));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_61));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_62));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_70));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_75));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_80));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_86));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_87));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_88));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_89));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_90));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_100));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_103));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_110));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_120));
-  assert(!cuda::__is_specific_arch(cuda::arch_id::sm_121));
-  assert(cuda::__is_specific_arch(cuda::arch_id::sm_90a));
-  assert(cuda::__is_specific_arch(cuda::arch_id::sm_100a));
-  assert(cuda::__is_specific_arch(cuda::arch_id::sm_103a));
-  assert(cuda::__is_specific_arch(cuda::arch_id::sm_110a));
-  assert(cuda::__is_specific_arch(cuda::arch_id::sm_120a));
-  assert(cuda::__is_specific_arch(cuda::arch_id::sm_121a));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_60));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_61));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_62));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_70));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_75));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_80));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_86));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_87));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_88));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_89));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_90));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_100));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_103));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_110));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_120));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_121));
+  assert(cuda::__is_family_specific(cuda::arch_id::sm_100f));
+  assert(cuda::__is_family_specific(cuda::arch_id::sm_103f));
+  assert(cuda::__is_family_specific(cuda::arch_id::sm_110f));
+  assert(cuda::__is_family_specific(cuda::arch_id::sm_120f));
+  assert(cuda::__is_family_specific(cuda::arch_id::sm_121f));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_90a));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_100a));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_103a));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_110a));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_120a));
+  assert(!cuda::__is_family_specific(cuda::arch_id::sm_121a));
+
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_60));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_61));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_62));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_70));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_75));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_80));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_86));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_87));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_88));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_89));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_90));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_100));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_103));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_110));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_120));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_121));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_100f));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_103f));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_110f));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_120f));
+  assert(!cuda::__is_arch_specific(cuda::arch_id::sm_121f));
+  assert(cuda::__is_arch_specific(cuda::arch_id::sm_90a));
+  assert(cuda::__is_arch_specific(cuda::arch_id::sm_100a));
+  assert(cuda::__is_arch_specific(cuda::arch_id::sm_103a));
+  assert(cuda::__is_arch_specific(cuda::arch_id::sm_110a));
+  assert(cuda::__is_arch_specific(cuda::arch_id::sm_120a));
+  assert(cuda::__is_arch_specific(cuda::arch_id::sm_121a));
 
   return true;
 }


### PR DESCRIPTION
This PR adds support for family specific architectures in libcu++ (`sm_XYf`)