### PR TITLE
Vectorize mbarrier initialization in warpspeed scan

### DIFF
--- a/cub/cub/detail/warpspeed/sync_handler.cuh
+++ b/cub/cub/detail/warpspeed/sync_handler.cuh
@@ -15,7 +15,6 @@
 #include <cub/detail/warpspeed/constant_assert.cuh>
 #include <cub/detail/warpspeed/special_registers.cuh>
 
-#include <cuda/__ptx/instructions/elect_sync.h>
 #include <cuda/__ptx/instructions/mbarrier_init.h>
 #include <cuda/std/cstdint>
 
@@ -34,7 +33,6 @@ struct SyncHandler
 {
   static constexpr int mMaxNumResources = 10;
   static constexpr int mMaxNumPhases    = 4;
-  static constexpr int mMaxNumStages    = 32;
 
   // Whether barriers have been initialized.
   bool mHasInitialized = false;
@@ -95,51 +93,46 @@ struct SyncHandler
   }
 
   // clusterInitSync can only be called on device.
+  template <int NumThreads>
   _CCCL_DEVICE_API void clusterInitSync(SpecialRegisters sr, SkipSync)
   {
     _WS_CONSTANT_ASSERT(!mHasInitialized, "Cannot initialize SyncHandler twice.");
     mHasInitialized = true;
 
-    // TODO: This could take a Group parameter to split the barrier
-    // initialization across groups. Or it could take the number of warps in the
-    // block as a parameter.
-
-    // TODO: This could use vectorized mbarrier initialization
-    if (sr.warpIdx == 0 && ::cuda::ptx::elect_sync(~0))
+    // All warps iterate through all resources and phases. Since all array indices have to be statically resolved by the
+    // SROA optimization to avoid spilling to local memory, we cannot split the iteration among warps etc.
+    for (int ri = 0; ri < mMaxNumResources; ri++)
     {
-      for (int ri = 0; ri < mMaxNumResources; ++ri)
+      if (ri >= mNextResourceHandle)
       {
-        if (mNextResourceHandle <= ri)
-        {
-          continue;
-        }
-        int resNumPhases = mNumPhases[ri];
-        int numStages    = mNumStages[ri];
+        break;
+      }
+      const int resNumPhases = mNumPhases[ri];
+      const int numStages    = mNumStages[ri];
 
-        // We loop over all phases with a conditional on resNumPhases. If we
-        // directly loop over only resNumPhases, then the SROA optimization does
-        // not kick in and the mPtrBar and mNumOwningThreads arrays are
-        // spilled to the stack.
-        for (int pi = 0; pi < mMaxNumPhases; ++pi)
+      for (int pi = 0; pi < mMaxNumPhases; pi++)
+      {
+        if (pi >= resNumPhases)
         {
-          if (pi < resNumPhases)
-          {
-            uint64_t* ptrBar     = mPtrBar[ri][pi];
-            int numOwningThreads = mNumOwningThreads[ri][pi];
-            for (int si = 0; si < numStages; ++si)
-            {
-              ::cuda::ptx::mbarrier_init(&ptrBar[si], numOwningThreads);
-            }
-          }
+          break;
+        }
+
+        uint64_t* ptrBar     = mPtrBar[ri][pi];
+        int numOwningThreads = mNumOwningThreads[ri][pi];
+        // use block strided iteration to vectorize setup of barriers
+        for (int si = sr.threadIdxX; si < numStages; si += NumThreads)
+        {
+          ::cuda::ptx::mbarrier_init(&ptrBar[si], numOwningThreads);
         }
       }
     }
   }
 
+  template <int NumThreads>
   _CCCL_DEVICE_API void clusterInitSync(SpecialRegisters sr)
   {
     NV_IF_TARGET(NV_PROVIDES_SM_90, ({
-                   clusterInitSync(sr, SkipSync{});
+                   clusterInitSync<NumThreads>(sr, SkipSync{});
                    __cluster_barrier_arrive_relaxed();
                    __cluster_barrier_wait();
                  }))

--- a/cub/cub/detail/warpspeed/sync_handler.cuh
+++ b/cub/cub/detail/warpspeed/sync_handler.cuh
@@ -31,6 +31,7 @@ struct SkipSync
 
 struct SyncHandler
 {
+  // reducing these values to the actually used number of resources and phases does not improve performance
   static constexpr int mMaxNumResources = 10;
   static constexpr int mMaxNumPhases    = 4;
 

--- a/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
+++ b/cub/cub/device/dispatch/kernels/kernel_scan_warpspeed.cuh
@@ -816,7 +816,7 @@ _CCCL_DEVICE_API _CCCL_FORCEINLINE void device_scan_lookahead_body(
     warpspeed::SyncHandler syncHandler{};
     warpspeed::SmemAllocator smemAllocator{};
     auto r = allocResources<PolicySelector, InputT, OutputT, AccumT>(syncHandler, smemAllocator, params.numStages);
-    syncHandler.clusterInitSync(specialRegisters);
+    syncHandler.clusterInitSync<num_total_threads(policy)>(specialRegisters);
     return r;
   }();
 


### PR DESCRIPTION
- [x] Merge before: #8418

## [0] NVIDIA B200

|  T{ct}  |  OffsetT{ct}  |  Elements{io}  |   Ref Time |   Ref Noise |   Cmp Time |   Cmp Noise |       Diff |   %Diff |  Status  |
|---------|---------------|----------------|------------|-------------|------------|-------------|------------|---------|----------|
|   I8    |      I64      |      2^16      |  11.284 us |       4.37% |  10.404 us |       9.78% |  -0.881 us |  -7.81% |  🟢 FAST  |
|   I8    |      I64      |      2^20      |  12.637 us |       6.95% |  12.232 us |       8.28% |  -0.405 us |  -3.20% |  🔵 SAME  |
|   I8    |      I64      |      2^24      |  27.189 us |       2.98% |  26.249 us |       3.77% |  -0.940 us |  -3.46% |  🟢 FAST  |
|   I8    |      I64      |      2^28      | 216.046 us |       0.50% | 215.908 us |       0.51% |  -0.138 us |  -0.06% |  🔵 SAME  |
|   I8    |      I64      |      2^32      |   3.228 ms |       0.22% |   3.240 ms |       0.11% |  12.728 us |   0.39% |  🔴 SLOW  |
|   I16   |      I64      |      2^16      |  11.099 us |       0.85% |  11.014 us |       3.55% |  -0.085 us |  -0.77% |  🔵 SAME  |
|   I16   |      I64      |      2^20      |  13.233 us |       3.21% |  13.155 us |       3.40% |  -0.078 us |  -0.59% |  🔵 SAME  |
|   I16   |      I64      |      2^24      |  31.521 us |       5.19% |  31.046 us |       5.18% |  -0.475 us |  -1.51% |  🔵 SAME  |
|   I16   |      I64      |      2^28      | 214.188 us |       0.67% | 214.029 us |       0.68% |  -0.159 us |  -0.07% |  🔵 SAME  |
|   I16   |      I64      |      2^32      |   3.237 ms |       1.39% |   3.238 ms |       1.24% |   1.405 us |   0.04% |  🔵 SAME  |
|   I32   |      I64      |      2^16      |   9.707 us |       9.89% |   9.304 us |       7.74% |  -0.402 us |  -4.14% |  🔵 SAME  |
|   I32   |      I64      |      2^20      |  13.705 us |       6.52% |  13.612 us |       6.87% |  -0.092 us |  -0.67% |  🔵 SAME  |
|   I32   |      I64      |      2^24      |  38.102 us |       4.68% |  37.646 us |       4.59% |  -0.456 us |  -1.20% |  🔵 SAME  |
|   I32   |      I64      |      2^28      | 321.954 us |       0.55% | 321.593 us |       0.55% |  -0.360 us |  -0.11% |  🔵 SAME  |
|   I32   |      I64      |      2^32      |   5.091 ms |       1.21% |   5.104 ms |       1.03% |  13.646 us |   0.27% |  🔵 SAME  |
|   I64   |      I64      |      2^16      |  11.283 us |       1.20% |  11.155 us |       4.52% |  -0.127 us |  -1.13% |  🔵 SAME  |
|   I64   |      I64      |      2^20      |  15.473 us |       4.21% |  15.286 us |       2.35% |  -0.187 us |  -1.21% |  🔵 SAME  |
|   I64   |      I64      |      2^24      |  60.226 us |       2.01% |  59.460 us |       2.00% |  -0.765 us |  -1.27% |  🔵 SAME  |
|   I64   |      I64      |      2^28      | 688.208 us |       0.18% | 687.991 us |       0.17% |  -0.217 us |  -0.03% |  🔵 SAME  |
|   I64   |      I64      |      2^32      |  11.264 ms |       0.82% |  11.246 ms |       0.85% | -18.469 us |  -0.16% |  🔵 SAME  |
|  I128   |      I64      |      2^16      |  13.072 us |       4.17% |  12.725 us |       7.03% |  -0.348 us |  -2.66% |  🔵 SAME  |
|  I128   |      I64      |      2^20      |  25.119 us |       4.18% |  24.435 us |       4.28% |  -0.685 us |  -2.73% |  🔵 SAME  |
|  I128   |      I64      |      2^24      | 172.993 us |       0.66% | 172.755 us |       0.69% |  -0.238 us |  -0.14% |  🔵 SAME  |
|  I128   |      I64      |      2^28      |   2.521 ms |       0.09% |   2.520 ms |       0.10% |  -0.871 us |  -0.03% |  🔵 SAME  |
|  I128   |      I64      |      2^32      |  40.173 ms |       0.02% |  40.162 ms |       0.02% | -10.644 us |  -0.03% |  🟢 FAST  |
|   F32   |      I64      |      2^16      |  10.094 us |      10.29% |  10.008 us |      10.06% |  -0.086 us |  -0.85% |  🔵 SAME  |
|   F32   |      I64      |      2^20      |  14.279 us |       7.19% |  14.439 us |       7.10% |   0.160 us |   1.12% |  🔵 SAME  |
|   F32   |      I64      |      2^24      |  41.303 us |       3.51% |  40.681 us |       3.60% |  -0.622 us |  -1.51% |  🔵 SAME  |
|   F32   |      I64      |      2^28      | 345.811 us |       0.44% | 344.699 us |       0.45% |  -1.112 us |  -0.32% |  🔵 SAME  |
|   F32   |      I64      |      2^32      |   5.222 ms |       0.39% |   5.218 ms |       0.10% |  -4.265 us |  -0.08% |  🔵 SAME  |
|   F64   |      I64      |      2^16      |  11.045 us |       2.02% |  11.020 us |       2.68% |  -0.025 us |  -0.23% |  🔵 SAME  |
|   F64   |      I64      |      2^20      |  15.549 us |       3.84% |  15.374 us |       0.83% |  -0.175 us |  -1.12% |  🟢 FAST  |
|   F64   |      I64      |      2^24      |  65.203 us |       1.66% |  64.440 us |       1.69% |  -0.764 us |  -1.17% |  🔵 SAME  |
|   F64   |      I64      |      2^28      | 779.808 us |       0.15% | 779.802 us |       0.14% |  -0.006 us |  -0.00% |  🔵 SAME  |
|   F64   |      I64      |      2^32      |  12.233 ms |       0.01% |  12.238 ms |       0.01% |   4.682 us |   0.04% |  🔴 SLOW  |
|   C32   |      I64      |      2^16      |  10.791 us |       7.36% |  10.687 us |       8.76% |  -0.104 us |  -0.97% |  🔵 SAME  |
|   C32   |      I64      |      2^20      |  15.241 us |       1.60% |  15.136 us |       3.35% |  -0.105 us |  -0.69% |  🔵 SAME  |
|   C32   |      I64      |      2^24      |  59.184 us |       2.01% |  58.248 us |       1.59% |  -0.936 us |  -1.58% |  🔵 SAME  |
|   C32   |      I64      |      2^28      | 682.193 us |       0.17% | 679.964 us |       0.17% |  -2.229 us |  -0.33% |  🟢 FAST  |
|   C32   |      I64      |      2^32      |  10.662 ms |       0.02% |  10.635 ms |       0.02% | -26.996 us |  -0.25% |  🟢 FAST  |

Fixes: #7440