### PR TITLE
[libcu++] Add missing bit_cast in the buffer construction

### DIFF
--- a/libcudacxx/include/cuda/__driver/driver_api.h
+++ b/libcudacxx/include/cuda/__driver/driver_api.h
@@ -24,6 +24,7 @@
 #if _CCCL_HAS_CTK() && !_CCCL_COMPILER(NVRTC)
 
 #  include <cuda/__runtime/api_wrapper.h>
+#  include <cuda/std/__bit/bit_cast.h>
 #  include <cuda/std/__cstddef/types.h>
 #  include <cuda/std/__exception/cuda_error.h>
 #  include <cuda/std/__exception/exception_macros.h>
@@ -375,20 +376,23 @@ _CCCL_HOST_API void __memsetAsync(void* __dst, _Tp __value, ::cuda::std::size_t 
   if constexpr (sizeof(_Tp) == 1)
   {
     static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD8Async);
+    auto __bits             = ::cuda::std::bit_cast<unsigned char>(__value);
     ::cuda::__driver::__call_driver_fn(
-      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __value, __count, __stream);
+      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __bits, __count, __stream);
   }
   else if constexpr (sizeof(_Tp) == 2)
   {
     static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD16Async);
+    auto __bits             = ::cuda::std::bit_cast<unsigned short>(__value);
     ::cuda::__driver::__call_driver_fn(
-      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __value, __count, __stream);
+      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __bits, __count, __stream);
   }
   else if constexpr (sizeof(_Tp) == 4)
   {
     static auto __driver_fn = _CCCLRT_GET_DRIVER_FUNCTION(cuMemsetD32Async);
+    auto __bits             = ::cuda::std::bit_cast<unsigned int>(__value);
     ::cuda::__driver::__call_driver_fn(
-      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __value, __count, __stream);
+      __driver_fn, "Failed to perform a memset", reinterpret_cast<::CUdeviceptr>(__dst), __bits, __count, __stream);
   }
   else
   {

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
@@ -136,7 +136,7 @@ struct equal_to_value
 };
 
 template <class Buffer>
-bool equal_size_value(const Buffer& buf, const size_t size, const int value)
+bool equal_size_value(const Buffer& buf, const size_t size, const typename Buffer::value_type value)
 {
   if constexpr (Buffer::properties_list::has_property(cuda::mr::host_accessible{}))
   {

--- a/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
+++ b/libcudacxx/test/libcudacxx/cuda/containers/buffer/helper.h
@@ -221,11 +221,16 @@ struct extract_properties<cuda::buffer<T, Properties...>>
 };
 
 #if _CCCL_CTK_AT_LEAST(12, 9)
-using test_types = c2h::type_list<cuda::buffer<int, cuda::mr::host_accessible>,
-                                  cuda::buffer<unsigned long long, cuda::mr::device_accessible>,
-                                  cuda::buffer<int, cuda::mr::host_accessible, cuda::mr::device_accessible>>;
+using test_types =
+  c2h::type_list<cuda::buffer<int, cuda::mr::host_accessible>,
+                 cuda::buffer<unsigned long long, cuda::mr::device_accessible>,
+                 cuda::buffer<short, cuda::mr::device_accessible>,
+                 cuda::buffer<float, cuda::mr::device_accessible>,
+                 cuda::buffer<int, cuda::mr::host_accessible, cuda::mr::device_accessible>>;
 #else // ^^^ _CCCL_CTK_AT_LEAST(12, 9) ^^^ / vvv _CCCL_CTK_BELOW(12, 9) vvv
-using test_types = c2h::type_list<cuda::buffer<int, cuda::mr::device_accessible>>;
+using test_types = c2h::type_list<cuda::buffer<int, cuda::mr::device_accessible>,
+                                  cuda::buffer<short, cuda::mr::device_accessible>,
+                                  cuda::buffer<float, cuda::mr::device_accessible>>;
 #endif // ^^^ _CCCL_CTK_BELOW(12, 9) ^^^
 
 #endif // CUDA_TEST_CONTAINER_VECTOR_HELPER_H


### PR DESCRIPTION
Fixes https://github.com/NVIDIA/cccl/issues/8417

We missed a bit_cast for memset in buffer construction. We also missed to add testing for float buffers. This PR adds the missing bit_cast and testing for float and short to test a 16 bit type