### PR TITLE
Fix bugs in DeviceReduce::ArgMax env overloads and add missing tests

### DIFF
--- a/cub/cub/device/device_reduce.cuh
+++ b/cub/cub/device/device_reduce.cuh
@@ -1992,8 +1992,7 @@ public:
     EnvT env = {})
   {
     _CCCL_NVTX_RANGE_SCOPE("cub::DeviceReduce::ArgMax");
-    return __arg_min_env(
-      d_in, d_index_out, num_items, detail::arg_less{detail::swap_args{compare_op}}, ::cuda::std::execution::env{});
+    return __arg_min_env(d_in, d_max_out, d_index_out, num_items, detail::arg_less{detail::swap_args{compare_op}}, env);
   }
 
   //! @overload
@@ -2001,7 +2000,10 @@ public:
   template <typename InputIteratorT,
             typename ExtremumOutIteratorT,
             typename IndexOutIteratorT,
-            typename EnvT = ::cuda::std::execution::env<>>
+            typename EnvT = ::cuda::std::execution::env<>,
+            // TODO(bgruber): this constraint is not accurate, since the implementation will compare the value types of
+            // ExtremumOutIteratorT, which is wrong IMO
+            ::cuda::std::enable_if_t<!::cuda::std::indirectly_comparable<InputIteratorT, InputIteratorT, EnvT>, int> = 0>
   [[nodiscard]] CUB_RUNTIME_FUNCTION static cudaError_t
   ArgMax(InputIteratorT d_in,
          ExtremumOutIteratorT d_max_out,

--- a/cub/test/catch2_test_device_reduce_env.cu
+++ b/cub/test/catch2_test_device_reduce_env.cu
@@ -11,14 +11,20 @@ struct stream_registry_factory_t;
 
 #include <thrust/device_vector.h>
 
+#include <cuda/devices>
 #include <cuda/iterator>
+#include <cuda/stream>
 
 #include "catch2_test_env_launch_helper.h"
 
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Reduce, device_reduce);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Sum, device_reduce_sum);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Min, device_reduce_min);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::Max, device_reduce_max);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::TransformReduce, device_transform_reduce);
 DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ReduceByKey, device_reduce_by_key);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMin, device_arg_min);
+DECLARE_LAUNCH_WRAPPER(cub::DeviceReduce::ArgMax, device_arg_max);
 
 // %PARAM% TEST_LAUNCH lid 0:1:2
 
@@ -413,6 +419,26 @@ C2H_TEST("Device sum uses environment", "[reduce][device]", requirements)
 
 #if TEST_LAUNCH == 0
 
+TEST_CASE("Device Min works with default environment", "[reduce][device]")
+{
+  auto input  = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto output = c2h::device_vector<float>(1);
+
+  auto error = cub::DeviceReduce::Min(input.begin(), output.begin(), static_cast<int>(input.size()));
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output[0] == 0.0f);
+}
+
+TEST_CASE("Device Max works with default environment", "[reduce][device]")
+{
+  auto input  = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto output = c2h::device_vector<float>(1);
+
+  auto error = cub::DeviceReduce::Max(input.begin(), output.begin(), static_cast<int>(input.size()));
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(output[0] == 4.0f);
+}
+
 TEST_CASE("Device TransformReduce works with default environment", "[reduce][device]")
 {
   auto d_in  = c2h::device_vector<int>{1, 2, 3, 4};
@@ -455,6 +481,58 @@ TEST_CASE("Device ReduceByKey works with default environment", "[reduce][device]
   REQUIRE(d_aggregates_out == expected_aggregates);
 }
 
+TEST_CASE("Device ArgMin works with default environment", "[reduce][device]")
+{
+  auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_output   = c2h::device_vector<float>(1);
+  auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
+
+  auto error =
+    cub::DeviceReduce::ArgMin(input.begin(), min_output.begin(), index_output.begin(), static_cast<int>(input.size()));
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_output[0] == 0.0f);
+  REQUIRE(index_output[0] == 3);
+}
+
+TEST_CASE("Device ArgMax works with default environment", "[reduce][device]")
+{
+  auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto max_output   = c2h::device_vector<float>(1);
+  auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
+
+  auto error =
+    cub::DeviceReduce::ArgMax(input.begin(), max_output.begin(), index_output.begin(), static_cast<int>(input.size()));
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(max_output[0] == 4.0f);
+  REQUIRE(index_output[0] == 2);
+}
+
+TEST_CASE("Device ArgMin with compare_op works with default environment", "[reduce][device]")
+{
+  auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_output   = c2h::device_vector<float>(1);
+  auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
+
+  auto error = cub::DeviceReduce::ArgMin(
+    input.begin(), min_output.begin(), index_output.begin(), static_cast<int>(input.size()), cuda::std::less{});
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(min_output[0] == 0.0f);
+  REQUIRE(index_output[0] == 3);
+}
+
+TEST_CASE("Device ArgMax with compare_op works with default environment", "[reduce][device]")
+{
+  auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto max_output   = c2h::device_vector<float>(1);
+  auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
+
+  auto error = cub::DeviceReduce::ArgMax(
+    input.begin(), max_output.begin(), index_output.begin(), static_cast<int>(input.size()), cuda::std::less{});
+  REQUIRE(error == cudaSuccess);
+  REQUIRE(max_output[0] == 4.0f);
+  REQUIRE(index_output[0] == 2);
+}
+
 #endif
 
 C2H_TEST("Device TransformReduce uses environment", "[reduce][device]")
@@ -483,6 +561,40 @@ C2H_TEST("Device TransformReduce uses environment", "[reduce][device]")
     d_in.begin(), d_out.begin(), static_cast<int>(d_in.size()), cuda::std::plus<int>{}, negate, 0, env);
 
   REQUIRE(d_out[0] == -10);
+}
+
+C2H_TEST("Device Min uses environment", "[reduce][device]")
+{
+  auto input  = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto output = c2h::device_vector<float>(1);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(cudaSuccess
+          == cub::DeviceReduce::Min(
+            nullptr, expected_bytes_allocated, input.begin(), output.begin(), static_cast<int>(input.size())));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_reduce_min(input.begin(), output.begin(), static_cast<int>(input.size()), env);
+
+  REQUIRE(output[0] == 0.0f);
+}
+
+C2H_TEST("Device Max uses environment", "[reduce][device]")
+{
+  auto input  = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto output = c2h::device_vector<float>(1);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(cudaSuccess
+          == cub::DeviceReduce::Max(
+            nullptr, expected_bytes_allocated, input.begin(), output.begin(), static_cast<int>(input.size())));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_reduce_max(input.begin(), output.begin(), static_cast<int>(input.size()), env);
+
+  REQUIRE(output[0] == 4.0f);
 }
 
 C2H_TEST("Device ReduceByKey uses environment", "[reduce][device]")
@@ -526,4 +638,108 @@ C2H_TEST("Device ReduceByKey uses environment", "[reduce][device]")
   d_aggregates_out.resize(5);
   REQUIRE(d_unique_out == expected_keys);
   REQUIRE(d_aggregates_out == expected_aggregates);
+}
+
+C2H_TEST("Device ArgMin uses environment", "[reduce][device]")
+{
+  auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_output   = c2h::device_vector<float>(1);
+  auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceReduce::ArgMin(
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      min_output.begin(),
+      index_output.begin(),
+      static_cast<int>(input.size())));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_arg_min(input.begin(), min_output.begin(), index_output.begin(), static_cast<int>(input.size()), env);
+
+  REQUIRE(min_output[0] == 0.0f);
+  REQUIRE(index_output[0] == 3);
+}
+
+C2H_TEST("Device ArgMin with compare_op uses environment", "[reduce][device]")
+{
+  auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto min_output   = c2h::device_vector<float>(1);
+  auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceReduce::ArgMin(
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      min_output.begin(),
+      index_output.begin(),
+      static_cast<int>(input.size()),
+      cuda::std::less{}));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_arg_min(
+    input.begin(), min_output.begin(), index_output.begin(), static_cast<int>(input.size()), cuda::std::less{}, env);
+
+  REQUIRE(min_output[0] == 0.0f);
+  REQUIRE(index_output[0] == 3);
+}
+
+C2H_TEST("Device ArgMax uses environment", "[reduce][device]")
+{
+  auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto max_output   = c2h::device_vector<float>(1);
+  auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceReduce::ArgMax(
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      max_output.begin(),
+      index_output.begin(),
+      static_cast<int>(input.size())));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_arg_max(input.begin(), max_output.begin(), index_output.begin(), static_cast<int>(input.size()), env);
+
+  REQUIRE(max_output[0] == 4.0f);
+  REQUIRE(index_output[0] == 2);
+}
+
+C2H_TEST("Device ArgMax with compare_op uses environment", "[reduce][device]")
+{
+  auto input        = c2h::device_vector<float>{3.0f, 1.0f, 4.0f, 0.0f, 2.0f};
+  auto max_output   = c2h::device_vector<float>(1);
+  auto index_output = c2h::device_vector<cuda::std::int64_t>(1);
+
+  size_t expected_bytes_allocated{};
+  REQUIRE(
+    cudaSuccess
+    == cub::DeviceReduce::ArgMax(
+      nullptr,
+      expected_bytes_allocated,
+      input.begin(),
+      max_output.begin(),
+      index_output.begin(),
+      static_cast<int>(input.size()),
+      cuda::std::less{}));
+
+  auto env = stdexec::env{expected_allocation_size(expected_bytes_allocated)};
+
+  device_arg_max(
+    input.begin(), max_output.begin(), index_output.begin(), static_cast<int>(input.size()), cuda::std::less{}, env);
+
+  REQUIRE(max_output[0] == 4.0f);
+  REQUIRE(index_output[0] == 2);
 }

--- a/cub/test/catch2_test_device_reduce_env_api.cu
+++ b/cub/test/catch2_test_device_reduce_env_api.cu
@@ -79,8 +79,8 @@ C2H_TEST("cub::DeviceReduce::Reduce accepts stream", "[reduce][env]")
   }
 
   thrust::device_vector<float> expected{6.0f};
-  stream.sync();
   // example-end reduce-env-stream
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);
@@ -145,8 +145,8 @@ C2H_TEST("cub::DeviceReduce::Sum accepts stream", "[reduce][env]")
   }
 
   thrust::device_vector<float> expected{6.0f};
-  stream.sync();
   // example-end sum-env-stream
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);
@@ -210,8 +210,8 @@ C2H_TEST("cub::DeviceReduce::Min accepts stream", "[reduce][env]")
   }
 
   thrust::device_vector<float> expected{0.0f};
-  stream.sync();
   // example-end min-env-stream
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);
@@ -275,8 +275,8 @@ C2H_TEST("cub::DeviceReduce::Max accepts stream", "[reduce][env]")
   }
 
   thrust::device_vector<float> expected{3.0f};
-  stream.sync();
   // example-end max-env-stream
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);
@@ -349,8 +349,8 @@ C2H_TEST("cub::DeviceReduce::ArgMin accepts stream", "[reduce][env]")
 
   thrust::device_vector<float> expected_min{0.0f};
   thrust::device_vector<cuda::std::int64_t> expected_index{3};
-  stream.sync();
   // example-end argmin-env-stream
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(min_output == expected_min);
@@ -501,8 +501,8 @@ C2H_TEST("cub::DeviceReduce::TransformReduce accepts stream", "[reduce][env]")
   }
 
   thrust::device_vector<float> expected{-10.0f};
-  stream.sync();
   // example-end transform-reduce-env-stream
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(output == expected);
@@ -610,8 +610,8 @@ C2H_TEST("cub::DeviceReduce::ReduceByKey accepts stream", "[reduce][env]")
 
   thrust::device_vector<int> expected_keys{0, 2, 9, 5, 8};
   thrust::device_vector<int> expected_aggregates{0, 1, 6, 2, 4};
-  stream.sync();
   // example-end reduce-by-key-env-stream
+  stream.sync();
 
   REQUIRE(error == cudaSuccess);
   REQUIRE(num_runs_out[0] == 5);


### PR DESCRIPTION
Fixing critical oversights in one of my [earliest](https://github.com/NVIDIA/cccl/pull/5143) env PRs for `ArgMIn/Max` 

  - Fix missing `d_max_out` arg in `ArgMax compare_op` env overload's `__arg_min_env` call                                                           
  - Fix user-provided env silently ignored, hardcoded env{} passed instead
  - Add missing `enable_if_t<!indirectly_comparable>` SFINAE guard on `ArgMax no-compare_op` env overload                                          
  - Add launch-wrapper tests (lid 0/1/2) for Min, Max, ArgMin, ArgMax with and without compare_op
  - Move `stream.sync()` after example-end markers in env_api tests to hide from doc snippet
